### PR TITLE
Fix update function for DB users

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -268,7 +268,7 @@ func resourceMongoDBAtlasDatabaseUserUpdate(d *schema.ResourceData, meta interfa
 		dbUser.Scopes = expandScopes(d)
 	}
 
-	_, _, err = conn.DatabaseUsers.Update(context.Background(), projectID, username, dbUser)
+	_, _, err = conn.DatabaseUsers.Update(context.Background(), projectID, usernameEscaped, dbUser)
 	if err != nil {
 		return fmt.Errorf("error updating database user(%s): %s", username, err)
 	}


### PR DESCRIPTION
The update function needs to use an escaped version as DB users can have slashes in their names.

## Description

While using the Terraform provider to manage IAM-based users, I ran into this error while updating a user in-place

```Error: error updating database user(arn:aws:iam::123456789012:role/role-name): PATCH https://cloud.mongodb.com/api/atlas/v1.0/groups/project-id/databaseUsers/$external/arn:aws:iam::123456789012:role/role-name: 404 (request "Not Found") Cannot find resource /api/atlas/v1.0/groups/project-id/databaseUsers/$external/arn:aws:iam::123456789012:role/role-name.```

I believe that this is because the `update` function of this resource uses the `usernameEscaped` variable in all locations except for the actual `update` call to the Atlas API, which is needed because it's a PATCH call with the username in the path. 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

I'd love to validate this fix on one of our own projects before going further, but I'm a little bit intimidated by the testing process. Any guidance on how best to test this (or if much testing is necessary in this case) would be much appreciated. 