### PR TITLE
INTMDB-201: Added to detect changes for name of cluster in update func

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -782,6 +782,10 @@ func resourceMongoDBAtlasClusterUpdate(d *schema.ResourceData, meta interface{})
 		cluster.BiConnector, _ = expandBiConnector(d)
 	}
 
+	if d.HasChange("name") {
+		cluster.Name, _ = d.Get("name").(string)
+	}
+
 	if d.HasChange("bi_connector_config") {
 		cluster.BiConnector, _ = expandBiConnectorConfig(d)
 	}


### PR DESCRIPTION
## Description

- Added d.HasChanges for name of the cluster
**NOTE**: When it detects changes for `name` and try to apply it will appear an error like this
```
        Error: error updating MongoDB Cluster (test-acc-ufsh42cmvx): PATCH https://cloud.mongodb.com/api/atlas/v1.0/groups/PROJECT/GROUP-ID/clusters/test-acc-ufsh42cmvx: 400 (request "CLUSTER_CANNOT_CHANGE_NAME") Cannot change name of cluster during an update.

```

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
Related to #189 