### PR TITLE
Database users: added x509_type attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-test/deep v1.0.1
 	github.com/gobuffalo/packr v1.30.1
 	github.com/hashicorp/terraform v0.12.1
-	github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6
+	github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzD
 github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=
 github.com/apparentlymart/go-cidr v1.0.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
+github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
@@ -90,11 +91,13 @@ github.com/gobuffalo/packr v1.30.1/go.mod h1:ljMyFO2EcrnzsHsN99cvbq055Y9OhRrIavi
 github.com/gobuffalo/packr/v2 v2.5.1/go.mod h1:8f9c96ITobJlPzI44jj+4tHnEKNt0xXWSVlXRN9X1Iw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -108,6 +111,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
@@ -200,7 +204,9 @@ github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
@@ -249,8 +255,8 @@ github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/I
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6 h1:DThBIUzmjrnQEKu4NtLkBHDyaAmskZC2fNazB7eX+DE=
 github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
-github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200116162614-e6f2e30401ac h1:sCeiLQ1of3mhZqBp5BFcdUwfl5WPCdww/78ZmXJRh+M=
-github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200116162614-e6f2e30401ac/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e h1:NwgM1De1tn6YmH1cn6/DlJ6XHOUp3SaYU58kt956rzs=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
 github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
 github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
@@ -267,6 +273,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17 h1:chPfVn+gpAM5CTpTyVU9j8J+xgRGwmoDlNDLjKnJiYo=
 github.com/pkg/errors v0.0.0-20170505043639-c605e284fe17/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
@@ -281,6 +288,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
@@ -326,6 +334,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
@@ -397,6 +406,7 @@ golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5Tlb
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -454,6 +464,7 @@ google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/mongodbatlas/data_source_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_user_test.go
@@ -49,7 +49,7 @@ func testAccMongoDBAtlasDatabaseUserDataSourceConfig(projectID, roleName, userna
 			password      = "test-acc-password"
 			project_id    = "%[1]s"
 			database_name = "admin"
-			
+
 			roles {
 				role_name     = "%[2]s"
 				database_name = "admin"
@@ -66,8 +66,9 @@ func testAccMongoDBAtlasDatabaseUserDataSourceConfig(projectID, roleName, userna
 		}
 
 		data "mongodbatlas_database_user" "test" {
-			username   = mongodbatlas_database_user.test.username
-			project_id = mongodbatlas_database_user.test.project_id
+			username   		= mongodbatlas_database_user.test.username
+			project_id 		= mongodbatlas_database_user.test.project_id
+			database_name = "admin"
 		}
 	`, projectID, roleName, username)
 }

--- a/mongodbatlas/data_source_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_user_test.go
@@ -15,9 +15,7 @@ func TestAccDataSourceMongoDBAtlasDatabaseUser_basic(t *testing.T) {
 
 	resourceName := "data.mongodbatlas_database_user.test"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-
 	roleName := "atlasAdmin"
-
 	username := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -31,7 +29,8 @@ func TestAccDataSourceMongoDBAtlasDatabaseUser_basic(t *testing.T) {
 					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "roles.0.role_name", roleName),
 					resource.TestCheckResourceAttr(resourceName, "roles.0.database_name", "admin"),
 					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
@@ -45,10 +44,10 @@ func TestAccDataSourceMongoDBAtlasDatabaseUser_basic(t *testing.T) {
 func testAccMongoDBAtlasDatabaseUserDataSourceConfig(projectID, roleName, username string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_database_user" "test" {
-			username      = "%[3]s"
-			password      = "test-acc-password"
-			project_id    = "%[1]s"
-			database_name = "admin"
+			username           = "%[3]s"
+			password           = "test-acc-password"
+			project_id         = "%[1]s"
+			auth_database_name = "admin"
 
 			roles {
 				role_name     = "%[2]s"
@@ -66,9 +65,9 @@ func testAccMongoDBAtlasDatabaseUserDataSourceConfig(projectID, roleName, userna
 		}
 
 		data "mongodbatlas_database_user" "test" {
-			username   		= mongodbatlas_database_user.test.username
-			project_id 		= mongodbatlas_database_user.test.project_id
-			database_name = "admin"
+			username           = mongodbatlas_database_user.test.username
+			project_id         = mongodbatlas_database_user.test.project_id
+			auth_database_name = "admin"
 		}
 	`, projectID, roleName, username)
 }

--- a/mongodbatlas/data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_users.go
@@ -35,8 +35,11 @@ func dataSourceMongoDBAtlasDatabaseUsers() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-
-						"database_name": {
+						"auth_database_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"x509_type": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -111,11 +114,12 @@ func flattenDBUsers(dbUsers []matlas.DatabaseUser) []map[string]interface{} {
 
 		for k, dbUser := range dbUsers {
 			dbUsersMap[k] = map[string]interface{}{
-				"roles":         flattenRoles(dbUser.Roles),
-				"username":      dbUser.Username,
-				"project_id":    dbUser.GroupID,
-				"database_name": dbUser.DatabaseName,
-				"labels":        flattenLabels(dbUser.Labels),
+				"roles":              flattenRoles(dbUser.Roles),
+				"username":           dbUser.Username,
+				"project_id":         dbUser.GroupID,
+				"auth_database_name": dbUser.DatabaseName,
+				"x509_type":          dbUser.X509Type,
+				"labels":             flattenLabels(dbUser.Labels),
 			}
 		}
 	}

--- a/mongodbatlas/data_source_mongodbatlas_database_users_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_users_test.go
@@ -31,7 +31,10 @@ func TestAccDataSourceMongoDBAtlasDatabaseUsers_basic(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasDatabaseUsersDataSourceConfigWithDS(projectID, roleName, username),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.x509_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.0.username"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.0.roles.#"),
 				),
@@ -44,11 +47,11 @@ func TestAccDataSourceMongoDBAtlasDatabaseUsers_basic(t *testing.T) {
 func testAccMongoDBAtlasDatabaseUsersDataSourceConfig(projectID, roleName, username string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_database_user" "db_user" {
-			username      = "%[3]s"
-			password      = "test-acc-password"
-			project_id    = "%[1]s"
-			database_name = "admin"
-			
+			username           = "%[3]s"
+			password           = "test-acc-password"
+			project_id         = "%[1]s"
+			auth_database_name = "admin"
+
 			roles {
 				role_name     = "%[2]s"
 				database_name = "admin"
@@ -56,11 +59,11 @@ func testAccMongoDBAtlasDatabaseUsersDataSourceConfig(projectID, roleName, usern
 		}
 
 		resource "mongodbatlas_database_user" "db_user_1" {
-			username      = "%[3]s-1"
-			password      = "test-acc-password-1"
-			project_id    = "%[1]s"
-			database_name = "admin"
-			
+			username           = "%[3]s-1"
+			password           = "test-acc-password-1"
+			project_id         = "%[1]s"
+			auth_database_name = "admin"
+
 			roles {
 				role_name     = "%[2]s"
 				database_name = "admin"

--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -28,7 +28,7 @@ func resourceMongoDBAtlasDatabaseUser() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"database_name": {
+			"auth_database_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -101,9 +101,9 @@ func resourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interface
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
-	databaseName := ids["database_name"]
+	authDatabaseName := ids["auth_database_name"]
 
-	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), databaseName, projectID, username)
+	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
 	if err != nil {
 		return fmt.Errorf("error getting database user information: %s", err)
 	}
@@ -111,8 +111,11 @@ func resourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interface
 	if err := d.Set("username", dbUser.Username); err != nil {
 		return fmt.Errorf("error setting `username` for database user (%s): %s", d.Id(), err)
 	}
-	if err := d.Set("database_name", dbUser.DatabaseName); err != nil {
-		return fmt.Errorf("error setting `database_name` for database user (%s): %s", d.Id(), err)
+	if err := d.Set("auth_database_name", dbUser.DatabaseName); err != nil {
+		return fmt.Errorf("error setting `auth_database_name` for database user (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("x509_type", dbUser.X509Type); err != nil {
+		return fmt.Errorf("error setting `x509_type` for database user (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("roles", flattenRoles(dbUser.Roles)); err != nil {
 		return fmt.Errorf("error setting `roles` for database user (%s): %s", d.Id(), err)
@@ -128,7 +131,7 @@ func resourceMongoDBAtlasDatabaseUserCreate(d *schema.ResourceData, meta interfa
 	//Get client connection.
 	conn := meta.(*matlas.Client)
 	projectID := d.Get("project_id").(string)
-	databaseName := d.Get("database_name").(string)
+	authDatabaseName := d.Get("auth_database_name").(string)
 
 	dbUserReq := &matlas.DatabaseUser{
 		Roles:        expandRoles(d),
@@ -136,7 +139,7 @@ func resourceMongoDBAtlasDatabaseUserCreate(d *schema.ResourceData, meta interfa
 		Username:     d.Get("username").(string),
 		Password:     d.Get("password").(string),
 		X509Type:     d.Get("x509_type").(string),
-		DatabaseName: databaseName,
+		DatabaseName: authDatabaseName,
 		Labels:       expandLabelSliceFromSetSchema(d),
 	}
 
@@ -146,9 +149,9 @@ func resourceMongoDBAtlasDatabaseUserCreate(d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(encodeStateID(map[string]string{
-		"project_id":    projectID,
-		"username":      dbUserRes.Username,
-		"database_name": databaseName,
+		"project_id":         projectID,
+		"username":           dbUserRes.Username,
+		"auth_database_name": authDatabaseName,
 	}))
 
 	return resourceMongoDBAtlasDatabaseUserRead(d, meta)
@@ -160,9 +163,9 @@ func resourceMongoDBAtlasDatabaseUserUpdate(d *schema.ResourceData, meta interfa
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
-	databaseName := ids["database_name"]
+	authDatabaseName := ids["auth_database_name"]
 
-	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), databaseName, projectID, username)
+	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
 	if err != nil {
 		return fmt.Errorf("error getting database user information: %s", err)
 	}
@@ -180,7 +183,6 @@ func resourceMongoDBAtlasDatabaseUserUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	_, _, err = conn.DatabaseUsers.Update(context.Background(), projectID, username, dbUser)
-
 	if err != nil {
 		return fmt.Errorf("error updating database user(%s): %s", username, err)
 	}
@@ -194,9 +196,9 @@ func resourceMongoDBAtlasDatabaseUserDelete(d *schema.ResourceData, meta interfa
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
-	databaseName := ids["database_name"]
+	authDatabaseName := ids["auth_database_name"]
 
-	_, err := conn.DatabaseUsers.Delete(context.Background(), databaseName, projectID, username)
+	_, err := conn.DatabaseUsers.Delete(context.Background(), authDatabaseName, projectID, username)
 	if err != nil {
 		return fmt.Errorf("error deleting database user (%s): %s", username, err)
 	}
@@ -208,27 +210,27 @@ func resourceMongoDBAtlasDatabaseUserImportState(d *schema.ResourceData, meta in
 
 	parts := strings.SplitN(d.Id(), "-", 3)
 	if len(parts) != 3 {
-		return nil, errors.New("import format error: to import a database user, use the format {project_id}-{username}")
+		return nil, errors.New("import format error: to import a database user, use the format {project_id}-{username}-{auth_database_name}")
 	}
 
 	projectID := parts[0]
 	username := parts[1]
-	databaseName := parts[2]
+	authDatabaseName := parts[2]
 
-	u, _, err := conn.DatabaseUsers.Get(context.Background(), databaseName, projectID, username)
+	u, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't import user %s in project %s, error: %s", username, projectID, err)
+		return nil, fmt.Errorf("couldn't import user(%s) in project(%s), error: %s", username, projectID, err)
 	}
-
-	d.SetId(encodeStateID(map[string]string{
-		"project_id":    projectID,
-		"username":      u.Username,
-		"database_name": databaseName,
-	}))
 
 	if err := d.Set("project_id", u.GroupID); err != nil {
 		log.Printf("[WARN] Error setting project_id for (%s): %s", d.Id(), err)
 	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id":         projectID,
+		"username":           username,
+		"auth_database_name": authDatabaseName,
+	}))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/database_users.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/database_users.go
@@ -13,10 +13,10 @@ const dbUsersBasePath = "groups/%s/databaseUsers"
 //See more: https://docs.atlas.mongodb.com/reference/api/database-users/index.html
 type DatabaseUsersService interface {
 	List(context.Context, string, *ListOptions) ([]DatabaseUser, *Response, error)
-	Get(context.Context, string, string) (*DatabaseUser, *Response, error)
+	Get(context.Context, string, string, string) (*DatabaseUser, *Response, error)
 	Create(context.Context, string, *DatabaseUser) (*DatabaseUser, *Response, error)
 	Update(context.Context, string, string, *DatabaseUser) (*DatabaseUser, *Response, error)
-	Delete(context.Context, string, string) (*Response, error)
+	Delete(context.Context, string, string, string) (*Response, error)
 }
 
 //DatabaseUsersServiceOp handles communication with the DatabaseUsers related methos of the
@@ -37,14 +37,15 @@ type Role struct {
 
 // DatabaseUser represents MongoDB users in your cluster.
 type DatabaseUser struct {
-	Roles           []Role  `json:"roles,omitempty"`
-	GroupID         string  `json:"groupId,omitempty"`
-	Username        string  `json:"username,omitempty"`
-	Password        string  `json:"password,omitempty"`
 	DatabaseName    string  `json:"databaseName,omitempty"`
+	DeleteAfterDate string  `json:"deleteAfterDate,omitempty"`
 	Labels          []Label `json:"labels,omitempty"`
 	LDAPAuthType    string  `json:"ldapAuthType,omitempty"`
-	DeleteAfterDate string  `json:"deleteAfterDate,omitempty"`
+	X509Type        string  `json:"x509Type,omitempty"`
+	GroupID         string  `json:"groupId,omitempty"`
+	Roles           []Role  `json:"roles,omitempty"`
+	Password        string  `json:"password,omitempty"`
+	Username        string  `json:"username,omitempty"`
 }
 
 // Label containing key-value pairs that tag and categorize the database user
@@ -91,13 +92,19 @@ func (s *DatabaseUsersServiceOp) List(ctx context.Context, groupID string, listO
 
 //Get gets a single user in the project.
 //See more: https://docs.atlas.mongodb.com/reference/api/database-users-get-single-user/
-func (s *DatabaseUsersServiceOp) Get(ctx context.Context, groupID string, username string) (*DatabaseUser, *Response, error) {
+func (s *DatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID, username string) (*DatabaseUser, *Response, error) {
+	if databaseName == "" {
+		return nil, nil, NewArgError("databaseName", "must be set")
+	}
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
 	if username == "" {
 		return nil, nil, NewArgError("username", "must be set")
 	}
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
-	path := fmt.Sprintf("%s/admin/%s", basePath, username)
+	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, username)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -162,13 +169,19 @@ func (s *DatabaseUsersServiceOp) Update(ctx context.Context, groupID string, use
 
 //Delete deletes a user for the project.
 // See more: https://docs.atlas.mongodb.com/reference/api/database-users-delete-a-user/
-func (s *DatabaseUsersServiceOp) Delete(ctx context.Context, groupID string, username string) (*Response, error) {
+func (s *DatabaseUsersServiceOp) Delete(ctx context.Context, databaseName, groupID, username string) (*Response, error) {
+	if databaseName == "" {
+		return nil, NewArgError("databaseName", "must be set")
+	}
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
 	if username == "" {
 		return nil, NewArgError("username", "must be set")
 	}
 
 	basePath := fmt.Sprintf(dbUsersBasePath, groupID)
-	path := fmt.Sprintf("%s/admin/%s", basePath, username)
+	path := fmt.Sprintf("%s/%s/%s", basePath, databaseName, username)
 
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6
+# github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6 => ../go-client-mongodb-atlas
 github.com/mongodb/go-client-mongodb-atlas/mongodbatlas
 # github.com/mwielbut/pointy v1.1.0
 github.com/mwielbut/pointy

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -18,43 +18,42 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ```hcl
 resource "mongodbatlas_database_user" "test" {
-	username      = "test-acc-username"
-	password      = "test-acc-password"
-	project_id      = "<PROJECT-ID>"
-	database_name = "admin"
+  username           = "test-acc-username"
+  password           = "test-acc-password"
+  project_id         = "<PROJECT-ID>"
+  auth_database_name = "admin"
 
-	roles {
-		role_name     = "readWrite"
-		database_name = "admin"
-	}
+  roles {
+    role_name     = "readWrite"
+    database_name = "admin"
+  }
 
-    roles {
-		role_name     = "atlasAdmin"
-		database_name = "admin"
-	}
+  roles {
+    role_name     = "atlasAdmin"
+    database_name = "admin"
+  }
 
-	labels {
-		key   = "key 1"
-		value = "value 1"
-	}
-	labels {
-		key   = "key 2"
-		value = "value 2"
-	}
+  labels {
+    key   = "key 1"
+    value = "value 1"
+  }
+  labels {
+    key   = "key 2"
+    value = "value 2"
+  }
 }
 
 data "mongodbatlas_database_user" "test" {
-	project_id = mongodbatlas_database_user.test.project_id
-	username = mongodbatlas_database_user.test.username
+  project_id = mongodbatlas_database_user.test.project_id
+  username   = mongodbatlas_database_user.test.username
 }
-
 ```
 
 ## Argument Reference
 
 * `username` - (Required) Username for authenticating to MongoDB.
 * `project_id` - (Required) The unique ID for the project to create the database user.
-* `database_name` - (Required) The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
+* `auth_database_name` - (Required) The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is almost always the admin database, for X509 it is $external.
 
 ## Attributes Reference
 
@@ -62,6 +61,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The database user's name.
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
+* `x509_type` - X.509 method by which the provided username is authenticated.
 
 ### Roles
 

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -22,7 +22,7 @@ resource "mongodbatlas_database_user" "test" {
 	password      = "test-acc-password"
 	project_id      = "<PROJECT-ID>"
 	database_name = "admin"
-	
+
 	roles {
 		role_name     = "readWrite"
 		database_name = "admin"
@@ -54,6 +54,7 @@ data "mongodbatlas_database_user" "test" {
 
 * `username` - (Required) Username for authenticating to MongoDB.
 * `project_id` - (Required) The unique ID for the project to create the database user.
+* `database_name` - (Required) The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
 
 ## Attributes Reference
 
@@ -61,7 +62,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The database user's name.
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
-* `database_name` - The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
 
 ### Roles
 

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -18,10 +18,10 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ```hcl
 resource "mongodbatlas_database_user" "test" {
-  username      = "test-acc-username"
-  password      = "test-acc-password"
-  project_id    = "<PROJECT-ID>"
-  database_name = "admin"
+  username           = "test-acc-username"
+  password           = "test-acc-password"
+  project_id         = "<PROJECT-ID>"
+  auth_database_name = "admin"
 
   roles {
     role_name     = "readWrite"
@@ -44,9 +44,8 @@ resource "mongodbatlas_database_user" "test" {
 }
 
 data "mongodbatlas_database_users" "test" {
-	project_id = mongodbatlas_database_user.test.project_id
+  project_id = mongodbatlas_database_user.test.project_id
 }
-
 ```
 
 ## Argument Reference
@@ -66,7 +65,9 @@ In addition to all arguments above, the following attributes are exported:
 * `project_id` - ID of the Atlas project the user belongs to.
 * `username` - Username for authenticating to MongoDB.
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
-* `database_name` - The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
+* `auth_database_name` - The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
+
+* `x509_type` - X.509 method by which the provided username is authenticated.
 
 ### Roles
 

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -16,14 +16,14 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ~> **IMPORTANT:** All arguments including the password will be stored in the raw state as plain-text. [Read more about sensitive data in state.](https://www.terraform.io/docs/state/sensitive-data.html)
 
-## Example Usage
+## Example Usages
 
 ```hcl
 resource "mongodbatlas_database_user" "test" {
-  username      = "test-acc-username"
-  password      = "test-acc-password"
-  project_id    = "<PROJECT-ID>"
-  database_name = "admin"
+  username           = "test-acc-username"
+  password           = "test-acc-password"
+  project_id         = "<PROJECT-ID>"
+  auth_database_name = "admin"
 
   roles {
     role_name     = "readWrite"
@@ -42,13 +42,38 @@ resource "mongodbatlas_database_user" "test" {
 }
 ```
 
+
+```hcl
+resource "mongodbatlas_database_user" "test" {
+  username           = "test-acc-username"
+  x509_type          = "MANAGED"
+  project_id         = "<PROJECT-ID>"
+  auth_database_name = "$external"
+
+  roles {
+    role_name     = "readAnyDatabase"
+    database_name = "admin"
+  }
+
+  labels {
+    key   = "%s"
+    value = "%s"
+  }
+}
+```
+
 ## Argument Reference
 
-* `database_name` - (Required) The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
+* `auth_database_name` - (Required) The user’s authentication database. A user must provide both a username and authentication database to log into MongoDB. In Atlas deployments of MongoDB, the authentication database is always the admin database.
 * `project_id` - (Required) The unique ID for the project to create the database user.
 * `roles` - (Required) 	List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
 * `username` - (Required) Username for authenticating to MongoDB.
 * `password` - (Required) User's initial password. A value is required to create the database user, however the argument but may be removed from your Terraform configuration after user creation without impacting the user, password or Terraform management. IMPORTANT --- Passwords may show up in Terraform related logs and it will be stored in the Terraform state file as plain-text. Password can be changed after creation using your preferred method, e.g. via the MongoDB Atlas UI, to ensure security.  If you do change management of the password to outside of Terraform be sure to remove the argument from the Terraform configuration so it is not inadvertently updated to the original password.
+
+* `x509_type` - (Optional) X.509 method by which the provided username is authenticated. If no value is given, Atlas uses the default value of NONE. The accepted types are:
+  * `NONE` -	The user does not use X.509 authentication.
+  * `MANAGED` - The user is being created for use with Atlas-managed X.509.Externally authenticated users can only be created on the `$external` database.
+  * `CUSTOMER` -  The user is being created for use with Self-Managed X.509. Users created with this x509Type require a Common Name (CN) in the username field. Externally authenticated users can only be created on the `$external` database.
 
 ### Roles
 
@@ -76,7 +101,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Database users can be imported using project ID and username, in the format `PROJECTID-USERNAME-DATABASENAME`, e.g.
+Database users can be imported using project ID and username, in the format `project_id`-`username`-`auth_database_name`, e.g.
 
 ```
 $ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user-admin

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -76,10 +76,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Database users can be imported using project ID and username, in the format `PROJECTID-USERNAME`, e.g.
+Database users can be imported using project ID and username, in the format `PROJECTID-USERNAME-DATABASENAME`, e.g.
 
 ```
-$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user
+$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user-admin
 ```
 
 ~> **NOTE:** Terraform will want to change the password after importing the user if a `password` argument is specified.


### PR DESCRIPTION
Added:
- `x509_type` attribute was added in the resource and the data source in the database resource, this allows us to configure it with the future X509 resource.
- The GET and DELETE Methods were refactored due to the client changed, so when the `x509_type` is enabled the database name must be `$external` and to be able to Get or Delete it we need to pass the database name to avoid errors.
- The documentation was updated.
