### PR TITLE
INTMDB-142: Fixes the bug for alertconfiguration using data dog

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -593,7 +593,7 @@ func flattenAlertConfigurationNotifications(notifications []matlas.Notification)
 		nts[i] = map[string]interface{}{
 			"api_token":              notifications[i].APIToken,
 			"channel_name":           notifications[i].ChannelName,
-			"datadog_api_key":        notifications[i].DatadogRegion,
+			"datadog_api_key":        notifications[i].DatadogAPIKey,
 			"datadog_region":         notifications[i].DatadogRegion,
 			"delay_min":              notifications[i].DelayMin,
 			"email_address":          notifications[i].EmailAddress,


### PR DESCRIPTION
## Description

Fixes the bug of alert configuration using data dog by changing the name of struct.
Added acceptance tests for the case:
- `TestAccResourceMongoDBAtlasAlertConfiguration_DataDog`

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments