### PR TITLE
fix: fixed DatabaseUserID to allows names with multiple dashes

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user_test.go
@@ -167,7 +167,7 @@ func TestAccResourceMongoDBAtlasDatabaseUser_WithLabels(t *testing.T) {
 func TestAccResourceMongoDBAtlasDatabaseUser_importBasic(t *testing.T) {
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 
-	username := fmt.Sprintf("test_username_%s", acctest.RandString(5))
+	username := fmt.Sprintf("test-username-%s", acctest.RandString(5))
 	resourceName := "mongodbatlas_database_user.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -177,6 +177,14 @@ func TestAccResourceMongoDBAtlasDatabaseUser_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasDatabaseUserConfig(projectID, "read", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "roles.0.role_name", "read"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
 			},
 			{
 				ResourceName:            resourceName,


### PR DESCRIPTION
Added
- Changes to fix the import function when the username has multiple dashes
- Test case validating the above fix

We can import it using multiple dashes e.g:

```bash
$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my-user-name-admin
```

closes #179 