### PR TITLE
docs: fix typo in GCP network_peering.network_name

### DIFF
--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -332,7 +332,7 @@ resource "mongodbatlas_network_peering" "test" {
 **GCP ONLY:**
 
 * `gcp_project_id` - (Required - GCP) GCP project ID of the owner of the network peer.
-* `network_name` - (Required- AWS) Name of the network peer to which Atlas connects.
+* `network_name` - (Required - GCP) Name of the network peer to which Atlas connects.
   
 **AZURE ONLY:** 
 


### PR DESCRIPTION
## Description

The "GCP ONLY" section of the `network_peering` has a wrong reference to AWS.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] ~I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements~ (docs only)
- [x] I have added any necessary documentation (if appropriate)
- [ ] ~I have run make fmt and formatted my code~ (docs only)