### PR TITLE
fix: fixes #53 accepter_region_name not required for AWS on read/import/update

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_network_peering_test.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -129,6 +130,69 @@ func TestAccResourceMongoDBAtlasNetworkPeering_basicGCP(t *testing.T) {
 	})
 }
 
+func TestAccResourceMongoDBAtlasNetworkPeering_AWSDifferentRegionName(t *testing.T) {
+	var (
+		peer                  matlas.Peer
+		resourcePeerName      = "mongodbatlas_network_peering.diff_region"
+		resourceContainerName = "mongodbatlas_network_container.test"
+		projectID             = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		vpcID                 = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock          = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID          = os.Getenv("AWS_ACCOUNT_ID")
+		containerRegion       = "US_WEST_2"
+		peerRegion            = strings.ToLower(strings.ReplaceAll(os.Getenv("AWS_REGION"), "_", "-"))
+		providerName          = "AWS"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			checkPeeringEnvAWS(t)
+			func() {
+				if strings.EqualFold(containerRegion, peerRegion) {
+					t.Fatalf("the `AWS_REGION` (%s) must be different region than %s", peerRegion, containerRegion)
+				}
+			}()
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkPeeringConfigAWSWithDifferentRegionName(projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					// Peering test
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourcePeerName, &peer),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "accepter_region_name"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "container_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "route_table_cidr_block"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "aws_account_id"),
+
+					resource.TestCheckResourceAttr(resourcePeerName, "accepter_region_name", peerRegion),
+					resource.TestCheckResourceAttr(resourcePeerName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourcePeerName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourcePeerName, "route_table_cidr_block", vpcCIDRBlock),
+					resource.TestCheckResourceAttr(resourcePeerName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(resourcePeerName, "aws_account_id", awsAccountID),
+
+					// Container test
+					resource.TestCheckResourceAttrSet(resourceContainerName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "atlas_cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "region_name"),
+
+					resource.TestCheckResourceAttr(resourceContainerName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceContainerName, "atlas_cidr_block", "192.168.200.0/21"),
+					resource.TestCheckResourceAttr(resourceContainerName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceContainerName, "region_name", containerRegion),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -247,4 +311,25 @@ func testAccMongoDBAtlasNetworkPeeringConfigGCP(projectID, providerName, gcpProj
 			network_name   = "%[4]s"
 		}
 	`, projectID, providerName, gcpProjectID, networkName)
+}
+
+func testAccMongoDBAtlasNetworkPeeringConfigAWSWithDifferentRegionName(projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.200.0/21"
+			provider_name		  = "%[2]s"
+			region_name			  = "%[3]s"
+		}
+
+		resource "mongodbatlas_network_peering" "diff_region" {
+			accepter_region_name	  = "%[4]s"
+			project_id    			    = "%[1]s"
+			container_id            = mongodbatlas_network_container.test.container_id
+			provider_name           = "%[2]s"
+			route_table_cidr_block  = "%[5]s"
+			vpc_id					        = "%[6]s"
+			aws_account_id	        = "%[7]s"
+		}
+	`, projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID)
 }


### PR DESCRIPTION
WIP DON'T MERGE

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 
closes: https://github.com/terraform-providers/terraform-provider-mongodbatlas/issues/53

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the MongoDB CLA
- [ ] I have read the Terraform contribution guidelines 
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments