### PR TITLE
INTMDB-198: Fixes a bug where it appears empty private endpoint in cluster

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -3,9 +3,13 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/spf13/cast"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -334,6 +338,24 @@ func dataSourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf(errorClusterRead, clusterName, err)
 	}
 
+	if cluster.ProviderSettings != nil && cast.ToString(cluster.ProviderSettings.ProviderName) == "AWS" {
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"PRIVATE_ENDPOINTS_NIL", "PRIVATE_ENDPOINTS_EMPTY"},
+			Target:     []string{"PRIVATE_ENDPOINTS_EXISTS", "NORMAL"},
+			Refresh:    datasourceClusterPrivateEndpointRefreshFunc(clusterName, projectID, conn),
+			Timeout:    10 * time.Minute,
+			MinTimeout: 1 * time.Minute,
+			Delay:      3 * time.Minute,
+		}
+
+		resp, err := stateConf.WaitForState()
+		if err != nil {
+			log.Printf("[ERROR] %v", fmt.Errorf(errorClusterRead, clusterName, err))
+		} else {
+			cluster = resp.(*matlas.Cluster)
+		}
+	}
+
 	if err := d.Set("auto_scaling_disk_gb_enabled", cluster.AutoScaling.DiskGBEnabled); err != nil {
 		return fmt.Errorf(errorClusterSetting, "auto_scaling_disk_gb_enabled", clusterName, err)
 	}
@@ -442,4 +464,34 @@ func dataSourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{})
 	d.SetId(cluster.ID)
 
 	return nil
+}
+
+func datasourceClusterPrivateEndpointRefreshFunc(name, projectID string, client *matlas.Client) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cluster, resp, err := client.Clusters.Get(context.Background(), projectID, name)
+
+		if err != nil && cluster == nil && resp == nil {
+			return nil, "", err
+		} else if err != nil {
+			if resp.StatusCode == 404 {
+				return "", "DELETED", nil
+			}
+			if resp.StatusCode == 503 {
+				return "", "PENDING", nil
+			}
+			return nil, "", err
+		}
+
+		if cluster.ConnectionStrings != nil {
+			if cluster.ConnectionStrings.PrivateEndpoint == nil {
+				return cluster, "PRIVATE_ENDPOINTS_NIL", err
+			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) == 0 {
+				return cluster, "PRIVATE_ENDPOINTS_EMPTY", err
+			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) != 0 {
+				return cluster, "PRIVATE_ENDPOINTS_EXISTS", err
+			}
+		}
+
+		return cluster, "NORMAL", nil
+	}
 }

--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -338,7 +338,8 @@ func dataSourceMongoDBAtlasClusterRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf(errorClusterRead, clusterName, err)
 	}
 
-	if cluster.ProviderSettings != nil && cast.ToString(cluster.ProviderSettings.ProviderName) == "AWS" {
+	if cluster.ProviderSettings != nil && (cast.ToString(cluster.ProviderSettings.ProviderName) == "AWS" ||
+		cast.ToString(cluster.ProviderSettings.ProviderName) == "AZURE") {
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"PRIVATE_ENDPOINTS_NIL", "PRIVATE_ENDPOINTS_EMPTY"},
 			Target:     []string{"PRIVATE_ENDPOINTS_EXISTS", "NORMAL"},

--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -484,11 +484,11 @@ func datasourceClusterPrivateEndpointRefreshFunc(name, projectID string, client 
 
 		if cluster.ConnectionStrings != nil {
 			if cluster.ConnectionStrings.PrivateEndpoint == nil {
-				return cluster, "PRIVATE_ENDPOINTS_NIL", err
+				return cluster, "PRIVATE_ENDPOINTS_NIL", nil
 			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) == 0 {
-				return cluster, "PRIVATE_ENDPOINTS_EMPTY", err
+				return cluster, "PRIVATE_ENDPOINTS_EMPTY", nil
 			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) != 0 {
-				return cluster, "PRIVATE_ENDPOINTS_EXISTS", err
+				return cluster, "PRIVATE_ENDPOINTS_EXISTS", nil
 			}
 		}
 

--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -485,9 +485,11 @@ func datasourceClusterPrivateEndpointRefreshFunc(name, projectID string, client 
 		if cluster.ConnectionStrings != nil {
 			if cluster.ConnectionStrings.PrivateEndpoint == nil {
 				return cluster, "PRIVATE_ENDPOINTS_NIL", nil
-			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) == 0 {
+			}
+			if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) == 0 {
 				return cluster, "PRIVATE_ENDPOINTS_EMPTY", nil
-			} else if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) != 0 {
+			}
+			if cluster.ConnectionStrings.PrivateEndpoint != nil && len(cluster.ConnectionStrings.PrivateEndpoint) != 0 {
 				return cluster, "PRIVATE_ENDPOINTS_EXISTS", nil
 			}
 		}


### PR DESCRIPTION
## Description
- Added a refresh state for cluster when it can wait for private endpoint to be available if will be used if the provider name is `AWS` or `AZURE` with 10 minutes as timeout in datasource of cluster.

This was tested manually because in issue, was using an existing cluster with datasource.

The example is the same in folder `/examples/aws-atlas-privatelink` with small modifications in file `atlas-cluster.tf` like this
```hcl
data "mongodbatlas_cluster" "cluster-atlas" {
  project_id                   = var.atlasprojectid
  name                         = "cluster-atlas"
  depends_on                   = [mongodbatlas_private_endpoint_interface_link.atlaseplink]
}

output "atlasclusterstring" {
  value = data.mongodbatlas_cluster.cluster-atlas.connection_strings
}
output "plstring" {
  value = lookup(data.mongodbatlas_cluster.cluster-atlas.connection_strings[0].aws_private_link_srv, aws_vpc_endpoint.ptfe_service.id)
}
```

The results are OK after waiting for `data.mongodbatlas_cluster.cluster-atlas`, it took between 3-5 min

```
Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

atlasclusterstring = tolist([
  {
    "aws_private_link" = tomap({
      "vpce-0ecdf684cbe5b980a" = "mongodb://pl-0-us-east-1.fg84w.mongodb.net:1108,pl-0-us-east-1.fg84w.mongodb.net:1109,pl-0-us-east-1.fg84w.mongodb.net:1110/?ssl=true&authSource=admin&replicaSet=atlas-2hsx2e-shard-0"
    })
    "aws_private_link_srv" = tomap({
      "vpce-0ecdf684cbe5b980a" = "mongodb+srv://cluster-atlas-pl-0.fg84w.mongodb.net"
    })
    "private" = ""
    "private_endpoint" = tolist([
      {
        "connection_string" = "mongodb://pl-0-us-east-1.fg84w.mongodb.net:1108,pl-0-us-east-1.fg84w.mongodb.net:1109,pl-0-us-east-1.fg84w.mongodb.net:1110/?ssl=true&authSource=admin&replicaSet=atlas-2hsx2e-shard-0"
        "endpoints" = tolist([
          {
            "endpoint_id" = "vpce-0ecdf684cbe5b980a"
            "provider_name" = "AWS"
            "region" = "US_EAST_1"
          },
        ])
        "srv_connection_string" = "mongodb+srv://cluster-atlas-pl-0.fg84w.mongodb.net"
        "type" = "MONGOD"
      },
    ])
    "private_srv" = ""
    "standard" = "mongodb://cluster-atlas-shard-00-00.fg84w.mongodb.net:27017,cluster-atlas-shard-00-01.fg84w.mongodb.net:27017,cluster-atlas-shard-00-02.fg84w.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-2hsx2e-shard-0"
    "standard_srv" = "mongodb+srv://cluster-atlas.fg84w.mongodb.net"
  },
])
plstring = "mongodb+srv://cluster-atlas-pl-0.fg84w.mongodb.net"

```


Link to any related issue(s):
#422 
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
