### PR TITLE
fix: add the correct func to check the env variables on peering datasources

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_network_peering_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_peering_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceMongoDBAtlasNetworkPeering_basic(t *testing.T) {
 	awsRegion := os.Getenv("AWS_REGION")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); checkPeeringEnv(t) },
+		PreCheck:     func() { testAccPreCheck(t); checkPeeringEnvAWS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMongoDBAtlasNetworkPeeringDestroy,
 		Steps: []resource.TestStep{

--- a/mongodbatlas/data_source_mongodbatlas_network_peerings_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_peerings_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceMongoDBAtlasNetworkPeerings_basic(t *testing.T) {
 	awsRegion := os.Getenv("AWS_REGION")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); checkPeeringEnv(t) },
+		PreCheck:     func() { testAccPreCheck(t); checkPeeringEnvAWS(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMongoDBAtlasNetworkPeeringDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
We needed to change the env function for peering resource to add more test cases (GCP and Azure) so now the data sources need to add these env functions to test work right.