### PR TITLE
mongodbatlas_alert_configuration - reset ID if was deleted and it's already in the plan

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -307,6 +307,14 @@ func resourceMongoDBAtlasAlertConfigurationRead(d *schema.ResourceData, meta int
 
 	alert, _, err := conn.AlertConfigurations.GetAnAlertConfig(context.Background(), ids["project_id"], ids["id"])
 	if err != nil {
+		// deleted in the backend case
+		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
+
+		if reset {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorReadAlertConf, err)
 	}
 


### PR DESCRIPTION
## Description

Fix for https://github.com/mongodb/terraform-provider-mongodbatlas/issues/305
The root cause is that we were not handling the case where the resource was already created, and resetting the id, to allow terraform to mark it as an Add in the plan/apply  

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
