### PR TITLE
Fix #228: Changes to mongodbatlas_database_user.role.collection_name are ignored

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -54,7 +54,7 @@ func resourceMongoDBAtlasDatabaseUser() *schema.Resource {
 				Default:  "NONE",
 			},
 			"roles": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -286,9 +286,9 @@ func splitDatabaseUserImportID(ID string) (*string, *string, *string, error) {
 func expandRoles(d *schema.ResourceData) []matlas.Role {
 	var roles []matlas.Role
 	if v, ok := d.GetOk("roles"); ok {
-		if rs := v.([]interface{}); len(rs) > 0 {
-			roles = make([]matlas.Role, len(rs))
-			for k, r := range rs {
+		if rs := v.(*schema.Set); rs.Len() > 0 {
+			roles = make([]matlas.Role, rs.Len())
+			for k, r := range rs.List() {
 				roleMap := r.(map[string]interface{})
 				roles[k] = matlas.Role{
 					RoleName:       roleMap["role_name"].(string),
@@ -301,8 +301,8 @@ func expandRoles(d *schema.ResourceData) []matlas.Role {
 	return roles
 }
 
-func flattenRoles(roles []matlas.Role) []map[string]interface{} {
-	roleList := make([]map[string]interface{}, 0)
+func flattenRoles(roles []matlas.Role) []interface{} {
+	roleList := make([]interface{}, 0)
 	for _, v := range roles {
 		roleList = append(roleList, map[string]interface{}{
 			"role_name":       v.RoleName,

--- a/mongodbatlas/resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user_test.go
@@ -385,7 +385,6 @@ func testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectID, roleName, userna
 }
 
 func testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectID string, rolesArr []*matlas.Role) string {
-
 	var roles string
 	for _, role := range rolesArr {
 		var roleName, databaseName, collection string


### PR DESCRIPTION
## Description
Changed the type of roles attribute to typeset to be able to manage the roles the best way of avoiding terraform issues. Also, added a test case to verify the issue.

Link to any related issue(s): #228 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

Let me know if you have another comment or concern, thanks