### PR TITLE
Update default IOPS and 0.9.0 info guide

### DIFF
--- a/website/docs/guides/0.9.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.0-upgrade-guide.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas Provider 0.8.0: Upgrade and Information Guide"
+sidebar_current: "docs-mongodbatlas-guides-080-upgrade-guide"
+description: |-
+    MongoDB Atlas Provider 0.9.0: Upgrade and Information Guide
+    
+---
+
+# MongoDB Atlas Provider v0.9.0: Upgrade and Information Guide
+
+Besides the bug fixes, improvements and enhancements listed in the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for 0.9.0 we want to call out some specific features and enhancements added to this version:
+* Added support for LDAP configuration and database users
+* Added two options to Cloud Provider Access to allow for both actions in a single apply
+* Apple Silicon (darwin/arm64) support
+* Added support for the GCP regions parameter for network containers
+* Added support for Custom DNS Configuration
+
+Note this release also includes a deprecation for provider_encrypt_ebs_volume which is no longer used.
+
+### Helpful Links
+
+* [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)
+
+* [Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+* [Contact Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.

--- a/website/docs/r/cloud_provider_snapshot.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot.html.markdown
@@ -26,7 +26,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
     provider_region_name        = "EU_WEST_2"
     provider_instance_size_name = "M10"
     provider_backup_enabled     = true   // enable cloud backup snapshots
-    provider_disk_iops          = 100
+    provider_disk_iops          = 3000
   }
 
   resource "mongodbatlas_cloud_provider_snapshot" "test" {

--- a/website/docs/r/cloud_provider_snapshot_backup_policy.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_backup_policy.html.markdown
@@ -28,7 +28,7 @@ resource "mongodbatlas_cluster" "my_cluster" {
   provider_region_name        = "EU_CENTRAL_1"
   provider_instance_size_name = "M10"
   provider_backup_enabled     = true // must be enabled in order to use cloud_provider_snapshot_backup_policy resource
-  provider_disk_iops          = 100
+  provider_disk_iops          = 3000
 }
 
 resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
@@ -94,7 +94,7 @@ resource "mongodbatlas_cluster" "my_cluster" {
   provider_region_name        = "EU_CENTRAL_1"
   provider_instance_size_name = "M10"
   provider_backup_enabled     = true // must be enabled in order to use cloud_provider_snapshot_backup_policy resource
-  provider_disk_iops          = 100
+  provider_disk_iops          = 3000
 }
 
 resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
@@ -162,7 +162,7 @@ resource "mongodbatlas_cluster" "my_cluster" {
   provider_region_name        = "EU_CENTRAL_1"
   provider_instance_size_name = "M10"
   provider_backup_enabled     = true // must be enabled in order to use cloud_provider_snapshot_backup_policy resource
-  provider_disk_iops          = 100
+  provider_disk_iops          = 3000
 }
 
 resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -34,7 +34,7 @@ description: |-
     provider_region_name        = "EU_WEST_2"
     provider_instance_size_name = "M10"
     provider_backup_enabled     = true   // enable cloud backup snapshots
-    provider_disk_iops          = 100
+    provider_disk_iops          = 3000
   }
 
   resource "mongodbatlas_cloud_provider_snapshot" "test" {
@@ -70,7 +70,7 @@ description: |-
     provider_region_name        = "EU_WEST_2"
     provider_instance_size_name = "M10"
     provider_backup_enabled     = true   // enable cloud backup snapshots
-    provider_disk_iops          = 100
+    provider_disk_iops          = 3000
   }
 
   resource "mongodbatlas_cloud_provider_snapshot" "test" {

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -45,7 +45,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
   //Provider Settings "block"
   provider_name               = "AWS"
   disk_size_gb                = 100
-  provider_disk_iops          = 300
+  provider_disk_iops         ops          = 300
   provider_volume_type        = "STANDARD"
   provider_instance_size_name = "M40"
 }
@@ -118,7 +118,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 
   //Provider Settings "block"
   provider_name               = "AWS"
-  provider_disk_iops          = 300
+  provider_disk_iops          = 3000
   provider_volume_type        = "STANDARD"
   provider_instance_size_name = "M10"
 
@@ -159,7 +159,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 
   //Provider Settings "block"
   provider_name               = "AWS"
-  provider_disk_iops          = 240
+  provider_disk_iops          = 3000
   provider_volume_type        = "STANDARD"
   provider_instance_size_name = "M30"
 

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -88,7 +88,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
   //Provider Settings "block"
   provider_name               = "AWS"
   disk_size_gb                = 100
-  provider_disk_iops          = 300
+  provider_disk_iops          = 3000
   provider_instance_size_name = "M40"
   provider_region_name        = "US_EAST_1"
 }

--- a/website/docs/r/ldap_verify.html.markdown
+++ b/website/docs/r/ldap_verify.html.markdown
@@ -28,7 +28,7 @@ resource "mongodbatlas_cluster" "test" {
     provider_region_name        = "US_EAST_2"
     provider_instance_size_name = "M10"
     provider_backup_enabled     = true //enable cloud provider snapshots
-    provider_disk_iops          = 100
+    provider_disk_iops          = 3000
     provider_encrypt_ebs_volume = false
 }
 


### PR DESCRIPTION


## Description

Update default IOPS for AWS which for most M sizes now defaults at 3000 and 0.9.0 info guide for release

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ X] Documentation fix/enhancement

## Required Checklist:

- [X ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ X] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
