### PR TITLE
Added labels attr for Database User resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
-log.txt
+log.*
 
 website/vendor
 

--- a/mongodbatlas/data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_user.go
@@ -46,6 +46,22 @@ func dataSourceMongoDBAtlasDatabaseUser() *schema.Resource {
 					},
 				},
 			},
+			"labels": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -61,17 +77,17 @@ func dataSourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return fmt.Errorf("error getting database user information: %s", err)
 	}
-
 	if err := d.Set("username", dbUser.Username); err != nil {
 		return fmt.Errorf("error setting `username` for database user (%s): %s", d.Id(), err)
 	}
-
 	if err := d.Set("database_name", dbUser.DatabaseName); err != nil {
 		return fmt.Errorf("error setting `database_name` for database user (%s): %s", d.Id(), err)
 	}
-
 	if err := d.Set("roles", flattenRoles(dbUser.Roles)); err != nil {
 		return fmt.Errorf("error setting `roles` for database user (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("labels", flattenLabels(dbUser.Labels)); err != nil {
+		return fmt.Errorf("error setting `labels` for database user (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(dbUser.Username)

--- a/mongodbatlas/data_source_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_user_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceMongoDBAtlasDatabaseUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "database_name", "admin"),
 					resource.TestCheckResourceAttr(resourceName, "roles.0.role_name", roleName),
 					resource.TestCheckResourceAttr(resourceName, "roles.0.database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
 				),
 			},
 		},
@@ -52,6 +53,15 @@ func testAccMongoDBAtlasDatabaseUserDataSourceConfig(projectID, roleName, userna
 			roles {
 				role_name     = "%[2]s"
 				database_name = "admin"
+			}
+
+			labels {
+				key   = "key 1"
+				value = "value 1"
+			}
+			labels {
+				key   = "key 2"
+				value = "value 2"
 			}
 		}
 

--- a/mongodbatlas/data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_users.go
@@ -60,6 +60,22 @@ func dataSourceMongoDBAtlasDatabaseUsers() *schema.Resource {
 								},
 							},
 						},
+						"labels": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -74,7 +90,6 @@ func dataSourceMongoDBAtlasDatabaseUsersRead(d *schema.ResourceData, meta interf
 	projectID := d.Get("project_id").(string)
 
 	dbUsers, _, err := conn.DatabaseUsers.List(context.Background(), projectID, nil)
-
 	if err != nil {
 		return fmt.Errorf("error getting database users information: %s", err)
 	}
@@ -100,6 +115,7 @@ func flattenDBUsers(dbUsers []matlas.DatabaseUser) []map[string]interface{} {
 				"username":      dbUser.Username,
 				"project_id":    dbUser.GroupID,
 				"database_name": dbUser.DatabaseName,
+				"labels":        flattenLabels(dbUser.Labels),
 			}
 		}
 	}

--- a/mongodbatlas/data_source_mongodbatlas_database_users_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_users_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceMongoDBAtlasDatabaseUsers_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mongodbatlas_database_user.db_user", "id"),
 					resource.TestCheckResourceAttrSet("mongodbatlas_database_user.db_user_1", "id"),
+					resource.TestCheckResourceAttr("mongodbatlas_database_user.db_user_1", "labels.#", "2"),
 				),
 			},
 			{
@@ -63,6 +64,15 @@ func testAccMongoDBAtlasDatabaseUsersDataSourceConfig(projectID, roleName, usern
 			roles {
 				role_name     = "%[2]s"
 				database_name = "admin"
+			}
+
+			labels {
+				key   = "key 1"
+				value = "value 1"
+			}
+			labels {
+				key   = "key 2"
+				value = "value 2"
 			}
 		}
 	`, projectID, roleName, username)

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
 	"github.com/spf13/cast"
 )
 
@@ -191,4 +192,29 @@ func valRegion(reg interface{}, opt ...string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("unable to cast %#v of type %T to string", reg, reg)
+}
+
+func flattenLabels(l []matlas.Label) []map[string]interface{} {
+	labels := make([]map[string]interface{}, len(l))
+	for i, v := range l {
+		labels[i] = map[string]interface{}{
+			"key":   v.Key,
+			"value": v.Value,
+		}
+	}
+	return labels
+}
+
+func expandLabelSliceFromSetSchema(d *schema.ResourceData) []matlas.Label {
+	list := d.Get("labels").(*schema.Set)
+	res := make([]matlas.Label, list.Len())
+
+	for i, val := range list.List() {
+		v := val.(map[string]interface{})
+		res[i] = matlas.Label{
+			Key:   v["key"].(string),
+			Value: v["value"].(string),
+		}
+	}
+	return res
 }

--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -254,28 +254,3 @@ func flattenRoles(roles []matlas.Role) []map[string]interface{} {
 	}
 	return roleList
 }
-
-func flattenLabels(l []matlas.Label) []map[string]interface{} {
-	labels := make([]map[string]interface{}, len(l))
-	for i, v := range l {
-		labels[i] = map[string]interface{}{
-			"key":   v.Key,
-			"value": v.Value,
-		}
-	}
-	return labels
-}
-
-func expandLabelSliceFromSetSchema(d *schema.ResourceData) []matlas.Label {
-	list := d.Get("labels").(*schema.Set)
-	res := make([]matlas.Label, list.Len())
-
-	for i, val := range list.List() {
-		v := val.(map[string]interface{})
-		res[i] = matlas.Label{
-			Key:   v["key"].(string),
-			Value: v["value"].(string),
-		}
-	}
-	return res
-}

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -32,6 +32,15 @@ resource "mongodbatlas_database_user" "test" {
 		role_name     = "atlasAdmin"
 		database_name = "admin"
 	}
+
+	labels {
+		key   = "key 1"
+		value = "value 1"
+	}
+	labels {
+		key   = "key 2"
+		value = "value 2"
+	}
 }
 
 data "mongodbatlas_database_user" "test" {
@@ -65,5 +74,11 @@ Block mapping a user's role to a database / collection. A role allows the user t
 * `name` - Name of the role to grant.
 * `database_name` -  Database on which the user has the specified role. A role on the `admin` database can include privileges that apply to the other databases.
 * `collection_name` - Collection for which the role applies. You can specify a collection for the `read` and `readWrite` roles. If you do not specify a collection for `read` and `readWrite`, the role applies to all collections in the database (excluding some collections in the `system`. database).
+
+### Labels
+Containing key-value pairs that tag and categorize the database user. Each key and value has a maximum length of 255 characters.
+
+* `key` - The key that you want to write.
+* `value` - The value that you want to write.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/database-users-get-single-user/) Documentation for more information.

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -18,20 +18,29 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ```hcl
 resource "mongodbatlas_database_user" "test" {
-	username      = "test-acc-username"
-	password      = "test-acc-password"
-	project_id      = "<PROJECT-ID>"
-	database_name = "admin"
-	
-	roles {
-		role_name     = "readWrite"
-		database_name = "admin"
-	}
+  username      = "test-acc-username"
+  password      = "test-acc-password"
+  project_id    = "<PROJECT-ID>"
+  database_name = "admin"
 
-    roles {
-		role_name     = "atlasAdmin"
-		database_name = "admin"
-	}
+  roles {
+    role_name     = "readWrite"
+    database_name = "admin"
+  }
+
+  roles {
+    role_name     = "atlasAdmin"
+    database_name = "admin"
+  }
+
+  labels {
+    key   = "key 1"
+    value = "value 1"
+  }
+  labels {
+    key   = "key 2"
+    value = "value 2"
+  }
 }
 
 data "mongodbatlas_database_users" "test" {
@@ -70,5 +79,11 @@ Block mapping a user's role to a database / collection. A role allows the user t
 * `name` - Name of the role to grant.
 * `database_name` -  Database on which the user has the specified role. A role on the `admin` database can include privileges that apply to the other databases.
 * `collection_name` - Collection for which the role applies. You can specify a collection for the `read` and `readWrite` roles. If you do not specify a collection for `read` and `readWrite`, the role applies to all collections in the database (excluding some collections in the `system`. database).
+
+### Labels
+Containing key-value pairs that tag and categorize the database user. Each key and value has a maximum length of 255 characters.
+
+* `key` - The key that you want to write.
+* `value` - The value that you want to write.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/database-users-get-single-user/) Documentation for more information.

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -20,20 +20,25 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ```hcl
 resource "mongodbatlas_database_user" "test" {
-	username      = "test-acc-username"
-	password      = "test-acc-password"
-	project_id    = "<PROJECT-ID>"
-	database_name = "admin"
+  username      = "test-acc-username"
+  password      = "test-acc-password"
+  project_id    = "<PROJECT-ID>"
+  database_name = "admin"
 
-	roles {
-		role_name     = "readWrite"
-		database_name = "dbforApp"
-	}
+  roles {
+    role_name     = "readWrite"
+    database_name = "dbforApp"
+  }
 
-    roles {
-		role_name     = "readAnyDatabase"
-		database_name = "admin"
-	}
+  roles {
+    role_name     = "readAnyDatabase"
+    database_name = "admin"
+  }
+
+  labels {
+    key   = "My Key"
+    value = "My Value"
+  }
 }
 ```
 
@@ -56,6 +61,12 @@ Block mapping a user's role to a database / collection. A role allows the user t
 * `name` - (Required) Name of the role to grant. See [Create a Database User](https://docs.atlas.mongodb.com/reference/api/database-users-create-a-user/) `roles.roleName` for valid values and restrictions.
 * `database_name` - (Required) Database on which the user has the specified role. A role on the `admin` database can include privileges that apply to the other databases.
 * `collection_name` - (Optional) Collection for which the role applies. You can specify a collection for the `read` and `readWrite` roles. If you do not specify a collection for `read` and `readWrite`, the role applies to all collections in the database (excluding some collections in the `system`. database).
+
+### Labels
+Containing key-value pairs that tag and categorize the database user. Each key and value has a maximum length of 255 characters.
+
+* `key` - The key that you want to write.
+* `value` - The value that you want to write.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Added `labels` attribute to allow create multiple labels for each database user resource
- Added Test case using dynamic labels attribute
- Updated the documentation and vendor files

### Example Usage 
```hcl
resource "mongodbatlas_database_user" "test" {
  username      = "test-acc-username"
  password      = "test-acc-password"
  project_id    = "<PROJECT-ID>"
  database_name = "admin"

  roles {
    role_name     = "readWrite"
    database_name = "dbforApp"
  }
  roles {
    role_name     = "readAnyDatabase"
    database_name = "admin"
  }

  labels {
    key   = "key 1"
    value = "value 1"
  }
  labels {
    key   = "key 2"
    value = "value 2"
  }
}
```