### PR TITLE
Project data source

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -66,7 +66,7 @@ func dataSourceMongoDBAtlasProjectRead(d *schema.ResourceData, meta interface{})
 	projectID, projectIDOk := d.GetOk("project_id")
 	name, nameOk := d.GetOk("name")
 	if !projectIDOk && !nameOk {
-		return errors.New("one of project_id or name must be configured")
+		return errors.New("either project_id or name must be configured")
 	}
 
 	var err error

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -2,6 +2,7 @@ package mongodbatlas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -14,8 +15,14 @@ func dataSourceMongoDBAtlasProject() *schema.Resource {
 		Read: dataSourceMongoDBAtlasProjectRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"project_id"},
 			},
 			"org_id": {
 				Type:     schema.TypeString,
@@ -55,29 +62,41 @@ func dataSourceMongoDBAtlasProject() *schema.Resource {
 func dataSourceMongoDBAtlasProjectRead(d *schema.ResourceData, meta interface{}) error {
 	//Get client connection.
 	conn := meta.(*matlas.Client)
-	projectID := d.Get("project_id").(string)
 
-	project, _, err := conn.Projects.GetOneProject(context.Background(), projectID)
+	projectID, projectIDOk := d.GetOk("project_id")
+	name, nameOk := d.GetOk("name")
+	if !projectIDOk && !nameOk {
+		return errors.New("one of project_id or name must be configured")
+	}
+
+	var err error
+	var project *matlas.Project
+
+	if projectIDOk {
+		project, _, err = conn.Projects.GetOneProject(context.Background(), projectID.(string))
+	} else {
+		project, _, err = conn.Projects.GetOneProjectByName(context.Background(), name.(string))
+	}
 	if err != nil {
 		return fmt.Errorf(errorProjectRead, projectID, err)
 	}
 
-	teams, _, err := conn.Projects.GetProjectTeamsAssigned(context.Background(), projectID)
+	teams, _, err := conn.Projects.GetProjectTeamsAssigned(context.Background(), project.ID)
 	if err != nil {
 		return fmt.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
 	if err := d.Set("org_id", project.OrgID); err != nil {
-		return fmt.Errorf(errorProjectSetting, `org_id`, projectID, err)
+		return fmt.Errorf(errorProjectSetting, `org_id`, project.ID, err)
 	}
 	if err := d.Set("cluster_count", project.ClusterCount); err != nil {
-		return fmt.Errorf(errorProjectSetting, `clusterCount`, projectID, err)
+		return fmt.Errorf(errorProjectSetting, `clusterCount`, project.ID, err)
 	}
 	if err := d.Set("created", project.Created); err != nil {
-		return fmt.Errorf(errorProjectSetting, `created`, projectID, err)
+		return fmt.Errorf(errorProjectSetting, `created`, project.ID, err)
 	}
 	if err := d.Set("teams", flattenTeams(teams)); err != nil {
-		return fmt.Errorf(errorProjectSetting, `teams`, projectID, err)
+		return fmt.Errorf(errorProjectSetting, `teams`, project.ID, err)
 	}
 
 	d.SetId(project.ID)

--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -10,7 +10,7 @@ import (
 	matlas "github.com/mongodb/go-client-mongodb-atlas/mongodbatlas"
 )
 
-func TestAccDataSourceMongoDBAtlasProject_basic(t *testing.T) {
+func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 
 	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -20,7 +20,7 @@ func TestAccDataSourceMongoDBAtlasProject_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectConfigWithDS(projectName, orgID,
+				Config: testAccMongoDBAtlasProjectConfigWithDSByID(projectName, orgID,
 					[]*matlas.ProjectTeam{
 						{
 							TeamID:    "5e0fa8c99ccf641c722fe683",
@@ -41,12 +41,53 @@ func TestAccDataSourceMongoDBAtlasProject_basic(t *testing.T) {
 	})
 }
 
-func testAccMongoDBAtlasProjectConfigWithDS(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
+
+	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithDSByName(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    "5e0fa8c99ccf641c722fe683",
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+							TeamID:    "5e1dd7b4f2a30ba80a70cd3a",
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasProjectConfigWithDSByID(projectName, orgID string, teams []*matlas.ProjectTeam) string {
 	return fmt.Sprintf(`
 		%s
 
 		data "mongodbatlas_project" "test" {
 			project_id = "${mongodbatlas_project.test.id}"
+		}
+	`, testAccMongoDBAtlasPropjectConfig(projectName, orgID, teams))
+}
+
+func testAccMongoDBAtlasProjectConfigWithDSByName(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+	return fmt.Sprintf(`
+		%s
+
+		data "mongodbatlas_project" "test" {
+			name = "${mongodbatlas_project.test.name}"
 		}
 	`, testAccMongoDBAtlasPropjectConfig(projectName, orgID, teams))
 }

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
-## Examples Usage
+## Example Usage
 
 ### Using project_id attribute to query
 ```hcl
@@ -63,7 +63,7 @@ data "mongodbatlas_project" "test" {
 * `project_id` - (Optional) The unique ID for the project.
 * `name` - (Optional) The unique ID for the project.
 
-~> **IMPORTANT:** One of the `project_id` or `name` must be configurated.
+~> **IMPORTANT:** Either `project_id` or `name` must be configurated.
 
 ## Attributes Reference
 

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -12,8 +12,9 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
-## Example Usage
+## Examples Usage
 
+### Using project_id attribute to query
 ```hcl
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
@@ -35,9 +36,34 @@ data "mongodbatlas_project" "test" {
 }
 ```
 
+### Using name attribute to query
+```hcl
+resource "mongodbatlas_project" "test" {
+  name   = "project-name"
+  org_id = "<ORG_ID>"
+
+  teams {
+    team_id    = "5e0fa8c99ccf641c722fe645"
+    role_names = ["GROUP_OWNER"]
+
+  }
+  teams {
+    team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
+    role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
+  }
+}
+
+data "mongodbatlas_project" "test" {
+  name = "${mongodbatlas_project.test.name}"
+}
+```
+
 ## Argument Reference
 
-* `project_id` - The unique ID for the project.
+* `project_id` - (Optional) The unique ID for the project.
+* `name` - (Optional) The unique ID for the project.
+
+~> **IMPORTANT:** One of the `project_id` or `name` must be configurated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added:

- The `name` and `project_id` can be used in the data source to query, but one of both must be configurated.
- A test case was added using the name attribute.
- The documentation was changed adding the `name` attribute.

### Example Usage
#### Using project_id attribute to query
```hcl
resource "mongodbatlas_project" "test" {
  name   = "project-name"
  org_id = "<ORG_ID>"

  teams {
    team_id    = "5e0fa8c99ccf641c722fe645"
    role_names = ["GROUP_OWNER"]

  }
  teams {
    team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
    role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
  }
}

data "mongodbatlas_project" "test" {
  project_id = "${mongodbatlas_project.test.id}"
}
```

#### Using name attribute to query
```hcl
resource "mongodbatlas_project" "test" {
  name   = "project-name"
  org_id = "<ORG_ID>"

  teams {
    team_id    = "5e0fa8c99ccf641c722fe645"
    role_names = ["GROUP_OWNER"]

  }
  teams {
    team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
    role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
  }
}

data "mongodbatlas_project" "test" {
  name = "${mongodbatlas_project.test.name}"
}
```


closes #140 