### PR TITLE
Improvement for 503 error response while creating a cluster

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -557,7 +557,7 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING"},
+		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING"},
 		Target:     []string{"IDLE"},
 		Refresh:    resourceClusterRefreshFunc(d.Get("name").(string), projectID, conn),
 		Timeout:    3 * time.Hour,
@@ -1266,6 +1266,9 @@ func resourceClusterRefreshFunc(name, projectID string, client *matlas.Client) r
 		} else if err != nil {
 			if resp.StatusCode == 404 {
 				return "", "DELETED", nil
+			}
+			if resp.StatusCode == 503 {
+				return "", "PENDING", nil
 			}
 			return nil, "", err
 		}


### PR DESCRIPTION
added validation for 503 response error and keep trying for CREATE a cluster

## Description

Added a validation where it gets 503 response error and keeps trying

Link to any related issue(s): 
#256 
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the MongoDB CLA
- [ ] I have read the Terraform contribution guidelines 
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
