### PR TITLE
Add Private IP Mode Resource.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
 	github.com/hashicorp/terraform v0.12.1
-	github.com/mongodb/go-client-mongodb-atlas v0.0.1
+	github.com/mongodb/go-client-mongodb-atlas v0.1.0
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,11 @@ github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/I
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mongodb/go-client-mongodb-atlas v0.0.1 h1:P1vLNaQR93GNXDNU965yU7d2eGumj/fPtLbjs8cJbwU=
 github.com/mongodb/go-client-mongodb-atlas v0.0.1/go.mod h1:jtcobJML1zMJ1QhdQwkcBiKzZGOTo3k9eo1Ztt6NA5s=
+github.com/mongodb/go-client-mongodb-atlas v0.0.3 h1:tSd60PEqYvZA3q/VUB6jkF/agbLqMo1qd4gNm+hSdHY=
+github.com/mongodb/go-client-mongodb-atlas v0.0.4-0.20190918035958-ff5000204464 h1:hcafNkB67JX44lPYtil/R+XVFr+8hGd7f5gXVe2oaBM=
+github.com/mongodb/go-client-mongodb-atlas v0.0.4-0.20190918035958-ff5000204464/go.mod h1:jtcobJML1zMJ1QhdQwkcBiKzZGOTo3k9eo1Ztt6NA5s=
+github.com/mongodb/go-client-mongodb-atlas v0.1.0 h1:qiovmFbudTe48rKcyTPXq1CzDRqyYFqsnxSbkZtHGSg=
+github.com/mongodb/go-client-mongodb-atlas v0.1.0/go.mod h1:jtcobJML1zMJ1QhdQwkcBiKzZGOTo3k9eo1Ztt6NA5s=
 github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
 github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -56,6 +56,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_cloud_provider_snapshot_restore_job": resourceMongoDBAtlasCloudProviderSnapshotRestoreJob(),
 			"mongodbatlas_network_peering":                     resourceMongoDBAtlasNetworkPeering(),
 			"mongodbatlas_encryption_at_rest":                  resourceMongoDBAtlasEncryptionAtRest(),
+			"mongodbatlas_private_ip_mode":                     resourceMongoDBAtlasPrivateIPMode(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
+++ b/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
@@ -1,0 +1,110 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+)
+
+const (
+	errorPrivateIPModeCreate = "error setting MongoDB Only Private IP Mode for Peering Connections: %s"
+	errorPrivateIPModeRead   = "error reading MongoDB Only Private IP Mode for Peering Connections (%s): %s"
+	errorPrivateIPModeDelete = "error deleting MongoDB Only Private IP Mode for Peering Connections (%s): %s"
+)
+
+func resourceMongoDBAtlasPrivateIPMode() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMongoDBAtlasPrivateIPModeCreate,
+		Read:   resourceMongoDBAtlasPrivateIPModeRead,
+		Update: resourceMongoDBAtlasPrivateIPModeCreate,
+		Delete: resourceMongoDBAtlasPrivateIPModeDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceMongoDBAtlasPrivateIPModeImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasPrivateIPModeCreate(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+	projectID := d.Get("project_id").(string)
+
+	//Get the required ones
+	privateIPModeRequest := &matlas.PrivateIPMode{
+		Enabled: pointy.Bool(d.Get("enabled").(bool)),
+	}
+
+	_, _, err := conn.PrivateIPMode.Update(context.Background(), projectID, privateIPModeRequest)
+	if err != nil {
+		return fmt.Errorf(errorPrivateIPModeCreate, err)
+	}
+
+	d.SetId(projectID)
+
+	return resourceMongoDBAtlasPrivateIPModeRead(d, meta)
+}
+
+func resourceMongoDBAtlasPrivateIPModeRead(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+
+	projectID := d.Id()
+
+	privateIPMode, resp, err := conn.PrivateIPMode.Get(context.Background(), projectID)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+
+			return nil
+		}
+		return fmt.Errorf(errorPrivateIPModeRead, projectID, err)
+	}
+
+	if err := d.Set("enabled", privateIPMode.Enabled); err != nil {
+		return fmt.Errorf(errorPrivateIPModeRead, projectID, err)
+	}
+
+	return nil
+}
+
+func resourceMongoDBAtlasPrivateIPModeDelete(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+	projectID := d.Id()
+
+	//Get the required ones
+	privateIPModeRequest := &matlas.PrivateIPMode{
+		Enabled: pointy.Bool(false),
+	}
+
+	_, _, err := conn.PrivateIPMode.Update(context.Background(), projectID, privateIPModeRequest)
+
+	if err != nil {
+		return fmt.Errorf(errorPrivateIPModeDelete, projectID, err)
+	}
+
+	return nil
+}
+
+func resourceMongoDBAtlasPrivateIPModeImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if err := d.Set("project_id", d.Id()); err != nil {
+		log.Printf("[WARN] Error setting project_id for private IP Mode: %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/mongodbatlas/resource_mongodbatlas_private_ip_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_ip_mode_test.go
@@ -1,0 +1,104 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+)
+
+func TestAccResourcePrivateIPMode_basic(t *testing.T) {
+	var privateIPMode matlas.PrivateIPMode
+
+	resourceName := "mongodbatlas_private_ip_mode.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPrivateIPModeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateIPModeConfig(projectID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPrivateIPModeExists(resourceName, &privateIPMode),
+					testAccCheckPrivateIPModeAttributes(&privateIPMode, pointy.Bool(true)),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func testAccCheckPrivateIPModeExists(resourceName string, privateIPMode *matlas.PrivateIPMode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*matlas.Client)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no project ID is set")
+		}
+
+		if privateIPModeResp, _, err := conn.PrivateIPMode.Get(context.Background(), rs.Primary.Attributes["project_id"]); err == nil {
+			*privateIPMode = *privateIPModeResp
+			enabled, _ := strconv.ParseBool(rs.Primary.Attributes["enabled"])
+			privateIPMode.Enabled = pointy.Bool(enabled)
+			return nil
+		}
+
+		return fmt.Errorf("privateIPMode(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["enabled"])
+	}
+}
+
+func testAccCheckPrivateIPModeAttributes(privateIPMode *matlas.PrivateIPMode, enabled *bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *privateIPMode.Enabled != *enabled {
+			return fmt.Errorf("bad enabled: %t", *privateIPMode.Enabled)
+		}
+		return nil
+	}
+}
+
+func testAccCheckPrivateIPModeDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*matlas.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_private_ip_mode" {
+			continue
+		}
+
+		privateIPMode, _, err := conn.PrivateIPMode.Get(context.Background(), rs.Primary.Attributes["project_id"])
+
+		if err == nil && *privateIPMode.Enabled {
+
+			return fmt.Errorf("privateIPMode from project (%s) still enabled", rs.Primary.Attributes["project_id"])
+		}
+	}
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateIPModeConfig(projectID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_private_ip_mode" "test" {
+			project_id  = "%s"
+			enabled		= true
+		}
+	`, projectID)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/schema/provider.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/provider.go
@@ -179,7 +179,7 @@ func (p *Provider) Stop() error {
 // TestReset resets any state stored in the Provider, and will call TestReset
 // on Meta if it implements the TestProvider interface.
 // This may be used to reset the schema.Provider at the start of a test, and is
-// automatically called by resource.ParallelTest.
+// automatically called by resource.Test.
 func (p *Provider) TestReset() error {
 	p.stopInit()
 	if p.MetaReset != nil {

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/api_keys.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/api_keys.go
@@ -9,9 +9,9 @@ import (
 
 const apiKeysPath = "orgs/%s/apiKeys"
 
-//APIKeysService is an interface for interfacing with the APIKeys
+// APIKeysService is an interface for interfacing with the APIKeys
 // endpoints of the MongoDB Atlas API.
-//See more: https://docs.atlas.mongodb.com/reference/api/clusters/
+//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys/
 type APIKeysService interface {
 	List(context.Context, string, *ListOptions) ([]APIKey, *Response, error)
 	Get(context.Context, string, string) (*APIKey, *Response, error)
@@ -20,7 +20,7 @@ type APIKeysService interface {
 	Delete(context.Context, string, string) (*Response, error)
 }
 
-//APIKeysServiceOp handles communication with the APIKey related methods
+// APIKeysServiceOp handles communication with the APIKey related methods
 // of the MongoDB Atlas API
 type APIKeysServiceOp struct {
 	client *Client
@@ -28,13 +28,13 @@ type APIKeysServiceOp struct {
 
 var _ APIKeysService = &APIKeysServiceOp{}
 
-// APIKeyInput represents MongoDB cluster input reuest for Create and Update.
+// APIKeyInput represents MongoDB API key input request for Create.
 type APIKeyInput struct {
 	Desc  string   `json:"desc,omitempty"`
 	Roles []string `json:"roles,omitempty"`
 }
 
-// APIKey represents MongoDB cluster.
+// APIKey represents MongoDB API Key.
 type APIKey struct {
 	ID         string       `json:"id,omitempty"`
 	Desc       string       `json:"desc,omitempty"`
@@ -43,6 +43,7 @@ type APIKey struct {
 	PublicKey  string       `json:"publicKey,omitempty"`
 }
 
+// APIKeyRole represents a role name of API key
 type APIKeyRole struct {
 	GroupID  string `json:"groupId,omitempty"`
 	OrgID    string `json:"orgId,omitempty"`
@@ -158,7 +159,7 @@ func (s *APIKeysServiceOp) Update(ctx context.Context, orgID string, apiKeyID st
 }
 
 //Delete the API Key specified to {API-KEY-ID} from the organization associated to {ORG-ID}.
-// See more: https://docs.atlas.mongodb.com/reference/api/clusters-delete-one/
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKey-delete-one-apiKey/
 func (s *APIKeysServiceOp) Delete(ctx context.Context, orgID string, apiKeyID string) (*Response, error) {
 	if apiKeyID == "" {
 		return nil, NewArgError("apiKeyID", "must be set")

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/mongodbatlas.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/mongodbatlas.go
@@ -42,6 +42,8 @@ type Client struct {
 	Peers                            PeersService
 	Containers                       ContainersService
 	EncryptionsAtRest                EncryptionsAtRestService
+	WhitelistAPIKeys                 WhitelistAPIKeysService
+	PrivateIPMode                    PrivateIpModeService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -132,18 +134,19 @@ func NewClient(httpClient *http.Client) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 
-	c.DatabaseUsers = &DatabaseUsersServiceOp{client: c}
-	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{client: c}
-	c.Projects = &ProjectsServiceOp{client: c}
-	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{client: c}
-	c.Clusters = &ClustersServiceOp{client: c}
-	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{client: c}
 	c.APIKeys = &APIKeysServiceOp{client: c}
-	c.ProjectAPIKeys = &ProjectAPIKeysOp{client: c}
+	c.CloudProviderSnapshots = &CloudProviderSnapshotsServiceOp{client: c}
 	c.CloudProviderSnapshotRestoreJobs = &CloudProviderSnapshotRestoreJobsServiceOp{client: c}
-	c.Peers = &PeersServiceOp{client: c}
+	c.Clusters = &ClustersServiceOp{client: c}
 	c.Containers = &ContainersServiceOp{client: c}
+	c.DatabaseUsers = &DatabaseUsersServiceOp{client: c}
 	c.EncryptionsAtRest = &EncryptionsAtRestServiceOp{client: c}
+	c.Projects = &ProjectsServiceOp{client: c}
+	c.ProjectAPIKeys = &ProjectAPIKeysOp{client: c}
+	c.Peers = &PeersServiceOp{client: c}
+	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{client: c}
+	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{client: c}
+	c.PrivateIPMode = &PrivateIpModeServiceOp{client: c}
 
 	return c
 }

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/private_ip_mode.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/private_ip_mode.go
@@ -1,0 +1,72 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const privateIpModePath = "groups/%s/privateIpMode"
+
+//PrivateIpModeService is an interface for interfacing with the PrivateIpMode
+// endpoints of the MongoDB Atlas API.
+//See more: https://docs.atlas.mongodb.com/reference/api/get-private-ip-mode-for-project/
+type PrivateIpModeService interface {
+	Get(context.Context, string) (*PrivateIPMode, *Response, error)
+	Update(context.Context, string, *PrivateIPMode) (*PrivateIPMode, *Response, error)
+}
+
+//PrivateIpModeServiceOp handles communication with the Private IP Mode related methods
+// of the MongoDB Atlas API
+type PrivateIpModeServiceOp struct {
+	client *Client
+}
+
+var _ PrivateIpModeService = &PrivateIpModeServiceOp{}
+
+// PrivateIPMode represents MongoDB Private IP Mode Configutation.
+type PrivateIPMode struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+//Get Verify Connect via Peering Only Mode from the project associated to {GROUP-ID}.
+//See more: https://docs.atlas.mongodb.com/reference/api/get-private-ip-mode-for-project/
+func (s *PrivateIpModeServiceOp) Get(ctx context.Context, groupID string) (*PrivateIPMode, *Response, error) {
+	path := fmt.Sprintf(privateIpModePath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateIPMode)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+//Update connection via Peering Only Mode in the project associated to {GROUP-ID}
+//See more: https://docs.atlas.mongodb.com/reference/api/set-private-ip-mode-for-project/
+func (s *PrivateIpModeServiceOp) Update(ctx context.Context, groupID string, updateRequest *PrivateIPMode) (*PrivateIPMode, *Response, error) {
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(privateIpModePath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateIPMode)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/project_api_key.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/project_api_key.go
@@ -14,7 +14,7 @@ const projectAPIKeysPath = "groups/%s/apiKeys"
 type ProjectAPIKeysService interface {
 	List(context.Context, string, *ListOptions) ([]APIKey, *Response, error)
 	Create(context.Context, string, *APIKeyInput) (*APIKey, *Response, error)
-	Assign(context.Context, string, string) (*Response, error)
+	Assign(context.Context, string, string, *AssignAPIKey) (*Response, error)
 	Unassign(context.Context, string, string) (*Response, error)
 }
 
@@ -25,6 +25,11 @@ type ProjectAPIKeysOp struct {
 }
 
 var _ ProjectAPIKeysService = &ProjectAPIKeysOp{}
+
+// AssignAPIKey contains the roles to be assigned to an Organization API key into a Project
+type AssignAPIKey struct {
+	Roles []string `json:"roles"`
+}
 
 //List all API-KEY in the organization associated to {GROUP-ID}.
 //See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/get-all-apiKeys-in-one-project/
@@ -56,7 +61,7 @@ func (s *ProjectAPIKeysOp) List(ctx context.Context, groupID string, listOptions
 }
 
 //Create an API Key by the {GROUP-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/create-one-apiKey-in-one-project/
 func (s *ProjectAPIKeysOp) Create(ctx context.Context, groupID string, createRequest *APIKeyInput) (*APIKey, *Response, error) {
 	if createRequest == nil {
 		return nil, nil, NewArgError("createRequest", "cannot be nil")
@@ -78,11 +83,11 @@ func (s *ProjectAPIKeysOp) Create(ctx context.Context, groupID string, createReq
 	return root, resp, err
 }
 
-//Assign an API-KEY related to {GROUP-ID} to a the project with {PROJECT-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-get-all/
-func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID string) (*Response, error) {
+//Assign an API-KEY related to {GROUP-ID} to a the project with {API-KEY-ID}.
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/assign-one-org-apiKey-to-one-project/
+func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID string, assignAPIKeyRequest *AssignAPIKey) (*Response, error) {
 	if groupID == "" {
-		return nil, NewArgError("apiKeyID", "must be set")
+		return nil, NewArgError("groupID", "must be set")
 	}
 
 	if keyID == "" {
@@ -93,7 +98,7 @@ func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID str
 
 	path := fmt.Sprintf("%s/%s", basePath, keyID)
 
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, assignAPIKeyRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +108,8 @@ func (s *ProjectAPIKeysOp) Assign(ctx context.Context, groupID string, keyID str
 	return resp, err
 }
 
-//Unassign an API-KEY related to {GROUP-ID} to a the project with {PROJECT-ID}.
-//See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-get-all/
+//Unassign an API-KEY related to {GROUP-ID} to a the project with {API-KEY-ID}.
+//See more: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/delete-one-apiKey-in-one-project/
 func (s *ProjectAPIKeysOp) Unassign(ctx context.Context, groupID string, keyID string) (*Response, error) {
 	if groupID == "" {
 		return nil, NewArgError("apiKeyID", "must be set")

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/whitelist_api_keys.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/whitelist_api_keys.go
@@ -1,0 +1,163 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const whitelistAPIKeysPath = "orgs/%s/apiKeys/%s/whitelist"
+
+// WhitelistAPIKeysService is an interface for interfacing with the Whitelist API Keys
+// endpoints of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys/#organization-api-key-endpoints
+type WhitelistAPIKeysService interface {
+	List(context.Context, string, string) (*WhitelistAPIKeys, *Response, error)
+	Get(context.Context, string, string, string) (*WhitelistAPIKey, *Response, error)
+	Create(context.Context, string, string, []*WhitelistAPIKeysReq) (*WhitelistAPIKeys, *Response, error)
+	Delete(context.Context, string, string, string) (*Response, error)
+}
+
+// WhitelistAPIKeysServiceOp handles communication with the Whitelist API keys related methods of the
+// MongoDB Atlas API
+type WhitelistAPIKeysServiceOp struct {
+	client *Client
+}
+
+var _ WhitelistAPIKeysService = &WhitelistAPIKeysServiceOp{}
+
+// WhitelistAPIKey represents a Whitelist API key.
+type WhitelistAPIKey struct {
+	CidrBlock       string  `json:"cidrBlock,omitempty"`       // CIDR-notated range of whitelisted IP addresses.
+	Count           int     `json:"count,omitempty"`           // Total number of requests that have originated from this IP address.
+	Created         string  `json:"created,omitempty"`         // Date this IP address was added to the whitelist.
+	IPAddress       string  `json:"ipAddress,omitempty"`       // Whitelisted IP address.
+	LastUsed        string  `json:"lastUsed,omitempty"`        // Date of the most recent request that originated from this IP address. This field only appears if at least one request has originated from this IP address, and is only updated when a whitelisted resource is accessed.
+	LastUsedAddress string  `json:"lastUsedAddress,omitempty"` // IP address from which the last call to the API was issued. This field only appears if at least one request has originated from this IP address.
+	Links           []*Link `json:"links,omitempty"`           // An array of documents, representing a link to one or more sub-resources and/or related resources such as list pagination. See Linking for more information.}
+}
+
+// WhitelistAPIKeys represents all Whitelist API keys.
+type WhitelistAPIKeys struct {
+	Results    []*WhitelistAPIKey `json:"results,omitempty"`    // Includes one WhitelistAPIKey object for each item detailed in the results array section.
+	Links      []*Link            `json:"links,omitempty"`      // One or more links to sub-resources and/or related resources.
+	TotalCount int                `json:"totalCount,omitempty"` // Count of the total number of items in the result set. It may be greater than the number of objects in the results array if the entire result set is paginated.
+}
+
+// WhitelistAPIKeysReq represents the request to the mehtod create
+type WhitelistAPIKeysReq struct {
+	IPAddress string `json:"ipAddress,omitempty"` // IP address to be added to the whitelist for the API key.
+	CidrBlock string `json:"cidrBlock,omitempty"` // Whitelist entry in CIDR notation to be added for the API key.
+}
+
+// List gets all Whitelist API keys.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-get-all/
+func (s *WhitelistAPIKeysServiceOp) List(ctx context.Context, orgID string, apiKeyID string) (*WhitelistAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKeys)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root, resp, nil
+}
+
+//Get gets the Whitelist API keys.
+//See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-get-one/
+func (s *WhitelistAPIKeysServiceOp) Get(ctx context.Context, orgID string, apiKeyID string, ipAddress string) (*WhitelistAPIKey, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, nil, NewArgError("ipAddress", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKey)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Create a submit a POST request containing ipAddress or cidrBlock values which are not already present in the whitelist, Atlas adds those entries to the list of existing entries in the whitelist.
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys-org-whitelist-create/
+func (s *WhitelistAPIKeysServiceOp) Create(ctx context.Context, orgID string, apiKeyID string, createRequest []*WhitelistAPIKeysReq) (*WhitelistAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath, orgID, apiKeyID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(WhitelistAPIKeys)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Delete deletes the Whitelist API keys.
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-delete-one/
+func (s *WhitelistAPIKeysServiceOp) Delete(ctx context.Context, orgID string, apiKeyID string, ipAddress string) (*Response, error) {
+	if orgID == "" {
+		return nil, NewArgError("groupId", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, NewArgError("clusterName", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, NewArgError("snapshotId", "must be set")
+	}
+
+	path := fmt.Sprintf(whitelistAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,6 +128,7 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.12.1
 github.com/hashicorp/terraform/plugin
+github.com/hashicorp/terraform/helper/hashcode
 github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/helper/schema
@@ -152,7 +153,6 @@ github.com/hashicorp/terraform/internal/initwd
 github.com/hashicorp/terraform/plans
 github.com/hashicorp/terraform/states
 github.com/hashicorp/terraform/tfdiags
-github.com/hashicorp/terraform/helper/hashcode
 github.com/hashicorp/terraform/helper/structure
 github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/dag
@@ -203,7 +203,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/mongodb/go-client-mongodb-atlas v0.0.1
+# github.com/mongodb/go-client-mongodb-atlas v0.1.0
 github.com/mongodb/go-client-mongodb-atlas/mongodbatlas
 # github.com/mwielbut/pointy v1.1.0
 github.com/mwielbut/pointy

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describe a Cluster.
 ---
 
-# mongodb_atlas_cluster
+# mongodbatlas_cluster
 
-`mongodb_atlas_cluster` describes a Cluster. The. The data source requires your Project ID.
+`mongodbatlas_cluster` describes a Cluster. The. The data source requires your Project ID.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describe all Clusters in Project.
 ---
 
-# mongodb_atlas_clusters
+# mongodbatlas_clusters
 
-`mongodb_atlas_cluster` describes all Clusters by the provided project_id. The data source requires your Project ID.
+`mongodbatlas_cluster` describes all Clusters by the provided project_id. The data source requires your Project ID.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describes a Database Users.
 ---
 
-# mongodb_atlas_database_users
+# mongodbatlas_database_users
 
-`mongodb_atlas_database_users` describe all Database Users. This represents a database user which will be applied to all clusters within the project.
+`mongodbatlas_database_users` describe all Database Users. This represents a database user which will be applied to all clusters within the project.
 
 Each user has a set of roles that provide access to the project’s databases. User's roles apply to all the clusters in the project: if two clusters have a `products` database and a user has a role granting `read` access on the products database, the user has that access on both clusters.
 

--- a/website/docs/d/network_container.html.markdown
+++ b/website/docs/d/network_container.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describes a Cluster resource.
 ---
 
-# mongodb_atlas_network_container
+# mongodbatlas_network_container
 
-`mongodb_atlas_network_container` describes a Network Peering Container. The resource requires your Project ID and container ID.
+`mongodbatlas_network_container` describes a Network Peering Container. The resource requires your Project ID and container ID.
 
 ~> **IMPORTANT:** This resource creates one Network Peering container into which Atlas can deploy Network Peering connections. An Atlas project can have a maximum of one container for each cloud provider. You must have either the Project Owner or Organization Owner role to successfully call this endpoint.
 

--- a/website/docs/d/network_containers.html.markdown
+++ b/website/docs/d/network_containers.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describes all Network Peering Containers in the project.
 ---
 
-# mongodb_atlas_network_containers
+# mongodbatlas_network_containers
 
-`mongodb_atlas_network_containers` describes all Network Peering Containers. The data source requires your Project ID.
+`mongodbatlas_network_containers` describes all Network Peering Containers. The data source requires your Project ID.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find **group_id** in the official documentation.
 

--- a/website/docs/d/network_peering.html.markdown
+++ b/website/docs/d/network_peering.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describes a Network Peering.
 ---
 
-# mongodb_atlas_network_peering
+# mongodbatlas_network_peering
 
-`mongodb_atlas_network_peering` describes a Network Peering Connection.
+`mongodbatlas_network_peering` describes a Network Peering Connection.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find **group_id** in the official documentation.
 

--- a/website/docs/d/network_peerings.html.markdown
+++ b/website/docs/d/network_peerings.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Describes all Network Peering Connections.
 ---
 
-# mongodb_atlas_network_peering
+# mongodbatlas_network_peering
 
-`mongodb_atlas_network_peerings` describes all Network Peering Connections.
+`mongodbatlas_network_peerings` describes all Network Peering Connections.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find **group_id** in the official documentation.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -16,8 +16,8 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the MongoDB Atlas Provider
 provider "mongodbatlas" {
-  public_key = "${var.mongodb_atlas_public_key}"
-  private_key  = "${var.mongodb_atlas_private_key}"
+  public_key = "${var.mongodbatlas_public_key}"
+  private_key  = "${var.mongodbatlas_private_key}"
 }
 
 #Create the resources

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Provides a Cluster resource.
 ---
 
-# mongodb_atlas_cluster
+# mongodbatlas_cluster
 
-`mongodb_atlas_cluster` provides a Cluster resource. The resource lets you create, edit and delete clusters. The resource requires your Project ID.
+`mongodbatlas_cluster` provides a Cluster resource. The resource lets you create, edit and delete clusters. The resource requires your Project ID.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # mongodbatlas_database_user
 
-`mongodb_atlas_database_user` provides a Database User resource. This represents a database user which will be applied to all clusters within the project.
+`mongodbatlas_database_user` provides a Database User resource. This represents a database user which will be applied to all clusters within the project.
 
 Each user has a set of roles that provide access to the project’s databases. User's roles apply to all the clusters in the project: if two clusters have a `products` database and a user has a role granting `read` access on the products database, the user has that access on both clusters.
 

--- a/website/docs/r/encryption_at_rest.html.markdown
+++ b/website/docs/r/encryption_at_rest.html.markdown
@@ -18,8 +18,8 @@ You can use the following clouds: AWS CMK, AZURE KEY VAULT and GOOGLE KEY VAULT 
 
 ```hcl
 resource "mongodbatlas_encryption_at_rest" "test" {
-  project_id          = "<PROJECT-ID>"
- 
+  project_id = "<PROJECT-ID>"
+
   aws_kms = {
     enabled                = true
     access_key_id          = "AKIAIOSFODNN7EXAMPLE"
@@ -29,15 +29,15 @@ resource "mongodbatlas_encryption_at_rest" "test" {
   }
 
   azure_key_vault = {
-    enabled               = true
-    client_id             = "g54f9e2-89e3-40fd-8188-EXAMPLEID"
-    azure_environment     = "AZURE"
-    subscription_id       = "0ec944e3-g725-44f9-a147-EXAMPLEID"
-    resource_group_name   = "ExampleRGName"
-    key_vault_name  	  = "EXAMPLEKeyVault"
-    key_identifier  	  = "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86"
-    secret  		  = "EXAMPLESECRET"
-    tenant_id  		  = "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID"
+    enabled             = true
+    client_id           = "g54f9e2-89e3-40fd-8188-EXAMPLEID"
+    azure_environment   = "AZURE"
+    subscription_id     = "0ec944e3-g725-44f9-a147-EXAMPLEID"
+    resource_group_name = "ExampleRGName"
+    key_vault_name      = "EXAMPLEKeyVault"
+    key_identifier      = "https://EXAMPLEKeyVault.vault.azure.net/keys/EXAMPLEKey/d891821e3d364e9eb88fbd3d11807b86"
+    secret              = "EXAMPLESECRET"
+    tenant_id           = "e8e4b6ba-ff32-4c88-a9af-EXAMPLEID"
   }
 
   google_cloud_kms = {
@@ -45,7 +45,6 @@ resource "mongodbatlas_encryption_at_rest" "test" {
     service_account_key     = "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\",\"private_key_id\": \"e120598ea4f88249469fcdd75a9a785c1bb3\",\"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBA(truncated)SfecnS0mT94D9\\n-----END PRIVATE KEY-----\\n\",\"client_email\": \"my-email-kms-0@my-project-common-0.iam.gserviceaccount.com\",\"client_id\": \"10180967717292066\",\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\"token_uri\": \"https://accounts.google.com/o/oauth2/token\",\"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/my-email-kms-0%40my-project-common-0.iam.gserviceaccount.com\"}"
     key_version_resource_id = "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
   }
-
 }
 ```
 

--- a/website/docs/r/network_container.html.markdown
+++ b/website/docs/r/network_container.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Provides a Network Peering resource.
 ---
 
-# mongodb_atlas_network_container
+# mongodbatlas_network_container
 
-`mongodb_atlas_network_container` provides a Network Peering Container resource. The resource lets you create, edit and delete network peering containers. The resource requires your Project ID.
+`mongodbatlas_network_container` provides a Network Peering Container resource. The resource lets you create, edit and delete network peering containers. The resource requires your Project ID.
 
 ~> **IMPORTANT:** This resource creates one Network Peering container into which Atlas can deploy Network Peering connections. An Atlas project can have a maximum of one container for each cloud provider. You must have either the Project Owner or Organization Owner role to successfully call this endpoint.
 
@@ -28,12 +28,12 @@ description: |-
   }
 
   resource "mongodbatlas_network_peering" "test" {
-    accepter_region_name	  = "us-east-1"	
-    project_id    			    = mongodbatlas_network_container.test.project_id
+    accepter_region_name    = "us-east-1"	
+    project_id              = mongodbatlas_network_container.test.project_id
     container_id            = mongodbatlas_network_container.test.container_id
     provider_name           = "AWS"
     route_table_cidr_block  = <AWS_VPC_CIDR_BLOCK>
-    vpc_id					        = <AWS_VPC_ID>
+    vpc_id                  = <AWS_VPC_ID>
     aws_account_id	        = <AWS_ACCOUNT_ID>
   }
 ```

--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Provides a Network Peering resource.
 ---
 
-# mongodb_atlas_network_peering
+# mongodbatlas_network_peering
 
-`mongodb_atlas_network_peering` provides a Network Peering Connection resource. The resource lets you create, edit and delete network peering connections. The resource requires your Project ID.
+`mongodbatlas_network_peering` provides a Network Peering Connection resource. The resource lets you create, edit and delete network peering connections. The resource requires your Project ID.
 
 
 ~> **GCP AND AZURE ONLY:** You must enable Connect via Peering Only mode to use network peering.
@@ -21,42 +21,42 @@ description: |-
 ### Example with AWS.
 
 ```hcl
-	resource "mongodbatlas_network_peering" "test" {
-		accepter_region_name	  = "us-east-1"	
-		project_id    		     	= "<YOUR-PROJEC-ID>"
-		container_id            = "507f1f77bcf86cd799439011"
-		provider_name           = "AWS"
-		route_table_cidr_block  = "192.168.0.0/24"
-		vpc_id					        = "vpc-abc123abc123"
-		aws_account_id		    	= "abc123abc123"
-	}
+resource "mongodbatlas_network_peering" "test" {
+  accepter_region_name   = "us-east-1"
+  project_id             = "<YOUR-PROJEC-ID>"
+  container_id           = "507f1f77bcf86cd799439011"
+  provider_name          = "AWS"
+  route_table_cidr_block = "192.168.0.0/24"
+  vpc_id                 = "vpc-abc123abc123"
+  aws_account_id         = "abc123abc123"
+}
 ```
 
 ### Example with GCP
 
 ```hcl
-	resource "mongodbatlas_network_peering" "test" {	
-		project_id    	  = "<YOUR-PROJEC-ID>"
-		container_id      = "507f1f77bcf86cd799439011"
-		provider_name     = "GCP"
-			gcp_project_id  = "my-sample-project-191923"
-			network_name    = "test1"	
-	}
+resource "mongodbatlas_network_peering" "test" {
+  project_id     = "<YOUR-PROJEC-ID>"
+  container_id   = "507f1f77bcf86cd799439011"
+  provider_name  = "GCP"
+  gcp_project_id = "my-sample-project-191923"
+  network_name   = "test1"
+}
 ```
 
 ### Example with Azure
 
 ```hcl
-	resource "mongodbatlas_network_peering" "test" {	
-		project_id    			  = "<YOUR-PROJEC-ID>"
-		atlas_cidr_block      = "192.168.0.0/21"
-		container_id          = "507f1f77bcf86cd799439011"
-		provider_name         = "AZURE"
-		azure_directory_id    = "35039750-6ebd-4ad5-bcfe-cb4e5fc2d915"
-		azure_subscription_id = "g893dec2-d92e-478d-bc50-cf99d31bgeg9"
-		resource_group_name   = "atlas-azure-peering"
-		vnet_name	            = "azure-peer"
-	}
+resource "mongodbatlas_network_peering" "test" {
+  project_id            = "<YOUR-PROJEC-ID>"
+  atlas_cidr_block      = "192.168.0.0/21"
+  container_id          = "507f1f77bcf86cd799439011"
+  provider_name         = "AZURE"
+  azure_directory_id    = "35039750-6ebd-4ad5-bcfe-cb4e5fc2d915"
+  azure_subscription_id = "g893dec2-d92e-478d-bc50-cf99d31bgeg9"
+  resource_group_name   = "atlas-azure-peering"
+  vnet_name             = "azure-peer"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/private_ip_mode.html.markdown
+++ b/website/docs/r/private_ip_mode.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: private_ip_mode"
+sidebar_current: "docs-mongodbatlas-resource-private-ip-mode"
+description: |-
+    Provides a Private IP Mode resource.
+---
+
+# mongodbatlas_private_ip_mode
+
+`mongodbatlas_private_ip_mode` provides a Private IP Mode resource. This allows one to enable/disable Connect via Peering Only mode for a MongoDB Atlas Project.
+
+
+~> **IMPORTANT**: <br>**What is Connect via Peering Only Mode?** <br>Connect via Peering Only mode prevents clusters in an Atlas project from connecting to any network destination other than an Atlas Network Peer. Connect via Peering Only mode applies only to **GCP** and **Azure-backed** dedicated clusters. This setting disables the ability to: <br><br>• Deploy non-GCP or Azure-backed dedicated clusters in an Atlas project, and
+<br>• Use MongoDB Stitch with dedicated clusters in an Atlas project.
+
+
+-> **NOTE:** You should create one private_ip_mode per project.
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_private_ip_mode" "my_private_ip_mode" {
+    project_id = "<YOUR PROJECT ID>"
+	enabled    = true
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) The unique ID for the project to enable Only Private IP Mode.
+* `enabled` - (Required) Indicates whether Connect via Peering Only mode is enabled or disabled for an Atlas project.
+
+
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The project id.
+
+## Import
+
+Project must be imported using project ID, e.g.
+
+```
+$ terraform import mongodbatlas_private_ip_mode.my_private_ip_mode 5d09d6a59ccf6445652a444a
+```
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/get-private-ip-mode-for-project/)

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Provides a Project resource.
 ---
 
-# mongodb_atlas_project
+# mongodbatlas_project
 
 `mongodbatlas_project` provides a Project resource. This allows project to be created.
 

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -81,6 +81,9 @@
                     <li<%= sidebar_current("docs-mongodbatlas-resource-network-peering") %>>
                         <a href="/docs/providers/mongodbatlas/r/network_peering.html">mongodbatlas_network_peering</a>
                     </li>
+                    <li<%= sidebar_current("docs-mongodbatlas-resource-private-ip-mode") %>>
+                        <a href="/docs/providers/mongodbatlas/r/private_ip_mode.html">mongodbatlas_private_ip_mode</a>
+                    </li>
                   </ul>
                 </li>
             </ul>


### PR DESCRIPTION
closes #24 

## Added:

- mongodbatlas_private_ip_mode resource
- mongodbatlas_private_ip_mode resource acceptance testing
- mongodbatlas_private_ip_mode resource website documentation
- Minor documentation's format fixes.


## Example Configuration:


```hcl
resource "mongodbatlas_private_ip_mode" "my_private_ip_mode" {
    project_id = "<YOUR PROJECT ID>"
	enabled    = true
}
```