### PR TITLE
INTMDB-206 Documentation and example updates

### DIFF
--- a/examples/atlas-encryption-at-rest/aws/aws-roles.tf
+++ b/examples/atlas-encryption-at-rest/aws/aws-roles.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_role_policy" "test_policy" {
+  name = "mongo_setup_policy"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "mongo_setup_test_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}

--- a/examples/atlas-encryption-at-rest/aws/main.tf
+++ b/examples/atlas-encryption-at-rest/aws/main.tf
@@ -23,3 +23,4 @@ resource "mongodbatlas_encryption_at_rest" "test" {
   }
 
 }
+

--- a/examples/atlas-encryption-at-rest/aws/main.tf
+++ b/examples/atlas-encryption-at-rest/aws/main.tf
@@ -1,0 +1,25 @@
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = var.project_id
+   provider_name = var.cloud_provider_access_name
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = var.project_id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws = {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+resource "mongodbatlas_encryption_at_rest" "test" {
+  project_id = var.project_id
+
+  aws_kms = {
+    enabled                = true
+    customer_master_key_id = var.customer_master_key
+    region                 = var.atlas_region
+    role_id                = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+  }
+
+}

--- a/examples/atlas-encryption-at-rest/aws/providers.tf
+++ b/examples/atlas-encryption-at-rest/aws/providers.tf
@@ -1,0 +1,9 @@
+provider "mongodbatlas" {
+  public_key  = var.public_key
+  private_key = var.private_key
+}
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.aws_region
+}

--- a/examples/atlas-encryption-at-rest/aws/variables.tf
+++ b/examples/atlas-encryption-at-rest/aws/variables.tf
@@ -1,0 +1,36 @@
+// mongo 
+variable project_id {
+    type = string
+}
+variable cloud_provider_access_name {
+    type = string
+    default = "AWS"
+}
+variable public_key {
+    type = string
+}
+variable private_key {
+    type = string
+}
+
+// aws
+variable access_key {
+    type = string
+}
+variable secret_key {
+    type = string
+}
+variable aws_region {
+    type = string
+}
+
+// encryption at rest
+variable "customer_master_key" {
+  description = "The customer master secret key for AWS Account"
+  default     = ""
+}
+
+variable "atlas_region" {
+  default     = "US_EAST_1"
+  description = "Atlas Region"
+}

--- a/examples/atlas-encryption-at-rest/aws/variables.tf
+++ b/examples/atlas-encryption-at-rest/aws/variables.tf
@@ -34,3 +34,4 @@ variable "atlas_region" {
   default     = "US_EAST_1"
   description = "Atlas Region"
 }
+

--- a/examples/atlas-encryption-at-rest/aws/versions.tf
+++ b/examples/atlas-encryption-at-rest/aws/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/atlas-encryption-at-rest/aws/versions.tf
+++ b/examples/atlas-encryption-at-rest/aws/versions.tf
@@ -6,3 +6,4 @@ terraform {
   }
   required_version = ">= 0.13"
 }
+

--- a/website/docs/guides/0.9.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.0-upgrade-guide.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Besides the bug fixes, improvements and enhancements listed in the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for 0.9.0 we want to call out some specific features and enhancements added to this version:
 * Added support for LDAP configuration and database users
-* Added two options to Cloud Provider Access to allow for both actions in a single apply
+* Added two options to Cloud Provider Access to allow for both actions in a single apply **NOTE** [migration guide to Cloud Provider Access Setup](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
 * Apple Silicon (darwin/arm64) support
 * Added support for the GCP regions parameter for network containers
 * Added support for Custom DNS Configuration

--- a/website/docs/guides/0.9.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.1-upgrade-guide.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas Provider 0.9.1: Upgrade and Information Guide"
+sidebar_current: "docs-mongodbatlas-guides-091-upgrade-guide"
+description: |-
+    MongoDB Atlas Provider 0.9.1: Upgrade and Information Guide
+---
+
+# MongoDB Atlas Provider v0.9.1: Upgrade and Information Guide
+
+## Migration to Cloud Provider Access Setup
+
+To migrate from `mongodbatlas_cloud_provider_access` to `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization`
+perform the following steps 
+
+1. Add the new `mongodbatlas_cloud_provider_access_setup` to your configuration file 
+
+```hcl
+resource "mongodbatlas_cloud_provider_access_setup" "unique" {
+   project_id = "<PROJECT-ID>"
+   provider_name = "AWS"
+}
+```
+
+2. Perform an import from your existing `mongodbatlas_cloud_provider_access` to `mongodbatlas_cloud_provider_access_setup`
+**NOTE:** if the import step is missing it will generate a new resource with a different ID
+
+```bash
+    terraform import mongodbatlas_cloud_provider_access_setup.unique <project_id>-AWS-<role-id>
+```
+
+3. Add the mongodbatlas_cloud_provider_access_authorization to the configuration file
+
+```hcl
+resource "mongodbatlas_cloud_provider_access_authorization" "auth" {
+
+  project_id = mongodbatlas_cloud_provider_access_setup.unique.project_id
+  role_id    = mongodbatlas_cloud_provider_access_setup.unique.role_id
+
+  aws = {
+    iam_assumed_role_arn = "arn:aws:iam::772401394250:role/test-user-role"
+  }
+}
+```
+
+4. Execute a terraform plan, apply 
+
+```
+    terraform plan
+    terraform apply
+```
+
+5. Remove your existing `mongodbatlas_cloud_provider_access` resource from terraform state 
+**NOTE** before doing any terraform state change please do a backup
+
+```bash
+    terraform state rm mongodbatlas_cloud_provider_access.test_role
+```
+
+6. Remove the resource from the config
+7. Do a terraform plan (no changes detected)
+
+```bash
+terraform plan
+
+(...)
+
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.
+```
+
+### Helpful Links
+
+* [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)
+
+* [Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+* [Contact Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -194,7 +194,7 @@ Notifications to send when an alert condition is detected.
 * `email_enabled` - Flag indicating if email notifications should be sent. Configurable for `ORG`, `GROUP`, and `USER` notifications types.
 * `flowdock_api_token` - The Flowdock personal API token. Required for the `FLOWDOCK` notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `flow_name` - Flowdock flow name in lower-case letters. Required for the `FLOWDOCK` notifications type
-* `interval_min` - Number of minutes to wait between successive notifications for unacknowledged alerts that are not resolved. The minimum value is 5.
+* `interval_min` - Number of minutes to wait between successive notifications for unacknowledged alerts that are not resolved. The minimum value is 5. **CONDITIONAL** PAGER_DUTY manages the interval value, please do not set it in case of PAGER_DUTY
 * `mobile_number` - Mobile number to which alert notifications are sent. Required for the SMS notifications type.
 * `ops_genie_api_key` - Opsgenie API Key. Required for the `OPS_GENIE` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `ops_genie_region` - Region that indicates which API URL to use. Accepted regions are: `US` ,`EU`. The default Opsgenie region is US.

--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -15,6 +15,8 @@ The MongoDB Atlas provider offers two paths to perform an authorization for a cl
 * A two resource path, consisting of `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization`. The first resource, `mongodbatlas_cloud_provider_access_setup`, only generates
 the initial configuration (create, delete operations). The second resource, `mongodbatlas_cloud_provider_access_authorization`, helps to perform the authorization using the role_id of the first resource. This path is helpful in a multi-provider Terraform file, and allows a single and decoupled apply.
 
+-> **IMPORTANT** If it is needed to migrate from the single resource to the two resource paths see the [migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
+
 ## mongodbatlas_cloud_provider_access
 
 `mongodbatlas_cloud_provider_access` Allows you to register and authorize AWS IAM roles in Atlas. This is the resource to use for the single resource path described above.

--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -15,7 +15,7 @@ The MongoDB Atlas provider offers two paths to perform an authorization for a cl
 * A two resource path, consisting of `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization`. The first resource, `mongodbatlas_cloud_provider_access_setup`, only generates
 the initial configuration (create, delete operations). The second resource, `mongodbatlas_cloud_provider_access_authorization`, helps to perform the authorization using the role_id of the first resource. This path is helpful in a multi-provider Terraform file, and allows a single and decoupled apply.
 
--> **IMPORTANT** If it is needed to migrate from the single resource to the two resource paths see the [migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
+-> **IMPORTANT** If you want to move from the single resource path to the two resources path see the [migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
 
 ## mongodbatlas_cloud_provider_access
 

--- a/website/docs/r/encryption_at_rest.html.markdown
+++ b/website/docs/r/encryption_at_rest.html.markdown
@@ -57,7 +57,7 @@ resource "mongodbatlas_encryption_at_rest" "test" {
 }
 ```
 
-**NOTE** in case using the `cloud_provider_access_setup` and `cloud_provider_access_authorization`, could be a use case where it needs to define the `depends_on` statement for these two resources, because terraform is not able to infer. 
+**NOTE**  if using the two resources path for cloud provider access, `cloud_provider_access_setup` and `cloud_provider_access_authorization`, you may need to define a `depends_on` statement for these two resources, because terraform is not able to infer the dependency.
 
 ```hcl
 resource "mongodbatlas_encryption_at_rest" "default" {

--- a/website/docs/r/encryption_at_rest.html.markdown
+++ b/website/docs/r/encryption_at_rest.html.markdown
@@ -57,6 +57,15 @@ resource "mongodbatlas_encryption_at_rest" "test" {
 }
 ```
 
+**NOTE** in case using the `cloud_provider_access_setup` and `cloud_provider_access_authorization`, could be a use case where it needs to define the `depends_on` statement for these two resources, because terraform is not able to infer. 
+
+```hcl
+resource "mongodbatlas_encryption_at_rest" "default" {
+  (...)
+  depends_on = [mongodbatlas_cloud_provider_access_setup.<resource_name>, mongodbatlas_cloud_provider_access_authorization.<resource_name>]
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) The unique identifier for the project.


### PR DESCRIPTION
## Description

Updating the documentation guide for migration for the cloud_provider_access_setup and adding one example to using it with the encryption_at_rest for aws.

Link to any related issue(s):

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/451
https://github.com/mongodb/terraform-provider-mongodbatlas/issues/409

## Type of change:

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments
