### PR TITLE
alertConfigs fix field update in terraform state

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -322,6 +322,10 @@ func resourceMongoDBAtlasAlertConfigurationRead(d *schema.ResourceData, meta int
 		return fmt.Errorf(errorAlertConfSetting, "alert_configuration_id", ids["id"], err)
 	}
 
+	if err := d.Set("event_type", alert.EventTypeName); err != nil {
+		return fmt.Errorf(errorAlertConfSetting, "event_type", ids["id"], err)
+	}
+
 	if err := d.Set("created", alert.Created); err != nil {
 		return fmt.Errorf(errorAlertConfSetting, "created", ids["id"], err)
 	}
@@ -365,8 +369,8 @@ func resourceMongoDBAtlasAlertConfigurationUpdate(d *schema.ResourceData, meta i
 		req.Enabled = pointy.Bool(d.Get("enabled").(bool))
 	}
 
-	if d.HasChange("event_type_name") {
-		req.EventTypeName = d.Get("event_type_name").(string)
+	if d.HasChange("event_type") {
+		req.EventTypeName = d.Get("event_type").(string)
 	}
 
 	if d.HasChange("metric_threshold") {


### PR DESCRIPTION
## Description

In comment @nikhil-mongo mentioned the plugin was not updating the eventTypeName, what happened there was a typo in the schema field name, then it does not find the change, and it was missing as well in the read section. 

`       created                = "2020-10-20T02:56:06Z"
        enabled                = true
      ~ event_type             = "CREDIT_CARD_ABOUT_TO_EXPIRE" -> "DAILY_BILL_OVER_THRESHOLD"
        id                     = "aWQ=:NWY4ZTRlYzhiNWE1YTkyNjk5YjQwYjVk-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2"
`
Link to any related issue(s):

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/305

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
