### PR TITLE
INTMDB-199: Fixes the error when updating an replication specs after removed one zone

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -223,7 +223,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 				Computed: true,
 			},
 			"replication_specs": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -1163,7 +1163,7 @@ func expandReplicationSpecs(d *schema.ResourceData) ([]matlas.ReplicationSpec, e
 	rSpecs := make([]matlas.ReplicationSpec, 0)
 
 	if v, ok := d.GetOk("replication_specs"); ok {
-		for _, s := range v.(*schema.Set).List() {
+		for _, s := range v.([]interface{}) {
 			spec := s.(map[string]interface{})
 			id := cast.ToString(spec["id"])
 			// Check if has changes
@@ -1475,7 +1475,7 @@ func clusterConnectionStringsSchema() *schema.Schema {
 }
 
 func compareReplicationSpecs(oldObject interface{}, newValues map[string]interface{}) (flag bool, idSpec string) {
-	for _, s := range oldObject.(*schema.Set).List() {
+	for _, s := range oldObject.([]interface{}) {
 		spec := s.(map[string]interface{})
 		if cast.ToString(spec["zone_name"]) == cast.ToString(newValues["zone_name"]) {
 			return true, cast.ToString(spec["id"])

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1166,11 +1166,11 @@ func expandReplicationSpecs(d *schema.ResourceData) ([]matlas.ReplicationSpec, e
 		for _, s := range v.(*schema.Set).List() {
 			spec := s.(map[string]interface{})
 			id := cast.ToString(spec["id"])
-			//Check if has changes
+			// Check if has changes
 			if d.HasChange("replication_specs") && cast.ToString(d.Get("cluster_type")) == "GEOSHARDED" {
-				//Get original and new object
+				// Get original and new object
 				original, _ := d.GetChange("replication_specs")
-				isSame, oldID := hasSameData(original, spec)
+				isSame, oldID := compareReplicationSpecs(original, spec)
 				if isSame {
 					id = oldID
 				}
@@ -1474,7 +1474,7 @@ func clusterConnectionStringsSchema() *schema.Schema {
 	}
 }
 
-func hasSameData(oldObject interface{}, newValues map[string]interface{}) (bool, string) {
+func compareReplicationSpecs(oldObject interface{}, newValues map[string]interface{}) (flag bool, idSpec string) {
 	for _, s := range oldObject.(*schema.Set).List() {
 		spec := s.(map[string]interface{})
 		if cast.ToString(spec["zone_name"]) == cast.ToString(newValues["zone_name"]) {


### PR DESCRIPTION

## Description
Changed to TypeSet for `replication_specs` schema, added a validation to compare the zone name if it's the same for old and new values and the get the ID generated from original object and set it in request for update to avoid an error like `Updating id of existing replication spec`

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
