### PR TITLE
Update backup, add links

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -73,3 +73,13 @@ Atlas `provider` block:
   environment variable.
 
 For more information about how to get this programmatic API Keys see the following [link](https://docs.atlas.mongodb.com/configure-api-access/#manage-programmatic-access-to-an-organization).
+
+## Helpful Links/Information
+
+[MongoDB Atlas and Terraform Landing Page](https://www.mongodb.com/atlas/terraform)
+
+[Report bugs](https://github.com/terraform-providers/terraform-provider-mongodbatlas/issues)
+
+[Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+[Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -27,7 +27,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
   num_shards   = 1
 
   replication_factor           = 3
-  backup_enabled               = true
+  provider_backup_enabled      = true
   auto_scaling_disk_gb_enabled = true
   mongo_db_major_version       = "4.0"
 
@@ -88,12 +88,12 @@ resource "mongodbatlas_cluster" "test" {
 
 ```hcl
 resource "mongodbatlas_cluster" "cluster-test" {
-  project_id     = "<YOUR-PROJECT-ID>"
-  name           = "cluster-test-multi-region"
-  disk_size_gb   = 100
-  num_shards     = 1
-  backup_enabled = true
-  cluster_type   = "REPLICASET"
+  project_id               = "<YOUR-PROJECT-ID>"
+  name                     = "cluster-test-multi-region"
+  disk_size_gb             = 100
+  num_shards               = 1
+  provider_backup_enabled  = true
+  cluster_type             = "REPLICASET"
 
   //Provider Settings "block"
   provider_name               = "AWS"
@@ -133,7 +133,6 @@ resource "mongodbatlas_cluster" "cluster-test" {
   name                    = "cluster-test-global"
   disk_size_gb            = 80
   num_shards              = 1
-  backup_enabled          = false
   provider_backup_enabled = true
   cluster_type            = "GEOSHARDED"
 
@@ -190,7 +189,10 @@ resource "mongodbatlas_cluster" "cluster-test" {
 
     You cannot enable continuous backups if you have an existing cluster in the project with Cloud Provider Snapshots enabled.
 
-    The default value is false.
+    You cannot enable continuous backups for new AWS clusters.   If backup is required for a new cluster use `provider_backup_enabled` to enable Cloud Provider Snapshots.
+
+    The default value is false.  M10 and above only.
+
 * `bi_connector` - (Optional) Specifies BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
 * `cluster_type` - (Optional) Specifies the type of the cluster that you want to modify. You cannot convert a sharded cluster deployment to a replica set deployment.
 


### PR DESCRIPTION
* Updated clusters to remove backup_enabled from AWS examples as not longer support for new AWS clusters.
* Added provider_backup_enabled to AWS examples.
* Provided details in argument section.
*Added a few relevant links/info to main provider page.

(note these changes need to happen in acceptance tests as well where backup_enabled is now used)