### PR TITLE
Missing formatting backtick in the documentation

### DIFF
--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -112,7 +112,7 @@ resource "mongodbatlas_global_cluster_config" "config" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to create the database user.
-* `cluster_name - (Required) The name of the Global Cluster.
+* `cluster_name` - (Required) The name of the Global Cluster.
 *  `managed_namespaces` - (Optional) Add a managed namespaces to a Global Cluster. For more information about managed namespaces, see [Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/). See [Managed Namespace](#managed-namespace) below for more details.
 *  `custom_zone_mappings` - (Optional) Each element in the list maps one ISO location code to a zone in your Global Cluster. See [Custom Zone Mapping](#custom-zone-mapping) below for more details.
 


### PR DESCRIPTION
## Description

There was a missing backtick in the documentation for mongodbatlas_global_cluster_config

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
