### PR TITLE
Path escape import id of database user

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -312,7 +312,9 @@ func resourceMongoDBAtlasDatabaseUserImportState(d *schema.ResourceData, meta in
 		return nil, err
 	}
 
-	u, _, err := conn.DatabaseUsers.Get(context.Background(), *authDatabaseName, *projectID, *username)
+	usernameEscaped := url.PathEscape(*username)
+
+	u, _, err := conn.DatabaseUsers.Get(context.Background(), *authDatabaseName, *projectID, usernameEscaped)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import user(%s) in project(%s), error: %s", *username, *projectID, err)
 	}


### PR DESCRIPTION
## Description

I path escaped the user input `id` for `mongodbatlas_database_user`.
When I tried to import DB user for AWS role type user, I ran this command.

```console
$ terraform import mongodbatlas_database_user.my_db_user 'MASKED_ATLAS_PROJECT_ID-arn:aws:iam::MASKED_AWS_PROJECT_ID:role/my-role-$external'
``` 

But got this error.

```
Error: couldn't import user(arn:aws:iam::MASKED_AWS_PROJECT_ID:role:role/my-role) in project(MASKED_ATLAS_PROJECT_ID), error: GET https://cloud.mongodb.com/api/atlas/v1.0/groups/MASKED_ATLAS_PROJECT_ID/databaseUsers/$external/arn:aws:iam::MASKED_ATLAS_PROJECT_ID:role/my-role: 404 (request "Not Found") Cannot find resource /api/atlas/v1.0/groups/MASKED_ATLAS_PROJECT_ID/databaseUsers/$external/arn:aws:iam::MASKED_ATLAS_PROJECT_ID:role:role/my-role.
```

But if I run the command below (with `/` path escaped), it's okay:

```console
$ terraform import mongodbatlas_database_user.my_db_user 'MASKED_ATLAS_PROJECT_ID-arn:aws:iam::MASKED_AWS_PROJECT_ID:role%2Fmy-role-$external'
``` 

I want the script to handle the space, not developers so that developers can import much easier.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirments
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
