### PR TITLE
fix: fix golangci lint and travis

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,7 +98,7 @@ issues:
         - testpackage
       # part of the golangci govet package is picking up things that go vet doesn't. Seems flaky, shutting that specific error off
 
-        # Exclude some staticcheck messages
+    # Exclude some staticcheck messages
     - linters:
       - staticcheck
       text: "SA1019:" # d.GetOkExists is deprecated: usage is discouraged due to undefined behaviors and may be removed in a future version of the SDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,20 @@
-dist: xenial
-sudo: required
-services:
-  - docker
 language: go
 
-env:
-  global:
-    GOFLAGS=-mod=vendor
-    GOGC=10
-    GOOPTS="-p 2"
+go:
+  - 1.14.x
+  - tip
+
 matrix:
   fast_finish: true
   allow_failures:
     - go: tip
   include:
-  - go: "1.14.x"
-    name: "Code Lint"
-    script: make lint
-  - go: "1.14.x"
-    name: "Code UnitTest"
-    script: make test
-  - go: "1.14.x"
-    name: "Website"
-    script:
-      #- make website-test #commented until Terraform Provider Program Validation
-      - make website-lint
-
-install:
-- make tools
+    - name: "Code Lint"
+      before_install: make tools
+      script: make lint
+    - name: "Website"
+      before_install: make tools
+      script:
+        #- make website-test #commented until Terraform Provider Program Validation
+        - make website-lint
+script: make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,11 +3,18 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=mongodbatlas
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 
+GOFLAGS=-mod=vendor
+GOGC=10
+GOOPTS="-p 2"
+
+GOLANGCI_VERSION=v1.29.0
+
+export PATH := ./bin:$(PATH)
+
 default: build
 
 build: fmtcheck
 	go install
-
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
@@ -29,12 +36,14 @@ websitefmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	# https://github.com/golangci/golangci-lint/issues/337 fixing error
-	golangci-lint run ./$(PKG_NAME) -v --deadline=30m
+	golangci-lint run ./$(PKG_NAME)
 
-tools:
+tools:  ## Install dev tools
+	@echo "==> Installing dependencies..."
 	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
+
+check: test lint
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -62,4 +71,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc fmt fmtcheck lint tools test-compile website website-lint website-test
+.PHONY: build test testacc fmt fmtcheck lint check tools test-compile website website-lint website-test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,8 @@ websitefmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./$(PKG_NAME)
+	# https://github.com/golangci/golangci-lint/issues/337 fixing error
+	golangci-lint run ./$(PKG_NAME) -v --deadline=30m
 
 tools:  ## Install dev tools
 	@echo "==> Installing dependencies..."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MongoDB Atlas Provider
+[![Build Status](https://travis-ci.org/terraform-providers/terraform-provider-mongodbatlas.svg?branch=master)](https://travis-ci.org/terraform-providers/terraform-provider-mongodbatlas)
 
 This is the repository for the Terraform MongoDB Atlas Provider, which allows one to use Terraform with MongoDB's Database as a Service offering, Atlas.
 Learn more about Atlas at  [https://www.mongodb.com/cloud/atlas](https://www.mongodb.com/cloud/atlas)

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1017,7 +1017,7 @@ func flattenBiConnector(biConnector *matlas.BiConnector) map[string]interface{} 
 }
 
 func getInstanceSizeToInt(instanceSize string) int {
-	regex := regexp.MustCompile("[0-9]+")
+	regex := regexp.MustCompile(`\d+`)
 	num := regex.FindString(instanceSize)
 
 	return cast.ToInt(num) // if the string is empty it always return 0

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role.go
@@ -37,7 +37,7 @@ func resourceMongoDBAtlasCustomDBRole() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`[\w\d-]+`), "`role_name` can contain only letters, digits, underscores, and dashes"),
+					validation.StringMatch(regexp.MustCompile(`[\w-]+`), "`role_name` can contain only letters, digits, underscores, and dashes"),
 					func(v interface{}, k string) (ws []string, es []error) {
 						value := v.(string)
 						if strings.HasPrefix(value, "x-gen") {

--- a/tools.go
+++ b/tools.go
@@ -3,6 +3,4 @@
 package main
 
 import (
-	_ "github.com/client9/misspell/cmd/misspell"
-	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-)
+	_ "github.com/client9/misspell/cmd/misspell")

--- a/tools.go
+++ b/tools.go
@@ -3,4 +3,5 @@
 package main
 
 import (
-	_ "github.com/client9/misspell/cmd/misspell")
+	_ "github.com/client9/misspell/cmd/misspell"
+)


### PR DESCRIPTION
## Description

golangci-lint should not be installed from source,[ their docs advice against it ](https://golangci-lint.run/usage/install/#install-from-source), this seems to be failing already on travis on a separate PR

I'm also fixing some linting errors flagged now by the tool

And also simplifying how travis is configured, some of the travis fixes I'm bringing them from the go client repo


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

Some linting errors where flagged around how some regex could be simplified, I'm relaying on unit testing of the functions to catch a the regex from breaking