### PR TITLE
feature: force new cluster on name change

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -140,6 +140,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			},
 			"name": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 			"mongo_db_major_version": {


### PR DESCRIPTION
## Description

Currently changing the cluster name shows a plan with in-place changes. The plan can be applied, but no change from the UI is visible. This is misleading since Atlas doesn't let you change cluster names, and in my case even severed the connections to our clusters. I'm guessing this name is used internally by Atlas, and changing it broke some things.

The documentation for the provider says [once the cluster is created, its name cannot be changed](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster#name), so this attribute should definitely be set to improve the user's experience.

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/189

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement (in this case the documentation is already correct! 😄)

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code