### PR TITLE
corrected the title by making the variable name plural

### DIFF
--- a/website/docs/d/network_peerings.html.markdown
+++ b/website/docs/d/network_peerings.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Describes all Network Peering Connections.
 ---
 
-# mongodbatlas_network_peering
+# mongodbatlas_network_peerings
 
 `mongodbatlas_network_peerings` describes all Network Peering Connections.
 


### PR DESCRIPTION
## Description

corrected the title by making the variable name plural
from mongodbatlas_network_peering to mongodbatlas_network_peerings

Link to any related issue(s):

## Type of change:
- [x] Documentation fix/enhancement


- [x] signed mongodb contributing agreement