### PR TITLE
mongodbatlas-project resource: add api_keys attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ $ export MONGODB_ATLAS_DB_USERNAME=<YOUR_DATABASE_NAME>
 - For `Project(s)` resource configuration:
 ```sh
 $ export MONGODB_ATLAS_TEAMS_IDS=<YOUR_TEAMS_IDS>
+$ export MONGODB_ATLAS_API_KEYS_IDS=<API_KEYS_IDS>
 ```
 ~> **Notice:** It should be at least one team id up to 3 teams ids depending of acceptance testing using separator comma like this `teamId1,teamdId2,teamId3`.
 

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -84,7 +84,7 @@ func dataSourceMongoDBAtlasProject() *schema.Resource {
 	}
 }
 
-func getProjectApiKeys(conn *matlas.Client, ctx context.Context, orgID, projectID string) ([]*apiKey, error) {
+func getProjectApiKeys(ctx context.Context, conn *matlas.Client, orgID, projectID string) ([]*apiKey, error) {
 	apiKeys, _, err := conn.ProjectAPIKeys.List(ctx, projectID, &matlas.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func dataSourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
-	apiKeys, err := getProjectApiKeys(conn, ctx, project.OrgID, project.ID)
+	apiKeys, err := getProjectApiKeys(ctx, conn, project.OrgID, project.ID)
 	if err != nil {
 		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -84,7 +84,7 @@ func dataSourceMongoDBAtlasProject() *schema.Resource {
 	}
 }
 
-func getProjectApiKeys(ctx context.Context, conn *matlas.Client, orgID, projectID string) ([]*apiKey, error) {
+func getProjectAPIKeys(ctx context.Context, conn *matlas.Client, orgID, projectID string) ([]*apiKey, error) {
 	apiKeys, _, err := conn.ProjectAPIKeys.List(ctx, projectID, &matlas.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func dataSourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
-	apiKeys, err := getProjectApiKeys(ctx, conn, project.OrgID, project.ID)
+	apiKeys, err := getProjectAPIKeys(ctx, conn, project.OrgID, project.ID)
 	if err != nil {
 		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -96,6 +96,8 @@ func getProjectApiKeys(conn *matlas.Client, ctx context.Context, orgID, projectI
 		id := key.ID
 		var roles []string
 		for _, role := range key.Roles {
+			// ProjectAPIKeys.List returns all API keys of the Project, including the org and project roles
+			// For more details: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/get-all-apiKeys-in-one-project/
 			if !strings.HasPrefix(role.RoleName, "ORG_") {
 				roles = append(roles, role.RoleName)
 			}
@@ -139,7 +141,7 @@ func dataSourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceDa
 
 	apiKeys, err := getProjectApiKeys(conn, ctx, project.OrgID, project.ID)
 	if err != nil {
-		return fmt.Errorf("error getting project's api keys (%s): %s", projectID, err)
+		return diag.FromErr(fmt.Errorf("error getting project's api keys (%s): %s", projectID, err))
 	}
 
 	if err := d.Set("org_id", project.OrgID); err != nil {

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -3,7 +3,6 @@ package mongodbatlas
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -90,10 +89,10 @@ func getProjectApiKeys(conn *matlas.Client, ctx context.Context, orgID, projectI
 	if err != nil {
 		return nil, err
 	}
-
 	var keys []*apiKey
 	for _, key := range apiKeys {
 		id := key.ID
+
 		var roles []string
 		for _, role := range key.Roles {
 			// ProjectAPIKeys.List returns all API keys of the Project, including the org and project roles
@@ -131,37 +130,37 @@ func dataSourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectRead, projectID, err))
+		return diag.Errorf(errorProjectRead, projectID, err)
 	}
 
 	teams, _, err := conn.Projects.GetProjectTeamsAssigned(ctx, project.ID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error getting project's teams assigned (%s): %s", projectID, err))
+		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
 	apiKeys, err := getProjectApiKeys(conn, ctx, project.OrgID, project.ID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error getting project's api keys (%s): %s", projectID, err))
+		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}
 
 	if err := d.Set("org_id", project.OrgID); err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectSetting, `org_id`, project.ID, err))
+		return diag.Errorf(errorProjectSetting, `org_id`, project.ID, err)
 	}
 
 	if err := d.Set("cluster_count", project.ClusterCount); err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectSetting, `clusterCount`, project.ID, err))
+		return diag.Errorf(errorProjectSetting, `clusterCount`, project.ID, err)
 	}
 
 	if err := d.Set("created", project.Created); err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectSetting, `created`, project.ID, err))
+		return diag.Errorf(errorProjectSetting, `created`, project.ID, err)
 	}
 
 	if err := d.Set("teams", flattenTeams(teams)); err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectSetting, `teams`, project.ID, err))
+		return diag.Errorf(errorProjectSetting, `teams`, project.ID, err)
 	}
 
 	if err := d.Set("api_keys", flattenAPIKeys(apiKeys)); err != nil {
-		return diag.FromErr(fmt.Errorf(errorProjectSetting, `api_keys`, project.ID, err))
+		return diag.Errorf(errorProjectSetting, `api_keys`, project.ID, err)
 	}
 
 	d.SetId(project.ID)

--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -19,6 +19,9 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
+	if len(apiKeysIds) < 2 {
+		t.Fatal("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); checkTeamsIds(t) },

--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -15,6 +15,7 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
@@ -35,6 +36,16 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
 						},
 					},
+					[]*apiKey{
+						{
+							id:    apiKeysIds[0],
+							roles: []string{"GROUP_READ_ONLY"},
+						},
+						{
+							id:    apiKeysIds[1],
+							roles: []string{"GROUP_OWNER"},
+						},
+					},
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
@@ -49,6 +60,7 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
@@ -70,6 +82,16 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
 						},
 					},
+					[]*apiKey{
+						{
+							id:    apiKeysIds[0],
+							roles: []string{"GROUP_READ_ONLY"},
+						},
+						{
+							id:    apiKeysIds[1],
+							roles: []string{"GROUP_OWNER"},
+						},
+					},
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
@@ -80,22 +102,22 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 	})
 }
 
-func testAccMongoDBAtlasProjectConfigWithDSByID(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+func testAccMongoDBAtlasProjectConfigWithDSByID(projectName, orgID string, teams []*matlas.ProjectTeam, apiKeys []*apiKey) string {
 	return fmt.Sprintf(`
 		%s
 
 		data "mongodbatlas_project" "test" {
 			project_id = "${mongodbatlas_project.test.id}"
 		}
-	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams))
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams, apiKeys))
 }
 
-func testAccMongoDBAtlasProjectConfigWithDSByName(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+func testAccMongoDBAtlasProjectConfigWithDSByName(projectName, orgID string, teams []*matlas.ProjectTeam, apiKeys []*apiKey) string {
 	return fmt.Sprintf(`
 		%s
 
 		data "mongodbatlas_project" "test" {
 			name = "${mongodbatlas_project.test.name}"
 		}
-	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams))
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams, apiKeys))
 }

--- a/mongodbatlas/data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects.go
@@ -67,6 +67,25 @@ func dataSourceMongoDBAtlasProjects() *schema.Resource {
 								},
 							},
 						},
+						"api_keys": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"api_key_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"role_names": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -116,6 +135,10 @@ func flattenProjects(ctx context.Context, conn *matlas.Client, projects []*matla
 				fmt.Printf("[WARN] error getting project's teams assigned (%s): %s", project.ID, err)
 			}
 
+			apiKeys, err := getProjectApiKeys(conn, project.OrgID, project.ID)
+			if err != nil {
+				fmt.Printf("[WARN] error getting project's api keys (%s): %s", project.ID, err)
+			}
 			results[k] = map[string]interface{}{
 				"id":            project.ID,
 				"org_id":        project.OrgID,
@@ -123,6 +146,7 @@ func flattenProjects(ctx context.Context, conn *matlas.Client, projects []*matla
 				"cluster_count": project.ClusterCount,
 				"created":       project.Created,
 				"teams":         flattenTeams(teams),
+				"api_keys":      flattenAPIKeys(apiKeys),
 			}
 		}
 	}

--- a/mongodbatlas/data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects.go
@@ -135,7 +135,7 @@ func flattenProjects(ctx context.Context, conn *matlas.Client, projects []*matla
 				fmt.Printf("[WARN] error getting project's teams assigned (%s): %s", project.ID, err)
 			}
 
-			apiKeys, err := getProjectApiKeys(conn, ctx, project.OrgID, project.ID)
+			apiKeys, err := getProjectApiKeys(ctx, conn, project.OrgID, project.ID)
 			if err != nil {
 				fmt.Printf("[WARN] error getting project's api keys (%s): %s", project.ID, err)
 			}

--- a/mongodbatlas/data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects.go
@@ -135,7 +135,7 @@ func flattenProjects(ctx context.Context, conn *matlas.Client, projects []*matla
 				fmt.Printf("[WARN] error getting project's teams assigned (%s): %s", project.ID, err)
 			}
 
-			apiKeys, err := getProjectApiKeys(conn, project.OrgID, project.ID)
+			apiKeys, err := getProjectApiKeys(conn, ctx, project.OrgID, project.ID)
 			if err != nil {
 				fmt.Printf("[WARN] error getting project's api keys (%s): %s", project.ID, err)
 			}

--- a/mongodbatlas/data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects.go
@@ -135,7 +135,7 @@ func flattenProjects(ctx context.Context, conn *matlas.Client, projects []*matla
 				fmt.Printf("[WARN] error getting project's teams assigned (%s): %s", project.ID, err)
 			}
 
-			apiKeys, err := getProjectApiKeys(ctx, conn, project.OrgID, project.ID)
+			apiKeys, err := getProjectAPIKeys(ctx, conn, project.OrgID, project.ID)
 			if err != nil {
 				fmt.Printf("[WARN] error getting project's api keys (%s): %s", project.ID, err)
 			}

--- a/mongodbatlas/data_source_mongodbatlas_projects_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects_test.go
@@ -16,6 +16,7 @@ func TestAccDataSourceMongoDBAtlasProjects_basic(t *testing.T) {
 	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
@@ -36,6 +37,16 @@ func TestAccDataSourceMongoDBAtlasProjects_basic(t *testing.T) {
 							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
 						},
 					},
+					[]*apiKey{
+						{
+							id:    apiKeysIds[0],
+							roles: []string{"GROUP_READ_ONLY"},
+						},
+						{
+							id:    apiKeysIds[1],
+							roles: []string{"GROUP_OWNER"},
+						},
+					},
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
@@ -50,6 +61,7 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
@@ -70,6 +82,16 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
 						},
 					},
+					[]*apiKey{
+						{
+							id:    apiKeysIds[0],
+							roles: []string{"GROUP_READ_ONLY"},
+						},
+						{
+							id:    apiKeysIds[1],
+							roles: []string{"GROUP_OWNER"},
+						},
+					},
 					2, 5,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -81,21 +103,21 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 	})
 }
 
-func testAccMongoDBAtlasProjectsConfigWithDS(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+func testAccMongoDBAtlasProjectsConfigWithDS(projectName, orgID string, teams []*matlas.ProjectTeam, apiKeys []*apiKey) string {
 	config := fmt.Sprintf(`
 		%s
 		data "mongodbatlas_projects" "test" {}
-	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams))
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams, apiKeys))
 	log.Printf("[DEBUG] config: %s", config)
 	return config
 }
 
-func testAccMongoDBAtlasProjectsConfigWithPagination(projectName, orgID string, teams []*matlas.ProjectTeam, pageNum, itemPage int) string {
+func testAccMongoDBAtlasProjectsConfigWithPagination(projectName, orgID string, teams []*matlas.ProjectTeam, apiKeys []*apiKey, pageNum, itemPage int) string {
 	return fmt.Sprintf(`
 		%s
 		data "mongodbatlas_projects" "test" {
 			page_num = %d
 			items_per_page = %d
 		}
-	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams), pageNum, itemPage)
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams, apiKeys), pageNum, itemPage)
 }

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -165,7 +165,7 @@ func resourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
-	apiKeys, err := getProjectApiKeys(conn, projectRes.OrgID, projectRes.ID)
+	apiKeys, err := getProjectApiKeys(conn, ctx, projectRes.OrgID, projectRes.ID)
 	if err != nil {
 		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -165,7 +165,7 @@ func resourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
-	apiKeys, err := getProjectApiKeys(ctx, conn, projectRes.OrgID, projectRes.ID)
+	apiKeys, err := getProjectAPIKeys(ctx, conn, projectRes.OrgID, projectRes.ID)
 	if err != nil {
 		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -73,6 +73,25 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"api_keys": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_key_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"role_names": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -109,6 +128,19 @@ func resourceMongoDBAtlasProjectCreate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	// Check if api keys were set, if so we need to add keys into the project
+	if apiKeys, ok := d.GetOk("api_keys"); ok {
+		// assign api keys to the project
+		for _, apiKey := range expandAPIKeysSet(apiKeys.(*schema.Set)) {
+			_, err := conn.ProjectAPIKeys.Assign(ctx, project.ID, apiKey.id, &matlas.AssignAPIKey{
+				Roles: apiKey.roles,
+			})
+			if err != nil {
+				return diag.Errorf("error assigning api keys to the project: %s", err)
+			}
+		}
+	}
+
 	d.SetId(project.ID)
 
 	return resourceMongoDBAtlasProjectRead(ctx, d, meta)
@@ -133,6 +165,11 @@ func resourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
+	apiKeys, err := getProjectApiKeys(conn, projectRes.OrgID, projectRes.ID)
+	if err != nil {
+		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
+	}
+
 	if err := d.Set("name", projectRes.Name); err != nil {
 		return diag.Errorf(errorProjectSetting, `name`, projectID, err)
 	}
@@ -153,6 +190,10 @@ func resourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf(errorProjectSetting, `created`, projectID, err)
 	}
 
+	if err := d.Set("api_keys", flattenAPIKeys(apiKeys)); err != nil {
+		return diag.Errorf(errorProjectSetting, `api_keys`, projectID, err)
+	}
+
 	return nil
 }
 
@@ -164,7 +205,7 @@ func resourceMongoDBAtlasProjectUpdate(ctx context.Context, d *schema.ResourceDa
 		// get the current teams and the new teams with changes
 		newTeams, changedTeams, removedTeams := getStateTeams(d)
 
-		// adding new teans into the project
+		// adding new teams into the project
 		if len(newTeams) > 0 {
 			_, _, err := conn.Projects.AddTeamsToProject(ctx, projectID, expandTeamsList(newTeams))
 			if err != nil {
@@ -193,6 +234,42 @@ func resourceMongoDBAtlasProjectUpdate(ctx context.Context, d *schema.ResourceDa
 			)
 			if err != nil {
 				return diag.Errorf("error updating role names for the team(%s): %s", team["team_id"], err)
+			}
+		}
+	}
+
+	if d.HasChange("api_keys") {
+		// get the current api_keys and the new api_keys with changes
+		newAPIKeys, changedAPIKeys, removedAPIKeys := getStateAPIKeys(d)
+
+		// adding new api_keys into the project
+		if len(newAPIKeys) > 0 {
+			for _, apiKey := range expandAPIKeysList(newAPIKeys) {
+				_, err := conn.ProjectAPIKeys.Assign(ctx, projectID, apiKey.id, &matlas.AssignAPIKey{
+					Roles: apiKey.roles,
+				})
+				if err != nil {
+					return diag.Errorf("error assigning api_keys into the project(%s): %s", projectID, err)
+				}
+			}
+		}
+
+		// Removing api_keys from the project
+		for _, apiKey := range removedAPIKeys {
+			apiKeyID := apiKey.(map[string]interface{})["api_key_id"].(string)
+			_, err := conn.ProjectAPIKeys.Unassign(ctx, projectID, apiKeyID)
+			if err != nil {
+				return diag.Errorf("error removing api_key(%s) from the project(%s): %s", apiKeyID, projectID, err)
+			}
+		}
+
+		// Updating the role names for the api_key
+		for _, apiKey := range expandAPIKeysList(changedAPIKeys) {
+			_, err := conn.ProjectAPIKeys.Assign(ctx, projectID, apiKey.id, &matlas.AssignAPIKey{
+				Roles: apiKey.roles,
+			})
+			if err != nil {
+				return diag.Errorf("error updating role names for the api_key(%s): %s", apiKey, err)
 			}
 		}
 	}
@@ -226,6 +303,20 @@ func expandTeamsSet(teams *schema.Set) []*matlas.ProjectTeam {
 	return res
 }
 
+func expandAPIKeysSet(apiKeys *schema.Set) []*apiKey {
+	res := make([]*apiKey, apiKeys.Len())
+
+	for i, value := range apiKeys.List() {
+		v := value.(map[string]interface{})
+		res[i] = &apiKey{
+			id:    v["api_key_id"].(string),
+			roles: expandStringList(v["role_names"].(*schema.Set).List()),
+		}
+	}
+
+	return res
+}
+
 func expandTeamsList(teams []interface{}) []*matlas.ProjectTeam {
 	res := make([]*matlas.ProjectTeam, len(teams))
 
@@ -240,6 +331,20 @@ func expandTeamsList(teams []interface{}) []*matlas.ProjectTeam {
 	return res
 }
 
+func expandAPIKeysList(apiKeys []interface{}) []*apiKey {
+	res := make([]*apiKey, len(apiKeys))
+
+	for i, value := range apiKeys {
+		v := value.(map[string]interface{})
+		res[i] = &apiKey{
+			id:    v["api_key_id"].(string),
+			roles: expandStringList(v["role_names"].(*schema.Set).List()),
+		}
+	}
+
+	return res
+}
+
 func flattenTeams(ta *matlas.TeamsAssigned) []map[string]interface{} {
 	teams := ta.Results
 	res := make([]map[string]interface{}, len(teams))
@@ -248,6 +353,19 @@ func flattenTeams(ta *matlas.TeamsAssigned) []map[string]interface{} {
 		res[i] = map[string]interface{}{
 			"team_id":    team.TeamID,
 			"role_names": team.RoleNames,
+		}
+	}
+
+	return res
+}
+
+func flattenAPIKeys(keys []*apiKey) []map[string]interface{} {
+	res := make([]map[string]interface{}, len(keys))
+
+	for i, key := range keys {
+		res[i] = map[string]interface{}{
+			"api_key_id": key.id,
+			"role_names": key.roles,
 		}
 	}
 
@@ -278,6 +396,34 @@ func getStateTeams(d *schema.ResourceData) (newTeams, changedTeams, removedTeams
 
 	newTeams = nTeams.List()
 	removedTeams = rTeams.List()
+
+	return
+}
+
+func getStateAPIKeys(d *schema.ResourceData) (newAPIKeys, changedAPIKeys, removedAPIKeys []interface{}) {
+	currentAPIKeys, changes := d.GetChange("api_keys")
+
+	rAPIKeys := currentAPIKeys.(*schema.Set).Difference(changes.(*schema.Set))
+	nAPIKeys := changes.(*schema.Set).Difference(currentAPIKeys.(*schema.Set))
+	changedAPIKeys = make([]interface{}, 0)
+
+	for _, changed := range nAPIKeys.List() {
+		for _, removed := range rAPIKeys.List() {
+			if changed.(map[string]interface{})["api_key_id"] == removed.(map[string]interface{})["api_key_id"] {
+				rAPIKeys.Remove(removed)
+			}
+		}
+
+		for _, current := range currentAPIKeys.(*schema.Set).List() {
+			if changed.(map[string]interface{})["api_key_id"] == current.(map[string]interface{})["api_key_id"] {
+				changedAPIKeys = append(changedAPIKeys, changed.(map[string]interface{}))
+				nAPIKeys.Remove(changed)
+			}
+		}
+	}
+
+	newAPIKeys = nAPIKeys.List()
+	removedAPIKeys = rAPIKeys.List()
 
 	return
 }

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -165,7 +165,7 @@ func resourceMongoDBAtlasProjectRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error getting project's teams assigned (%s): %s", projectID, err)
 	}
 
-	apiKeys, err := getProjectApiKeys(conn, ctx, projectRes.OrgID, projectRes.ID)
+	apiKeys, err := getProjectApiKeys(ctx, conn, projectRes.OrgID, projectRes.ID)
 	if err != nil {
 		return diag.Errorf("error getting project's api keys (%s): %s", projectID, err)
 	}

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -86,8 +86,8 @@ The following are valid roles:
   * `GROUP_DATA_ACCESS_READ_WRITE`
   * `GROUP_DATA_ACCESS_READ_ONLY`
   * `GROUP_CLUSTER_MANAGER`
-* `api_keys.#.api_key_id` - The unique identifier of the api key you want to associate with the project. The api key and project must share the same parent organization.
-* `api_keys.#.role_names` - Each string in the array represents a project role assigned to the api key.
+* `api_keys.#.api_key_id` - The unique identifier of the programmatic API key you want to associate with the project. The programmatic API key and project must share the same parent organization.
+* `api_keys.#.role_names` - Each string in the array represents a project role assigned to the programmatic API key.
 The following are valid roles:
   * `GROUP_OWNER`
   * `GROUP_READ_ONLY`

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -51,6 +51,10 @@ resource "mongodbatlas_project" "test" {
     team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
     role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
   }
+  api_keys {
+    api_key_id = "61003b299dda8d54a9d7d10c"
+    role_names = ["GROUP_READ_ONLY"]
+  }
 }
 
 data "mongodbatlas_project" "test" {
@@ -82,6 +86,14 @@ The following are valid roles:
   * `GROUP_DATA_ACCESS_READ_WRITE`
   * `GROUP_DATA_ACCESS_READ_ONLY`
   * `GROUP_CLUSTER_MANAGER`
-
+* `api_keys.#.api_key_id` - The unique identifier of the api key you want to associate with the project. The api key and project must share the same parent organization.
+* `api_keys.#.role_names` - Each string in the array represents a project role assigned to the api key.
+The following are valid roles:
+  * `GROUP_OWNER`
+  * `GROUP_READ_ONLY`
+  * `GROUP_DATA_ACCESS_ADMIN`
+  * `GROUP_DATA_ACCESS_READ_WRITE`
+  * `GROUP_DATA_ACCESS_READ_ONLY`
+  * `GROUP_CLUSTER_MANAGER`
 
 See [MongoDB Atlas API - Project](https://docs.atlas.mongodb.com/reference/api/project-get-one/) - [and MongoDB Atlas API - Teams](https://docs.atlas.mongodb.com/reference/api/project-get-teams/) Documentation for more information.

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -66,8 +66,8 @@ The following are valid roles:
   * `GROUP_DATA_ACCESS_READ_WRITE`
   * `GROUP_DATA_ACCESS_READ_ONLY`
   * `GROUP_CLUSTER_MANAGER`
-* `api_keys.#.api_key_id` - The unique identifier of the api key you want to associate with the project. The api key and project must share the same parent organization.
-* `api_keys.#.role_names` - Each string in the array represents a project role assigned to the api key.
+* `api_keys.#.api_key_id` - The unique identifier of the Organization Programmatic API key assigned to the Project. 
+* `api_keys.#.role_names` -  List of roles that the Organization Programmatic API key has been assigned. 
 The following are valid roles:
   * `GROUP_OWNER`
   * `GROUP_READ_ONLY`

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -28,6 +28,10 @@ resource "mongodbatlas_project" "test" {
     team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
     role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
   }
+  api_keys {
+    api_key_id = "61003b299dda8d54a9d7d10c"
+    role_names = ["GROUP_READ_ONLY"]
+  }
 }
 
 data "mongodbatlas_project" "test" {
@@ -62,7 +66,15 @@ The following are valid roles:
   * `GROUP_DATA_ACCESS_READ_WRITE`
   * `GROUP_DATA_ACCESS_READ_ONLY`
   * `GROUP_CLUSTER_MANAGER`
-
+* `api_keys.#.api_key_id` - The unique identifier of the api key you want to associate with the project. The api key and project must share the same parent organization.
+* `api_keys.#.role_names` - Each string in the array represents a project role assigned to the api key.
+The following are valid roles:
+  * `GROUP_OWNER`
+  * `GROUP_READ_ONLY`
+  * `GROUP_DATA_ACCESS_ADMIN`
+  * `GROUP_DATA_ACCESS_READ_WRITE`
+  * `GROUP_DATA_ACCESS_READ_ONLY`
+  * `GROUP_CLUSTER_MANAGER`
 
 
 See [MongoDB Atlas API - Projects](https://docs.atlas.mongodb.com/reference/api/project-get-all/) - [and MongoDB Atlas API - Teams](https://docs.atlas.mongodb.com/reference/api/project-get-teams/) Documentation for more information.

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -63,14 +63,13 @@ Teams attribute is optional
 
 ~> **NOTE:** Project created by API Keys must belong to an existing organization.
 
-### Api Keys
-api_keys attribute is optional
+### Programmatic API Keys
+api_keys allows one to assign an existing organization programmatic API key to a Project. The api_keys attribute is optional.
 
-~> **NOTE:** Atlas limits the number of api keys to a maximum of 500 api keys per organization.
 
-* `api_key_id` - (Required) The unique identifier of the api key you want to associate with the project.
+* `api_key_id` - (Required) The unique identifier of the Programmatic API key you want to associate with the Project.  The Programmatic API key and Project must share the same parent organization.
 
-* `role_names` - (Required) Each string in the array represents a project role you want to assign to the api key. You must specify an array even if you are only associating a single role with the api key.
+* `role_names` - (Required) List of Project roles that the Programmatic API key needs to have. Ensure you provide: at least one role and ensure all roles are valid for the Project.  You must specify an array even if you are only associating a single role with the Programmatic API key.
  The following are valid roles:
   * `GROUP_OWNER`
   * `GROUP_READ_ONLY`

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -29,6 +29,11 @@ resource "mongodbatlas_project" "test" {
     team_id    = "5e1dd7b4f2a30ba80a70cd4rw"
     role_names = ["GROUP_READ_ONLY", "GROUP_DATA_ACCESS_READ_WRITE"]
   }
+
+  api_keys {
+    api_key_id = "61003b299dda8d54a9d7d10c"
+    role_names = ["GROUP_READ_ONLY"]
+  }
 }
 ```
 
@@ -57,6 +62,22 @@ Teams attribute is optional
 
 
 ~> **NOTE:** Project created by API Keys must belong to an existing organization.
+
+### Api Keys
+api_keys attribute is optional
+
+~> **NOTE:** Atlas limits the number of api keys to a maximum of 500 api keys per organization.
+
+* `api_key_id` - (Required) The unique identifier of the api key you want to associate with the project.
+
+* `role_names` - (Required) Each string in the array represents a project role you want to assign to the api key. You must specify an array even if you are only associating a single role with the api key.
+ The following are valid roles:
+  * `GROUP_OWNER`
+  * `GROUP_READ_ONLY`
+  * `GROUP_DATA_ACCESS_ADMIN`
+  * `GROUP_DATA_ACCESS_READ_WRITE`
+  * `GROUP_DATA_ACCESS_READ_ONLY`
+  * `GROUP_CLUSTER_MANAGER`
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
- add `api_keys` attribute to the mongodbatlas-project resource
Now the only one api key that will be added to the newly created project is the api key used to create the project. To perform different automation tasks: like get processes logs, read process/disk measurements I want to be able to add more api keys to the new project.

Link to any related issue(s): https://feedback.mongodb.com/forums/924145-atlas/suggestions/43840743-add-possibility-to-invite-api-key-s-to-newly-crea

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
