### PR TITLE
INTMDB-155: Fixes a bug related to bi_connector cluster by deprecating

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -39,12 +39,30 @@ func dataSourceMongoDBAtlasCluster() *schema.Resource {
 				Computed: true,
 			},
 			"bi_connector": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:       schema.TypeMap,
+				Computed:   true,
+				Deprecated: "use bi_connector_config instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeString, // Convert to Bool
+							Computed: true,
+						},
+						"read_preference": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"bi_connector_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 						"read_preference": {
@@ -389,6 +407,10 @@ func dataSourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{})
 
 	if err := d.Set("bi_connector", flattenBiConnector(cluster.BiConnector)); err != nil {
 		return fmt.Errorf(errorClusterSetting, "bi_connector", clusterName, err)
+	}
+
+	if err := d.Set("bi_connector_config", flattenBiConnectorConfig(cluster.BiConnector)); err != nil {
+		return fmt.Errorf(errorClusterSetting, "bi_connector_config", clusterName, err)
 	}
 
 	if cluster.ProviderSettings != nil {

--- a/mongodbatlas/data_source_mongodbatlas_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters.go
@@ -46,12 +46,30 @@ func dataSourceMongoDBAtlasClusters() *schema.Resource {
 							Computed: true,
 						},
 						"bi_connector": {
-							Type:     schema.TypeMap,
-							Computed: true,
+							Type:       schema.TypeMap,
+							Computed:   true,
+							Deprecated: "use bi_connector_config instead",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
 										Type:     schema.TypeString, // Convert to Bool
+										Computed: true,
+									},
+									"read_preference": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"bi_connector_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
 										Computed: true,
 									},
 									"read_preference": {
@@ -370,6 +388,7 @@ func flattenClusters(d *schema.ResourceData, conn *matlas.Client, clusters []mat
 			"provider_name":                clusters[i].ProviderSettings.ProviderName,
 			"provider_region_name":         clusters[i].ProviderSettings.RegionName,
 			"bi_connector":                 flattenBiConnector(clusters[i].BiConnector),
+			"bi_connector_config":          flattenBiConnectorConfig(clusters[i].BiConnector),
 			"replication_specs":            flattenReplicationSpecs(clusters[i].ReplicationSpecs),
 			"labels":                       flattenLabels(clusters[i].Labels),
 			"snapshot_backup_policy":       snapshotBackupPolicy,

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -487,16 +487,6 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	biConnector, err := expandBiConnector(d)
-	if err != nil {
-		return fmt.Errorf(errorClusterCreate, err)
-	}
-
-	biConnector, err = expandBiConnectorConfig(d)
-	if err != nil {
-		return fmt.Errorf(errorClusterCreate, err)
-	}
-
 	providerSettings, err := expandProviderSetting(d)
 	if err != nil {
 		return fmt.Errorf(errorClusterCreate, err)
@@ -515,9 +505,24 @@ func resourceMongoDBAtlasClusterCreate(d *schema.ResourceData, meta interface{})
 		ProviderBackupEnabled:    pointy.Bool(d.Get("provider_backup_enabled").(bool)),
 		PitEnabled:               pointy.Bool(d.Get("pit_enabled").(bool)),
 		AutoScaling:              autoScaling,
-		BiConnector:              biConnector,
 		ProviderSettings:         providerSettings,
 		ReplicationSpecs:         replicationSpecs,
+	}
+
+	if _, ok := d.GetOk("bi_connector"); ok {
+		biConnector, err := expandBiConnector(d)
+		if err != nil {
+			return fmt.Errorf(errorClusterCreate, err)
+		}
+		clusterRequest.BiConnector = biConnector
+	}
+
+	if _, ok := d.GetOk("bi_connector_config"); ok {
+		biConnector, err := expandBiConnector(d)
+		if err != nil {
+			return fmt.Errorf(errorClusterCreate, err)
+		}
+		clusterRequest.BiConnector = biConnector
 	}
 
 	if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
@@ -991,7 +996,7 @@ func splitSClusterImportID(id string) (projectID, clusterName *string, err error
 	return
 }
 
-// Deprecated, will be deleted later
+// Deprecated: will be deleted later
 func expandBiConnector(d *schema.ResourceData) (*matlas.BiConnector, error) {
 	var biConnector matlas.BiConnector
 
@@ -1029,7 +1034,7 @@ func expandBiConnectorConfig(d *schema.ResourceData) (*matlas.BiConnector, error
 	return &biConnector, nil
 }
 
-// Deprecated, will be deleted later
+// Deprecated: will be deleted later
 func flattenBiConnector(biConnector *matlas.BiConnector) map[string]interface{} {
 	biConnectorMap := make(map[string]interface{})
 

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -82,7 +82,8 @@ In addition to all arguments above, the following attributes are exported:
 * `auto_scaling_compute_scale_down_enabled` - (Optional) Set to `true` to enable the cluster tier to scale down.
 
 * `backup_enabled` - Legacy Option, Indicates whether Atlas continuous backups are enabled for the cluster.
-* `bi_connector` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
+* `bi_connector` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details. **DEPRECATED** Use `bi_connector_config` instead.
+* `bi_connector_config` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
 * `cluster_type` - Indicates the type of the cluster that you want to modify. You cannot convert a sharded cluster deployment to a replica set deployment.
 * `connection_strings` - Set of connection strings that your applications use to connect to this cluster. More info in [Connection-strings](https://docs.mongodb.com/manual/reference/connection-string/). Use the parameters in this object to connect your applications to this cluster. To learn more about the formats of connection strings, see [Connection String Options](https://docs.atlas.mongodb.com/reference/faq/connection-changes/). NOTE: Atlas returns the contents of this object after the cluster is operational, not while it builds the cluster.
     - `connection_strings.standard` -   Public mongodb:// connection string for this cluster.

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -84,7 +84,8 @@ In addition to all arguments above, the following attributes are exported:
 * `auto_scaling_compute_enabled` - (Optional) Specifies whether cluster tier auto-scaling is enabled. The default is false.
 * `auto_scaling_compute_scale_down_enabled` - (Optional) Set to `true` to enable the cluster tier to scale down.
 * `backup_enabled` - Legacy Option, Indicates whether Atlas continuous backups are enabled for the cluster.
-* `bi_connector` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
+* `bi_connector` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details. **DEPRECATED** Use `bi_connector_config` instead.
+* `bi_connector_config` - Indicates BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
 * `cluster_type` - Indicates the type of the cluster that you want to modify. You cannot convert a sharded cluster deployment to a replica set deployment.
 * `connection_strings` - Set of connection strings that your applications use to connect to this cluster. More info in [Connection-strings](https://docs.mongodb.com/manual/reference/connection-string/). Use the parameters in this object to connect your applications to this cluster. To learn more about the formats of connection strings, see [Connection String Options](https://docs.atlas.mongodb.com/reference/faq/connection-changes/). NOTE: Atlas returns the contents of this object after the cluster is operational, not while it builds the cluster.
     - `connection_strings.standard` -   Public mongodb:// connection string for this cluster.

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -264,7 +264,8 @@ But in order to explicitly change `provider_instance_size_name` comment the `lif
     ```
     * The default value is false.  M10 and above only.
 
-* `bi_connector` - (Optional) Specifies BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
+* `bi_connector` - (Optional) Specifies BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details. **DEPRECATED** Use `bi_connector_config` instead.
+* `bi_connector_config` - (Optional) Specifies BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
 * `cluster_type` - (Required) Specifies the type of the cluster that you want to modify. You cannot convert a sharded cluster deployment to a replica set deployment.
 
     -> **WHEN SHOULD YOU USE CLUSTERTYPE?**


### PR DESCRIPTION
## Description

- Deprecated the parameter `bi_connector` and added parameter `bi_connector_config` to avoid a behavior bug of update in change in terraform version 14
- Added test `TestAccResourceMongoDBAtlasCluster_WithBiConnectorGCP`

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
