### PR TITLE
CLOUDP-90710: Expose BASE_URL so that we can test terraform with a custom server

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export MONGODB_ATLAS_PUBLIC_KEY=<YOUR_PUBLIC_KEY>
 export MONGODB_ATLAS_PRIVATE_KEY=<YOUR_PRIVATE_KEY>
 
 # This env variable is optional and allow you to run terraform with a custom server
-export MONGODB_ATLAS_BASE_URL=<CUSTOM_SERVER>
+export MONGODB_ATLAS_BASE_URL=<CUSTOM_SERVER_URL>
 ```
 
 - For `Authentication database user` resource configuration:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ export MONGODB_ATLAS_ORG_ID=<YOUR_ORG_ID>
 export MONGODB_ATLAS_PUBLIC_KEY=<YOUR_PUBLIC_KEY>
 export MONGODB_ATLAS_PRIVATE_KEY=<YOUR_PRIVATE_KEY>
 
-# This env variable is optional and allow you to use atlas cloud-dev to run your tests
-export MONGODB_ATLAS_BASE_URL=https://cloud-dev.mongodb.com/api/atlas/v1.0/
+# This env variable is optional and allow you to run terraform with a custom server
+export MONGODB_ATLAS_BASE_URL=<CUSTOM_SERVER>
 ```
 
 - For `Authentication database user` resource configuration:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ export MONGODB_ATLAS_PROJECT_ID=<YOUR_PROJECT_ID>
 export MONGODB_ATLAS_ORG_ID=<YOUR_ORG_ID>
 export MONGODB_ATLAS_PUBLIC_KEY=<YOUR_PUBLIC_KEY>
 export MONGODB_ATLAS_PRIVATE_KEY=<YOUR_PRIVATE_KEY>
+
+# This env variable is optional and allow you to use atlas cloud-dev to run your tests
+export MONGODB_ATLAS_BASE_URL=https://cloud-dev.mongodb.com/api/atlas/v1.0/
 ```
 
 - For `Authentication database user` resource configuration:

--- a/integration-testing/common.go
+++ b/integration-testing/common.go
@@ -6,6 +6,7 @@ type MongoDBCredentials struct {
 	ProjectID  string
 	PublicKey  string
 	PrivateKey string
+	BaseURL    string
 }
 
 type AWSCredentials struct {
@@ -20,6 +21,7 @@ func GetCredentialsFromEnv() MongoDBCredentials {
 		ProjectID:  os.Getenv("MONGODB_ATLAS_PROJECT_ID"),
 		PublicKey:  os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey: os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		BaseURL:    os.Getenv("MONGODB_ATLAS_BASE_URL"),
 	}
 }
 

--- a/integration-testing/resource_mongodbatlas_cloud_provider_access_test.go
+++ b/integration-testing/resource_mongodbatlas_cloud_provider_access_test.go
@@ -31,6 +31,7 @@ func TestTerraformResourceMongoDBAtlasCloudProviderAccess_basicAWS(t *testing.T)
 			"cloud_provider_access_name": "AWS",
 			"public_key":                 mongoSecrets.PublicKey,
 			"private_key":                mongoSecrets.PrivateKey,
+			"base_url":                   mongoSecrets.BaseURL,
 			"access_key":                 awsSecrets.AccessKey,
 			"secret_key":                 awsSecrets.SecretKey,
 			"aws_region":                 awsSecrets.AwsRegion,

--- a/integration-testing/resource_mongodbatlas_encryption_at_rest_test.go
+++ b/integration-testing/resource_mongodbatlas_encryption_at_rest_test.go
@@ -28,6 +28,7 @@ func TestTerraformResourceMongoDBAtlasEncryptionAtRestWithRole_basicAWS(t *testi
 			"project_id":          mongoSecrets.ProjectID,
 			"public_key":          mongoSecrets.PublicKey,
 			"private_key":         mongoSecrets.PrivateKey,
+			"base_url":            mongoSecrets.BaseURL,
 		},
 	})
 
@@ -55,6 +56,7 @@ func TestTerraformResourceMongoDBAtlasEncryptionAtRestWithRole_basicAWS(t *testi
 			"project_id":          mongoSecrets.ProjectID,
 			"public_key":          mongoSecrets.PublicKey,
 			"private_key":         mongoSecrets.PrivateKey,
+			"base_url":            mongoSecrets.BaseURL,
 			"aws_iam_role_arn":    awsRoleARN,
 		},
 	})
@@ -70,6 +72,7 @@ func TestTerraformResourceMongoDBAtlasEncryptionAtRestWithRole_basicAWS(t *testi
 			"project_id":          mongoSecrets.ProjectID,
 			"public_key":          mongoSecrets.PublicKey,
 			"private_key":         mongoSecrets.PrivateKey,
+			"base_url":            mongoSecrets.BaseURL,
 			"cpa_role_id":         cpaRoleID,
 		},
 	})

--- a/integration-testing/test-upgrades_test.go
+++ b/integration-testing/test-upgrades_test.go
@@ -208,6 +208,7 @@ func TestUpgradePrivateEndpoint(t *testing.T) {
 		projectName = acctest.RandomWithPrefix("test-acc")
 		publicKey   = os.Getenv("MONGODB_ATLAS_PUBLIC_KEY")
 		privateKey  = os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
+		baseURL     = os.Getenv("MONGODB_ATLAS_BASE_URL")
 		awsAccess   = os.Getenv("AWS_ACCESS_KEY_ID")
 		awsSecret   = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		awsVPC      = os.Getenv("AWS_VPC_ID")
@@ -224,6 +225,7 @@ func TestUpgradePrivateEndpoint(t *testing.T) {
 			"org_id":         orgID,
 			"public_key":     publicKey,
 			"private_key":    privateKey,
+			"base_url":       baseURL,
 			"aws_access_key": awsAccess,
 			"aws_secret_key": awsSecret,
 			"aws_vpc_id":     awsVPC,
@@ -254,6 +256,7 @@ func TestUpgradePrivateEndpoint(t *testing.T) {
 			"org_id":         orgID,
 			"public_key":     publicKey,
 			"private_key":    privateKey,
+			"base_url":       baseURL,
 			"aws_access_key": awsAccess,
 			"aws_secret_key": awsSecret,
 			"aws_vpc_id":     awsVPC,

--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -10,7 +10,7 @@ import (
 type Config struct {
 	PublicKey  string
 	PrivateKey string
-	BaseUrl	   string
+	BaseURL    string
 }
 
 // NewClient func...
@@ -27,8 +27,8 @@ func (c *Config) NewClient() interface{} {
 	client.Transport = logging.NewTransport("MongoDB Atlas", transport)
 
 	opts := []matlasClient.ClientOpt{matlasClient.SetUserAgent("terraform-provider-mongodbatlas/" + ProviderVersion)}
-	if c.BaseUrl != ""{
-		opts = append(opts,matlasClient.SetBaseURL(c.BaseUrl))
+	if c.BaseURL != "" {
+		opts = append(opts, matlasClient.SetBaseURL(c.BaseURL))
 	}
 
 	// Initialize the MongoDB Atlas API Client.

--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	PublicKey  string
 	PrivateKey string
+	BaseUrl	   string
 }
 
 // NewClient func...
@@ -25,9 +26,16 @@ func (c *Config) NewClient() interface{} {
 
 	client.Transport = logging.NewTransport("MongoDB Atlas", transport)
 
+	opts := []matlasClient.ClientOpt{matlasClient.SetUserAgent("terraform-provider-mongodbatlas/" + ProviderVersion)}
+	if c.BaseUrl != ""{
+		opts = append(opts,matlasClient.SetBaseURL(c.BaseUrl))
+	}
+
 	// Initialize the MongoDB Atlas API Client.
-	atlasClient := matlasClient.NewClient(client)
-	atlasClient.UserAgent = "terraform-provider-mongodbatlas/" + ProviderVersion
+	atlasClient, err := matlasClient.New(client, opts...)
+	if err != nil {
+		return err
+	}
 
 	return atlasClient
 }

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -30,6 +30,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("MONGODB_ATLAS_PRIVATE_KEY", ""),
 				Description: "MongoDB Atlas Programmatic Private Key",
 			},
+			"base_url": {
+				Type:        schema.TypeString,
+				Required:    false,
+				DefaultFunc: schema.EnvDefaultFunc("MONGODB_ATLAS_BASE_URL", ""),
+				Description: "MongoDB Atlas Base URL",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -114,6 +120,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		PublicKey:  d.Get("public_key").(string),
 		PrivateKey: d.Get("private_key").(string),
+	}
+
+	if baseUrl := d.Get("base_url"); baseUrl != nil{
+		config.BaseUrl = baseUrl.(string)
 	}
 
 	return config.NewClient(), nil

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -122,8 +122,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		PrivateKey: d.Get("private_key").(string),
 	}
 
-	if baseUrl := d.Get("base_url"); baseUrl != nil{
-		config.BaseUrl = baseUrl.(string)
+	if baseUrl := d.Get("base_url"); baseUrl != nil {
+		config.BaseURL = baseUrl.(string)
 	}
 
 	return config.NewClient(), nil

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -32,7 +32,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"base_url": {
 				Type:        schema.TypeString,
-				Required:    false,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MONGODB_ATLAS_BASE_URL", ""),
 				Description: "MongoDB Atlas Base URL",
 			},
@@ -122,8 +122,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		PrivateKey: d.Get("private_key").(string),
 	}
 
-	if baseUrl := d.Get("base_url"); baseUrl != nil {
-		config.BaseURL = baseUrl.(string)
+	if baseURL := d.Get("base_url"); baseURL != nil {
+		config.BaseURL = baseURL.(string)
 	}
 
 	return config.NewClient(), nil


### PR DESCRIPTION
## Description

I have exposed the property  `MONGODB_ATLAS_BASE_URL` so that we can test terraform with a custom server.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
