### PR TITLE
Updating `git clone` command to reference current repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Clone repository to: `$HOME/development/terraform-providers/`
 
 ```
 $ mkdir -p $HOME/development/terraform-providers/; cd $HOME/development/terraform-providers/
-$ git clone git@github.com:mongodb/terraform-mongodbatlas
+$ git clone git@github.com:terraform-providers/terraform-provider-mongodbatlas
 ...
 ```
 


### PR DESCRIPTION
Noticed while trying to build the provider that the README was referencing the old location for the MongoDB Atlas Terraform Provider. This is a small fix to address that.