### PR TITLE
INTMDB-194: Added func to get db major version for testing

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -993,7 +993,6 @@ func testAccMongoDBAtlasClusterConfigAWS(projectID, name string, backupEnabled, 
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_disk_iops          = 300
-			provider_encrypt_ebs_volume = false
 			provider_instance_size_name = "M30"
 			provider_region_name        = "EU_CENTRAL_1"
 		}

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"testing"
 
@@ -843,13 +844,15 @@ func TestAccResourceMongoDBAtlasCluster_tenant(t *testing.T) {
 		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 	)
 
+	dbMajorVersion := testAccGetMongoDBAtlasMajorVersion()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, name, "M2", "2"),
+				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, name, "M2", "2", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
@@ -879,6 +882,7 @@ func TestAccResourceMongoDBAtlasCluster_tenant_m5(t *testing.T) {
 	resourceName := "mongodbatlas_cluster.tenant"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	name := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	dbMajorVersion := testAccGetMongoDBAtlasMajorVersion()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -886,7 +890,7 @@ func TestAccResourceMongoDBAtlasCluster_tenant_m5(t *testing.T) {
 		CheckDestroy: testAccCheckMongoDBAtlasClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, name, "M5", "5"),
+				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, name, "M5", "5", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
@@ -909,6 +913,13 @@ func testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName string) resou
 
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["name"]), nil
 	}
+}
+
+func testAccGetMongoDBAtlasMajorVersion() string {
+	conn, _ := matlas.New(http.DefaultClient, matlas.SetBaseURL(matlas.CloudURL))
+	majorVersion, _, _ := conn.DefaultMongoDBMajorVersion.Get(context.Background())
+
+	return majorVersion
 }
 
 func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
@@ -1216,7 +1227,7 @@ func testAccMongoDBAtlasClusterConfigGlobal(projectID, name, backupEnabled strin
 	`, projectID, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskSize string) string {
+func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskSize, majorDBVersion string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_cluster" "tenant" {
 		project_id = "%s"
@@ -1230,10 +1241,10 @@ func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskS
 
 		provider_instance_size_name  = "%s"
 		//These must be the following values
- 	 	mongo_db_major_version = "4.2"
+ 	 	mongo_db_major_version = "%s"
 		auto_scaling_disk_gb_enabled = false
 	  }
-	`, projectID, name, diskSize, instanceSize)
+	`, projectID, name, diskSize, instanceSize, majorDBVersion)
 }
 
 func testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, name string) string {


### PR DESCRIPTION
## Description

- Added a func to get db major version and use it to pass to config via parameter for testing so it
- Tests passed for `TestAccResourceMongoDBAtlasCluster_tenant` and `TestAccResourceMongoDBAtlasCluster_tenant_m5`

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
Fixes #419 