### PR TITLE
Fix database user resource broken indent

### DIFF
--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -82,9 +82,7 @@ resource "mongodbatlas_database_user" "test" {
 * `auth_database_name` - (Required) Database against which Atlas authenticates the user. A user must provide both a username and authentication database to log into MongoDB.
 Accepted values include:
   * `admin` if `x509_type` and `aws_iam_type` are omitted or NONE.
-  * `$external` if:
-    * `x509_type` is MANAGED or CUSTOMER, or
-    * `aws_iam_type` is USER or ROLE.
+  * `$external` if `x509_type` is MANAGED or CUSTOMER or `aws_iam_type` is USER or ROLE.
 * `project_id` - (Required) The unique ID for the project to create the database user.
 * `roles` - (Required) 	List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
 * `username` - (Required) Username for authenticating to MongoDB.


### PR DESCRIPTION
## Description

I fixed the broken indent for the `mongodb_database_user` resource document.
As you can see below, the indent level is wrong and a bit confusing.

![Screen Shot 2020-12-18 at 16 22 40](https://user-images.githubusercontent.com/23056537/102586332-4cb2b700-414d-11eb-92a6-8b2951b97abd.png)


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
