### PR TITLE
INTMDB-208: Updated docs for upgrading private endpoints

### DIFF
--- a/.github/workflows/automated-test-acceptances.yml
+++ b/.github/workflows/automated-test-acceptances.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     types: [ labeled ]
     paths:
+      - 'integration-testing/**' ##testing only
       - 'mongodbatlas/**'
       - '!website/docs/**'
 

--- a/.github/workflows/automated-test-acceptances.yml
+++ b/.github/workflows/automated-test-acceptances.yml
@@ -4,8 +4,14 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'mongodbatlas/**'
+      - '!website/docs/**'
   pull_request:
     types: [ labeled ]
+    paths:
+      - 'mongodbatlas/**'
+      - '!website/docs/**'
 
 jobs:
   authorize:

--- a/.github/workflows/automated-test-acceptances.yml
+++ b/.github/workflows/automated-test-acceptances.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     types: [ labeled ]
     paths:
-      - 'integration-testing/**' ##testing only
       - 'mongodbatlas/**'
       - '!website/docs/**'
 

--- a/examples/test-upgrade/v090/private-endpoint/v080/main.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v080/main.tf
@@ -1,0 +1,41 @@
+resource "mongodbatlas_project" "test" {
+  name   = var.project_name
+  org_id = var.org_id
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+resource "mongodbatlas_private_endpoint" "test" {
+  project_id    = mongodbatlas_project.test.id
+  provider_name = "AWS"
+  region        = "us-east-1"
+}
+
+resource "aws_vpc_endpoint" "ptfe_service" {
+  vpc_id             = var.aws_vpc_id
+  service_name       = mongodbatlas_private_endpoint.test.endpoint_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [var.aws_subnet_ids]
+  security_group_ids = [var.aws_sg_ids]
+}
+
+resource "mongodbatlas_private_endpoint_interface_link" "test" {
+  project_id            = mongodbatlas_private_endpoint.test.project_id
+  private_link_id       = mongodbatlas_private_endpoint.test.private_link_id
+  interface_endpoint_id = aws_vpc_endpoint.ptfe_service.id
+}
+
+
+output "project_id" {
+  value = mongodbatlas_project.test.id
+}
+output "private_endpoint_id" {
+  value = mongodbatlas_private_endpoint.test.private_link_id
+}
+output "vpc_endpoint_id" {
+  value = aws_vpc_endpoint.ptfe_service.id
+}

--- a/examples/test-upgrade/v090/private-endpoint/v080/variables.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v080/variables.tf
@@ -1,0 +1,44 @@
+variable "public_key" {
+  description = "The public API key for MongoDB Atlas"
+  default     = ""
+}
+variable "private_key" {
+  description = "The private API key for MongoDB Atlas"
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  default     = ""
+}
+variable "org_id" {
+  description = "The organization ID"
+  default     = ""
+}
+variable "username" {
+  description = "Username"
+  default     = ""
+}
+variable "role_name" {
+  description = "The role name"
+  default     = ""
+}
+variable "aws_access_key" {
+  description = "The access key for AWS Account"
+  default     = ""
+}
+variable "aws_secret_key" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_vpc_id" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_subnet_ids" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_sg_ids" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}

--- a/examples/test-upgrade/v090/private-endpoint/v080/versions.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v080/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+      version = "0.8.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/test-upgrade/v090/private-endpoint/v090/main.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v090/main.tf
@@ -1,0 +1,30 @@
+resource "mongodbatlas_project" "test" {
+  name   = var.project_name
+  org_id = var.org_id
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}
+
+resource "mongodbatlas_private_endpoint" "test" {
+  project_id    = mongodbatlas_project.test.id
+  provider_name = "AWS"
+  region        = "us-east-1"
+}
+
+resource "aws_vpc_endpoint" "ptfe_service" {
+  vpc_id             = var.aws_vpc_id
+  service_name       = mongodbatlas_private_endpoint.test.endpoint_service_name
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = [var.aws_subnet_ids]
+  security_group_ids = [var.aws_sg_ids]
+}
+
+resource "mongodbatlas_private_endpoint_interface_link" "test" {
+  project_id            = mongodbatlas_private_endpoint.test.project_id
+  private_link_id       = mongodbatlas_private_endpoint.test.private_link_id
+  interface_endpoint_id = aws_vpc_endpoint.ptfe_service.id
+}

--- a/examples/test-upgrade/v090/private-endpoint/v090/variables.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v090/variables.tf
@@ -1,0 +1,45 @@
+variable "public_key" {
+  description = "The public API key for MongoDB Atlas"
+  default     = ""
+}
+variable "private_key" {
+  description = "The private API key for MongoDB Atlas"
+  default     = ""
+}
+variable "project_name" {
+  description = "Atlas project name"
+  default     = ""
+}
+variable "org_id" {
+  description = "The organization ID"
+  default     = ""
+}
+variable "username" {
+  description = "Username"
+  default     = ""
+}
+variable "role_name" {
+  description = "The role name"
+  default     = ""
+}
+variable "aws_access_key" {
+  description = "The access key for AWS Account"
+  default     = ""
+}
+variable "aws_secret_key" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_vpc_id" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_subnet_ids" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+variable "aws_sg_ids" {
+  description = "The secret key for AWS Account"
+  default     = ""
+}
+

--- a/examples/test-upgrade/v090/private-endpoint/v090/versions.tf
+++ b/examples/test-upgrade/v090/private-endpoint/v090/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+      version = "0.9.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+

--- a/integration-testing/test-upgrades_test.go
+++ b/integration-testing/test-upgrades_test.go
@@ -200,6 +200,79 @@ func TestUpgradeClusterDeprecationEBSVolume(t *testing.T) {
 
 }
 
+func TestUpgradePrivateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		publicKey   = os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
+		privateKey  = os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+		awsAccess   = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecret   = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		awsVPC      = os.Getenv("AWS_VPC_ID")
+		awsSubnets  = os.Getenv("AWS_SUBNET_ID")
+		awsSG       = os.Getenv("AWS_SECURITY_GROUP_ID")
+	)
+	// Construct the terraform options with default retryable errors to handle the most common
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../examples/test-upgrade/v090/private-endpoint/v080",
+		Vars: map[string]interface{}{
+			"project_name":   projectName,
+			"org_id":         orgID,
+			"public_key":     publicKey,
+			"private_key":    privateKey,
+			"aws_access_key": awsAccess,
+			"aws_secret_key": awsSecret,
+			"aws_vpc_id":     awsVPC,
+			"aws_subnet_ids": awsSubnets,
+			"aws_sg_ids":     awsSG,
+		},
+	})
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
+
+	terraform.Plan(t, terraformOptions)
+
+	projectID := terraform.Output(t, terraformOptions, "project_id")
+	vpcEndpoint := terraform.Output(t, terraformOptions, "vpc_endpoint_id")
+	privateEndpoint := terraform.Output(t, terraformOptions, "private_endpoint_id")
+
+	tempTestFolder := CleanUpState(t, "examples/test-upgrade/v090/private-endpoint/v090")
+
+	terraformOptionsSecond := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: tempTestFolder,
+		Vars: map[string]interface{}{
+			"project_name":   projectName,
+			"org_id":         orgID,
+			"public_key":     publicKey,
+			"private_key":    privateKey,
+			"aws_access_key": awsAccess,
+			"aws_secret_key": awsSecret,
+			"aws_vpc_id":     awsVPC,
+			"aws_subnet_ids": awsSubnets,
+			"aws_sg_ids":     awsSG,
+		},
+	})
+
+	terraform.RunTerraformCommand(t, terraformOptionsSecond, "init")
+	//Remove states
+	terraform.RunTerraformCommand(t, terraformOptionsSecond, "import", "mongodbatlas_project.test", projectID)
+	terraform.RunTerraformCommand(t, terraformOptionsSecond, "import", "mongodbatlas_private_endpoint.test", fmt.Sprintf("%s-%s-%s-%s", projectID, privateEndpoint, "AWS", "us-east-1"))
+	terraform.RunTerraformCommand(t, terraformOptionsSecond, "import", "aws_vpc_endpoint.ptfe_service", vpcEndpoint)
+	terraform.RunTerraformCommand(t, terraformOptionsSecond, "import", "mongodbatlas_private_endpoint_interface_link.test", fmt.Sprintf("%s-%s-%s", projectID, privateEndpoint, vpcEndpoint))
+	// Run `terraform apply`. Fail the test if there are any errors.
+	terraform.Plan(t, terraformOptionsSecond)
+
+}
+
 // This func means that the terraform state will be always clean to avoid error about resource already used
 func CleanUpState(t *testing.T, path string) string {
 	// Root folder where terraform files should be (relative to the test folder)

--- a/website/docs/guides/0.9.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.1-upgrade-guide.html.markdown
@@ -72,6 +72,55 @@ configuration and real physical resources that exist. As a result, no
 actions need to be performed.
 ```
 
+## Upgrading private endpoint and private endpoint interface link
+
+To upgrade from v0.8.0 to v0.9.1 with the existing resources `mongodbatlas_private_endpoint` and `mongodbatlas_private_endpoint_interface_link`
+perform the following steps
+
+1. Remove your existing `mongodbatlas_private_endpoint` and `mongodbatlas_private_endpoint_interface_link` resources from terraform state
+   **NOTE** before doing any terraform state change please do a backup
+
+```bash
+$ terraform state rm mongodbatlas_private_endpoint.test
+$ terraform state rm mongodbatlas_private_endpoint_interface_link.test
+```
+
+2. Change the version of provider to the newest version
+
+3. Perform an import from your existing `mongodbatlas_private_endpoint` and `mongodbatlas_private_endpoint_interface_link`
+```bash
+    terraform import mongodbatlas_private_endpoint.test <project_id>-<private_link_id>-<provider_name>-<region>
+    terraform import mongodbatlas_private_endpoint_interface_link.test <project_id>-<private_link_id>-<interface_endpoint_id>
+```
+
+4. Do a terraform plan (no changes detected)
+
+```bash
+terraform plan
+
+(...)
+
+
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.
+
+Warning: this resource is deprecated, please transition as soon as possible to mongodbatlas_privatelink_endpoint
+
+  on main.tf line 12, in resource "mongodbatlas_private_endpoint" "test":
+  12: resource "mongodbatlas_private_endpoint" "test" {
+
+
+
+Warning: this resource is deprecated, please transition as soon as possible to mongodbatlas_privatelink_endpoint_service
+
+  on main.tf line 26, in resource "mongodbatlas_private_endpoint_interface_link" "test":
+  26: resource "mongodbatlas_private_endpoint_interface_link" "test" {
+
+```
+
 ### Helpful Links
 
 * [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)

--- a/website/docs/guides/0.9.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.1-upgrade-guide.html.markdown
@@ -85,7 +85,7 @@ $ terraform state rm mongodbatlas_private_endpoint.test
 $ terraform state rm mongodbatlas_private_endpoint_interface_link.test
 ```
 
-2. Change the version of provider to the newest version
+2. Change the version of provider to the v0.9.1
 
 3. Perform an import from your existing `mongodbatlas_private_endpoint` and `mongodbatlas_private_endpoint_interface_link`
 ```bash

--- a/website/docs/guides/0.9.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.1-upgrade-guide.html.markdown
@@ -120,6 +120,7 @@ Warning: this resource is deprecated, please transition as soon as possible to m
   26: resource "mongodbatlas_private_endpoint_interface_link" "test" {
 
 ```
+**NOTE** Doc links for [mongodbatlas_privatelink_endpoint](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint) and [mongodbatlas_privatelink_endpoint_service](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service)
 
 ### Helpful Links
 


### PR DESCRIPTION
## Description

- Added terratest for upgrading with resources `mongodbatlas_private_endpoint` and `mongodbatlas_private_endpoint_interface_link`
- Updated docs for guide upgrading v0.9.1
- Added validation where it should run make testacc if there's changes for folder mongodbatlas/ and should not run for changes inside folder website/docs

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
