### PR TITLE
Setting deterministic encoding id output, just sorting the keys

### DIFF
--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -102,8 +103,16 @@ func encodeStateID(values map[string]string) string {
 	encode := func(e string) string { return base64.StdEncoding.EncodeToString([]byte(e)) }
 	encodedValues := make([]string, 0)
 
-	for key, value := range values {
-		encodedValues = append(encodedValues, fmt.Sprintf("%s:%s", encode(key), encode(value)))
+	// sort to make sure the same encoding is returned in case of same input
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		encodedValues = append(encodedValues, fmt.Sprintf("%s:%s", encode(key), encode(values[key])))
 	}
 
 	return strings.Join(encodedValues, "-")

--- a/mongodbatlas/provider_test.go
+++ b/mongodbatlas/provider_test.go
@@ -161,10 +161,3 @@ func checkTeamsIds(t *testing.T) {
 		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must be set for Projects acceptance testing")
 	}
 }
-
-// SkipTestImport temporary solution to avoid error about failed verification, will solve later
-func SkipTestImport(t *testing.T) {
-	if strings.EqualFold(os.Getenv("SKIP_TEST_IMPORT"), "true") {
-		t.Skip()
-	}
-}

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
@@ -212,7 +212,6 @@ func TestAccResourceMongoDBAtlasAlertConfiguration_whitoutRoles(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasAlertConfiguration_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		resourceName = "mongodbatlas_alert_configuration.test"
@@ -238,7 +237,6 @@ func TestAccResourceMongoDBAtlasAlertConfiguration_importBasic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasAlertConfiguration_importConfigNotifications(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		resourceName = "mongodbatlas_alert_configuration.test"

--- a/mongodbatlas/resource_mongodbatlas_auditing_test.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing_test.go
@@ -64,7 +64,6 @@ func TestAccResourceMongoDBAtlasAuditing_basic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasAuditing_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		auditing     = &matlas.Auditing{}
 		resourceName = "mongodbatlas_auditing.test"

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
@@ -103,7 +103,6 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotBackupPolicy_withoutRestore
 }
 
 func TestAccResourceMongoDBAtlasCloudProviderSnapshotBackupPolicy_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_cloud_provider_snapshot_backup_policy.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -52,7 +52,6 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_basic(t *testing
 }
 
 func TestAccResourceMongoDBAtlasCloudProviderSnapshotRestoreJob_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName      = "mongodbatlas_cloud_provider_snapshot_restore_job.test"
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_test.go
@@ -45,7 +45,6 @@ func TestAccResourceMongoDBAtlasCloudProviderSnapshot_basic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCloudProviderSnapshot_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName    = "mongodbatlas_cloud_provider_snapshot.test"
 		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -765,7 +765,6 @@ func TestAccResourceMongoDBAtlasCluster_withAutoScalingAWS(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCluster_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_cluster.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
@@ -450,7 +450,6 @@ func TestAccResourceMongoDBAtlasCustomDBRoles_MultipleResources(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCustomDBRoles_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_custom_db_role.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user_test.go
@@ -292,7 +292,6 @@ func TestAccResourceMongoDBAtlasDatabaseUser_withRoles(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasDatabaseUser_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		username     = fmt.Sprintf("test-username-%s", acctest.RandString(5))
 		resourceName = "mongodbatlas_database_user.basic_ds"
@@ -327,7 +326,6 @@ func TestAccResourceMongoDBAtlasDatabaseUser_importBasic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasDatabaseUser_importX509TypeCustomer(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		dbUser       matlas.DatabaseUser
 		resourceName = "mongodbatlas_database_user.test"

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -74,7 +74,6 @@ func TestAccResourceMongoDBAtlasGlobalCluster_WithAWSCluster(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasGlobalCluster_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_global_cluster_config.config"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_maintenance_window_test.go
+++ b/mongodbatlas/resource_mongodbatlas_maintenance_window_test.go
@@ -65,7 +65,6 @@ func TestAccResourceMongoDBAtlasMaintenanceWindow_basic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasMaintenanceWindow_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		maintenance  matlas.MaintenanceWindow
 		resourceName = "mongodbatlas_maintenance_window.test"

--- a/mongodbatlas/resource_mongodbatlas_network_container_test.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container_test.go
@@ -140,7 +140,6 @@ func TestAccResourceMongoDBAtlasNetworkContainer_basicGCP(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasNetworkContainer_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		randInt      = acctest.RandIntRange(0, 255)
 		resourceName = "mongodbatlas_network_container.test"

--- a/mongodbatlas/resource_mongodbatlas_project_ip_whitelist_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_ip_whitelist_test.go
@@ -202,7 +202,6 @@ func TestAccResourceMongoDBAtlasProjectIPWhitelist_SettingMultiple(t *testing.T)
 }
 
 func TestAccResourceMongoDBAtlasProjectIPWhitelist_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
 	comment := fmt.Sprintf("TestAcc for ipaddres (%s)", ipAddress)

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -152,7 +152,6 @@ func TestAccResourceMongoDBAtlasProject_withUpdatedRole(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasProject_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		projectName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -80,7 +80,6 @@ func TestAccResourceMongoDBAtlasTeam_basic(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasTeam_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_teams.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
@@ -88,7 +88,6 @@ func TestAccResourceMongoDBAtlasX509AuthDBUser_WithCustomerX509(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasX509AuthDBUser_importBasic(t *testing.T) {
-	SkipTestImport(t)
 	var (
 		resourceName = "mongodbatlas_x509_authentication_database_user.test"
 		username     = os.Getenv("MONGODB_ATLAS_DB_USERNAME")


### PR DESCRIPTION
## Description

behaviour found by Edgar, sometimes the encodeStateID function generates a different ID with the same input.
This is given it encodes iterating over a map, and maps are unordered, the iteration sequence is not ensure.

So quick fix, sort the keys and access in that way to encode the ID. 

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
