### PR TITLE
Added default Disk Size when it doesn't set up on cluster resource

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -743,10 +743,13 @@ func expandProviderSetting(d *schema.ResourceData) matlas.ProviderSettings {
 	providerSettings := matlas.ProviderSettings{}
 
 	if d.Get("provider_name") == "AWS" {
-		// Asks if the Provider Disk IOS was set if it didn't the server will set it up automatically
+
+		// Check if the Provider Disk IOS sets in the Terraform configuration.
+		// If it didn't, the MongoDB Atlas server would set it to the default for the amount of storage.
 		if v, ok := d.GetOk("provider_disk_iops"); ok {
 			providerSettings.DiskIOPS = pointy.Int64(cast.ToInt64(v))
 		}
+
 		providerSettings.EncryptEBSVolume = pointy.Bool(true)
 		if encryptEBSVolume, ok := d.GetOkExists("provider_encrypt_ebs_volume"); ok {
 			providerSettings.EncryptEBSVolume = pointy.Bool(cast.ToBool(encryptEBSVolume))

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -369,24 +369,20 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf(errorCreate, err)
 	}
 
-	// set the default disk size gb for the provider and tier
-	diskSizeGB := matlas.DefaultDiskSizeGB[providerName][d.Get("provider_instance_size_name").(string)]
-	// But if it's specify the disk size will set up
-	if v, ok := d.GetOk("disk_size_gb"); ok {
-		diskSizeGB = v.(float64)
-	}
-
 	clusterRequest := &matlas.Cluster{
 		Name:                     d.Get("name").(string),
 		EncryptionAtRestProvider: d.Get("encryption_at_rest_provider").(string),
 		ClusterType:              cast.ToString(d.Get("cluster_type")),
 		BackupEnabled:            pointy.Bool(d.Get("backup_enabled").(bool)),
-		DiskSizeGB:               &diskSizeGB,
 		ProviderBackupEnabled:    pointy.Bool(d.Get("provider_backup_enabled").(bool)),
 		AutoScaling:              autoScaling,
 		BiConnector:              biConnector,
 		ProviderSettings:         &providerSettings,
 		ReplicationSpecs:         replicationSpecs,
+	}
+
+	if v, ok := d.GetOk("disk_size_gb"); ok {
+		clusterRequest.DiskSizeGB = pointy.Float64(v.(float64))
 	}
 
 	if v, ok := d.GetOk("mongo_db_major_version"); ok {

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -20,7 +20,7 @@ func TestAccResourceMongoDBAtlasCluster_basicAWS(t *testing.T) {
 
 	resourceName := "mongodbatlas_cluster.test"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-	tiers := []string{"M10", "M20", "M30", "M40"}
+	tiers := []string{"M10", "M30"}
 	region := "EU_CENTRAL_1"
 
 	for _, tier := range tiers {
@@ -109,6 +109,7 @@ func TestAccResourceMongoDBAtlasCluster_basicAzure(t *testing.T) {
 	}
 
 }
+
 func TestAccResourceMongoDBAtlasCluster_basicGCP(t *testing.T) {
 	var cluster matlas.Cluster
 
@@ -164,10 +165,10 @@ func TestAccResourceMongoDBAtlasCluster_basicGCP(t *testing.T) {
 	}
 }
 
-func TestAccResourceMongoDBAtlasCluster_tenant(t *testing.T) {
+func TestAccResourceMongoDBAtlasCluster_shared(t *testing.T) {
 	var cluster matlas.Cluster
 
-	resourceName := "mongodbatlas_cluster.tenant"
+	resourceName := "mongodbatlas_cluster.shared"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	var region string
 
@@ -183,7 +184,7 @@ func TestAccResourceMongoDBAtlasCluster_tenant(t *testing.T) {
 				CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
 				Steps: []resource.TestStep{
 					{
-						Config: testAccMongoDBAtlasClusterConfigTenant(projectID, name, "false", cast.ToString(size), tier, region),
+						Config: testAccMongoDBAtlasClusterConfigShared(projectID, name, "false", cast.ToString(size), tier, region),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 							testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
@@ -199,10 +200,10 @@ func TestAccResourceMongoDBAtlasCluster_tenant(t *testing.T) {
 	}
 }
 
-func TestAccResourceMongoDBAtlasCluster_tenantWithoutDiskSizeGb(t *testing.T) {
+func TestAccResourceMongoDBAtlasCluster_sharedWithoutDiskSizeGb(t *testing.T) {
 	var cluster matlas.Cluster
 
-	resourceName := "mongodbatlas_cluster.tenant"
+	resourceName := "mongodbatlas_cluster.shared"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	var region string
 
@@ -218,7 +219,7 @@ func TestAccResourceMongoDBAtlasCluster_tenantWithoutDiskSizeGb(t *testing.T) {
 				CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
 				Steps: []resource.TestStep{
 					{
-						Config: testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, tier, region),
+						Config: testAccMongoDBAtlasClusterConfigSharedWithoutDiskSizeGb(projectID, name, tier, region),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 							testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
@@ -232,6 +233,7 @@ func TestAccResourceMongoDBAtlasCluster_tenantWithoutDiskSizeGb(t *testing.T) {
 		})
 	}
 }
+
 func TestAccResourceMongoDBAtlasCluster_basicAdvancedConf(t *testing.T) {
 	var cluster matlas.Cluster
 
@@ -553,9 +555,9 @@ func testAccMongoDBAtlasClusterConfigGCP(projectID, name, backupEnabled, tier, r
 	`, projectID, name, backupEnabled, tier, region)
 }
 
-func testAccMongoDBAtlasClusterConfigTenant(projectID, name, autoScaling, size, tier, region string) string {
+func testAccMongoDBAtlasClusterConfigShared(projectID, name, autoScaling, size, tier, region string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "tenant" {
+		resource "mongodbatlas_cluster" "shared" {
 			project_id             = "%s"
 			name                   = "%s"
 			mongo_db_major_version = "4.0"
@@ -571,9 +573,9 @@ func testAccMongoDBAtlasClusterConfigTenant(projectID, name, autoScaling, size, 
 	`, projectID, name, autoScaling, size, tier, region)
 }
 
-func testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, tier, region string) string {
+func testAccMongoDBAtlasClusterConfigSharedWithoutDiskSizeGb(projectID, name, tier, region string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "tenant" {
+		resource "mongodbatlas_cluster" "shared" {
 			project_id             = "%s"
 			name                   = "%s"
 			mongo_db_major_version = "4.0"

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -218,7 +218,7 @@ func TestAccResourceMongoDBAtlasCluster_tenantWithoutDiskSizeGb(t *testing.T) {
 				CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
 				Steps: []resource.TestStep{
 					{
-						Config: testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, "false", tier, region),
+						Config: testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, tier, region),
 						Check: resource.ComposeTestCheckFunc(
 							testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 							testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
@@ -521,7 +521,7 @@ func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled, tier,
 			
 			replication_factor           = 3
 			backup_enabled               = %s
-			auto_scaling_disk_gb_enabled = true
+			auto_scaling_disk_gb_enabled = false
 			mongo_db_major_version       = "4.0"
 			
 			//Provider Settings "block"
@@ -571,7 +571,7 @@ func testAccMongoDBAtlasClusterConfigTenant(projectID, name, autoScaling, size, 
 	`, projectID, name, autoScaling, size, tier, region)
 }
 
-func testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, autoScaling, tier, region string) string {
+func testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, tier, region string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "tenant" {
 			project_id             = "%s"
@@ -579,13 +579,12 @@ func testAccMongoDBAtlasClusterConfigTenantWithoutDiskSizeGb(projectID, name, au
 			mongo_db_major_version = "4.0"
 		
 			backing_provider_name        = "AWS"
-			auto_scaling_disk_gb_enabled = "%s"
 		
 			provider_name               = "TENANT"
 			provider_instance_size_name = "%s"
 			provider_region_name        = "%s"
 		}
-	`, projectID, name, autoScaling, tier, region)
+	`, projectID, name, tier, region)
 }
 
 func testAccMongoDBAtlasClusterConfigMultiRegion(projectID, name, backupEnabled string) string {


### PR DESCRIPTION
Added:

- Now you don't need to specify the `disk_size_gb` and `provider_disk_iops` attrs. The last one will set it up by the MongoDB server automatically.
- Test cases improved making a test for each provider with its tier
- The `auto_scaling_disk_gb_enabled` attribute will default to false when the provider name sets to TENANT.


closes #72 