### PR TITLE
Add "Sensitive: true" for securing sensitive data in state

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -113,18 +113,18 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"api_token": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"channel_name": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"datadog_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"datadog_region": {
 							Type:     schema.TypeString,
@@ -143,9 +143,9 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Computed: true,
 						},
 						"flowdock_api_token": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"flow_name": {
 							Type:     schema.TypeString,
@@ -160,9 +160,9 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Computed: true,
 						},
 						"ops_genie_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"ops_genie_region": {
 							Type:     schema.TypeString,
@@ -173,9 +173,9 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Computed: true,
 						},
 						"service_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"sms_enabled": {
 							Type:     schema.TypeBool,
@@ -194,14 +194,14 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Computed: true,
 						},
 						"victor_ops_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"victor_ops_routing_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Computed: true,
+							Computed:  true,
 						},
 						"roles": {
 							Type:     schema.TypeList,

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -114,6 +114,7 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"api_token": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"channel_name": {
@@ -122,6 +123,7 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"datadog_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"datadog_region": {
@@ -142,6 +144,7 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"flowdock_api_token": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"flow_name": {
@@ -158,6 +161,7 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"ops_genie_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"ops_genie_region": {
@@ -170,6 +174,7 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"service_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"sms_enabled": {
@@ -190,10 +195,12 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"victor_ops_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"victor_ops_routing_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Computed: true,
 						},
 						"roles": {

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -169,6 +169,7 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"api_token": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"channel_name": {
@@ -177,6 +178,7 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"datadog_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"datadog_region": {
@@ -198,6 +200,7 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"flowdock_api_token": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"flow_name": {
@@ -214,6 +217,7 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"ops_genie_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"ops_genie_region": {
@@ -227,6 +231,7 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"service_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"sms_enabled": {
@@ -247,10 +252,12 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						},
 						"victor_ops_api_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"victor_ops_routing_key": {
 							Type:     schema.TypeString,
+							Sensitive: true,
 							Optional: true,
 						},
 						"roles": {

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -168,18 +168,18 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"api_token": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"channel_name": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"datadog_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"datadog_region": {
 							Type:         schema.TypeString,
@@ -199,9 +199,9 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Optional: true,
 						},
 						"flowdock_api_token": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"flow_name": {
 							Type:     schema.TypeString,
@@ -216,9 +216,9 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Optional: true,
 						},
 						"ops_genie_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"ops_genie_region": {
 							Type:         schema.TypeString,
@@ -230,9 +230,9 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Optional: true,
 						},
 						"service_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"sms_enabled": {
 							Type:     schema.TypeBool,
@@ -251,14 +251,14 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Optional: true,
 						},
 						"victor_ops_api_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"victor_ops_routing_key": {
-							Type:     schema.TypeString,
+							Type:      schema.TypeString,
 							Sensitive: true,
-							Optional: true,
+							Optional:  true,
 						},
 						"roles": {
 							Type:     schema.TypeList,


### PR DESCRIPTION
## Description
Access tokens and API keys are sensitive data that should be stored as sensitive data.
Therefore, I've added `Sensitive: true` for those fields in the `alert_configuration` data source and resource.

Thanks in advance.

See https://www.terraform.io/docs/state/sensitive-data.html for more details.

I can't find any link to sign the MongoDB CLA. Could you please tell me how I can sign it? Thanks.

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the MongoDB CLA
- [x] I have read the Terraform contribution guidelines 
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
