### PR TITLE
Fix: Network container

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -307,7 +307,7 @@ func testAccMongoDBAtlasClusterConfigAWS(projectID, name, backupEnabled string) 
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 40
+			disk_size_gb = 100
 			num_shards   = 1
 			
 			replication_factor           = 3

--- a/mongodbatlas/resource_mongodbatlas_network_container.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
@@ -221,14 +223,22 @@ func resourceMongoDBAtlasNetworkContainerUpdate(d *schema.ResourceData, meta int
 func resourceMongoDBAtlasNetworkContainerDelete(d *schema.ResourceData, meta interface{}) error {
 	//Get client connection.
 	conn := meta.(*matlas.Client)
-	ids := decodeStateID(d.Id())
-	projectID := ids["project_id"]
-	containerID := ids["container_id"]
 
-	_, err := conn.Containers.Delete(context.Background(), projectID, containerID)
-	if err != nil {
-		return fmt.Errorf(errorContainerDelete, containerID, err)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"provisioned_container"},
+		Target:     []string{"deleted"},
+		Refresh:    resourceNetworkContainerRefreshFunc(d, conn),
+		Timeout:    3 * time.Hour,
+		MinTimeout: 60 * time.Second,
+		Delay:      5 * time.Minute,
 	}
+
+	// Wait, catching any errors
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error %s", err)
+	}
+
 	return nil
 }
 
@@ -266,4 +276,27 @@ func resourceMongoDBAtlasNetworkContainerImportState(d *schema.ResourceData, met
 		log.Printf("[WARN] Error setting container_id (%s): %s", containerID, err)
 	}
 	return []*schema.ResourceData{d}, nil
+}
+
+func resourceNetworkContainerRefreshFunc(d *schema.ResourceData, client *matlas.Client) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ids := decodeStateID(d.Id())
+		projectID := ids["project_id"]
+		containerID := ids["container_id"]
+
+		var err error
+		container, _, err := client.Containers.Get(context.Background(), projectID, containerID)
+		if *container.Provisioned && err == nil {
+			return nil, "provisioned_container", nil
+		} else if err != nil {
+			return nil, "", err
+		}
+
+		_, err = client.Containers.Delete(context.Background(), projectID, containerID)
+		if err != nil {
+			return nil, "provisioned_container", nil
+		}
+
+		return 42, "deleted", nil
+	}
 }


### PR DESCRIPTION
I added the refresh function to avoid error 409 from the server, and this happens due to the container wants to be removed when the provisioned attribute of the container is enabled, this means that the container is still in use. To avoid this issue the refresh function requests to the server to verify this attribute, so when the attribute change to disabled, then the container can be removed.

closes #30 