### PR TITLE
INTMDB-163: Wrong order for PrivateLink Endpoint Service and detects unnecessary changes

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/spf13/cast"
@@ -74,8 +75,9 @@ func dataSourceMongoDBAtlasPrivateEndpointServiceLinkRead(d *schema.ResourceData
 	privateLinkID := d.Get("private_link_id").(string)
 	endpointServiceID := d.Get("endpoint_service_id").(string)
 	providerName := d.Get("provider_name").(string)
+	encodedEndpointID := url.PathEscape(endpointServiceID)
 
-	serviceEndpoint, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), projectID, providerName, endpointServiceID, privateLinkID)
+	serviceEndpoint, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), projectID, providerName, privateLinkID, encodedEndpointID)
 	if err != nil {
 		return fmt.Errorf(errorServiceEndpointRead, endpointServiceID, err)
 	}
@@ -95,7 +97,7 @@ func dataSourceMongoDBAtlasPrivateEndpointServiceLinkRead(d *schema.ResourceData
 	d.SetId(encodeStateID(map[string]string{
 		"project_id":          projectID,
 		"private_link_id":     privateLinkID,
-		"endpoint_service_id": serviceEndpoint.ID,
+		"endpoint_service_id": endpointServiceID,
 		"provider_name":       providerName,
 	}))
 

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceMongoDBAtlasPrivateLinkEndpointServiceAWS_basic(t *testing
 	securityGroupID := os.Getenv("AWS_SECURITY_GROUP_ID")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t); checkAwsEnv(t); checkPeeringEnvAWS(t) },
+		PreCheck:  func() { testAccPreCheck(t); checkAwsEnv(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -66,8 +66,8 @@ func testAccMongoDBAtlasPrivateLinkEndpointServiceDataSourceConfig(awsAccessKey,
 
 		resource "mongodbatlas_privatelink_endpoint_service" "test" {
 			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
-			private_link_id       =  aws_vpc_endpoint.ptfe_service.id
-			endpoint_service_id = mongodbatlas_privatelink_endpoint.test.private_link_id
+			endpoint_service_id       =  aws_vpc_endpoint.ptfe_service.id
+			private_link_id = mongodbatlas_privatelink_endpoint.test.private_link_id
 			provider_name = "%[4]s"
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_interface_link.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_interface_link.go
@@ -121,6 +121,14 @@ func resourceMongoDBAtlasPrivateEndpointInterfaceLinkRead(d *schema.ResourceData
 		return fmt.Errorf(errorInterfaceEndpointSetting, "connection_status", interfaceEndpointID, err)
 	}
 
+	if err := d.Set("private_link_id", privateLinkID); err != nil {
+		return fmt.Errorf(errorPrivateEndpointsSetting, "private_link_id", privateLinkID, err)
+	}
+
+	if err := d.Set("interface_endpoint_id", interfaceEndpointID); err != nil {
+		return fmt.Errorf(errorPrivateEndpointsSetting, "interface_endpoint_id", privateLinkID, err)
+	}
+
 	return nil
 }
 

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceAWS_Complete(t *testin
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); checkAwsEnv(t); checkPeeringEnvAWS(t) },
+		PreCheck:     func() { testAccPreCheck(t); checkAwsEnv(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
 		Steps: []resource.TestStep{
@@ -117,7 +118,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName strin
 
 		ids := decodeStateID(rs.Primary.ID)
 
-		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["endpoint_service_id"], ids["private_link_id"])
+		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], url.QueryEscape(ids["endpoint_service_id"]))
 		if err == nil {
 			return nil
 		}
@@ -169,8 +170,8 @@ func testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(awsAccessKey
 
 		resource "mongodbatlas_privatelink_endpoint_service" "test" {
 			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
-			private_link_id       =  aws_vpc_endpoint.ptfe_service.id
-			endpoint_service_id = mongodbatlas_privatelink_endpoint.test.private_link_id
+			endpoint_service_id       =  aws_vpc_endpoint.ptfe_service.id
+			private_link_id = mongodbatlas_privatelink_endpoint.test.private_link_id
 			provider_name = "%[4]s"
 		}
 	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID)

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_test.go
@@ -68,11 +68,10 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointAWS_import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"provider_name", "region"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -134,11 +133,10 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointAzure_import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"provider_name", "region"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -153,7 +151,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName s
 
 		ids := decodeStateID(rs.Primary.ID)
 
-		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["private_link_id"], ids["provider_name"]), nil
+		return fmt.Sprintf("%s-%s-%s-%s", ids["project_id"], ids["private_link_id"], ids["provider_name"], ids["region"]), nil
 	}
 }
 

--- a/website/docs/d/privatelink_endpoint_service.html.markdown
+++ b/website/docs/d/privatelink_endpoint_service.html.markdown
@@ -32,7 +32,8 @@ resource "aws_vpc_endpoint" "ptfe_service" {
 resource "mongodbatlas_privatelink_endpoint_service" "test" {
   project_id            = "${mongodbatlas_privatelink_endpoint.test.project_id}"
   private_link_id       = "${mongodbatlas_privatelink_endpoint.test.private_link_id}"
-  interface_endpoint_id = "${aws_vpc_endpoint.ptfe_service.id}"
+  endpoint_service_id   = "${aws_vpc_endpoint.ptfe_service.id}"
+  provider_name         ="AWS"
 }
 
 data "mongodbatlas_privatelink_endpoint_service" "test" {
@@ -45,8 +46,8 @@ data "mongodbatlas_privatelink_endpoint_service" "test" {
 ## Argument Reference
 
 * `project_id` - (Required) Unique identifier for the project.
-* `private_link_id` - (Required) Unique identifier of the `AWS` or `AZURE` PrivateLink connection.
-* `endpoint_service_id` - (Required) Unique identifier of the private endpoint service for which you want to create a private endpoint service.
+* `private_link_id` - (Required) Unique identifier of the private endpoint service for which you want to retrieve a private endpoint.
+* `endpoint_service_id` - (Required) Unique identifier of the `AWS` or `AZURE` resource.
 * `provider_name` - (Required) Cloud provider for which you want to create a private endpoint. Atlas accepts `AWS` or `AZURE`.
 
 ## Attributes Reference

--- a/website/docs/guides/0.8.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.8.0-upgrade-guide.html.markdown
@@ -134,7 +134,7 @@ In order to transition from the deprecated resources to the new without disablin
 3) Then [import](https://www.terraform.io/docs/commands/import.html) the privatelink information into the new resources, e.g:
 
 ```hcl
-terraform import mongodbatlas_privatelink_endpoint.test {project_id}-{private_link_id}-{provider_name}
+terraform import mongodbatlas_privatelink_endpoint.test {project_id}-{private_link_id}-{provider_name}-{region}
 
 terraform import mongodbatlas_privatelink_endpoint_service.test {project_id}--{private_link_id}--{endpoint_service_id}--{provider_name}
 ```

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -75,10 +75,10 @@ In addition to all arguments above, the following attributes are exported:
   * `DELETING` 	The AWS PrivateLink connection is being deleted.
 
 ## Import
-Private Endpoint Connection can be imported using project ID and username, in the format `{project_id}-{private_link_id}`, e.g.
+Private Endpoint Connection can be imported using project ID and private link ID, provider name and region, in the format `{project_id}-{private_link_id}-{provider_name}-{region}`, e.g.
 
 ```
-$ terraform import mongodbatlas_private_endpoint.test 1112222b3bf99403840e8934-3242342343112
+$ terraform import mongodbatlas_private_endpoint.test 1112222b3bf99403840e8934-3242342343112-AWS-us-east-2
 ```
 
 See detailed information for arguments and attributes: [MongoDB API Private Endpoint Connection](https://docs.atlas.mongodb.com/reference/api/private-endpoint-create-one-private-endpoint-connection/)

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -115,10 +115,10 @@ In addition to all arguments above, the following attributes are exported:
   * `DELETING` 	The Private Link service is being deleted.
 
 ## Import
-Private Endpoint Service can be imported using project ID and username, in the format `{project_id}-{private_link_id}-{provider_name}`, e.g.
+Private Endpoint Service can be imported using project ID, private link ID, provider name and region, in the format `{project_id}-{private_link_id}-{provider_name}-{region}`, e.g.
 
 ```
-$ terraform import mongodbatlas_privatelink_endpoint.test 1112222b3bf99403840e8934-3242342343112-AWS
+$ terraform import mongodbatlas_privatelink_endpoint.test 1112222b3bf99403840e8934-3242342343112-AWS-us-east-1
 ```
 
 See detailed information for arguments and attributes: [MongoDB API Private Endpoint Service](https://docs.atlas.mongodb.com/reference/api/private-endpoints-service-create-one//)

--- a/website/docs/r/privatelink_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service.html.markdown
@@ -76,7 +76,7 @@ In addition to all arguments above, the following attributes are exported:
 Private Endpoint Link Connection can be imported using project ID and username, in the format `{project_id}--{private_link_id}--{endpoint_service_id}--{provider_name}`, e.g.
 
 ```
-$ terraform import mongodbatlas_privatelink_endpoint_service.test 1112222b3bf99403840e8934--vpce-4242342343--3242342343112--AWS
+$ terraform import mongodbatlas_privatelink_endpoint_service.test 1112222b3bf99403840e8934--3242342343112--vpce-4242342343--AWS
 ```
 
 See detailed information for arguments and attributes: [MongoDB API Private Endpoint Link Connection](https://docs.atlas.mongodb.com/reference/api/private-endpoints-endpoint-create-one/)


### PR DESCRIPTION
## Description

Private Endpoint (deprecated)
- Added provider name and region in state id for import and read so it won't detect the unnecessary changes for region/provider name while plan after import

Private Endpoint Interface (deprecated)
- Set the fields private link id and interface id in read so it can't detect unnecessary changes.

PrivateLink Endpoint 
- Added region in state id for import and other func(create, read and delete) so it it won't detect the unnecessary changes for region

PrivateLink Endpoint Service
- Changed the wrong order, the field `private_link_id` was using with `endpoint_service_id` information instead of `private_link_id` from private_link_endpoint resource and vice versa(`endpoint_service_id` using with `private_link_id` info)
-  Set the fields private link id in read so it won't detect unnecessary changes.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
