### PR TITLE
INTMDB-116: Added parameter ldap auth type for resource and datasource(s) of database user

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_user.go
@@ -41,6 +41,10 @@ func dataSourceMongoDBAtlasDatabaseUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ldap_auth_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"roles": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -142,6 +146,10 @@ func dataSourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interfa
 
 	if err := d.Set("aws_iam_type", dbUser.AWSIAMType); err != nil {
 		return fmt.Errorf("error setting `aws_iam_type` for database user (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("ldap_auth_type", dbUser.LDAPAuthType); err != nil {
+		return fmt.Errorf("error setting `ldap_auth_type` for database user (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("roles", flattenRoles(dbUser.Roles)); err != nil {

--- a/mongodbatlas/data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/data_source_mongodbatlas_database_users.go
@@ -45,6 +45,10 @@ func dataSourceMongoDBAtlasDatabaseUsers() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ldap_auth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"roles": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -138,6 +142,7 @@ func flattenDBUsers(dbUsers []matlas.DatabaseUser) []map[string]interface{} {
 				"auth_database_name": dbUsers[i].DatabaseName,
 				"x509_type":          dbUsers[i].X509Type,
 				"aws_iam_type":       dbUsers[i].AWSIAMType,
+				"ldap_auth_type":     dbUsers[i].LDAPAuthType,
 				"labels":             flattenLabels(dbUsers[i].Labels),
 				"scopes":             flattenScopes(dbUsers[i].Scopes),
 			}

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -63,6 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
 * `x509_type` - X.509 method by which the provided username is authenticated.
 * `aws_iam_type` - The new database user authenticates with AWS IAM credentials. Default is `NONE`, `USER` means user has AWS IAM user credentials, `ROLE` - means user has credentials associated with an AWS IAM role.
+* `ldap_auth_type` - Method by which the provided username is authenticated.
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -63,7 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
 * `x509_type` - X.509 method by which the provided username is authenticated.
 * `aws_iam_type` - The new database user authenticates with AWS IAM credentials. Default is `NONE`, `USER` means user has AWS IAM user credentials, `ROLE` - means user has credentials associated with an AWS IAM role.
-* `ldap_auth_type` - Method by which the provided username is authenticated.
+* `ldap_auth_type` - Method by which the provided username is authenticated. Default is `NONE`. Other valid values are: `USER`, `GROUP`.
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -67,13 +67,15 @@ In addition to all arguments above, the following attributes are exported:
 * `roles` - List of user’s roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well. See [Roles](#roles) below for more details.
 * `auth_database_name` - (Required) Database against which Atlas authenticates the user. A user must provide both a username and authentication database to log into MongoDB.
 Possible values include:
-  * `admin` if `x509_type` and `aws_iam_type` are omitted or NONE.
+  * `admin` if `x509_type` and `aws_iam_type` and `ldap_auth_type` are omitted or NONE.
   * `$external` if:
     * `x509_type` is MANAGED or CUSTOMER, or
     * `aws_iam_type` is USER or ROLE.
+    * `ldap_auth_type` - is USER or GROUP.
 
 * `x509_type` - X.509 method by which the provided username is authenticated.
 * `aws_iam_type` - The new database user authenticates with AWS IAM credentials. Default is `NONE`, `USER` means user has AWS IAM user credentials, `ROLE` - means user has credentials associated with an AWS IAM role.
+* `ldap_auth_type` - Method by which the provided username is authenticated.
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -75,7 +75,7 @@ Possible values include:
 
 * `x509_type` - X.509 method by which the provided username is authenticated.
 * `aws_iam_type` - The new database user authenticates with AWS IAM credentials. Default is `NONE`, `USER` means user has AWS IAM user credentials, `ROLE` - means user has credentials associated with an AWS IAM role.
-* `ldap_auth_type` - Method by which the provided username is authenticated.
+* `ldap_auth_type` - Method by which the provided username is authenticated. Default is `NONE`. Other valid values are: `USER`, `GROUP`.
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -98,6 +98,11 @@ Accepted values include:
   * `USER` - New database user has AWS IAM user credentials.
   * `ROLE` -  New database user has credentials associated with an AWS IAM role.
 
+* `ldap_auth_type` - (Optional) Method by which the provided username is authenticated. If no value is given, Atlas uses the default value of NONE.
+  * `NONE` -	Atlas authenticates this user through SCRAM-SHA, not LDAP.
+  * `USER` - LDAP server authenticates this user through the user's LDAP user. `username` must also be a fully qualified distinguished name, as defined in RFC-2253.
+  * `GROUP` -  LDAP server authenticates this user using their LDAP user and authorizes this user using their LDAP group.
+
 ### Roles
 
 Block mapping a user's role to a database / collection. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well.

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -98,10 +98,10 @@ Accepted values include:
   * `USER` - New database user has AWS IAM user credentials.
   * `ROLE` -  New database user has credentials associated with an AWS IAM role.
 
-* `ldap_auth_type` - (Optional) Method by which the provided username is authenticated. If no value is given, Atlas uses the default value of NONE.
-  * `NONE` -	Atlas authenticates this user through SCRAM-SHA, not LDAP.
-  * `USER` - LDAP server authenticates this user through the user's LDAP user. `username` must also be a fully qualified distinguished name, as defined in RFC-2253.
-  * `GROUP` -  LDAP server authenticates this user using their LDAP user and authorizes this user using their LDAP group.
+* `ldap_auth_type` - (Optional) Method by which the provided `username` is authenticated. If no value is given, Atlas uses the default value of `NONE`.
+  * `NONE` -	Atlas authenticates this user through [SCRAM-SHA](https://docs.mongodb.com/manual/core/security-scram/), not LDAP.
+  * `USER` - LDAP server authenticates this user through the user's LDAP user. `username` must also be a fully qualified distinguished name, as defined in [RFC-2253](https://tools.ietf.org/html/rfc2253).
+  * `GROUP` - LDAP server authenticates this user using their LDAP user and authorizes this user using their LDAP group. To learn more about LDAP security, see [Set up User Authentication and Authorization with LDAP](https://docs.atlas.mongodb.com/security-ldaps). `username` must also be a fully qualified distinguished name, as defined in [RFC-2253](https://tools.ietf.org/html/rfc2253).
 
 ### Roles
 


### PR DESCRIPTION
## Description

- Added parameter `ldap_auth_type` for resource and datasource(s) of database user
- Added acceptance test `TestAccResourceMongoDBAtlasDatabaseUser_withLDAPAuthType` and `TestAccResourceMongoDBAtlasDatabaseUser_importLDAPAuthType` for import

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
