### PR TITLE
Chore: Fix the ProviderVersion in the useragent string

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X mongodbatlas.ProviderVersion={{.Version}}'
+    - -s -w -X mongodbatlas/version.ProviderVersion={{.Version}}
   goos:
     - freebsd
     - windows

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ GOOPTS="-p 2"
 
 GITTAG=$(shell git describe --always --tags)
 VERSION=$(GITTAG:v%=%)
-LINKER_FLAGS="-X mongodbatlas/version.ProviderVersion=${VERSION}"
+LINKER_FLAGS=-X mongodbatlas/version.ProviderVersion=${VERSION}
 
 GOLANGCI_VERSION=v1.29.0
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,10 @@ GOFLAGS=-mod=vendor
 GOGC=10
 GOOPTS="-p 2"
 
+GITTAG=$(shell git describe --always --tags)
+VERSION=$(GITTAG:v%=%)
+LINKER_FLAGS="-X mongodbatlas/version.ProviderVersion=${VERSION}"
+
 GOLANGCI_VERSION=v1.29.0
 
 export PATH := ./bin:$(PATH)
@@ -14,13 +18,14 @@ export PATH := ./bin:$(PATH)
 default: build
 
 build: fmtcheck
-	go install
+	go install "$(LINKER_FLAGS)"
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -parallel 20 $(TESTARGS) -timeout 120m -cover
+	@$(eval VERSION=acc)
+	TF_ACC=1 go test $(TEST) -v -parallel 20 $(TESTARGS) -timeout 120m -cover "$(LINKER_FLAGS)"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,14 +18,14 @@ export PATH := ./bin:$(PATH)
 default: build
 
 build: fmtcheck
-	go install "$(LINKER_FLAGS)"
+	go install -ldflags="$(LINKER_FLAGS)"
 
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	@$(eval VERSION=acc)
-	TF_ACC=1 go test $(TEST) -v -parallel 20 $(TESTARGS) -timeout 120m -cover "$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(TEST) -v -parallel 20 $(TESTARGS) -timeout 120m -cover -ldflags="$(LINKER_FLAGS)"
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/mongodbatlas/version.go
+++ b/mongodbatlas/version.go
@@ -2,5 +2,5 @@ package mongodbatlas
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary
-	ProviderVersion = "dev"
+	ProviderVersion = "devel"
 )


### PR DESCRIPTION
## Description

The current implementation does not correctly set the Provider's version.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
