### PR TITLE
X509 Authentication Database User

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-test/deep v1.0.1
 	github.com/gobuffalo/packr v1.30.1
 	github.com/hashicorp/terraform v0.12.1
-	github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e
+	github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206183950-6d73c8e570f5
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -253,10 +253,11 @@ github.com/mitchellh/panicwrap v0.0.0-20190213213626-17011010aaa4/go.mod h1:YYMf
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6 h1:DThBIUzmjrnQEKu4NtLkBHDyaAmskZC2fNazB7eX+DE=
-github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
-github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e h1:NwgM1De1tn6YmH1cn6/DlJ6XHOUp3SaYU58kt956rzs=
-github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200205164654-a46da013820e/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
+github.com/mongodb/go-client-mongodb-atlas v0.1.3 h1:/l36BomZ93+YTQhqcnJLhgphP5+/VGqbmwAVQlWKhng=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206174030-9b2d31e9616c h1:ojniQErYhiMEB1VmksZRtVVye7bUX7thJ9f9/5VpJbI=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206174030-9b2d31e9616c/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206183950-6d73c8e570f5 h1:SIFJgPyQFRITWM2ZoPSvPm1pdVPS+hTbvvdIAaabap4=
+github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206183950-6d73c8e570f5/go.mod h1:LS8O0YLkA+sbtOb3fZLF10yY3tJM+1xATXMJ3oU35LU=
 github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
 github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=

--- a/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user.go
@@ -1,0 +1,94 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func dataSourceMongoDBAtlasX509AuthDBUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMongoDBAtlasX509AuthDBUserRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"customer_x509_cas": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"certificates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"not_after": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subject": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceMongoDBAtlasX509AuthDBUserRead(d *schema.ResourceData, meta interface{}) error {
+	//Get client connection.
+	conn := meta.(*matlas.Client)
+	projectID := d.Get("project_id").(string)
+	username := d.Get("username").(string)
+
+	if username != "" {
+		certificates, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), projectID, username)
+		if err != nil {
+			return fmt.Errorf(errorX509AuthDBUsersRead, username, projectID, err)
+		}
+		if err := d.Set("certificates", flattenCertificates(certificates)); err != nil {
+			return fmt.Errorf(errorX509AuthDBUsersSetting, "certificates", username, err)
+		}
+	}
+
+	customerX509, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), projectID)
+	if err != nil {
+		return fmt.Errorf(errorCustomerX509AuthDBUsersRead, projectID, err)
+	}
+	if err := d.Set("customer_x509_cas", customerX509.Cas); err != nil {
+		return fmt.Errorf(errorX509AuthDBUsersSetting, "certificates", username, err)
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id":          projectID,
+		"username":            username,
+		"current_certificate": "",
+	}))
+
+	return nil
+}

--- a/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user_test.go
@@ -1,0 +1,88 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceMongoX509AuthDBUser_basic(t *testing.T) {
+	resourceName := "data.mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	username := os.Getenv("DB_USERNAME")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			func() {
+				if os.Getenv("DB_USERNAME") == "" {
+					t.Fatal("`DB_USERNAME` must be set for MongoDB Atlas X509 Authentication Database users  testing")
+				}
+			}()
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoX509AuthDBUserDataSourceConfig(projectID, username),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceMongoX509AuthDBUser_WithCustomerX509(t *testing.T) {
+	resourceName := "data.mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	cas := `-----BEGIN CERTIFICATE-----\nMIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC\nVVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl\nc3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG\nSIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy\nMDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF\nVGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV\nBAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp\nc3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB\niQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr\ncURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O\nFh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG\nSIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA\n7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A\niul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz\n-----END CERTIFICATE-----`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoX509AuthDBUserDataSourceConfigWithCustomerX509(projectID, cas),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoX509AuthDBUserDataSourceConfig(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = "%s"
+			username   = "%s"
+		}
+
+		data "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+			username   = "${mongodbatlas_x509_authentication_database_user.test.username}"
+		}
+	`, projectID, username)
+}
+
+func testAccMongoX509AuthDBUserDataSourceConfigWithCustomerX509(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id        = "%s"
+			customer_x509_cas = "%s"
+		}
+
+		data "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+		}
+	`, projectID, username)
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -56,6 +56,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_teams":                                dataSourceMongoDBAtlasTeam(),
 			"mongodbatlas_global_cluster_config":                dataSourceMongoDBAtlasGlobalCluster(),
 			"mongodbatlas_alert_configuration":                  dataSourceMongoDBAtlasAlertConfiguration(),
+			"mongodbatlas_x509_authentication_database_user":    dataSourceMongoDBAtlasX509AuthDBUser(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -76,6 +77,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_teams":                               resourceMongoDBAtlasTeam(),
 			"mongodbatlas_global_cluster_config":               resourceMongoDBAtlasGlobalCluster(),
 			"mongodbatlas_alert_configuration":                 resourceMongoDBAtlasAlertConfiguration(),
+			"mongodbatlas_x509_authentication_database_user":   resourceMongoDBAtlasX509AuthDBUser(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
@@ -1,0 +1,231 @@
+package mongodbatlas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/spf13/cast"
+
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+const (
+	errorX509AuthDBUsersCreate         = "error creating MongoDB X509 Authentication for DB User(%s) in the project(%s): %s"
+	errorX509AuthDBUsersRead           = "error reading MongoDB X509 Authentication for DB Users(%s) in the project(%s): %s"
+	errorX509AuthDBUsersSetting        = "error setting `%s` for MongoDB X509 Authentication DB User(%s): %s"
+	errorCustomerX509AuthDBUsersCreate = "error creating Customer X509 Authentication in the project(%s): %s"
+	errorCustomerX509AuthDBUsersRead   = "error reading Customer X509 Authentication in the project(%s): %s"
+	errorCustomerX509AuthDBUsersDelete = "error deleting Customer X509 Authentication in the project(%s): %s"
+)
+
+func resourceMongoDBAtlasX509AuthDBUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMongoDBAtlasX509AuthDBUserCreate,
+		Read:   resourceMongoDBAtlasX509AuthDBUserRead,
+		Delete: resourceMongoDBAtlasX509AuthDBUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceMongoDBAtlasX509AuthDBUserImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"months_until_expiration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(int)
+					if v < 1 || v > 24 {
+						errs = append(errs, fmt.Errorf("%q value should be between 1 and 24, got: %d", key, v))
+					}
+					return
+				},
+			},
+			"current_certificate": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"customer_x509_cas": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"months_until_expiration", "username"},
+			},
+			"certificates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"not_after": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subject": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasX509AuthDBUserCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	projectID := d.Get("project_id").(string)
+	username := d.Get("username").(string)
+
+	var currentCertificate string
+	if expirationMonths, ok := d.GetOk("months_until_expiration"); ok {
+		res, _, err := conn.X509AuthDBUsers.CreateUserCertificate(context.Background(), projectID, username, expirationMonths.(int))
+		if err != nil {
+			return fmt.Errorf(errorX509AuthDBUsersCreate, username, projectID, err)
+		}
+		currentCertificate = res.Certificate
+	} else {
+		customerX509Cas := d.Get("customer_x509_cas").(string)
+		_, _, err := conn.X509AuthDBUsers.SaveConfiguration(context.Background(), projectID, &matlas.CustomerX509{Cas: customerX509Cas})
+		if err != nil {
+			return fmt.Errorf(errorCustomerX509AuthDBUsersCreate, projectID, err)
+		}
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id":          projectID,
+		"username":            username,
+		"current_certificate": currentCertificate,
+	}))
+
+	return resourceMongoDBAtlasX509AuthDBUserRead(d, meta)
+}
+
+func resourceMongoDBAtlasX509AuthDBUserRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	ids := decodeStateID(d.Id())
+	projectID := ids["project_id"]
+	username := ids["username"]
+	currentCertificate := ids["current_certificate"]
+
+	var certificates []matlas.UserCertificate
+	var err error
+	if username != "" {
+		certificates, _, err = conn.X509AuthDBUsers.GetUserCertificates(context.Background(), projectID, username)
+		if err != nil {
+			return fmt.Errorf(errorX509AuthDBUsersRead, username, projectID, err)
+		}
+	}
+
+	if err := d.Set("current_certificate", cast.ToString(currentCertificate)); err != nil {
+		return fmt.Errorf(errorX509AuthDBUsersSetting, "current_certificate", username, err)
+	}
+	if err := d.Set("certificates", flattenCertificates(certificates)); err != nil {
+		return fmt.Errorf(errorX509AuthDBUsersSetting, "certificates", username, err)
+	}
+
+	return nil
+}
+
+func resourceMongoDBAtlasX509AuthDBUserDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	ids := decodeStateID(d.Id())
+	currentCertificate := ids["current_certificate"]
+	projectID := ids["project_id"]
+
+	if currentCertificate == "" {
+		_, err := conn.X509AuthDBUsers.DisableCustomerX509(context.Background(), projectID)
+		if err != nil {
+			return fmt.Errorf(errorCustomerX509AuthDBUsersDelete, projectID, err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceMongoDBAtlasX509AuthDBUserImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*matlas.Client)
+
+	parts := strings.SplitN(d.Id(), "-", 2)
+	if len(parts) < 1 && len(parts) > 2 {
+		return nil, errors.New("import format error: to import a X509 Authentication, use the formats {project_id} or {project_id}-{username}")
+	}
+
+	var username string
+	if len(parts) == 2 {
+		username = parts[1]
+	}
+	projectID := parts[0]
+
+	if username != "" {
+		_, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), projectID, username)
+		if err != nil {
+			return nil, fmt.Errorf(errorX509AuthDBUsersRead, username, projectID, err)
+		}
+		if err := d.Set("username", username); err != nil {
+			return nil, fmt.Errorf(errorX509AuthDBUsersSetting, "username", username, err)
+		}
+	}
+
+	customerX509, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), projectID)
+	if err != nil {
+		return nil, fmt.Errorf(errorCustomerX509AuthDBUsersRead, projectID, err)
+	}
+
+	if err := d.Set("customer_x509_cas", customerX509.Cas); err != nil {
+		return nil, fmt.Errorf(errorX509AuthDBUsersSetting, "certificates", username, err)
+	}
+	if err := d.Set("project_id", projectID); err != nil {
+		return nil, fmt.Errorf(errorX509AuthDBUsersSetting, "project_id", username, err)
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id":          projectID,
+		"username":            username,
+		"current_certificate": "",
+	}))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func flattenCertificates(userCertificates []matlas.UserCertificate) []map[string]interface{} {
+	certificates := make([]map[string]interface{}, len(userCertificates))
+	for i, v := range userCertificates {
+		certificates[i] = map[string]interface{}{
+			"id":         v.ID,
+			"created_at": v.CreatedAt,
+			"group_id":   v.GroupID,
+			"not_after":  v.NotAfter,
+			"subject":    v.Subject,
+		}
+	}
+	return certificates
+}

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
@@ -1,0 +1,231 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
+)
+
+func TestAccResourceMongoDBAtlasX509AuthDBUser_basic(t *testing.T) {
+	resourceName := "mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	username := os.Getenv("DB_USERNAME")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			func() {
+				if os.Getenv("DB_USERNAME") == "" {
+					t.Fatal("`DB_USERNAME` must be set for MongoDB Atlas X509 Authentication Database users  testing")
+				}
+			}()
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectID, username),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasX509AuthDBUser_WithCustomerX509(t *testing.T) {
+	resourceName := "mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	cas := `-----BEGIN CERTIFICATE-----\nMIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC\nVVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl\nc3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG\nSIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy\nMDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF\nVGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV\nBAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp\nc3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB\niQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr\ncURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O\nFh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG\nSIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA\n7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A\niul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz\n-----END CERTIFICATE-----`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectID, cas),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasX509AuthDBUser_importBasic(t *testing.T) {
+	resourceName := "mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	username := os.Getenv("DB_USERNAME")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			func() {
+				if os.Getenv("DB_USERNAME") == "" {
+					t.Fatal("`DB_USERNAME` must be set for MongoDB Atlas X509 Authentication Database users  testing")
+				}
+			}()
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectID, username),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportState:       true,
+				// ImportStateVerify: true,
+				// ImportStateVerifyIgnore: []string{""},
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasX509AuthDBUser_importWithCustomerX509(t *testing.T) {
+	resourceName := "mongodbatlas_x509_authentication_database_user.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	cas := `-----BEGIN CERTIFICATE-----\nMIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC\nVVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl\nc3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG\nSIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy\nMDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF\nVGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV\nBAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp\nc3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB\niQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr\ncURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O\nFh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG\nSIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA\n7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A\niul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz\n-----END CERTIFICATE-----`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectID, cas),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportState:       true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["username"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*matlas.Client)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		if ids["current_certificate"] != "" {
+			if _, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"]); err == nil {
+				return nil
+			}
+			return fmt.Errorf("X509 Authentication Database User(%s) does not exist in the project(%s)", ids["username"], ids["project_id"])
+		}
+		if _, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
+			return nil
+		}
+		return fmt.Errorf("Customer X509 Authentication does not exist in the project(%s)", ids["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*matlas.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_x509_authentication_database_user" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if ids["current_certificate"] != "" {
+			_, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"])
+			if err == nil {
+				/*
+					There is no way to remove one user certificate so until this comes it will keep in this way
+				*/
+				// return fmt.Errorf("X509 Authentication Database User(%s) still exists in the project(%s)", ids["username"], ids["project_id"])
+				return nil
+			}
+		}
+		if _, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
+			return nil
+		}
+
+	}
+	return nil
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfig(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id              = "%s"
+			username                = "%s"
+			months_until_expiration = 5
+		}
+	`, projectID, username)
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectID, cas string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id        = "%s"
+			customer_x509_cas = "%s"
+		}
+	`, projectID, cas)
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfigWithDatabaseUser(projectID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "user" {
+			project_id    = "%s"
+			username      = "%s"
+			x509_type     = "CUSTOMER"
+			database_name = "$external"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "My Key"
+				value = "My Value"
+			}
+		}
+
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id              = "${mongodbatlas_database_user.user.project_id}"
+			username                = "${mongodbatlas_database_user.user.username}"
+			months_until_expiration = 2
+		}
+	`, projectID, username)
+}

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/LICENSE
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/LICENSE
@@ -186,8 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2018] [© AnyChart.com - JavaScript charts](https://www.anychart.com).
-
+   Copyright [yyyy] [name of copyright owner]
+   
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/clusters.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/clusters.go
@@ -88,6 +88,7 @@ type Cluster struct {
 	Name                     string                   `json:"name,omitempty"`
 	NumShards                *int64                   `json:"numShards,omitempty"`
 	Paused                   *bool                    `json:"paused,omitempty"`
+	PitEnabled               *bool                    `json:"pitEnabled,omitempty"`
 	ProviderBackupEnabled    *bool                    `json:"providerBackupEnabled,omitempty"`
 	ProviderSettings         *ProviderSettings        `json:"providerSettings,omitempty"`
 	ReplicationFactor        *int64                   `json:"replicationFactor,omitempty"`

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/mongodbatlas.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/mongodbatlas.go
@@ -51,6 +51,8 @@ type Client struct {
 	GlobalClusters                   GlobalClustersService
 	Auditing                         AuditingsService
 	AlertConfigurations              AlertConfigurationsService
+	PrivateEndpoints                 PrivateEndpointsService
+	X509AuthDBUsers                  X509AuthDBUsersService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -161,6 +163,8 @@ func NewClient(httpClient *http.Client) *Client {
 	c.GlobalClusters = &GlobalClustersServiceOp{client: c}
 	c.Auditing = &AuditingsServiceOp{client: c}
 	c.AlertConfigurations = &AlertConfigurationsServiceOp{client: c}
+	c.PrivateEndpoints = &PrivateEndpointsServiceOp{client: c}
+	c.X509AuthDBUsers = &X509AuthDBUsersServiceOp{client: c}
 
 	return c
 }

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/private_endpoints.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/private_endpoints.go
@@ -1,0 +1,236 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const privateEndpointsPath = "groups/%s/privateEndpoint"
+
+// PrivateEndpointsService is an interface for interfacing with the Private Endpoints
+// of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint/
+type PrivateEndpointsService interface {
+	Create(context.Context, string, *PrivateEndpointConnection) (*PrivateEndpointConnection, *Response, error)
+	Get(context.Context, string, string) (*PrivateEndpointConnection, *Response, error)
+	List(context.Context, string, *ListOptions) ([]PrivateEndpointConnection, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
+	AddOneInterfaceEndpoint(context.Context, string, string, string) (*InterfaceEndpointConnection, *Response, error)
+	GetOneInterfaceEndpoint(context.Context, string, string, string) (*InterfaceEndpointConnection, *Response, error)
+	DeleteOneInterfaceEndpoint(context.Context, string, string, string) (*Response, error)
+}
+
+// PrivateEndpointsServiceOp handles communication with the PrivateEndpoints related methods
+// of the MongoDB Atlas API
+type PrivateEndpointsServiceOp struct {
+	client *Client
+}
+
+var _ PrivateEndpointsService = &PrivateEndpointsServiceOp{}
+
+// PrivateEndpointConnection represents MongoDB Private Endpoint Connection.
+type PrivateEndpointConnection struct {
+	ID                  string   `json:"id,omitempty"`                  // Unique identifier of the AWS PrivateLink connection.
+	ProviderName        string   `json:"providerName,omitempty"`        // Name of the cloud provider you want to create the private endpoint connection for. Must be AWS.
+	Region              string   `json:"region,omitempty"`              // Cloud provider region in which you want to create the private endpoint connection.
+	EndpointServiceName string   `json:"endpointServiceName,omitempty"` // Name of the PrivateLink endpoint service in AWS. Returns null while the endpoint service is being created.
+	ErrorMessage        string   `json:"errorMessage,omitempty"`        // Error message pertaining to the AWS PrivateLink connection. Returns null if there are no errors.
+	InterfaceEndpoints  []string `json:"interfaceEndpoints,omitempty"`  // Unique identifiers of the interface endpoints in your VPC that you added to the AWS PrivateLink connection.
+	Status              string   `json:"status,omitempty"`              // Status of the AWS PrivateLink connection: INITIATING, WAITING_FOR_USER, FAILED, DELETING.
+}
+
+// InterfaceEndpointConnection represents MongoDB Interface Endpoint Connection.
+type InterfaceEndpointConnection struct {
+	ID               string `json:"interfaceEndpointId,omitempty"` // Unique identifier of the interface endpoint.
+	DeleteRequested  *bool  `json:"deleteRequested,omitempty"`     // Indicates if Atlas received a request to remove the interface endpoint from the private endpoint connection.
+	ErrorMessage     string `json:"errorMessage,omitempty"`        // Error message pertaining to the interface endpoint. Returns null if there are no errors.
+	ConnectionStatus string `json:"connectionStatus,omitempty"`    // Status of the interface endpoint: NONE, PENDING_ACCEPTANCE, PENDING, AVAILABLE, REJECTED, DELETING.
+}
+
+// Create one private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-create-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOp) Create(ctx context.Context, groupID string, createRequest *PrivateEndpointConnection) (*PrivateEndpointConnection, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(privateEndpointsPath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateEndpointConnection)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Get retrieves details for one private endpoint connection by ID in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOp) Get(ctx context.Context, groupID, privateLinkID string) (*PrivateEndpointConnection, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateEndpointConnection)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// List retrieves details for all private endpoint connections in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-all-private-endpoint-connections/
+func (s *PrivateEndpointsServiceOp) List(ctx context.Context, groupID string, listOptions *ListOptions) ([]PrivateEndpointConnection, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(privateEndpointsPath, groupID)
+
+	// Add query params from listOptions
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new([]PrivateEndpointConnection)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *root, resp, nil
+}
+
+// Delete removes one private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-delete-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOp) Delete(ctx context.Context, groupID, privateLinkID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, NewArgError("whitelistEntry", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// AddOneInterfaceEndpoint adds one interface endpoint to a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-create-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOp) AddOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*InterfaceEndpointConnection, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints", basePath, privateLinkID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, &InterfaceEndpointConnection{ID: interfaceEndpointID})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(InterfaceEndpointConnection)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// GetOneInterfaceEndpoint retrieves one interface endpoint in a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOp) GetOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*InterfaceEndpointConnection, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(InterfaceEndpointConnection)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// DeleteOneInterfaceEndpoint removes one interface endpoint from a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-delete-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOp) DeleteOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/x509_authentication_database_users.go
+++ b/vendor/github.com/mongodb/go-client-mongodb-atlas/mongodbatlas/x509_authentication_database_users.go
@@ -1,0 +1,191 @@
+package mongodbatlas
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const x509AuthDBUsersPath = "groups/%s/databaseUsers/%s/certs"
+const x509CustomerAuthDBUserPath = "groups/%s/userSecurity"
+
+// X509AuthDBUsersService is an interface for interfacing with the x509 Authentication Database Users.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration/
+type X509AuthDBUsersService interface {
+	CreateUserCertificate(context.Context, string, string, int) (*UserCertificate, *Response, error)
+	GetUserCertificates(context.Context, string, string) ([]UserCertificate, *Response, error)
+	SaveConfiguration(context.Context, string, *CustomerX509) (*CustomerX509, *Response, error)
+	GetCurrentX509Conf(context.Context, string) (*CustomerX509, *Response, error)
+	DisableCustomerX509(context.Context, string) (*Response, error)
+}
+
+// X509AuthDBUsersServiceOp handles communication with the  X509AuthDBUsers related methods
+// of the MongoDB Atlas API
+type X509AuthDBUsersServiceOp struct {
+	client *Client
+}
+
+var _ X509AuthDBUsersService = &X509AuthDBUsersServiceOp{}
+
+// UserCertificate represents an X.509 Certificate for a User.
+type UserCertificate struct {
+	Username              string `json:"username,omitempty"`              // Username of the database user to create a certificate for.
+	MonthsUntilExpiration int    `json:"monthsUntilExpiration,omitempty"` // A number of months that the created certificate is valid for before expiry, up to 24 months.default 3.
+	Certificate           string `json:"certificate,omitempty"`
+
+	ID        *int64 `json:"_id,omitempty"`       // Serial number of this certificate.
+	CreatedAt string `json:"createdAt,omitempty"` // Timestamp in ISO 8601 date and time format in UTC when Atlas created this X.509 certificate.
+	GroupID   string `json:"groupId,omitempty"`   // Unique identifier of the Atlas project to which this certificate belongs.
+	NotAfter  string `json:"notAfter,omitempty"`  // Timestamp in ISO 8601 date and time format in UTC when this certificate expires.
+	Subject   string `json:"subject,omitempty"`   // Fully distinguished name of the database user to which this certificate belongs. To learn more, see RFC 2253.
+}
+
+// UserCertificates is Array of objects where each details one unexpired database user certificate.
+type UserCertificates struct {
+	Links      []*Link           `json:"links"`      // One or more links to sub-resources and/or related resources.
+	Results    []UserCertificate `json:"results"`    // Array of objects where each details one unexpired database user certificate.
+	TotalCount int               `json:"totalCount"` // Total number of unexpired certificates returned in this response.
+}
+
+// UserSecurity represents the wrapper CustomerX509 struct
+type UserSecurity struct {
+	CustomerX509 CustomerX509 `json:"customerX509,omitempty"` // CustomerX509 represents Customer-managed X.509 configuration for an Atlas project.
+}
+
+// CustomerX509 represents Customer-managed X.509 configuration for an Atlas project.
+type CustomerX509 struct {
+	Cas string `json:"cas,omitempty"` // PEM string containing one or more customer CAs for database user authentication.
+}
+
+// CreateUserCertificate generates an Atlas-managed X.509 certificate for a MongoDB user that authenticates using X.509 certificates.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration-create-certificate/
+func (s *X509AuthDBUsersServiceOp) CreateUserCertificate(ctx context.Context, groupID, username string, monthsUntilExpiration int) (*UserCertificate, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if username == "" {
+		return nil, nil, NewArgError("username", "must be set")
+	}
+	if monthsUntilExpiration == 0 {
+		return nil, nil, NewArgError("monthsUntilExpiration", "must be set")
+	}
+
+	userCertificate := &UserCertificate{
+		MonthsUntilExpiration: monthsUntilExpiration,
+	}
+
+	path := fmt.Sprintf(x509AuthDBUsersPath, groupID, username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, userCertificate)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var cer bytes.Buffer
+	resp, err := s.client.Do(ctx, req, &cer)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	userCertificate.Username = username
+	userCertificate.Certificate = cer.String()
+
+	return userCertificate, resp, err
+}
+
+// GetUserCertificates gets a list of all Atlas-managed, unexpired certificates for a user.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-certificates/
+func (s *X509AuthDBUsersServiceOp) GetUserCertificates(ctx context.Context, groupID, username string) ([]UserCertificate, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if username == "" {
+		return nil, nil, NewArgError("username", "must be set")
+	}
+
+	path := fmt.Sprintf(x509AuthDBUsersPath, groupID, username)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UserCertificates)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Results, resp, err
+}
+
+// SaveConfiguration saves a customer-managed X.509 configuration for an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration-save/
+func (s *X509AuthDBUsersServiceOp) SaveConfiguration(ctx context.Context, groupID string, customerX509 *CustomerX509) (*CustomerX509, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if customerX509 == nil {
+		return nil, nil, NewArgError("customerX509", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(x509CustomerAuthDBUserPath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, &UserSecurity{CustomerX509: *customerX509})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UserSecurity)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &root.CustomerX509, resp, err
+}
+
+// GetCurrentX509Conf gets the current customer-managed X.509 configuration details for an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-current/
+func (s *X509AuthDBUsersServiceOp) GetCurrentX509Conf(ctx context.Context, groupID string) (*CustomerX509, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(x509CustomerAuthDBUserPath, groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(UserSecurity)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &root.CustomerX509, resp, err
+}
+
+// DisableCustomerX509 clears customer-managed X.509 settings on a project. This disables customer-managed X.509.
+// See more: https://docs.atlas.mongodb.com/reference/api/x509-configuration-disable-advanced/
+func (s *X509AuthDBUsersServiceOp) DisableCustomerX509(ctx context.Context, groupID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(x509CustomerAuthDBUserPath+"/customerX509", groupID)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/mitchellh/hashstructure
 github.com/mitchellh/mapstructure
 # github.com/mitchellh/reflectwalk v1.0.0
 github.com/mitchellh/reflectwalk
-# github.com/mongodb/go-client-mongodb-atlas v0.1.3-0.20200124011041-e364211a87d6 => ../go-client-mongodb-atlas
+# github.com/mongodb/go-client-mongodb-atlas v0.1.4-0.20200206183950-6d73c8e570f5
 github.com/mongodb/go-client-mongodb-atlas/mongodbatlas
 # github.com/mwielbut/pointy v1.1.0
 github.com/mwielbut/pointy

--- a/website/docs/d/x509_authentication_database_user.html.markdown
+++ b/website/docs/d/x509_authentication_database_user.html.markdown
@@ -1,0 +1,97 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: x509_authentication_database_user"
+sidebar_current: "docs-mongodbatlas-datasource-x509-authentication-database-user"
+description: |-
+    Describes a Custom DB Role.
+---
+
+# mongodbatlas_x509_authentication_database_user
+
+`mongodbatlas_x509_authentication_database_user` describe a X509 Authentication Database User. This represents a X509 Authentication Database User.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+## Example Usages
+
+### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user
+```hcl
+resource "mongodbatlas_database_user" "user" {
+  project_id    = "<PROJECT-ID>"
+  username      = "myUsername"
+  x509_type     = "MANAGED"
+  database_name = "$external"
+
+  roles {
+    role_name     = "atlasAdmin"
+    database_name = "admin"
+  }
+
+  labels {
+    key   = "My Key"
+    value = "My Value"
+  }
+}
+
+resource "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id              = "${mongodbatlas_database_user.user.project_id}"
+  username                = "${mongodbatlas_database_user.user.username}"
+  months_until_expiration = 2
+}
+
+data "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+  username   = "${mongodbatlas_x509_authentication_database_user.test.username}"
+}
+```
+
+### Example Usage: Save a customer-managed X.509 configuration for an Atlas project
+```hcl
+resource "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id        = "<PROJECT-ID>"
+  customer_x509_cas = <<-EOT
+    -----BEGIN CERTIFICATE-----
+    MIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC
+    VVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl
+    c3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG
+    SIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy
+    MDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF
+    VGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV
+    BAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp
+    c3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+    iQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr
+    cURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O
+    Fh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG
+    SIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA
+    7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A
+    iul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz
+    -----END CERTIFICATE-----"
+  EOT
+}
+
+data "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) Identifier for the Atlas project associated with the X.509 configuration.
+* `username` - (Optional) Username of the database user to create a certificate for.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `current_certificate` - Contains the last X.509 certificate and private key created for a database user.
+
+  #### Certificates
+* `certificates` - Array of objects where each details one unexpired database user certificate.
+
+* `certificates.#.id` - Serial number of this certificate.
+* `certificates.#.created_at` - Timestamp in ISO 8601 date and time format in UTC when Atlas created this X.509 certificate.
+* `certificates.#.group_id` - Unique identifier of the Atlas project to which this certificate belongs.
+* `certificates.#.not_after` - Timestamp in ISO 8601 date and time format in UTC when this certificate expires.
+* `certificates.#.subject` - Fully distinguished name of the database user to which this certificate belongs. To learn more, see RFC 2253.
+
+
+See [MongoDB Atlas - X509 User Certificates](https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-certificates/) and [MongoDB Atlas - Current X509 Configuratuion](https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-current/) Documentation for more information.

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -1,0 +1,111 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: x509_authentication_database_user"
+sidebar_current: "docs-mongodbatlas-resource-x509-authentication-database-user"
+description: |-
+    Provides a X509 Authentication Database User resource.
+---
+
+# mongodbatlas_x509_authentication_database_user
+
+`mongodbatlas_x509_authentication_database_user` provides a X509 Authentication Database User resource. The mongodbatlas_x509_authentication_database_user resource lets you manage MongoDB users who authenticate using X.509 certificates. You can manage these X.509 certificates or let Atlas do it for you.
+
+| Management  | Description  |
+|---|---|
+| Atlas  | Atlas manages your Certificate Authority and can generate certificates for your MongoDB users. No additional X.509 configuration is required.  |
+| Customer  |  You must provide a Certificate Authority and generate certificates for your MongoDB users. |
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+## Example Usages
+
+### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user
+```hcl
+resource "mongodbatlas_database_user" "user" {
+  project_id    = "<PROJECT-ID>"
+  username      = "myUsername"
+  x509_type     = "MANAGED"
+  database_name = "$external"
+
+  roles {
+    role_name     = "atlasAdmin"
+    database_name = "admin"
+  }
+
+  labels {
+    key   = "My Key"
+    value = "My Value"
+  }
+}
+
+resource "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id              = "${mongodbatlas_database_user.user.project_id}"
+  username                = "${mongodbatlas_database_user.user.username}"
+  months_until_expiration = 2
+}
+```
+
+### Example Usage: Save a customer-managed X.509 configuration for an Atlas project
+```hcl
+resource "mongodbatlas_x509_authentication_database_user" "test" {
+  project_id        = "<PROJECT-ID>"
+  customer_x509_cas = <<-EOT
+    -----BEGIN CERTIFICATE-----
+    MIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC
+    VVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl
+    c3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG
+    SIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy
+    MDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF
+    VGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV
+    BAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp
+    c3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+    iQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr
+    cURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O
+    Fh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG
+    SIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA
+    7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A
+    iul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz
+    -----END CERTIFICATE-----"
+  EOT
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) Identifier for the Atlas project associated with the X.509 configuration.
+* `months_until_expiration` - (Required) A number of months that the created certificate is valid for before expiry, up to 24 months. By default is 3.
+* `username` - (Optional) Username of the database user to create a certificate for.
+* `customer_x509_cas` - (Optional) PEM string containing one or more customer CAs for database user authentication.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `current_certificate` - Contains the last X.509 certificate and private key created for a database user.
+
+  #### Certificates
+* `certificates` - Array of objects where each details one unexpired database user certificate.
+
+* `certificates.#.id` - Serial number of this certificate.
+* `certificates.#.created_at` - Timestamp in ISO 8601 date and time format in UTC when Atlas created this X.509 certificate.
+* `certificates.#.group_id` - Unique identifier of the Atlas project to which this certificate belongs.
+* `certificates.#.not_after` - Timestamp in ISO 8601 date and time format in UTC when this certificate expires.
+* `certificates.#.subject` - Fully distinguished name of the database user to which this certificate belongs. To learn more, see RFC 2253.
+
+## Import
+
+X.509 Certificates for a User can be imported using project ID and username, in the format `project_id-username`, e.g.
+
+```
+$ terraform import mongodbatlas_x509_authentication_database_user.test 1112222b3bf99403840e8934-myUsername
+```
+
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-certificates/)
+
+
+Current X.509 Configuration can be imported using project ID, in the format `project_id`, e.g.
+
+```
+$ terraform import mongodbatlas_x509_authentication_database_user.test 1112222b3bf99403840e8934
+```
+
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/x509-configuration-get-certificates/)


### PR DESCRIPTION
Added:

* mongodbatlas_x509_authentication_database_user resource.
* mongodbatlas_x509_authentication_database_user resource acceptance testing.
* mongodbatlas_x509_authentication_database_user resource website documentation.
* mongodbatlas_x509_authentication_database_user data source.
* mongodbatlas_x509_authentication_database_user data source acceptance testing.
* mongodbatlas_x509_authentication_database_user data source website documentation.

## Example Usages

### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user
```hcl
resource "mongodbatlas_database_user" "user" {
  project_id    = "<PROJECT-ID>"
  username      = "myUsername"
  x509_type     = "MANAGED"
  database_name = "$external"

  roles {
    role_name     = "atlasAdmin"
    database_name = "admin"
  }

  labels {
    key   = "My Key"
    value = "My Value"
  }
}

resource "mongodbatlas_x509_authentication_database_user" "test" {
  project_id              = "${mongodbatlas_database_user.user.project_id}"
  username                = "${mongodbatlas_database_user.user.username}"
  months_until_expiration = 2
}

data "mongodbatlas_x509_authentication_database_user" "test" {
  project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
  username   = "${mongodbatlas_x509_authentication_database_user.test.username}"
}
```

### Example Usage: Save a customer-managed X.509 configuration for an Atlas project
```hcl
resource "mongodbatlas_x509_authentication_database_user" "test" {
  project_id        = "<PROJECT-ID>"
# The following certificate can be used for testing
  customer_x509_cas = <<-EOT
    -----BEGIN CERTIFICATE-----
    MIICmTCCAgICCQDZnHzklxsT9TANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC
    VVMxDjAMBgNVBAgMBVRleGFzMQ8wDQYDVQQHDAZBdXN0aW4xETAPBgNVBAoMCHRl
    c3QuY29tMQ0wCwYDVQQLDARUZXN0MREwDwYDVQQDDAh0ZXN0LmNvbTErMCkGCSqG
    SIb3DQEJARYcbWVsaXNzYS5wbHVua2V0dEBtb25nb2RiLmNvbTAeFw0yMDAyMDQy
    MDQ2MDFaFw0yMTAyMDMyMDQ2MDFaMIGQMQswCQYDVQQGEwJVUzEOMAwGA1UECAwF
    VGV4YXMxDzANBgNVBAcMBkF1c3RpbjERMA8GA1UECgwIdGVzdC5jb20xDTALBgNV
    BAsMBFRlc3QxETAPBgNVBAMMCHRlc3QuY29tMSswKQYJKoZIhvcNAQkBFhxtZWxp
    c3NhLnBsdW5rZXR0QG1vbmdvZGIuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
    iQKBgQCf1LRqr1zftzdYx2Aj9G76tb0noMPtj6faGLlPji1+m6Rn7RWD9L0ntWAr
    cURxvypa9jZ9MXFzDtLevvd3tHEmfrUT3ukNDX6+Jtc4kWm+Dh2A70Pd+deKZ2/O
    Fh8audEKAESGXnTbeJCeQa1XKlIkjqQHBNwES5h1b9vJtFoLJwIDAQABMA0GCSqG
    SIb3DQEBCwUAA4GBADMUncjEPV/MiZUcVNGmktP6BPmEqMXQWUDpdGW2+Tg2JtUA
    7MMILtepBkFzLO+GlpZxeAlXO0wxiNgEmCRONgh4+t2w3e7a8GFijYQ99FHrAC5A
    iul59bdl18gVqXia1Yeq/iK7Ohfy/Jwd7Hsm530elwkM/ZEkYDjBlZSXYdyz
    -----END CERTIFICATE-----"
  EOT
}

data "mongodbatlas_x509_authentication_database_user" "test" {
  project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
}
```