### PR TITLE
Standardize Regions

### DIFF
--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/cast"
 )
 
 //Provider returns the provider to be use by the code.
@@ -95,4 +96,96 @@ func decodeStateID(stateID string) map[string]string {
 		decodedValues[decode(keyValue[0])] = decode(keyValue[1])
 	}
 	return decodedValues
+}
+
+func valRegion(reg interface{}, opt ...string) (string, error) {
+
+	regions := []string{
+		"US_EAST_1",
+		"US_EAST_2",
+		"US_WEST_1",
+		"US_WEST_2",
+		"CA_CENTRAL_1",
+		"SA_EAST_1",
+		"AP_NORTHEAST_1",
+		"AP_NORTHEAST_2",
+		"AP_SOUTH_1",
+		"AP_SOUTHEAST_1",
+		"AP_SOUTHEAST_2",
+		"EU_CENTRAL_1",
+		"EU_NORTH_1",
+		"EU_WEST_1",
+		"EU_WEST_2",
+		"EU_WEST_3",
+		"AZURE",
+		"AZURE_CHINA",
+		"AZURE_GERMANY",
+		"US_CENTRAL",
+		"US_EAST",
+		"US_NORTH_CENTRAL",
+		"US_WEST",
+		"US_SOUTH_CENTRAL",
+		"BRAZIL_SOUTH",
+		"CANADA_EAST",
+		"CANADA_CENTRAL",
+		"EUROPE_NORTH",
+		"EUROPE_WEST",
+		"UK_SOUTH",
+		"UK_WEST",
+		"FRANCE_CENTRAL",
+		"ASIA_EAST",
+		"ASIA_SOUTH_EAST",
+		"AUSTRALIA_EAST",
+		"AUSTRALIA_SOUTH_EAST",
+		"INDIA_CENTRAL",
+		"INDIA_SOUTH",
+		"INDIA_WEST",
+		"JAPAN_EAST",
+		"JAPAN_WEST",
+		"KOREA_CENTRAL",
+		"KOREA_SOUTH",
+		"SOUTH_AFRICA_NORTH",
+		"UAE_NORTH",
+		"CENTRAL_US",
+		"EASTERN_US",
+		"US_EAST_4",
+		"NORTH_AMERICA_NORTHEAST_1",
+		"SOUTH_AMERICA_EAST_1",
+		"WESTERN_US",
+		"US_WEST_2",
+		"EASTERN_ASIA_PACIFIC",
+		"ASIA_EAST_2",
+		"NORTHEASTERN_ASIA_PACIFIC",
+		"ASIA_NORTHEAST_2",
+		"SOUTHEASTERN_ASIA_PACIFIC",
+		"ASIA_SOUTH_1",
+		"AUSTRALIA_SOUTHEAST_1",
+		"WESTERN_EUROPE",
+		"EUROPE_NORTH_1",
+		"EUROPE_WEST_2",
+		"EUROPE_WEST_3",
+		"EUROPE_WEST_4",
+		"EUROPE_WEST_6",
+	}
+
+	region, err := cast.ToStringE(reg)
+	if err != nil {
+		return "", err
+	}
+
+	for _, r := range regions {
+		if strings.EqualFold(string(r), strings.ReplaceAll(region, "-", "_")) {
+			/*
+				We need to check if the option will be similar to network_pering word
+				 (this comes in from the same resource) because network_pering resource
+				 has not the standard region name patron "US_EAST_1",
+				 instead it needs the following one: "us-east-1".
+			*/
+			if len(opt) > 0 && strings.EqualFold("network_peering", opt[0]) {
+				return strings.ToLower(strings.ReplaceAll(region, "_", "-")), nil
+			}
+			return string(r), nil
+		}
+	}
+	return "", fmt.Errorf("unable to cast %#v of type %T to string", reg, reg)
 }

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -599,6 +599,7 @@ func flattenBiConnector(biConnector matlas.BiConnector) map[string]interface{} {
 func expandProviderSetting(d *schema.ResourceData) matlas.ProviderSettings {
 	diskIOPS := cast.ToInt64(d.Get("provider_disk_iops"))
 	encryptEBSVolume := cast.ToBool(d.Get("provider_encrypt_ebs_volume"))
+	region, _ := valRegion(d.Get("provider_region_name"))
 
 	providerSettings := matlas.ProviderSettings{
 		DiskIOPS:            &diskIOPS,
@@ -607,7 +608,7 @@ func expandProviderSetting(d *schema.ResourceData) matlas.ProviderSettings {
 		DiskTypeName:        cast.ToString(d.Get("provider_disk_type_name")),
 		InstanceSizeName:    cast.ToString(d.Get("provider_instance_size_name")),
 		ProviderName:        cast.ToString(d.Get("provider_name")),
-		RegionName:          cast.ToString(d.Get("provider_region_name")),
+		RegionName:          region,
 		VolumeType:          cast.ToString(d.Get("provider_volume_type")),
 	}
 
@@ -693,7 +694,8 @@ func expandRegionsConfig(regions []interface{}) (map[string]matlas.RegionsConfig
 	regionsConfig := make(map[string]matlas.RegionsConfig)
 	for _, r := range regions {
 		region := r.(map[string]interface{})
-		r, err := cast.ToStringE(region["region_name"])
+
+		r, err := valRegion(region["region_name"])
 		if err != nil {
 			return regionsConfig, err
 		}

--- a/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
@@ -142,6 +142,8 @@ func resourceMongoDBAtlasEncryptionAtRest() *schema.Resource {
 
 func resourceMongoDBAtlasEncryptionAtRestCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*matlas.Client)
+	awsRegion, _ := valRegion(d.Get("aws_kms.region"))
+
 	encryptionAtRestReq := &matlas.EncryptionAtRest{
 		GroupID: d.Get("project_id").(string),
 		AwsKms: matlas.AwsKms{
@@ -149,7 +151,7 @@ func resourceMongoDBAtlasEncryptionAtRestCreate(d *schema.ResourceData, meta int
 			AccessKeyID:         d.Get("aws_kms.access_key_id").(string),
 			SecretAccessKey:     d.Get("aws_kms.secret_access_key").(string),
 			CustomerMasterKeyID: d.Get("aws_kms.customer_master_key_id").(string),
-			Region:              d.Get("aws_kms.region").(string),
+			Region:              awsRegion,
 		},
 		AzureKeyVault: matlas.AzureKeyVault{
 			Enabled:           pointy.Bool(cast.ToBool(d.Get("azure_key_vault.enabled"))),

--- a/mongodbatlas/resource_mongodbatlas_encryption_at_rest_test.go
+++ b/mongodbatlas/resource_mongodbatlas_encryption_at_rest_test.go
@@ -25,7 +25,7 @@ func TestAccResourceMongoDBAtlasEncryptionAtRest_basicAWS(t *testing.T) {
 		AccessKeyID:         os.Getenv("AWS_ACCESS_KEY_ID"),
 		SecretAccessKey:     os.Getenv("AWS_SECRET_ACCESS_KEY"),
 		CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID"),
-		Region:              "US_EAST_1",
+		Region:              os.Getenv("AWS_REGION"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/mongodbatlas/resource_mongodbatlas_network_container.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container.go
@@ -100,14 +100,19 @@ func resourceMongoDBAtlasNetworkContainerCreate(d *schema.ResourceData, meta int
 	}
 
 	if providerName == "AWS" {
-		if _, ok := d.GetOk("region_name"); !ok {
+		region, err := valRegion(d.Get("region_name"))
+		if err != nil {
 			return fmt.Errorf("`region_name` must be set when `provider_name` is AWS")
 		}
-		containerRequest.RegionName = d.Get("region_name").(string)
+		containerRequest.RegionName = region
 	}
 
 	if providerName == "Azure" {
-		containerRequest.Region = d.Get("region").(string)
+		region, err := valRegion(d.Get("region"))
+		if err != nil {
+			return fmt.Errorf("`region` must be set when `provider_name` is AWS")
+		}
+		containerRequest.Region = region
 	}
 
 	container, _, err := conn.Containers.Create(context.Background(), projectID, containerRequest)
@@ -193,11 +198,13 @@ func resourceMongoDBAtlasNetworkContainerUpdate(d *schema.ResourceData, meta int
 	}
 
 	if d.HasChange("region_name") {
-		container.RegionName = d.Get("region_name").(string)
+		region, _ := valRegion(d.Get("region_name"))
+		container.RegionName = region
 	}
 
 	if d.HasChange("region") {
-		container.Region = d.Get("region").(string)
+		region, _ := valRegion(d.Get("region"))
+		container.Region = region
 	}
 
 	// Has changes

--- a/mongodbatlas/resource_mongodbatlas_network_peering.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering.go
@@ -156,8 +156,8 @@ func resourceMongoDBAtlasNetworkPeeringCreate(d *schema.ResourceData, meta inter
 	}
 
 	if providerName == "AWS" {
-		accepter, ok := d.GetOk("accepter_region_name")
-		if !ok {
+		region, err := valRegion(d.Get("accepter_region_name"), "network_peering")
+		if err != nil {
 			return errors.New("`accepter_region_name` must be set when `provider_name` is `AWS`")
 		}
 
@@ -176,7 +176,7 @@ func resourceMongoDBAtlasNetworkPeeringCreate(d *schema.ResourceData, meta inter
 			return errors.New("`vpc_id` must be set when `provider_name` is `AWS`")
 		}
 
-		peerRequest.AccepterRegionName = accepter.(string)
+		peerRequest.AccepterRegionName = region
 		peerRequest.AWSAccountId = awsAccountID.(string)
 		peerRequest.RouteTableCIDRBlock = rtCIDR.(string)
 		peerRequest.VpcID = vpcID.(string)
@@ -351,7 +351,8 @@ func resourceMongoDBAtlasNetworkPeeringUpdate(d *schema.ResourceData, meta inter
 	peer := new(matlas.Peer)
 
 	if d.HasChange("accepter_region_name") {
-		peer.AccepterRegionName = d.Get("accepter_region_name").(string)
+		region, _ := valRegion(d.Get("accepter_region_name"), "network_peering")
+		peer.AccepterRegionName = region
 	}
 
 	if d.HasChange("aws_account_id") {


### PR DESCRIPTION
Hello @nitrag thanks for your review, we have implemented the standardize to be able to use it through the MongoDB resources, you can use it as the following: 

```hcl
resource "mongodbatlas_cluster" "test" {
  project_id     = <PROJECT-ID>
  name           = "myClusterTest"
  disk_size_gb   = 100
  num_shards     = 1
  backup_enabled = false
  cluster_type   = "REPLICASET"

  provider_name               = "AWS"
  provider_disk_iops          = 300
  provider_instance_size_name = "M10"

  replication_specs {
    num_shards = 1
    regions_config {
      region_name     = "US_WEST_2"
      electable_nodes = 1
      priority        = 7
      read_only_nodes = 1
    }
    regions_config {
      region_name     = "us-west-1"
      electable_nodes = 3
      priority        = 7
      read_only_nodes = 0
    }
    regions_config {
      region_name     = "eu_central_1"
      electable_nodes = 2
      priority        = 6
      read_only_nodes = 0
    }
    regions_config {
      region_name     = "US-WEST-1"
      electable_nodes = 2
      priority        = 5
      read_only_nodes = 2
    }
  }
}
```
could you please test it again with this branch? please, if you have some comments, just let us know.

closes #31 