### PR TITLE
DB user creation error because bad encoding in path

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -124,7 +124,7 @@ func resourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interface
 			authDatabaseName = d.Get("auth_database_name").(string)
 		}
 	}
-	usernameEscaped := url.QueryEscape(username)
+	usernameEscaped := url.PathEscape(username)
 
 	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, usernameEscaped)
 	if err != nil {
@@ -221,7 +221,7 @@ func resourceMongoDBAtlasDatabaseUserUpdate(d *schema.ResourceData, meta interfa
 	username := ids["username"]
 	authDatabaseName := ids["auth_database_name"]
 
-	usernameEscaped := url.QueryEscape(username)
+	usernameEscaped := url.PathEscape(username)
 
 	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, usernameEscaped)
 	if err != nil {
@@ -256,7 +256,7 @@ func resourceMongoDBAtlasDatabaseUserDelete(d *schema.ResourceData, meta interfa
 	username := ids["username"]
 	authDatabaseName := ids["auth_database_name"]
 
-	usernameEscaped := url.QueryEscape(username)
+	usernameEscaped := url.PathEscape(username)
 
 	_, err := conn.DatabaseUsers.Delete(context.Background(), authDatabaseName, projectID, usernameEscaped)
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user_test.go
@@ -392,7 +392,7 @@ func testAccCheckMongoDBAtlasDatabaseUserExists(resourceName string, dbUser *mat
 		ids := decodeStateID(rs.Primary.ID)
 		username := ids["username"]
 
-		dbUsername := url.QueryEscape(username)
+		dbUsername := url.PathEscape(username)
 
 		if dbUserResp, _, err := conn.DatabaseUsers.Get(context.Background(), ids["auth_database_name"], ids["project_id"], dbUsername); err == nil {
 			*dbUser = *dbUserResp

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -32,8 +32,8 @@ func TestAccResourceMongoDBAtlasTeam_basic(t *testing.T) {
 				Config: testAccMongoDBAtlasTeamConfig(orgID, name,
 					[]string{
 						"mongodbatlas.testing@gmail.com",
-						"francisco.preciado@digitalonus.com",
 						"antonio.cabrera@digitalonus.com",
+						"marin.salinas@digitalonus.com",
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -64,7 +64,7 @@ func TestAccResourceMongoDBAtlasTeam_basic(t *testing.T) {
 					[]string{
 						"marin.salinas@digitalonus.com",
 						"mongodbatlas.testing@gmail.com",
-						"francisco.preciado@digitalonus.com",
+						"antonio.cabrera@digitalonus.com",
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
## Description

The issue of the regression is the way the net/url QueryEncode works in golang.
The username is used as an element of the url path, not for querying ?= , so replacing with the proper function.
quick [example](https://play.golang.org/p/dGJI8nZlOGV)

reported issue test https://github.com/mongodb/terraform-provider-mongodbatlas/issues/312
``` 
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # mongodbatlas_database_user.atlas["NodeJS-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-dev"] will be created
  + resource "mongodbatlas_database_user" "atlas" {
      + auth_database_name = "$external"
      + aws_iam_type       = "NONE"
      + id                 = (known after apply)
      + project_id         = "REDACTED"
      + username           = "C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-dev"
      + x509_type          = "CUSTOMER"

      + labels {
          + key   = (known after apply)
          + value = (known after apply)
        }

      + roles {
          + collection_name = (known after apply)
          + database_name   = "sample_geo"
          + role_name       = "readWrite"
        }
    }

  # mongodbatlas_database_user.atlas["Python-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-qa"] will be created
  + resource "mongodbatlas_database_user" "atlas" {
      + auth_database_name = "$external"
      + aws_iam_type       = "NONE"
      + id                 = (known after apply)
      + project_id         = "REDACTED"
      + username           = "C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-qa"
      + x509_type          = "CUSTOMER"

      + labels {
          + key   = (known after apply)
          + value = (known after apply)
        }

      + roles {
          + collection_name = (known after apply)
          + database_name   = "admin"
          + role_name       = "atlasAdmin"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mongodbatlas_database_user.atlas["Python-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-qa"]: Creating...
mongodbatlas_database_user.atlas["NodeJS-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-dev"]: Creating...
mongodbatlas_database_user.atlas["Python-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-qa"]: Creation complete after 0s [id=YXV0aF9kYXRhYmFzZV9uYW1l:JGV4dGVybmFs-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2-dXNlcm5hbWU=:Qz1VUyxTVD1DYWxpZm9ybmlhLEw9U2FudGFDbGFyYSxPPVBBTiBJbmMuLE9VPUFwcFNlcnZpY2VzLENOPWFwcHN2Yy1xYQ==]
mongodbatlas_database_user.atlas["NodeJS-C=US,ST=California,L=SantaClara,O=PAN Inc.,OU=AppServices,CN=appsvc-dev"]: Creation complete after 0s [id=YXV0aF9kYXRhYmFzZV9uYW1l:JGV4dGVybmFs-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2-dXNlcm5hbWU=:Qz1VUyxTVD1DYWxpZm9ybmlhLEw9U2FudGFDbGFyYSxPPVBBTiBJbmMuLE9VPUFwcFNlcnZpY2VzLENOPWFwcHN2Yy1kZXY=]
```



Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
