### PR TITLE
INTMDB-16: Added resource and datasource for Custom DNS Configuration for Atlas Clusters on AWS

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -1,0 +1,47 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func dataSourceMongoDBAtlasCustomDNSConfigurationAWS() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(d *schema.ResourceData, meta interface{}) error {
+	// Get client connection.
+	conn := meta.(*matlas.Client)
+
+	projectID := d.Get("project_id").(string)
+
+	customDNSSetting, _, err := conn.CustomAWSDNS.Get(context.Background(), projectID)
+	if err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationRead, err)
+	}
+
+	if err := d.Set("enabled", customDNSSetting.Enabled); err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationSetting, "enabled", projectID, err)
+	}
+
+	d.SetId(projectID)
+
+	return nil
+}

--- a/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
@@ -1,0 +1,42 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceMongoDBAtlasCustomDNSConfigurationAWS_basic(t *testing.T) {
+	resourceName := "data.mongodbatlas_custom_dns_configuration_cluster_aws.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(projectID string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id     = "%s"
+			enabled       = %t
+		}
+
+		data "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id      = mongodbatlas_custom_dns_configuration_cluster_aws.test.id
+		}
+	`, projectID, enabled)
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_third_party_integration":               dataSourceMongoDBAtlasThirdPartyIntegration(),
 			"mongodbatlas_project_ip_access_list":                dataSourceMongoDBAtlasProjectIPAccessList(),
 			"mongodbatlas_cloud_provider_access":                 dataSourceMongoDBAtlasCloudProviderAccessList(),
+			"mongodbatlas_custom_dns_configuration_cluster_aws":  dataSourceMongoDBAtlasCustomDNSConfigurationAWS(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -95,6 +96,7 @@ func Provider() terraform.ResourceProvider {
 			"mongodbatlas_third_party_integration":               resourceMongoDBAtlasThirdPartyIntegration(),
 			"mongodbatlas_project_ip_access_list":                resourceMongoDBAtlasProjectIPAccessList(),
 			"mongodbatlas_cloud_provider_access":                 resourceMongoDBAtlasCloudProviderAccess(),
+			"mongodbatlas_custom_dns_configuration_cluster_aws":  resourceMongoDBAtlasCustomDNSConfiguration(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -1,0 +1,102 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	errorCustomDNSConfigurationCreate  = "error creating custom dns configuration cluster aws information: %s"
+	errorCustomDNSConfigurationRead    = "error getting custom dns configuration cluster aws information: %s"
+	errorCustomDNSConfigurationUpdate  = "error updating custom dns configuration cluster aws information: %s"
+	errorCustomDNSConfigurationDelete  = "error deleting custom dns configuration cluster aws (%s): %s"
+	errorCustomDNSConfigurationSetting = "error setting `%s` for custom dns configuration cluster aws (%s): %s"
+)
+
+func resourceMongoDBAtlasCustomDNSConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMongoDBAtlasCustomDNSConfigurationCreate,
+		Read:   resourceMongoDBAtlasCustomDNSConfigurationRead,
+		Update: resourceMongoDBAtlasCustomDNSConfigurationUpdate,
+		Delete: resourceMongoDBAtlasCustomDNSConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasCustomDNSConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+	orgID := d.Get("project_id").(string)
+
+	// Creating(Updating) the Custom DNS Configuration for Atlas Clusters on AWS
+	_, _, err := conn.CustomAWSDNS.Update(context.Background(), orgID,
+		&matlas.AWSCustomDNSSetting{
+			Enabled: d.Get("enabled").(bool),
+		})
+	if err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationCreate, err)
+	}
+
+	d.SetId(orgID)
+
+	return resourceMongoDBAtlasCustomDNSConfigurationRead(d, meta)
+}
+
+func resourceMongoDBAtlasCustomDNSConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	dnsResp, _, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
+	if err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationRead, err)
+	}
+
+	if err = d.Set("enabled", dnsResp.Enabled); err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationSetting, "name", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceMongoDBAtlasCustomDNSConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	if d.HasChange("enabled") {
+		_, _, err := conn.CustomAWSDNS.Update(context.Background(), d.Id(), &matlas.AWSCustomDNSSetting{
+			Enabled: d.Get("enabled").(bool),
+		})
+		if err != nil {
+			return fmt.Errorf(errorCustomDNSConfigurationUpdate, err)
+		}
+	}
+
+	return resourceMongoDBAtlasCustomDNSConfigurationRead(d, meta)
+}
+
+func resourceMongoDBAtlasCustomDNSConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*matlas.Client)
+
+	_, _, err := conn.CustomAWSDNS.Update(context.Background(), d.Id(), &matlas.AWSCustomDNSSetting{
+		Enabled: false,
+	})
+	if err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationDelete, d.Id(), err)
+	}
+
+	return nil
+}

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -67,7 +67,11 @@ func resourceMongoDBAtlasCustomDNSConfigurationRead(d *schema.ResourceData, meta
 	}
 
 	if err = d.Set("enabled", dnsResp.Enabled); err != nil {
-		return fmt.Errorf(errorCustomDNSConfigurationSetting, "name", d.Id(), err)
+		return fmt.Errorf(errorCustomDNSConfigurationSetting, "enabled", d.Id(), err)
+	}
+
+	if err = d.Set("project_id", d.Id()); err != nil {
+		return fmt.Errorf(errorCustomDNSConfigurationSetting, "project_id", d.Id(), err)
 	}
 
 	return nil

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
@@ -1,0 +1,137 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccResourceMongoDBAtlasCustomDNSConfigurationAWS_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(projectID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasCustomDNSConfigurationAWS_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*matlas.Client)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("custom dns configuration cluster(%s) does not exist", rs.Primary.ID)
+	}
+}
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*matlas.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_custom_dns_configuration_cluster_aws" {
+			continue
+		}
+
+		// Try to find the Custom DNS Configuration for Atlas Clusters on AWS
+		resp, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		if err != nil && resp != nil && resp.Enabled {
+			return fmt.Errorf("custom dns configuration cluster aws (%s) still enabled", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(projectID string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id     = "%s"
+			enabled       = %t
+		}`, projectID, enabled)
+}

--- a/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
+++ b/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: custom_dns_configuration_cluster_aws"
+sidebar_current: "docs-mongodbatlas-datasource-custom_dns_configuration_cluster_aws"
+description: |-
+    Describes a Custom DNS Configuration for Atlas Clusters on AWS.
+---
+
+# mongodbatlas_custom_dns_configuration_cluster_aws
+
+`mongodbatlas_custom_dns_configuration_cluster_aws` describes a Custom DNS Configuration for Atlas Clusters on AWS.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find **group_id** in the official documentation.
+
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+	project_id                  = "<project-id>"
+	enabled                     = true
+}
+
+data "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+    project_id = mongodbatlas_custom_dns_configuration_cluster_aws.test.id
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) Unique identifier for the project.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `enabled` - Indicates whether the project's clusters deployed to AWS use custom DNS.
+
+
+See detailed information for arguments and attributes: [MongoDB API Custom DNS Configuration for Atlas Clusters on AWS](https://docs.atlas.mongodb.com/reference/api/aws-custom-dns-get)

--- a/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
+++ b/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
@@ -34,6 +34,7 @@ data "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `id` - The project ID.
 * `enabled` - Indicates whether the project's clusters deployed to AWS use custom DNS.
 
 

--- a/website/docs/r/custom_dns_configuration_cluster_aws.markdown
+++ b/website/docs/r/custom_dns_configuration_cluster_aws.markdown
@@ -1,0 +1,42 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: custom_dns_configuration_cluster_aws"
+sidebar_current: "docs-mongodbatlas-resource-custom_dns_configuration_cluster_aws"
+description: |-
+    Provides a Custom DNS Configuration for Atlas Clusters on AWS resource.
+---
+
+# mongodbatlas_custom_dns_configuration_cluster_aws
+
+`mongodbatlas_custom_dns_configuration_cluster_aws` provides a Custom DNS Configuration for Atlas Clusters on AWS resource. This represents a Custom DNS Configuration for Atlas Clusters on AWS that can be updated in an Atlas project.
+
+~> **IMPORTANT:**You must have one of the following roles to successfully handle the resource:
+  * Organization Owner
+  * Project Owner
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+  project_id    = "<PROJECT-ID>"
+  enabled = true
+}
+```
+
+## Argument Reference
+
+* `project_id` - Required 	Unique identifier for the project.
+* `enabled` - (Required) Indicates whether the project's clusters deployed to AWS use custom DNS. If `true`, the `Get All Clusters` and `Get One Cluster` endpoints return the `connectionStrings.private` and `connectionStrings.privateSrv` fields for clusters deployed to AWS .
+
+
+## Import
+Custom DNS Configuration for Atlas Clusters on AWS must be imported using auditing ID, e.g.
+
+```
+$ terraform import mongodbatlas_custom_dns_configuration_cluster_aws.test 1112222b3bf99403840e8934
+```
+
+See detailed information for arguments and attributes: [MongoDB API Custom DNS Configuration for Atlas Clusters on AWS](https://docs.atlas.mongodb.com/reference/api/aws-custom-dns)


### PR DESCRIPTION
## Description

Added resource and datasource and its docs for Custom DNS Configuration for Atlas Clusters on AWS

Added Acceptance tests for Custom DNS Configuration for Atlas Clusters on AWS
- TestAccResourceMongoDBAtlasCustomDNSConfigurationAWS_basic
- TestAccDataSourceMongoDBAtlasCustomDNSConfigurationAWS_basic

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
