### PR TITLE
Maintenance window ds

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_maintenance_window.go
+++ b/mongodbatlas/data_source_mongodbatlas_maintenance_window.go
@@ -1,0 +1,66 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/spf13/cast"
+
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func dataSourceMongoDBAtlasMaintenanceWindow() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMongoDBAtlasMaintenanceWindowRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"day_of_week": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"hour_of_day": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"start_asap": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"number_of_deferrals": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMongoDBAtlasMaintenanceWindowRead(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+	projectID := d.Get("project_id").(string)
+
+	maintenance, _, err := conn.MaintenanceWindows.Get(context.Background(), projectID)
+	if err != nil {
+		return fmt.Errorf(errorMaintenanceRead, projectID, err)
+	}
+
+	if err := d.Set("day_of_week", maintenance.DayOfWeek); err != nil {
+		return fmt.Errorf(errorMaintenanceRead, projectID, err)
+	}
+	if err := d.Set("hour_of_day", maintenance.HourOfDay); err != nil {
+		return fmt.Errorf(errorMaintenanceRead, projectID, err)
+	}
+	if err := d.Set("number_of_deferrals", maintenance.NumberOfDeferrals); err != nil {
+		return fmt.Errorf(errorMaintenanceRead, projectID, err)
+	}
+	if err := d.Set("start_asap", cast.ToBool(maintenance.StartASAP)); err != nil {
+		return fmt.Errorf(errorMaintenanceRead, projectID, err)
+	}
+
+	d.SetId(projectID)
+	return nil
+}

--- a/mongodbatlas/data_source_mongodbatlas_maintenance_window_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_maintenance_window_test.go
@@ -1,0 +1,81 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func TestAccDataSourceMongoDBAtlasMaintenanceWindow_basic(t *testing.T) {
+	var maintenance matlas.MaintenanceWindow
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	dayOfWeek := 7
+	hourOfDay := 3
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(projectID, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists("mongodbatlas_maintenance_window.test", &maintenance),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "project_id"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "day_of_week"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "hour_of_day"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceMongoDBAtlasMaintenanceWindow_basicWithStartASAP(t *testing.T) {
+	var maintenance matlas.MaintenanceWindow
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceMaintenanceWindowConfigWithStartASAP(projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists("mongodbatlas_maintenance_window.test", &maintenance),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "start_asap"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(projectID string, dayOfWeek, hourOfDay int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = "%s"
+			day_of_week = %d
+			hour_of_day = %d
+		}
+
+		data "mongodbatlas_maintenance_window" "test" {
+			project_id = "${mongodbatlas_maintenance_window.test.id}"
+		}
+	`, projectID, dayOfWeek, hourOfDay)
+}
+
+func testAccMongoDBAtlasDataSourceMaintenanceWindowConfigWithStartASAP(projectID string, startAsap bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = "%s"
+			start_asap  = %t
+		}
+		
+		data "mongodbatlas_maintenance_window" "test" {
+			project_id  = "${mongodbatlas_maintenance_window.test.id}"
+		}
+	`, projectID, startAsap)
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -44,6 +44,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_network_peerings":                     dataSourceMongoDBAtlasNetworkPeerings(),
 			"mongodbatlas_cloud_provider_snapshot_restore_job":  dataSourceMongoDBAtlasCloudProviderSnapshotRestoreJob(),
 			"mongodbatlas_cloud_provider_snapshot_restore_jobs": dataSourceMongoDBAtlasCloudProviderSnapshotRestoreJobs(),
+			"mongodbatlas_maintenance_window":                   dataSourceMongoDBAtlasMaintenanceWindow(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: maintenance_window"
+sidebar_current: "docs-mongodbatlas-datasource-maintenance_window"
+description: |-
+    Provides a Maintenance Window Datasource.
+---
+
+# mongodbatlas_maintenance_window
+
+`mongodbatlas_maintenance_window` provides a Maintenance Window entry datasource. Gets scheduled maintenance event for a project.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
+
+## Examples Usage
+
+```hcl
+resource "mongodbatlas_maintenance_window" "test" {
+  project_id  = "<your-project-id>"
+  day_of_week = 3
+  hour_of_day = 4
+}
+
+data "mongodbatlas_maintenance_window" "test" {
+  project_id = "${mongodbatlas_maintenance_window.test.id}"
+}
+```
+
+
+```hcl
+resource "mongodbatlas_maintenance_window" "test" {
+  project_id  = "<your-project-id>"
+  start_asap  = true 
+}
+
+data "mongodbatlas_maintenance_window" "test" {
+  project_id = "${mongodbatlas_maintenance_window.test.id}"
+}
+```
+
+## Argument Reference
+
+* `project_id` - The unique identifier of the project for the Maintenance Window.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
+* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+* `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred.
+
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/maintenance-windows/)

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # mongodbatlas_maintenance_window
 
-`mongodbatlas_maintenance_window` provides a Maintenance Window entry datasource. Gets scheduled maintenance event for a project.
+`mongodbatlas_maintenance_window` provides a Maintenance Window entry datasource. Gets information regarding the configured maintenance window for a MongoDB Atlas project.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
@@ -47,8 +47,8 @@ data "mongodbatlas_maintenance_window" "test" {
 In addition to all arguments above, the following attributes are exported:
 
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
-* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
-* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred.
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, you can set a maximum of 2 deferrals.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/maintenance-windows/)

--- a/website/mongodbatlas.erb
+++ b/website/mongodbatlas.erb
@@ -49,6 +49,9 @@
                     <li<%= sidebar_current("docs-mongodbatlas-datasource-network-peerings") %>>
                         <a href="/docs/providers/mongodbatlas/d/network_peerings.html">mongodbatlas_network_peerings</a>
                     </li>
+                    <li<%= sidebar_current("docs-mongodbatlas-maintenance-window") %>>
+                        <a href="/docs/providers/mongodbatlas/d/maintenance_window.html">mongodbatlas_maintenance_window</a>
+                    </li>
                   </ul>
                 </li>
 


### PR DESCRIPTION
Added: 

- `mongodbatlas_maintenance_window` data source.

- `mongodbatlas_maintenance_window` data source acceptance testing.

- `mongodbatlas_maintenance_window` data source website documentation.

Example configuration:

```hcl
resource "mongodbatlas_maintenance_window" "test" {
  project_id  = "<your-project-id>"
  day_of_week = 3
  hour_of_day = 4
}

data "mongodbatlas_maintenance_window" "test" {
  project_id = "${mongodbatlas_maintenance_window.test.id}"
}
```
