### PR TITLE
fixes #210: Issues with advanced_configuration section on mongodbatlas_cluster

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -45,6 +45,14 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceMongoDBAtlasClusterImportState,
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceMongoDBAtlasClusterResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceMongoDBAtlasClusterStateUpgradeV0,
+				Version: 0,
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -308,9 +316,10 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 				Computed: true,
 			},
 			"advanced_configuration": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"fail_index_key_too_long": {
@@ -490,7 +499,7 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 
 	// We need to validate the oplog_size_mb attr of the advanced configuration option to show the error
 	// before that the cluster is created
-	if oplogSizeMB, ok := d.GetOk("advanced_configuration.oplog_size_mb"); ok {
+	if oplogSizeMB, ok := d.GetOk("advanced_configuration.0.oplog_size_mb"); ok {
 		if cast.ToInt64(oplogSizeMB) <= 0 {
 			return fmt.Errorf("`advanced_configuration.oplog_size_mb` cannot be <= 0")
 		}
@@ -572,12 +581,15 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 		the advanced configuration option to attach it
 	*/
 	ac, ok := d.GetOk("advanced_configuration")
-	advancedConfReq := expandProcessArgs(ac.(map[string]interface{}))
-	if ok {
-		_, _, err := conn.Clusters.UpdateProcessArgs(context.Background(), projectID, cluster.Name, advancedConfReq)
-		if err != nil {
-			return fmt.Errorf(errorAdvancedConfUpdate, cluster.Name, err)
+	if aclist, ok1 := ac.([]interface{}); ok1 && len(aclist) > 0 {
+		advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
+		if ok {
+			_, _, err := conn.Clusters.UpdateProcessArgs(context.Background(), projectID, cluster.Name, advancedConfReq)
+			if err != nil {
+				return fmt.Errorf(errorAdvancedConfUpdate, cluster.Name, err)
+			}
 		}
+
 	}
 
 	d.SetId(encodeStateID(map[string]string{
@@ -878,12 +890,14 @@ func resourceMongoDBAtlasClusterUpdate(d *schema.ResourceData, meta interface{})
 		Check if advaced configuration option has a changes to update it
 	*/
 	if d.HasChange("advanced_configuration") {
-		advancedConfReq := expandProcessArgs(d.Get("advanced_configuration").(map[string]interface{}))
-
-		if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
-			_, _, err := conn.Clusters.UpdateProcessArgs(context.Background(), projectID, clusterName, advancedConfReq)
-			if err != nil {
-				return fmt.Errorf(errorAdvancedConfUpdate, clusterName, err)
+		ac := d.Get("advanced_configuration")
+		if aclist, ok1 := ac.([]interface{}); ok1 && len(aclist) > 0 {
+			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
+			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
+				_, _, err := conn.Clusters.UpdateProcessArgs(context.Background(), projectID, clusterName, advancedConfReq)
+				if err != nil {
+					return fmt.Errorf(errorAdvancedConfUpdate, clusterName, err)
+				}
 			}
 		}
 	}
@@ -1126,32 +1140,47 @@ func flattenRegionsConfig(regionsConfig map[string]matlas.RegionsConfig) []map[s
 	return regions
 }
 
-func expandProcessArgs(p map[string]interface{}) *matlas.ProcessArgs {
-	res := &matlas.ProcessArgs{
-		FailIndexKeyTooLong:              pointy.Bool(cast.ToBool(p["fail_index_key_too_long"])),
-		JavascriptEnabled:                pointy.Bool(cast.ToBool(p["javascript_enabled"])),
-		MinimumEnabledTLSProtocol:        cast.ToString(p["minimum_enabled_tls_protocol"]),
-		NoTableScan:                      pointy.Bool(cast.ToBool(p["no_table_scan"])),
-		SampleSizeBIConnector:            pointy.Int64(cast.ToInt64(p["sample_size_bi_connector"])),
-		SampleRefreshIntervalBIConnector: pointy.Int64(cast.ToInt64(p["sample_refresh_interval_bi_connector"])),
+func expandProcessArgs(d *schema.ResourceData, p map[string]interface{}) *matlas.ProcessArgs {
+	res := &matlas.ProcessArgs{}
+	if _, ok := d.GetOk("advanced_configuration.0.fail_index_key_too_long"); ok {
+		res.FailIndexKeyTooLong = pointy.Bool(cast.ToBool(p["fail_index_key_too_long"]))
 	}
-	if sizeMB := cast.ToInt64(p["oplog_size_mb"]); sizeMB != 0 {
-		res.OplogSizeMB = pointy.Int64(cast.ToInt64(p["oplog_size_mb"]))
-	} else {
-		log.Printf(errorClusterSetting, `oplog_size_mb`, "", cast.ToString(sizeMB))
+	if _, ok := d.GetOk("advanced_configuration.0.javascript_enabled"); ok {
+		res.JavascriptEnabled = pointy.Bool(cast.ToBool(p["javascript_enabled"]))
+	}
+	if _, ok := d.GetOk("advanced_configuration.0.minimum_enabled_tls_protocol"); ok {
+		res.MinimumEnabledTLSProtocol = cast.ToString(p["minimum_enabled_tls_protocol"])
+	}
+	if _, ok := d.GetOk("advanced_configuration.0.no_table_scan"); ok {
+		res.NoTableScan = pointy.Bool(cast.ToBool(p["no_table_scan"]))
+	}
+	if _, ok := d.GetOk("advanced_configuration.0.sample_size_bi_connector"); ok {
+		res.SampleSizeBIConnector = pointy.Int64(cast.ToInt64(p["sample_size_bi_connector"]))
+	}
+	if _, ok := d.GetOk("advanced_configuration.0.sample_refresh_interval_bi_connector"); ok {
+		res.SampleRefreshIntervalBIConnector = pointy.Int64(cast.ToInt64(p["sample_refresh_interval_bi_connector"]))
+	}
+	if _, ok := d.GetOk("advanced_configuration.0.oplog_size_mb"); ok {
+		if sizeMB := cast.ToInt64(p["oplog_size_mb"]); sizeMB != 0 {
+			res.OplogSizeMB = pointy.Int64(cast.ToInt64(p["oplog_size_mb"]))
+		} else {
+			log.Printf(errorClusterSetting, `oplog_size_mb`, "", cast.ToString(sizeMB))
+		}
 	}
 	return res
 }
 
-func flattenProcessArgs(p *matlas.ProcessArgs) map[string]interface{} {
-	return map[string]interface{}{
-		"fail_index_key_too_long":              cast.ToString(*p.FailIndexKeyTooLong),
-		"javascript_enabled":                   cast.ToString(*p.JavascriptEnabled),
-		"minimum_enabled_tls_protocol":         cast.ToString(p.MinimumEnabledTLSProtocol),
-		"no_table_scan":                        cast.ToString(*p.NoTableScan),
-		"oplog_size_mb":                        cast.ToString(p.OplogSizeMB),
-		"sample_size_bi_connector":             cast.ToString(p.SampleSizeBIConnector),
-		"sample_refresh_interval_bi_connector": cast.ToString(p.SampleRefreshIntervalBIConnector),
+func flattenProcessArgs(p *matlas.ProcessArgs) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"fail_index_key_too_long":              *p.FailIndexKeyTooLong,
+			"javascript_enabled":                   *p.JavascriptEnabled,
+			"minimum_enabled_tls_protocol":         p.MinimumEnabledTLSProtocol,
+			"no_table_scan":                        *p.NoTableScan,
+			"oplog_size_mb":                        p.OplogSizeMB,
+			"sample_size_bi_connector":             p.SampleSizeBIConnector,
+			"sample_refresh_interval_bi_connector": p.SampleRefreshIntervalBIConnector,
+		},
 	}
 }
 

--- a/mongodbatlas/resource_mongodbatlas_cluster_migrate.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_migrate.go
@@ -1,0 +1,340 @@
+package mongodbatlas
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceMongoDBAtlasClusterResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_scaling_disk_gb_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"backup_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"bi_connector": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"read_preference": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"connection_strings": {
+				Type:     schema.TypeList,
+				MinItems: 1,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"standard": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"standard_srv": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"aws_private_link": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"aws_private_link_srv": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"private": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_srv": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"disk_size_gb": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Computed: true,
+			},
+			"encryption_at_rest_provider": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mongo_db_major_version": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				StateFunc: formatMongoDBMajorVersion,
+			},
+			"num_shards": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
+			"provider_backup_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"provider_instance_size_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"provider_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"pit_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"backing_provider_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_disk_iops": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_disk_type_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_encrypt_ebs_volume": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_region_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"provider_volume_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"replication_factor": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"replication_specs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"num_shards": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"regions_config": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"region_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"electable_nodes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"priority": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"read_only_nodes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  0,
+									},
+									"analytics_nodes": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  0,
+									},
+								},
+							},
+						},
+						"zone_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "ZoneName managed by Terraform",
+						},
+					},
+				},
+			},
+			"mongo_db_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri_updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongo_uri_with_options": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"paused": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"srv_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"advanced_configuration": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fail_index_key_too_long": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"javascript_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"minimum_enabled_tls_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"no_table_scan": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"oplog_size_mb": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"sample_size_bi_connector": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"sample_refresh_interval_bi_connector": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"labels": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(m["key"].(string))
+					buf.WriteString(m["value"].(string))
+					return hashcode.String(buf.String())
+				},
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"snapshot_backup_policy": computedCloudProviderSnapshotBackupPolicySchema(),
+		},
+	}
+}
+
+func resourceMongoDBAtlasClusterStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Println("[INFO] Found MongoDB Cluser state v0; migrating to v1")
+	rawState = migrateAdvancedConfiguration(rawState)
+
+	return rawState, nil
+}
+
+func migrateAdvancedConfiguration(rawState map[string]interface{}) map[string]interface{} {
+	rawState["advanced_configuration"] = []interface{}{}
+	return rawState
+}

--- a/mongodbatlas/resource_mongodbatlas_cluster_migration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_migration_test.go
@@ -1,0 +1,123 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccMongoDBAtlasClusterMigrateState_empty_advancedConfig(t *testing.T) {
+	v0State := map[string]interface{}{
+		"project_id":                  "test-id",
+		"name":                        "test-cluster",
+		"provider_instance_size_name": "M10",
+		"provider_name":               "AWS",
+		"replication_specs": []interface{}{
+			map[string]interface{}{
+				"num_shards": 1,
+			},
+		},
+		"advanced_configuration": map[string]interface{}{},
+	}
+
+	v0Config := terraform.NewResourceConfigRaw(v0State)
+	warns, errs := resourceMongoDBAtlasClusterResourceV0().Validate(v0Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		t.Error("test precondition failed - invalid mongodb cluster v0 config")
+		return
+	}
+
+	//test migrate function
+	v1State := migrateAdvancedConfiguration(v0State)
+
+	v1Config := terraform.NewResourceConfigRaw(v1State)
+	warns, errs = resourceMongoDBAtlasCluster().Validate(v1Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		fmt.Println(warns, errs)
+		t.Error("migrated cluster advanced config is invalid")
+		return
+	}
+}
+
+func TestAccMongoDBAtlasClusterMigrateState_with_advancedConfig(t *testing.T) {
+	v0State := map[string]interface{}{
+		"project_id":                  "test-id",
+		"name":                        "test-cluster",
+		"provider_instance_size_name": "M10",
+		"provider_name":               "AWS",
+		"replication_specs": []interface{}{
+			map[string]interface{}{
+				"num_shards": 1,
+			},
+		},
+		"advanced_configuration": map[string]interface{}{
+			"fail_index_key_too_long":              "true",
+			"javascript_enabled":                   "true",
+			"minimum_enabled_tls_protocol":         "TLS1_2",
+			"no_table_scan":                        "false",
+			"oplog_size_mb":                        "1000",
+			"sample_refresh_interval_bi_connector": "310",
+			"sample_size_bi_connector":             "110",
+		},
+	}
+
+	v0Config := terraform.NewResourceConfigRaw(v0State)
+	warns, errs := resourceMongoDBAtlasClusterResourceV0().Validate(v0Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		t.Error("test precondition failed - invalid mongodb cluster v0 config")
+		return
+	}
+
+	//test migrate function
+	v1State := migrateAdvancedConfiguration(v0State)
+
+	v1Config := terraform.NewResourceConfigRaw(v1State)
+	warns, errs = resourceMongoDBAtlasCluster().Validate(v1Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		fmt.Println(warns, errs)
+		t.Error("migrated cluster advanced config is invalid")
+		return
+	}
+}
+
+func TestAccMongoDBAtlasClusterMigrateState_with_defaultAdvancedConfig_v0_5_1(t *testing.T) {
+	v0State := map[string]interface{}{
+		"project_id":                  "test-id",
+		"name":                        "test-cluster",
+		"provider_instance_size_name": "M10",
+		"provider_name":               "AWS",
+		"replication_specs": []interface{}{
+			map[string]interface{}{
+				"num_shards": 1,
+			},
+		},
+		"advanced_configuration": map[string]interface{}{
+			"fail_index_key_too_long":              "true",
+			"javascript_enabled":                   "true",
+			"minimum_enabled_tls_protocol":         "TLS1_2",
+			"no_table_scan":                        "false",
+			"oplog_size_mb":                        "",
+			"sample_refresh_interval_bi_connector": "",
+			"sample_size_bi_connector":             "",
+		},
+	}
+
+	v0Config := terraform.NewResourceConfigRaw(v0State)
+	warns, errs := resourceMongoDBAtlasClusterResourceV0().Validate(v0Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		t.Error("test precondition failed - invalid mongodb cluster v0 config")
+		return
+	}
+
+	//test migrate function
+	v1State := migrateAdvancedConfiguration(v0State)
+
+	v1Config := terraform.NewResourceConfigRaw(v1State)
+	warns, errs = resourceMongoDBAtlasCluster().Validate(v1Config)
+	if len(warns) > 0 || len(errs) > 0 {
+		fmt.Println(warns, errs)
+		t.Error("migrated cluster advanced config is invalid")
+		return
+	}
+}

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -102,6 +102,59 @@ func TestAccResourceMongoDBAtlasCluster_basicAWS_instanceScale(t *testing.T) {
 		},
 	})
 }
+func TestAccResourceMongoDBAtlasCluster_basic_Partial_AdvancedConf(t *testing.T) {
+	var cluster matlas.Cluster
+
+	resourceName := "mongodbatlas_cluster.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	name := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, "false", &matlas.ProcessArgs{
+					FailIndexKeyTooLong:              pointy.Bool(true),
+					JavascriptEnabled:                pointy.Bool(true),
+					MinimumEnabledTLSProtocol:        "TLS1_1",
+					NoTableScan:                      pointy.Bool(false),
+					OplogSizeMB:                      pointy.Int64(1000),
+					SampleRefreshIntervalBIConnector: pointy.Int64(310),
+					SampleSizeBIConnector:            pointy.Int64(110),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, "false", &matlas.ProcessArgs{
+					MinimumEnabledTLSProtocol: "TLS1_2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccResourceMongoDBAtlasCluster_basicAdvancedConf(t *testing.T) {
 	var cluster matlas.Cluster
@@ -128,18 +181,17 @@ func TestAccResourceMongoDBAtlasCluster_basicAdvancedConf(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.fail_index_key_too_long", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.minimum_enabled_tls_protocol", "TLS1_2"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.no_table_scan", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.oplog_size_mb", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.sample_size_bi_connector", "110"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.sample_refresh_interval_bi_connector", "310"),
-					resource.TestCheckResourceAttrSet(resourceName, "advanced_configuration.%"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, "true", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              pointy.Bool(false),
 					JavascriptEnabled:                pointy.Bool(false),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -151,14 +203,13 @@ func TestAccResourceMongoDBAtlasCluster_basicAdvancedConf(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.fail_index_key_too_long", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.javascript_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.minimum_enabled_tls_protocol", "TLS1_1"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.no_table_scan", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.oplog_size_mb", "990"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.sample_size_bi_connector", "0"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.sample_refresh_interval_bi_connector", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "advanced_configuration.%"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "990"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "0"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "0"),
 				),
 			},
 		},
@@ -812,15 +863,15 @@ func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, backupEnab
 	`, projectID, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, backupEnabled string, p *matlas.ProcessArgs) string {
+func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, AutoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%s"
 			name         = "%s"
 			disk_size_gb = 10
 			replication_factor           = 3
-			backup_enabled               = %s
-			auto_scaling_disk_gb_enabled = true
+			backup_enabled               = false 
+			auto_scaling_disk_gb_enabled =  %s
 			mongo_db_major_version       = "4.0"
 
 			// Provider Settings "block"
@@ -830,7 +881,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, backupEnabled
 			provider_instance_size_name = "M10"
 			provider_region_name        = "EU_CENTRAL_1"
 
-			advanced_configuration = {
+			advanced_configuration  {
 				fail_index_key_too_long              = %t
 				javascript_enabled                   = %t
 				minimum_enabled_tls_protocol         = "%s"
@@ -840,9 +891,33 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, backupEnabled
 				sample_refresh_interval_bi_connector = %d
 			}
 		}
-	`, projectID, name, backupEnabled,
+	`, projectID, name, AutoscalingEnabled,
 		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
 		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector)
+}
+func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, AutoscalingEnabled string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = "%s"
+			name         = "%s"
+			disk_size_gb = 10
+			replication_factor           = 3
+			backup_enabled               = false 
+			auto_scaling_disk_gb_enabled =  %s
+			mongo_db_major_version       = "4.0"
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_disk_iops          = 100
+			provider_encrypt_ebs_volume = false
+			provider_instance_size_name = "M10"
+			provider_region_name        = "EU_CENTRAL_1"
+
+			advanced_configuration {
+				minimum_enabled_tls_protocol         = "%s"
+			}
+		}
+	`, projectID, name, AutoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
 func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled string) string {

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -327,11 +327,13 @@ Physical location of the region.
 
 -> **NOTE:** Prior to setting these options please ensure you read https://docs.atlas.mongodb.com/cluster-config/additional-options/.
 
+-> **NOTE:** This argument has been changed to type list make sure you have the proper syntax. The list can have only one  item maximum.
+
 Include **desired options** within advanced_configuration:
 
 ```hcl
 // Nest options within advanced_configuration
- advanced_configuration = {
+ advanced_configuration {
    javascript_enabled                   = false
    minimum_enabled_tls_protocol         = "TLS1_2"
  }


### PR DESCRIPTION
fixes #210 Issues with advanced_configuration section on mongodbatlas_cluster Opt2
This is option 2:
Based on some testing, research and some conversation with @marinsalinas and @PacoDw  :

Since the migration process happens before a state change (on refresh or on apply) using the new binary. All the arguments of advanced_configuration are [computed/optional](https://github.com/terraform-providers/terraform-provider-mongodbatlas/pull/238/files#diff-104ff45c049e7dbfb15899b74adb243dL296-R338)  meaning that these values will be retrieved from the API after state migration.

Link to any related issue(s): 
closes: https://github.com/terraform-providers/terraform-provider-mongodbatlas/issues/210

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments