### PR TITLE
Added field container_id in resource cluster

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -237,6 +237,10 @@ func dataSourceMongoDBAtlasCluster() *schema.Resource {
 				},
 			},
 			"snapshot_backup_policy": computedCloudProviderSnapshotBackupPolicySchema(),
+			"container_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/mongodbatlas/data_source_mongodbatlas_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters.go
@@ -244,6 +244,10 @@ func dataSourceMongoDBAtlasClusters() *schema.Resource {
 							},
 						},
 						"snapshot_backup_policy": computedCloudProviderSnapshotBackupPolicySchema(),
+						"container_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -502,12 +502,12 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	var containerId string
-	if providerName == "AZURE"{
+	if providerName == "AZURE" {
 		if v, ok := d.GetOk("container_id"); ok {
 			containerId = v.(string)
 			_, res, err := conn.Containers.Get(context.Background(), projectID, containerId)
 			if err != nil {
-				if res.StatusCode == 404 {//Container doesn't exists
+				if res.StatusCode == 404 { //Container doesn't exists
 					options := &matlas.ContainersListOptions{
 						ProviderName: providerName,
 					}
@@ -527,7 +527,7 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 						return fmt.Errorf(errorContainerDelete, decodeStateID(d.Id())["container_id"], err)
 					}
 					containers := containersResp.([]matlas.Container)
-					if len(containers) > 0{
+					if len(containers) > 0 {
 						containerId = containers[0].ID
 					}
 				}
@@ -654,7 +654,9 @@ func resourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf(errorClusterSetting, "labels", clusterName, err)
 	}
 
-	d.Set("container_id", ids["container_id"])
+	if err := d.Set("container_id", ids["container_id"]); err != nil {
+		return fmt.Errorf(errorClusterSetting, "container_id", clusterName, err)
+	}
 
 	/*
 		Get the advaced configuration options and set up to the terraform state

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -620,7 +620,7 @@ func resourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf(errorClusterSetting, "labels", clusterName, err)
 	}
 
-	if providerName == "AZURE" {
+	if providerName == "AZURE" || providerName == "AWS" {
 		options := &matlas.ContainersListOptions{
 			ProviderName: providerName,
 		}
@@ -631,7 +631,9 @@ func resourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{}) e
 
 		if len(containers) != 0 {
 			for _, container := range containers {
-				if container.ProviderName == "AZURE" && container.Region == cluster.ProviderSettings.RegionName {
+				if container.ProviderName == providerName &&
+					container.Region == cluster.ProviderSettings.RegionName || // For Azure
+					container.RegionName == cluster.ProviderSettings.RegionName { // For AWS
 					if err := d.Set("container_id", container.ID); err != nil {
 						return fmt.Errorf(errorClusterSetting, "container_id", clusterName, err)
 					}

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -359,7 +359,6 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"snapshot_backup_policy": computedCloudProviderSnapshotBackupPolicySchema(),
 			"container_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -467,6 +467,40 @@ func TestAccResourceMongoDBAtlasCluster_withGCPNetworkPeering(t *testing.T) {
 	})
 }
 
+func TestAccResourceMongoDBAtlasClusterContainerId_withAzureNetworkPeering(t *testing.T) {
+	var cluster matlas.Cluster
+
+	resourceName := "mongodbatlas_cluster.test"
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	directoryID := os.Getenv("AZURE_DIRECTORY_ID")
+	subcrptionID := os.Getenv("AZURE_SUBCRIPTION_ID")
+	resourceGroupName := os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+	vNetName := os.Getenv("AZURE_VNET_NAME")
+	providerName := "AZURE"
+	region := os.Getenv("AZURE_REGION")
+
+	atlasCidrBlock := "192.168.208.0/21"
+	clusterName := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); checkPeeringEnvAzure(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceMongoDBAtlasCluster_importBasic(t *testing.T) {
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 

--- a/mongodbatlas/resource_mongodbatlas_network_container.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container.go
@@ -304,3 +304,28 @@ func resourceNetworkContainerRefreshFunc(d *schema.ResourceData, client *matlas.
 		return 42, "deleted", nil
 	}
 }
+
+func resourceListNetworkContainerRefreshFunc(d *schema.ResourceData, client *matlas.Client, originaList []matlas.Container) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ids := decodeStateID(d.Id())
+		projectID := ids["project_id"]
+		providerName := ids["provider_name"]
+		options := &matlas.ContainersListOptions{
+			ProviderName: providerName,
+		}
+
+		var err error
+		containers, res, err := client.Containers.List(context.Background(), projectID, options)
+		if err != nil {
+			if res.StatusCode == 404 {
+				return 42, "deleted", nil
+			}
+			return nil, "", err
+		}
+		if len(containers) == len(originaList) {
+			return nil, "same", nil
+		}
+
+		return containers, "different", nil
+	}
+}

--- a/mongodbatlas/resource_mongodbatlas_network_container.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container.go
@@ -304,28 +304,3 @@ func resourceNetworkContainerRefreshFunc(d *schema.ResourceData, client *matlas.
 		return 42, "deleted", nil
 	}
 }
-
-func resourceListNetworkContainerRefreshFunc(d *schema.ResourceData, client *matlas.Client, originaList []matlas.Container) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		ids := decodeStateID(d.Id())
-		projectID := ids["project_id"]
-		providerName := ids["provider_name"]
-		options := &matlas.ContainersListOptions{
-			ProviderName: providerName,
-		}
-
-		var err error
-		containers, res, err := client.Containers.List(context.Background(), projectID, options)
-		if err != nil {
-			if res.StatusCode == 404 {
-				return 42, "deleted", nil
-			}
-			return nil, "", err
-		}
-		if len(containers) == len(originaList) {
-			return nil, "same", nil
-		}
-
-		return containers, "different", nil
-	}
-}

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -102,7 +102,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `replication_specs` - Configuration for cluster regions.  See [Replication Spec](#replication-spec) below for more details.
 
-
+* `container_id` - The Network Peering Container ID.
 
 ### BI Connector
 

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -103,6 +103,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `replication_specs` - Configuration for cluster regions.  See [Replication Spec](#replication-spec) below for more details.
 
+* `container_id` - The Network Peering Container ID.
+
 
 
 ### BI Connector

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -355,6 +355,7 @@ In addition to all arguments above, the following attributes are exported:
     - `connection_strings.aws_private_link_srv` - [Private-endpoint-aware](https://docs.atlas.mongodb.com/security-private-endpoint/#private-endpoint-connection-strings) mongodb+srv://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a AWS PrivateLink connection to this cluster. Use this URI format if your driver supports it. If it doesn’t, use connectionStrings.awsPrivateLink.
     - `connection_strings.private` -   [Network-peering-endpoint-aware](https://docs.atlas.mongodb.com/security-vpc-peering/#vpc-peering) mongodb://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a network peering connection to this cluster.
     - `connection_strings.private_srv` -  [Network-peering-endpoint-aware](https://docs.atlas.mongodb.com/security-vpc-peering/#vpc-peering) mongodb+srv://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a network peering connection to this cluster.
+* `container_id` - The Network Peering Container ID.
 
     To review the connection string format, see the connection string format documentation. To add MongoDB users to a Atlas project, see Configure MongoDB Users.
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -355,7 +355,7 @@ In addition to all arguments above, the following attributes are exported:
     - `connection_strings.aws_private_link_srv` - [Private-endpoint-aware](https://docs.atlas.mongodb.com/security-private-endpoint/#private-endpoint-connection-strings) mongodb+srv://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a AWS PrivateLink connection to this cluster. Use this URI format if your driver supports it. If it doesn’t, use connectionStrings.awsPrivateLink.
     - `connection_strings.private` -   [Network-peering-endpoint-aware](https://docs.atlas.mongodb.com/security-vpc-peering/#vpc-peering) mongodb://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a network peering connection to this cluster.
     - `connection_strings.private_srv` -  [Network-peering-endpoint-aware](https://docs.atlas.mongodb.com/security-vpc-peering/#vpc-peering) mongodb+srv://connection strings for each interface VPC endpoint you configured to connect to this cluster. Returned only if you created a network peering connection to this cluster.
-* `container_id` - The Network Peering Container ID.
+* `container_id` - The Network Peering Container ID. The id of the container either created programmatically by the user before any clusters existed in the project or when the first cluster in the region (AWS/Azure) or project (GCP) was created.
 
     To review the connection string format, see the connection string format documentation. To add MongoDB users to a Atlas project, see Configure MongoDB Users.
 


### PR DESCRIPTION
- Added field in schema of cluster called `container_id` in resource cluster
- Show `container_id` in cluster state when needed and if is `AZURE` as provider name

Now we can use it as the following configuration when the cluster is created first and let it creates the container automatically to retrieve the `container_id` in the cluster and be used for the peering connection.

## AWS
```hcl
resource "mongodbatlas_cluster" "test" {
  project_id   = local.project_id
  name         = "terraform-test"
  disk_size_gb = 5

  replication_factor           = 3
  auto_scaling_disk_gb_enabled = false
  mongo_db_major_version       = "4.0"

  //Provider Settings "block"
  provider_name               = "AWS"
  provider_instance_size_name = "M10"
  provider_region_name        = "US_EAST_2"
}

resource "aws_default_vpc" "default" {
  tags = {
    Name = "Default VPC"
  }
}

resource "mongodbatlas_network_peering" "mongo_peer" {
  accepter_region_name   = "us-east-2"
  project_id             = local.project_id
  container_id           = mongodbatlas_cluster.test.container_id
  provider_name          = "AWS"
  route_table_cidr_block = "172.31.0.0/16"
  vpc_id                 = aws_default_vpc.default.id
  aws_account_id         = local.AWS_ACCOUNT_ID
}

resource "aws_vpc_peering_connection_accepter" "aws_peer" {
  vpc_peering_connection_id = mongodbatlas_network_peering.mongo_peer.connection_id
  auto_accept               = true

  tags = {
    Side = "Accepter"
  }
}
```

## AZURE
```hcl
resource "mongodbatlas_cluster" "test" {
  project_id = local.project_id
  name       = "terraform-test"
  num_shards = 1

  replication_factor           = 3
  auto_scaling_disk_gb_enabled = false
  mongo_db_major_version       = "4.0"

  //Provider Settings "block"
  provider_name               = "AZURE"
  provider_instance_size_name = "M10"
  provider_region_name        = "US_EAST_2"
}

resource "mongodbatlas_network_peering" "test" {
  project_id            = local.project_id
  atlas_cidr_block      = "192.168.0.0/21"
  container_id          = mongodbatlas_cluster.test.container_id
  provider_name         = "AZURE"
  azure_directory_id    = local.AZURE_DIRECTORY_ID
  azure_subscription_id = local.AZURE_SUBCRIPTION_ID
  resource_group_name   = local.AZURE_RESOURSE_GROUP_NAME
  vnet_name             = local.AZURE_VNET_NAME
}
```
## GCP
```hcl
resource "mongodbatlas_cluster" "test" {
  project_id   = local.project_id
  name         = "terraform-manually-test"
  num_shards   = 1
  disk_size_gb = 5

  replication_factor           = 3
  auto_scaling_disk_gb_enabled = true
  mongo_db_major_version       = "4.0"

  //Provider Settings "block"
  provider_name               = "GCP"
  provider_instance_size_name = "M10"
  provider_region_name        = "US_EAST_2"
}

resource "mongodbatlas_network_peering" "test" {
  project_id       = "${local.project_id}"
  atlas_cidr_block = "192.168.0.0/18"

  container_id   = mongodbatlas_cluster.test.container_id
  provider_name  = "GCP"
  gcp_project_id = local.GCP_PROJECT_ID
  network_name   = "default"
}

data "google_compute_network" "default" {
  name = "default"
}

resource "google_compute_network_peering" "peering" {
  name         = "peering-gcp-terraform-test"
  network      = data.google_compute_network.default.self_link
  peer_network = "https://www.googleapis.com/compute/v1/projects/${mongodbatlas_network_peering.test.atlas_gcp_project_id}/global/networks/${mongodbatlas_network_peering.test.atlas_vpc_name}"
}
```