### PR TITLE
INTMDB-188: fixed issue related with read non-existing resource

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -3,10 +3,10 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mwielbut/pointy"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -84,8 +84,13 @@ func resourceMongoDBAtlasAuditingCreate(d *schema.ResourceData, meta interface{}
 func resourceMongoDBAtlasAuditingRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*MongoDBClient).Atlas
 
-	auditing, _, err := conn.Auditing.Get(context.Background(), d.Id())
+	auditing, resp, err := conn.Auditing.Get(context.Background(), d.Id())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorAuditingRead, d.Id(), err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -107,9 +108,14 @@ func resourceMongoDBAtlasCloudProviderAccessRead(d *schema.ResourceData, meta in
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 
-	roles, _, err := conn.CloudProviderAccess.ListRoles(context.Background(), projectID)
+	roles, resp, err := conn.CloudProviderAccess.ListRoles(context.Background(), projectID)
 
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorGetRead, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization.go
@@ -66,8 +66,13 @@ func resourceMongoDBAtlasCloudProviderAccessAuthorizationRead(d *schema.Resource
 	projectID := ids["project_id"]
 
 	targetRole, err := FindRole(conn, projectID, roleID)
-
 	if err != nil {
+		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
+		if reset {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_setup.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_setup.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -71,9 +72,13 @@ func resourceMongoDBAtlasCloudProviderAccessSetupRead(d *schema.ResourceData, me
 	projectID := ids["project_id"]
 	providerName := ids["provider_name"]
 
-	roles, _, err := conn.CloudProviderAccess.ListRoles(context.Background(), projectID)
-
+	roles, resp, err := conn.CloudProviderAccess.ListRoles(context.Background(), projectID)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorGetRead, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -95,8 +94,13 @@ func resourceMongoDBAtlasCloudProviderSnapshotRead(d *schema.ResourceData, meta 
 		ClusterName: ids["cluster_name"],
 	}
 
-	snapshotReq, _, err := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
+	snapshotReq, resp, err := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("error getting snapshot Information: %s", err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -154,8 +153,13 @@ func resourceMongoDBAtlasCloudProviderSnapshotBackupPolicyRead(d *schema.Resourc
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	backupPolicy, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
+	backupPolicy, resp, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorSnapshotBackupPolicyRead, clusterName, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 
-	"github.com/spf13/cast"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
+	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -223,8 +222,13 @@ func resourceMongoDBAtlasCloudProviderSnapshotRestoreJobRead(d *schema.ResourceD
 		ClusterName: ids["cluster_name"],
 	}
 
-	snapshotReq, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+	snapshotReq, resp, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -152,8 +153,13 @@ func resourceMongoDBAtlasCustomDBRoleRead(d *schema.ResourceData, meta interface
 	projectID := ids["project_id"]
 	roleName := ids["role_name"]
 
-	customDBRole, _, err := conn.CustomDBRoles.Get(context.Background(), projectID, roleName)
+	customDBRole, resp, err := conn.CustomDBRoles.Get(context.Background(), projectID, roleName)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("error getting custom db role information: %s", err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -3,9 +3,9 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -61,8 +61,13 @@ func resourceMongoDBAtlasCustomDNSConfigurationCreate(d *schema.ResourceData, me
 func resourceMongoDBAtlasCustomDNSConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*MongoDBClient).Atlas
 
-	dnsResp, _, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
+	dnsResp, resp, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorCustomDNSConfigurationRead, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
-	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -146,13 +145,11 @@ func resourceMongoDBAtlasDatabaseUserRead(d *schema.ResourceData, meta interface
 		}
 	}
 
-	dbUser, _, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
+	dbUser, resp, err := conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
 	if err != nil {
 		// case 404
 		// deleted in the backend case
-		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
-
-		if reset {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}

--- a/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
@@ -3,11 +3,11 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -192,8 +192,13 @@ func resourceMongoDBAtlasEncryptionAtRestCreate(d *schema.ResourceData, meta int
 func resourceMongoDBAtlasEncryptionAtRestRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*MongoDBClient).Atlas
 
-	resp, _, err := conn.EncryptionsAtRest.Get(context.Background(), d.Id())
+	resp, response, err := conn.EncryptionsAtRest.Get(context.Background(), d.Id())
 	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorReadEncryptionAtRest, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -299,8 +300,12 @@ func resourceMongoDBAtlasEventTriggersRead(d *schema.ResourceData, meta interfac
 	appID := ids["app_id"]
 	triggerID := ids["trigger_id"]
 
-	resp, _, err := conn.EventTriggers.Get(context.Background(), projectID, appID, triggerID)
+	resp, recodes, err := conn.EventTriggers.Get(context.Background(), projectID, appID, triggerID)
 	if err != nil {
+		if recodes != nil && recodes.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf(errorEventTriggersRead, projectID, appID, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -6,11 +6,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -148,6 +146,7 @@ func resourceMongoDBAtlasGlobalClusterCreate(d *schema.ResourceData, meta interf
 
 	return resourceMongoDBAtlasGlobalClusterRead(d, meta)
 }
+
 func resourceMongoDBAtlasGlobalClusterRead(d *schema.ResourceData, meta interface{}) error {
 	// Get client connection.
 	conn := meta.(*MongoDBClient).Atlas
@@ -158,6 +157,7 @@ func resourceMongoDBAtlasGlobalClusterRead(d *schema.ResourceData, meta interfac
 	globalCluster, resp, err := conn.GlobalClusters.Get(context.Background(), projectID, clusterName)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
 			return nil
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_ldap_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_configuration.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -154,8 +155,13 @@ func resourceMongoDBAtlasLDAPConfigurationCreate(d *schema.ResourceData, meta in
 func resourceMongoDBAtlasLDAPConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*MongoDBClient).Atlas
 
-	ldapResp, _, err := conn.LDAPConfigurations.Get(context.Background(), d.Id())
+	ldapResp, resp, err := conn.LDAPConfigurations.Get(context.Background(), d.Id())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorLDAPConfigurationRead, d.Id(), err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_ldap_verify.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_verify.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -169,8 +169,13 @@ func resourceMongoDBAtlasLDAPVerifyRead(d *schema.ResourceData, meta interface{}
 	projectID := ids["project_id"]
 	requestID := ids["request_id"]
 
-	ldapResp, _, err := conn.LDAPConfigurations.GetStatus(context.Background(), projectID, requestID)
+	ldapResp, resp, err := conn.LDAPConfigurations.GetStatus(context.Background(), projectID, requestID)
 	if err != nil || ldapResp == nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorLDAPVerifyRead, d.Id(), err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_maintenance_window.go
+++ b/mongodbatlas/resource_mongodbatlas_maintenance_window.go
@@ -3,11 +3,11 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -117,8 +117,13 @@ func resourceMongoDBAtlasMaintenanceWindowRead(d *schema.ResourceData, meta inte
 	// Get the client connection.
 	conn := meta.(*MongoDBClient).Atlas
 
-	maintenanceWindow, _, err := conn.MaintenanceWindows.Get(context.Background(), d.Id())
+	maintenanceWindow, resp, err := conn.MaintenanceWindows.Get(context.Background(), d.Id())
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorMaintenanceRead, d.Id(), err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_network_container.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container.go
@@ -10,11 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cast"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -158,6 +157,7 @@ func resourceMongoDBAtlasNetworkContainerRead(d *schema.ResourceData, meta inter
 	container, resp, err := conn.Containers.Get(context.Background(), projectID, containerID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
 			return nil
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_network_peering.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -279,6 +278,7 @@ func resourceMongoDBAtlasNetworkPeeringRead(d *schema.ResourceData, meta interfa
 	peer, resp, err := conn.Peers.Get(context.Background(), projectID, peerID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
 			return nil
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -207,14 +208,13 @@ func resourceMongoDBAtlasOnlineArchiveRead(d *schema.ResourceData, meta interfac
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	onlineArchive, _, err := conn.OnlineArchives.Get(context.Background(), projectID, clusterName, atlasID)
-
+	onlineArchive, resp, err := conn.OnlineArchives.Get(context.Background(), projectID, clusterName, atlasID)
 	if err != nil {
-		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
-		if reset {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}
+
 		return fmt.Errorf("error MongoDB Atlas Online Archive with id %s, read error %s", atlasID, err.Error())
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
+++ b/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -70,6 +69,7 @@ func resourceMongoDBAtlasPrivateIPModeRead(d *schema.ResourceData, meta interfac
 	privateIPMode, resp, err := conn.PrivateIPMode.Get(context.Background(), projectID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
 			return nil
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -98,8 +99,13 @@ func resourceMongoDBAtlasProjectRead(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*MongoDBClient).Atlas
 	projectID := d.Id()
 
-	projectRes, _, err := conn.Projects.GetOneProject(context.Background(), projectID)
+	projectRes, resp, err := conn.Projects.GetOneProject(context.Background(), projectID)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf(errorProjectRead, projectID, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_team.go
+++ b/mongodbatlas/resource_mongodbatlas_team.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -84,15 +84,15 @@ func resourceMongoDBAtlasTeamRead(d *schema.ResourceData, meta interface{}) erro
 	orgID := ids["org_id"]
 	teamID := ids["id"]
 
-	team, _, err := conn.Teams.Get(context.Background(), orgID, teamID)
+	team, resp, err := conn.Teams.Get(context.Background(), orgID, teamID)
 
 	if err != nil {
 		// new resource missing
-		reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
-		if reset {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}
+
 		return fmt.Errorf(errorTeamRead, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -162,9 +163,13 @@ func resourceMongoDBAtlasThirdPartyIntegrationRead(d *schema.ResourceData, meta 
 	projectID := ids["project_id"]
 	integrationType := ids["type"]
 
-	integration, _, err := conn.Integrations.Get(context.Background(), projectID, integrationType)
-
+	integration, resp, err := conn.Integrations.Get(context.Background(), projectID, integrationType)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("error getting third party integration resource info %s %w", integrationType, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/spf13/cast"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -144,6 +143,13 @@ func resourceMongoDBAtlasX509AuthDBUserRead(d *schema.ResourceData, meta interfa
 	if username != "" {
 		certificates, _, err = conn.X509AuthDBUsers.GetUserCertificates(context.Background(), projectID, username)
 		if err != nil {
+			// new resource missing
+			reset := strings.Contains(err.Error(), "404") && !d.IsNewResource()
+			if reset {
+				d.SetId("")
+				return nil
+			}
+
 			return fmt.Errorf(errorX509AuthDBUsersRead, username, projectID, err)
 		}
 	}


### PR DESCRIPTION
## Description

Read methods fixed in resources, there was a bug when refreshing the state when the resource is removed from the outside terraform, but still in the configuration file
Related to [TeamsUpdate - fixing small bug, again missing update](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/417)

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
