### PR TITLE
Cloud provider snapshot restore job rs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
 	github.com/hashicorp/terraform v0.12.1
+	github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330
 	github.com/mongodb/go-client-mongodb-atlas v0.0.0
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
 	github.com/hashicorp/terraform v0.12.1
-	github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330
 	github.com/mongodb/go-client-mongodb-atlas v0.0.0
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/mitchellh/panicwrap v0.0.0-20190213213626-17011010aaa4/go.mod h1:YYMf
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330 h1:bnoS/iuyLhWCRCby05GPBBOD/n8pK+lEkRYJfj6PYgo=
+github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330/go.mod h1:wrnvHWZU2s9gS18Dc3wMmbOSggHOjNJ1Juw2+iPEcec=
 github.com/mongodb/go-client-mongodb-atlas v0.0.0-20190708162703-1e64eacf179a h1:K79wyVVC6etzU1fOd2cJAEYmrWXH95srErNFM5Nckdc=
 github.com/mongodb/go-client-mongodb-atlas v0.0.0-20190708162703-1e64eacf179a/go.mod h1:jtcobJML1zMJ1QhdQwkcBiKzZGOTo3k9eo1Ztt6NA5s=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=

--- a/go.sum
+++ b/go.sum
@@ -348,10 +348,6 @@ github.com/mitchellh/panicwrap v0.0.0-20190213213626-17011010aaa4/go.mod h1:YYMf
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330 h1:bnoS/iuyLhWCRCby05GPBBOD/n8pK+lEkRYJfj6PYgo=
-github.com/mongodb-partners/go-client-mongodb-atlas v0.0.0-20190701200211-67237e3c6330/go.mod h1:wrnvHWZU2s9gS18Dc3wMmbOSggHOjNJ1Juw2+iPEcec=
-github.com/mongodb/go-client-mongodb-atlas v0.0.0-20190708162703-1e64eacf179a h1:K79wyVVC6etzU1fOd2cJAEYmrWXH95srErNFM5Nckdc=
-github.com/mongodb/go-client-mongodb-atlas v0.0.0-20190708162703-1e64eacf179a/go.mod h1:jtcobJML1zMJ1QhdQwkcBiKzZGOTo3k9eo1Ztt6NA5s=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
 github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -37,12 +37,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"mongodbatlas_database_user":           resourceMongoDBAtlasDatabaseUser(),
-			"mongodbatlas_project_ip_whitelist":    resourceMongoDBAtlasProjectIPWhitelist(),
-			"mongodbatlas_project":                 resourceMongoDBAtlasProject(),
-			"mongodbatlas_cluster":                 resourceMongoDBAtlasCluster(),
-			"mongodbatlas_cloud_provider_snapshot": resourceMongoDBAtlasCloudProviderSnapshot(),
-			"mongodbatlas_network_container":       resourceMongoDBAtlasNetworkContainer(),
+			"mongodbatlas_database_user":                       resourceMongoDBAtlasDatabaseUser(),
+			"mongodbatlas_project_ip_whitelist":                resourceMongoDBAtlasProjectIPWhitelist(),
+			"mongodbatlas_project":                             resourceMongoDBAtlasProject(),
+			"mongodbatlas_cluster":                             resourceMongoDBAtlasCluster(),
+			"mongodbatlas_cloud_provider_snapshot":             resourceMongoDBAtlasCloudProviderSnapshot(),
+			"mongodbatlas_network_container":                   resourceMongoDBAtlasNetworkContainer(),
+			"mongodbatlas_cloud_provider_snapshot_restore_job": resourceMongoDBAtlasCloudProviderSnapshotRestoreJob(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
@@ -1,0 +1,247 @@
+package mongodbatlas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func resourceMongoDBAtlasCloudProviderSnapshotRestoreJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMongoDBAtlasCloudProviderSnapshotRestoreJobCreate,
+		Read:   resourceMongoDBAtlasCloudProviderSnapshotRestoreJobRead,
+		Delete: resourceMongoDBAtlasCloudProviderSnapshotRestoreJobDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceMongoDBAtlasCloudProviderSnapshotRestoreJobImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"delivery_type": {
+				Type:     schema.TypeMap,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"download": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"automated": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"target_cluster_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"target_group_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(map[string]interface{})
+
+					_, automated := v["automated"]
+					_, download := v["download"]
+
+					if (v["automated"] == "true" && v["download"] == "true") || (v["automated"] == "false" && v["download"] == "false") || (!automated && !download) {
+						errs = append(errs, fmt.Errorf("%q you need to implement only one: automated and download delivery types", key))
+					}
+					if v["automated"] == "true" && (v["download"] == "false" || v["download"] == "" || !download) {
+						if targetClusterName, ok := v["target_cluster_name"]; !ok || targetClusterName == "" {
+							errs = append(errs, fmt.Errorf("%q target_cluster_name must be set", key))
+						}
+						if targetGroupID, ok := v["target_group_id"]; !ok || targetGroupID == "" {
+							errs = append(errs, fmt.Errorf("%q target_group_id must be set", key))
+						}
+					}
+					if v["download"] == "true" && (v["automated"] == "false" || v["automated"] == "" || !automated) {
+						if targetClusterName, ok := v["target_cluster_name"]; ok || targetClusterName == "" {
+							errs = append(errs, fmt.Errorf("%q it's not necessary implement target_cluster_name when you are using download delivery type", key))
+						}
+						if targetGroupID, ok := v["target_group_id"]; ok || targetGroupID == "" {
+							errs = append(errs, fmt.Errorf("%q it's not necessary implement target_group_id when you are using download delivery type", key))
+						}
+					}
+					return
+				},
+			},
+			"delivery_url": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"cancelled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expired": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"finished_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"timestamp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobRead(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+
+	requestParameters := &matlas.SnapshotReqPathParameters{
+		JobID:       d.Id(),
+		GroupID:     d.Get("group_id").(string),
+		ClusterName: d.Get("cluster_name").(string),
+	}
+
+	snapshotReq, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+	if err != nil {
+		return fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err)
+	}
+
+	if err = d.Set("delivery_url", snapshotReq.DeliveryURL); err != nil {
+		return fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("cancelled", snapshotReq.Cancelled); err != nil {
+		return fmt.Errorf("error setting `cancelled` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("created_at", snapshotReq.CreatedAt); err != nil {
+		return fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("expired", snapshotReq.Expired); err != nil {
+		return fmt.Errorf("error setting `expired` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("expires_at", snapshotReq.ExpiresAt); err != nil {
+		return fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("finished_at", snapshotReq.FinishedAt); err != nil {
+		return fmt.Errorf("error setting `Finished_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	if err = d.Set("timestamp", snapshotReq.Timestamp); err != nil {
+		return fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+	}
+	return nil
+}
+
+func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobCreate(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+
+	requestParameters := &matlas.SnapshotReqPathParameters{
+		GroupID:     d.Get("group_id").(string),
+		ClusterName: d.Get("cluster_name").(string),
+	}
+
+	deliveryType := "automated"
+	if aut, _ := d.Get("delivery_type.automated").(string); aut != "true" {
+		deliveryType = "download"
+	}
+
+	snapshotReq := &matlas.CloudProviderSnapshotRestoreJob{
+		SnapshotID:        d.Get("snapshot_id").(string),
+		DeliveryType:      deliveryType,
+		TargetClusterName: d.Get("delivery_type.target_cluster_name").(string),
+		TargetGroupID:     d.Get("delivery_type.target_group_id").(string),
+	}
+
+	cloudProviderSnapshotRestoreJob, _, err := conn.CloudProviderSnapshotRestoreJobs.Create(context.Background(), requestParameters, snapshotReq)
+	if err != nil {
+		return fmt.Errorf("error restore a snapshot: %s", err)
+	}
+
+	d.SetId(cloudProviderSnapshotRestoreJob.ID)
+	return resourceMongoDBAtlasCloudProviderSnapshotRestoreJobRead(d, meta)
+}
+
+func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	requestParameters := &matlas.SnapshotReqPathParameters{
+		GroupID:     d.Get("group_id").(string),
+		ClusterName: d.Get("cluster_name").(string),
+		JobID:       d.Id(),
+	}
+
+	// Validate because atomated restore can not be cancelled
+	if aut, _ := d.Get("delivery_type.automated").(string); aut == "true" {
+		log.Print("Automated restore cannot be cancelled")
+	} else {
+		_, err := conn.CloudProviderSnapshotRestoreJobs.Delete(context.Background(), requestParameters)
+		if err != nil {
+			return fmt.Errorf("error deleting a cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*matlas.Client)
+
+	parts := strings.SplitN(d.Id(), "-", 3)
+	if len(parts) != 3 {
+		return nil, errors.New("import format error: to import a cloudProviderSnapshotRestoreJob, use the format {group_id}-{cluster_name}-{job_id}")
+	}
+
+	requestParameters := &matlas.SnapshotReqPathParameters{
+		GroupID:     parts[0],
+		ClusterName: parts[1],
+		JobID:       parts[2],
+	}
+
+	u, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't import cloudProviderSnapshotRestoreJob %s in project %s, error: %s", requestParameters.ClusterName, requestParameters.GroupID, err)
+	}
+
+	if err := d.Set("group_id", requestParameters.GroupID); err != nil {
+		log.Printf("[WARN] Error setting group_id for (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("cluster_name", requestParameters.ClusterName); err != nil {
+		log.Printf("[WARN] Error setting cluster_name for (%s): %s", d.Id(), err)
+	}
+
+	d.SetId(u.ID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
@@ -21,7 +21,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJob() *schema.Resource {
 			State: resourceMongoDBAtlasCloudProviderSnapshotRestoreJobImportState,
 		},
 		Schema: map[string]*schema.Schema{
-			"group_id": {
+			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -54,7 +54,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJob() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"target_group_id": {
+						"target_project_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -73,16 +73,16 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJob() *schema.Resource {
 						if targetClusterName, ok := v["target_cluster_name"]; !ok || targetClusterName == "" {
 							errs = append(errs, fmt.Errorf("%q target_cluster_name must be set", key))
 						}
-						if targetGroupID, ok := v["target_group_id"]; !ok || targetGroupID == "" {
-							errs = append(errs, fmt.Errorf("%q target_group_id must be set", key))
+						if targetGroupID, ok := v["target_project_id"]; !ok || targetGroupID == "" {
+							errs = append(errs, fmt.Errorf("%q target_project_id must be set", key))
 						}
 					}
 					if v["download"] == "true" && (v["automated"] == "false" || v["automated"] == "" || !automated) {
 						if targetClusterName, ok := v["target_cluster_name"]; ok || targetClusterName == "" {
 							errs = append(errs, fmt.Errorf("%q it's not necessary implement target_cluster_name when you are using download delivery type", key))
 						}
-						if targetGroupID, ok := v["target_group_id"]; ok || targetGroupID == "" {
-							errs = append(errs, fmt.Errorf("%q it's not necessary implement target_group_id when you are using download delivery type", key))
+						if targetGroupID, ok := v["target_project_id"]; ok || targetGroupID == "" {
+							errs = append(errs, fmt.Errorf("%q it's not necessary implement target_project_id when you are using download delivery type", key))
 						}
 					}
 					return
@@ -129,7 +129,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobRead(d *schema.ResourceD
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		JobID:       d.Id(),
-		GroupID:     d.Get("group_id").(string),
+		GroupID:     d.Get("project_id").(string),
 		ClusterName: d.Get("cluster_name").(string),
 	}
 
@@ -167,7 +167,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobCreate(d *schema.Resourc
 	conn := meta.(*matlas.Client)
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
-		GroupID:     d.Get("group_id").(string),
+		GroupID:     d.Get("project_id").(string),
 		ClusterName: d.Get("cluster_name").(string),
 	}
 
@@ -180,7 +180,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobCreate(d *schema.Resourc
 		SnapshotID:        d.Get("snapshot_id").(string),
 		DeliveryType:      deliveryType,
 		TargetClusterName: d.Get("delivery_type.target_cluster_name").(string),
-		TargetGroupID:     d.Get("delivery_type.target_group_id").(string),
+		TargetGroupID:     d.Get("delivery_type.target_project_id").(string),
 	}
 
 	cloudProviderSnapshotRestoreJob, _, err := conn.CloudProviderSnapshotRestoreJobs.Create(context.Background(), requestParameters, snapshotReq)
@@ -196,7 +196,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobDelete(d *schema.Resourc
 	conn := meta.(*matlas.Client)
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
-		GroupID:     d.Get("group_id").(string),
+		GroupID:     d.Get("project_id").(string),
 		ClusterName: d.Get("cluster_name").(string),
 		JobID:       d.Id(),
 	}
@@ -220,7 +220,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobImportState(d *schema.Re
 
 	parts := strings.SplitN(d.Id(), "-", 3)
 	if len(parts) != 3 {
-		return nil, errors.New("import format error: to import a cloudProviderSnapshotRestoreJob, use the format {group_id}-{cluster_name}-{job_id}")
+		return nil, errors.New("import format error: to import a cloudProviderSnapshotRestoreJob, use the format {project_id}-{cluster_name}-{job_id}")
 	}
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
@@ -234,8 +234,8 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobImportState(d *schema.Re
 		return nil, fmt.Errorf("couldn't import cloudProviderSnapshotRestoreJob %s in project %s, error: %s", requestParameters.ClusterName, requestParameters.GroupID, err)
 	}
 
-	if err := d.Set("group_id", requestParameters.GroupID); err != nil {
-		log.Printf("[WARN] Error setting group_id for (%s): %s", d.Id(), err)
+	if err := d.Set("project_id", requestParameters.GroupID); err != nil {
+		log.Printf("[WARN] Error setting project_id for (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("cluster_name", requestParameters.ClusterName); err != nil {
 		log.Printf("[WARN] Error setting cluster_name for (%s): %s", d.Id(), err)

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	matlas "github.com/mongodb-partners/go-client-mongodb-atlas/mongodbatlas"
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
 )
 
 func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_basic(t *testing.T) {

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -1,0 +1,200 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	matlas "github.com/mongodb-partners/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_basic(t *testing.T) {
+	var cloudProviderSnapshotRestoreJob = matlas.CloudProviderSnapshotRestoreJob{}
+
+	resourceName := "mongodbatlas_cloud_provider_snapshot_restore_job.test"
+
+	groupID := "5cf5a45a9ccf6400e60981b6"
+	clusterName := "MyCluster"
+	description := "myDescription"
+	retentionInDays := "1"
+	targetClusterName := "MyCluster"
+	targetGroupID := "5cf5a45a9ccf6400e60981b6"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName, &cloudProviderSnapshotRestoreJob),
+					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobAttributes(&cloudProviderSnapshotRestoreJob, "automated"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type.target_cluster_name", targetClusterName),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type.target_group_id", targetGroupID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(groupID, clusterName, description, retentionInDays),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName, &cloudProviderSnapshotRestoreJob),
+					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobAttributes(&cloudProviderSnapshotRestoreJob, "download"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type.download", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_importBasic(t *testing.T) {
+
+	resourceName := "mongodbatlas_cloud_provider_snapshot_restore_job.test"
+
+	groupID := "5cf5a45a9ccf6400e60981b6"
+	clusterName := "MyCluster"
+	description := "myDescription"
+	retentionInDays := "1"
+	targetClusterName := "MyCluster"
+	targetGroupID := "5cf5a45a9ccf6400e60981b6"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName string, cloudProviderSnapshotRestoreJob *matlas.CloudProviderSnapshotRestoreJob) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*matlas.Client)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] cloudProviderSnapshotRestoreJob ID: %s", rs.Primary.ID)
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			JobID:       rs.Primary.ID,
+			GroupID:     rs.Primary.Attributes["group_id"],
+			ClusterName: rs.Primary.Attributes["cluster_name"],
+		}
+
+		if snapshotRes, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters); err == nil {
+			*cloudProviderSnapshotRestoreJob = *snapshotRes
+			return nil
+		}
+		return fmt.Errorf("cloudProviderSnapshotRestoreJob (%s) does not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobAttributes(cloudProviderSnapshotRestoreJob *matlas.CloudProviderSnapshotRestoreJob, deliveryType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cloudProviderSnapshotRestoreJob.DeliveryType != deliveryType {
+			return fmt.Errorf("bad cloudProviderSnapshotRestoreJob deliveryType: %s", cloudProviderSnapshotRestoreJob.DeliveryType)
+		}
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*matlas.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_provider_snapshot_restore_job" {
+			continue
+		}
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			GroupID:     rs.Primary.Attributes["group_id"],
+			ClusterName: rs.Primary.Attributes["cluster_name"],
+			JobID:       rs.Primary.ID,
+		}
+
+		snapshotReq, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+		if err != nil {
+			return fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err)
+		}
+
+		if snapshotReq.DeliveryType == "download" {
+			_, err := conn.CloudProviderSnapshotRestoreJobs.Delete(context.Background(), requestParameters)
+			if err != nil {
+				return fmt.Errorf("cloudProviderSnapshotRestoreJob (%s) still exists", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["group_id"], rs.Primary.Attributes["cluster_name"], rs.Primary.ID), nil
+	}
+}
+
+func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cloud_provider_snapshot" "test" {
+			group_id          = "%s"
+			cluster_name      = "%s"
+			description       = "%s"
+			retention_in_days = %s
+		}
+		
+		resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
+			group_id      = "${mongodbatlas_cloud_provider_snapshot.test.group_id}"
+			cluster_name  = "${mongodbatlas_cloud_provider_snapshot.test.cluster_name}"
+			snapshot_id   = "${mongodbatlas_cloud_provider_snapshot.test.id}"
+			delivery_type = {
+				automated           = true
+				target_cluster_name = "%s"
+				target_group_id     = "%s"
+			}
+			depends_on = ["mongodbatlas_cloud_provider_snapshot.test"]
+		}
+	`, groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID)
+}
+
+func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(groupID, clusterName, description, retentionInDays string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cloud_provider_snapshot" "test" {
+			group_id          = "%s"
+			cluster_name      = "%s"
+			description       = "%s"
+			retention_in_days = %s
+		}
+		
+		resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
+			group_id      = "${mongodbatlas_cloud_provider_snapshot.test.group_id}"
+			cluster_name  = "${mongodbatlas_cloud_provider_snapshot.test.cluster_name}"
+			snapshot_id   = "${mongodbatlas_cloud_provider_snapshot.test.id}"
+			delivery_type = {
+				download = true
+			}
+			depends_on = ["mongodbatlas_cloud_provider_snapshot.test"]
+		}
+	`, groupID, clusterName, description, retentionInDays)
+}

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -16,7 +16,7 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_basic(t *testing
 
 	resourceName := "mongodbatlas_cloud_provider_snapshot_restore_job.test"
 
-	groupID := "5cf5a45a9ccf6400e60981b6"
+	projectID := "5cf5a45a9ccf6400e60981b6"
 	clusterName := "MyCluster"
 	description := "myDescription"
 	retentionInDays := "1"
@@ -29,16 +29,16 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_basic(t *testing
 		CheckDestroy: testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(projectID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName, &cloudProviderSnapshotRestoreJob),
 					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobAttributes(&cloudProviderSnapshotRestoreJob, "automated"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_type.target_cluster_name", targetClusterName),
-					resource.TestCheckResourceAttr(resourceName, "delivery_type.target_group_id", targetGroupID),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type.target_project_id", targetGroupID),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(groupID, clusterName, description, retentionInDays),
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(projectID, clusterName, description, retentionInDays),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName, &cloudProviderSnapshotRestoreJob),
 					testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobAttributes(&cloudProviderSnapshotRestoreJob, "download"),
@@ -53,7 +53,7 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_importBasic(t *t
 
 	resourceName := "mongodbatlas_cloud_provider_snapshot_restore_job.test"
 
-	groupID := "5cf5a45a9ccf6400e60981b6"
+	projectID := "5cf5a45a9ccf6400e60981b6"
 	clusterName := "MyCluster"
 	description := "myDescription"
 	retentionInDays := "1"
@@ -66,7 +66,7 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_importBasic(t *t
 		CheckDestroy: testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
+				Config: testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(projectID, clusterName, description, retentionInDays, targetClusterName, targetGroupID),
 			},
 			{
 				ResourceName:            resourceName,
@@ -95,7 +95,7 @@ func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobExists(resourceName 
 
 		requestParameters := &matlas.SnapshotReqPathParameters{
 			JobID:       rs.Primary.ID,
-			GroupID:     rs.Primary.Attributes["group_id"],
+			GroupID:     rs.Primary.Attributes["project_id"],
 			ClusterName: rs.Primary.Attributes["cluster_name"],
 		}
 
@@ -125,7 +125,7 @@ func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobDestroy(s *terraform
 		}
 
 		requestParameters := &matlas.SnapshotReqPathParameters{
-			GroupID:     rs.Primary.Attributes["group_id"],
+			GroupID:     rs.Primary.Attributes["project_id"],
 			ClusterName: rs.Primary.Attributes["cluster_name"],
 			JobID:       rs.Primary.ID,
 		}
@@ -151,44 +151,44 @@ func testAccCheckMongoDBAtlasCloudProviderSnapshotRestoreJobImportStateIDFunc(re
 		if !ok {
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
-		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["group_id"], rs.Primary.Attributes["cluster_name"], rs.Primary.ID), nil
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"], rs.Primary.ID), nil
 	}
 }
 
-func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID string) string {
+func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(projectID, clusterName, description, retentionInDays, targetClusterName, targetGroupID string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cloud_provider_snapshot" "test" {
-			group_id          = "%s"
+			project_id          = "%s"
 			cluster_name      = "%s"
 			description       = "%s"
 			retention_in_days = %s
 		}
 		
 		resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
-			group_id      = "${mongodbatlas_cloud_provider_snapshot.test.group_id}"
+			project_id      = "${mongodbatlas_cloud_provider_snapshot.test.project_id}"
 			cluster_name  = "${mongodbatlas_cloud_provider_snapshot.test.cluster_name}"
 			snapshot_id   = "${mongodbatlas_cloud_provider_snapshot.test.id}"
 			delivery_type = {
 				automated           = true
 				target_cluster_name = "%s"
-				target_group_id     = "%s"
+				target_project_id     = "%s"
 			}
 			depends_on = ["mongodbatlas_cloud_provider_snapshot.test"]
 		}
-	`, groupID, clusterName, description, retentionInDays, targetClusterName, targetGroupID)
+	`, projectID, clusterName, description, retentionInDays, targetClusterName, targetGroupID)
 }
 
-func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(groupID, clusterName, description, retentionInDays string) string {
+func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(projectID, clusterName, description, retentionInDays string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cloud_provider_snapshot" "test" {
-			group_id          = "%s"
+			project_id          = "%s"
 			cluster_name      = "%s"
 			description       = "%s"
 			retention_in_days = %s
 		}
 		
 		resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
-			group_id      = "${mongodbatlas_cloud_provider_snapshot.test.group_id}"
+			project_id      = "${mongodbatlas_cloud_provider_snapshot.test.project_id}"
 			cluster_name  = "${mongodbatlas_cloud_provider_snapshot.test.cluster_name}"
 			snapshot_id   = "${mongodbatlas_cloud_provider_snapshot.test.id}"
 			delivery_type = {
@@ -196,5 +196,5 @@ func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(groupID, c
 			}
 			depends_on = ["mongodbatlas_cloud_provider_snapshot.test"]
 		}
-	`, groupID, clusterName, description, retentionInDays)
+	`, projectID, clusterName, description, retentionInDays)
 }

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -21,13 +21,13 @@ description: |-
 
 ```hcl
 resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
-  group_id      = "5cf5a45a9ccf6400e60981b6"
+  project_id      = "5cf5a45a9ccf6400e60981b6"
   cluster_name  = "MyCluster"
   snapshot_id   = "5d1b654ecf09a24b888f4c79"
   delivery_type = {
     automated           = true
     target_cluster_name = "MyTargetCluster"
-    target_group_id     = "5cf5a45a9ccf6400e60981b6"
+    target_project_id     = "5cf5a45a9ccf6400e60981b6"
   }
 }
 ```
@@ -35,7 +35,7 @@ resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
 
 ```hcl
 resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
-  group_id      = "5cf5a45a9ccf6400e60981b6"
+  project_id      = "5cf5a45a9ccf6400e60981b6"
   cluster_name  = "MyCluster"
   snapshot_id   = "5d1b654ecf09a24b888f4c79"
   delivery_type = {
@@ -46,7 +46,7 @@ resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
 
 ## Argument Reference
 
-* `group_id` - (Required) The unique identifier of the project for the Atlas cluster whose snapshot you want to restore.
+* `project_id` - (Required) The unique identifier of the project for the Atlas cluster whose snapshot you want to restore.
 * `cluster_name` - (Required) The name of the Atlas cluster whose snapshot you want to restore.
 * `snapshot_id` - (Required) Unique identifier of the snapshot to restore.
 * `delivery_type` - (Required) Type of restore job to create. Possible values are: **download** or **automated**, only one must be set it in ``true``.
@@ -81,7 +81,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloud Provider Snapshot Restore Job entries can be imported using project group_id, cluster_name and snapshot_id (Unique identifier of the snapshot), in the format `GROUPID-CLUSTERNAME-JOBID`, e.g.
+Cloud Provider Snapshot Restore Job entries can be imported using project project_id, cluster_name and snapshot_id (Unique identifier of the snapshot), in the format `GROUPID-CLUSTERNAME-JOBID`, e.g.
 
 ```
 $ terraform import mongodbatlas_cloud_provider_snapshot_restore_job.test 5cf5a45a9ccf6400e60981b6-MyCluster-5d1b654ecf09a24b888f4c79

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # mongodbatlas_cloud_provider_snapshot_restore_job
 
-`mongodbatlas_cloud_provider_snapshot_restore_job` provides a resource to create a new restore job from a cloud provider snapshot associated to the specified cluster. The restore job depends of the type of restore job to create it: 
+`mongodbatlas_cloud_provider_snapshot_restore_job` provides a resource to create a new restore job from a cloud provider snapshot of a specified cluster. The restore job can be one of two types: 
 * **automated:** Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId.
 
 * **download:** Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. The contents of the archive contain the data files for your Atlas cluster.
@@ -31,7 +31,7 @@ resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
   }
 }
 ```
-### Example download delivered type.
+### Example download delivery type.
 
 ```hcl
 resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
@@ -81,7 +81,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloud Provider Snapshot Restore Job entries can be imported using project project_id, cluster_name and snapshot_id (Unique identifier of the snapshot), in the format `GROUPID-CLUSTERNAME-JOBID`, e.g.
+Cloud Provider Snapshot Restore Job entries can be imported using project project_id, cluster_name and snapshot_id (Unique identifier of the snapshot), in the format `PROJECTID-CLUSTERNAME-JOBID`, e.g.
 
 ```
 $ terraform import mongodbatlas_cloud_provider_snapshot_restore_job.test 5cf5a45a9ccf6400e60981b6-MyCluster-5d1b654ecf09a24b888f4c79

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -1,0 +1,90 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: cloud_provider_snapshot_restore_job"
+sidebar_current: "docs-mongodbatlas-resource-cloud_provider_snapshot_restore_job"
+description: |-
+    Provides an Cloud Provider Snapshot Restore Job resource.
+---
+
+# mongodbatlas_cloud_provider_snapshot_restore_job
+
+`mongodbatlas_cloud_provider_snapshot_restore_job` provides a resource to create a new restore job from a cloud provider snapshot associated to the specified cluster. The restore job depends of the type of restore job to create it: 
+* **automated:** Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId.
+
+* **download:** Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. The contents of the archive contain the data files for your Atlas cluster.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
+
+## Example Usage
+
+### Example automated delivery type.
+
+```hcl
+resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
+  group_id      = "5cf5a45a9ccf6400e60981b6"
+  cluster_name  = "MyCluster"
+  snapshot_id   = "5d1b654ecf09a24b888f4c79"
+  delivery_type = {
+    automated           = true
+    target_cluster_name = "MyTargetCluster"
+    target_group_id     = "5cf5a45a9ccf6400e60981b6"
+  }
+}
+```
+### Example download delivered type.
+
+```hcl
+resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
+  group_id      = "5cf5a45a9ccf6400e60981b6"
+  cluster_name  = "MyCluster"
+  snapshot_id   = "5d1b654ecf09a24b888f4c79"
+  delivery_type = {
+    download = true
+  }
+}
+```
+
+## Argument Reference
+
+* `group_id` - (Required) The unique identifier of the project for the Atlas cluster whose snapshot you want to restore.
+* `cluster_name` - (Required) The name of the Atlas cluster whose snapshot you want to restore.
+* `snapshot_id` - (Required) Unique identifier of the snapshot to restore.
+* `delivery_type` - (Required) Type of restore job to create. Possible values are: **download** or **automated**, only one must be set it in ``true``.
+
+### Download
+Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. 
+
+### Automated
+Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId. if you want to use automated delivery type, you must to set the following arguments:
+
+* `targetClusterName` - (Required) 	Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
+* `targetGroupId` - (Required) 	Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `cancelled` -	Indicates whether the restore job was canceled.
+* `createdAt` -	UTC ISO 8601 formatted point in time when Atlas created the restore job.
+* `deliveryType` - Type of restore job to create. Possible values are: automated and download.
+* `deliveryUrl` -	One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
+* `expired` -	Indicates whether the restore job expired.
+* `expiresAt` -	UTC ISO 8601 formatted point in time when the restore job expires.
+* `finishedAt` -	UTC ISO 8601 formatted point in time when the restore job completed.
+* `id` -	The unique identifier of the restore job.
+* `links` -	One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
+* `snapshotId` -	Unique identifier of the source snapshot ID of the restore job.
+* `targetGroupId` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `targetClusterName` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
+* `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+
+## Import
+
+Cloud Provider Snapshot Restore Job entries can be imported using project group_id, cluster_name and snapshot_id (Unique identifier of the snapshot), in the format `GROUPID-CLUSTERNAME-JOBID`, e.g.
+
+```
+$ terraform import mongodbatlas_cloud_provider_snapshot_restore_job.test 5cf5a45a9ccf6400e60981b6-MyCluster-5d1b654ecf09a24b888f4c79
+```
+
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs/)


### PR DESCRIPTION
Added:

- cloud_provider_snapshot_restore_job resource.
- cloud_provider_snapshot_restore_job_test acceptance testing.
- cloud_provider_snapshot_restore_job website documentation.

You can run the acceptance test with:
make testacc

Terraform configuration:

#### Example automated delivery type.

```hcl
resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
  project_id    = "5cf5a45a9ccf6400e60981b6"
  cluster_name  = "MyCluster"
  snapshot_id   = "5d1b654ecf09a24b888f4c79"
  delivery_type = {
    automated           = true
    target_cluster_name = "MyTargetCluster"
    target_project_id   = "5cf5a45a9ccf6400e60981b6"
  }
}
```

#### Example download delivery type.
```hcl
resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
  project_id    = "5cf5a45a9ccf6400e60981b6"
  cluster_name  = "MyCluster"
  snapshot_id   = "5d1b654ecf09a24b888f4c79"
  delivery_type = {
    download = true
  }
}
```