### PR TITLE
TeamsUpdate - fixing small bug, again missing update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global rule
+*	@themantissa
+
+# examples 
+/examples/**	@nikhil-mongo
+
+# resources & datasources, provider
+/mongodbatlas/**	@coderGo93 @leofigy

--- a/mongodbatlas/resource_mongodbatlas_team.go
+++ b/mongodbatlas/resource_mongodbatlas_team.go
@@ -85,7 +85,14 @@ func resourceMongoDBAtlasTeamRead(d *schema.ResourceData, meta interface{}) erro
 	teamID := ids["id"]
 
 	team, _, err := conn.Teams.Get(context.Background(), orgID, teamID)
+
 	if err != nil {
+		// new resource missing
+		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
+		if reset {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf(errorTeamRead, err)
 	}
 


### PR DESCRIPTION
## Description

Missing refreshing the state when the team is removed from the outside terraform, but still in the configuration file

Link to any related issue(s):

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments
