### PR TITLE
Fix #277: mongodbatlas_team data provider team_id null after successful API query

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_team_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_team_test.go
@@ -7,17 +7,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
-	var team matlas.Team
-
-	resourceName := "data.mongodbatlas_teams.test"
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
-
-	name := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-	username := "mongodbatlas.testing@gmail.com"
+	var (
+		dataSourseName = "data.mongodbatlas_teams.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		username       = "mongodbatlas.testing@gmail.com"
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,12 +25,10 @@ func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceMongoDBAtlasTeamConfig(orgID, name, username),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasTeamExists(resourceName, &team),
-					testAccCheckMongoDBAtlasTeamAttributes(&team, name),
-					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "team_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourseName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourseName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourseName, "name", name),
+					resource.TestCheckResourceAttr(dataSourseName, "usernames.#", "1"),
 				),
 			},
 		},
@@ -40,13 +36,12 @@ func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
 }
 
 func TestAccDataSourceMongoDBAtlasTeamByName_basic(t *testing.T) {
-	var team matlas.Team
-
-	resourceName := "data.mongodbatlas_teams.test"
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
-
-	name := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-	username := "mongodbatlas.testing@gmail.com"
+	var (
+		dataSourseName = "data.mongodbatlas_teams.test2"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		username       = "mongodbatlas.testing@gmail.com"
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -56,12 +51,10 @@ func TestAccDataSourceMongoDBAtlasTeamByName_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceMongoDBAtlasTeamConfigByName(orgID, name, username),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasTeamExists(resourceName, &team),
-					testAccCheckMongoDBAtlasTeamAttributes(&team, name),
-					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "team_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourseName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourseName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourseName, "name", name),
+					resource.TestCheckResourceAttr(dataSourseName, "usernames.#", "1"),
 				),
 			},
 		},

--- a/mongodbatlas/data_source_mongodbatlas_team_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_team_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
 	var (
-		dataSourseName = "data.mongodbatlas_teams.test"
+		dataSourceName = "data.mongodbatlas_teams.test"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 		username       = "mongodbatlas.testing@gmail.com"
@@ -25,10 +25,10 @@ func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceMongoDBAtlasTeamConfig(orgID, name, username),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourseName, "org_id"),
-					resource.TestCheckResourceAttrSet(dataSourseName, "team_id"),
-					resource.TestCheckResourceAttr(dataSourseName, "name", name),
-					resource.TestCheckResourceAttr(dataSourseName, "usernames.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
 				),
 			},
 		},
@@ -37,7 +37,7 @@ func TestAccDataSourceMongoDBAtlasTeam_basic(t *testing.T) {
 
 func TestAccDataSourceMongoDBAtlasTeamByName_basic(t *testing.T) {
 	var (
-		dataSourseName = "data.mongodbatlas_teams.test2"
+		dataSourceName = "data.mongodbatlas_teams.test2"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 		username       = "mongodbatlas.testing@gmail.com"
@@ -51,10 +51,10 @@ func TestAccDataSourceMongoDBAtlasTeamByName_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceMongoDBAtlasTeamConfigByName(orgID, name, username),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourseName, "org_id"),
-					resource.TestCheckResourceAttrSet(dataSourseName, "team_id"),
-					resource.TestCheckResourceAttr(dataSourseName, "name", name),
-					resource.TestCheckResourceAttr(dataSourseName, "usernames.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
 				),
 			},
 		},

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -92,8 +92,16 @@ func TestAccResourceMongoDBAtlasTeam_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckMongoDBAtlasTeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasTeamConfig(orgID, name,
-					[]string{"mongodbatlas.testing@gmail.com"},
+				Config: testAccMongoDBAtlasTeamConfig(orgID, name, []string{"mongodbatlas.testing@gmail.com"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "usernames.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "team_id"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
## Description

- It was set the missing computed attribute "teams_id"
- Improved test cases to validate it

Link to any related issue(s): #277

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

