### PR TITLE
Update network_peering.html.markdown

### DIFF
--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -82,8 +82,6 @@ resource "mongodbatlas_network_container" "test" {
 
 resource "mongodbatlas_network_peering" "test" {
   project_id       = "${local.project_id}"
-  atlas_cidr_block = "192.168.0.0/18"
-
   container_id   = "${mongodbatlas_network_container.test.container_id}"
   provider_name  = "GCP"
   gcp_project_id = "${local.GCP_PROJECT_ID}"


### PR DESCRIPTION
remove un-needed parameter from the GCP example - checked at https://docs.atlas.mongodb.com/reference/api/vpc-create-peering-connection/ and https://github.com/terraform-providers/terraform-provider-mongodbatlas/blob/master/mongodbatlas/resource_mongodbatlas_network_peering_test.go