### PR TITLE
INTMDB-225: Fixed network peering resource for Azure

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_network_peering.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -208,11 +207,6 @@ func resourceMongoDBAtlasNetworkPeeringCreate(ctx context.Context, d *schema.Res
 	}
 
 	if providerName == "AZURE" {
-		atlasCidrBlock, ok := d.GetOk("atlas_cidr_block")
-		if !ok {
-			return diag.FromErr(errors.New("`atlas_cidr_block` must be set when `provider_name` is `AZURE`"))
-		}
-
 		azureDirectoryID, ok := d.GetOk("azure_directory_id")
 		if !ok {
 			return diag.FromErr(errors.New("`azure_directory_id` must be set when `provider_name` is `AZURE`"))
@@ -233,7 +227,6 @@ func resourceMongoDBAtlasNetworkPeeringCreate(ctx context.Context, d *schema.Res
 			return diag.FromErr(errors.New("`vnet_name` must be set when `provider_name` is `AZURE`"))
 		}
 
-		peerRequest.AtlasCIDRBlock = atlasCidrBlock.(string)
 		peerRequest.AzureDirectoryID = azureDirectoryID.(string)
 		peerRequest.AzureSubscriptionID = azureSubscriptionID.(string)
 		peerRequest.ResourceGroupName = resourceGroupName.(string)

--- a/mongodbatlas/resource_mongodbatlas_network_peering_test.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering_test.go
@@ -88,7 +88,7 @@ func TestAccResourceMongoDBAtlasNetworkPeering_basicAzure(t *testing.T) {
 				ImportStateIdFunc:       testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"atlas_cidr_block", "container_id"},
+				ImportStateVerifyIgnore: []string{"container_id"},
 			},
 		},
 	})
@@ -288,7 +288,6 @@ func testAccMongoDBAtlasNetworkPeeringConfigAzure(projectID, providerName, direc
 
 		resource "mongodbatlas_network_peering" "test" {
 			project_id   		      = "%[1]s"
-			atlas_cidr_block      = "192.168.0.0/21"
 			container_id          = mongodbatlas_network_container.test.container_id
 			provider_name         = "%[2]s"
 			azure_directory_id    = "%[3]s"

--- a/website/docs/d/network_peering.html.markdown
+++ b/website/docs/d/network_peering.html.markdown
@@ -53,7 +53,6 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_id` - Unique identifier of the peer VPC.
 * `error_state_name` - Error state, if any. The VPC peering connection error state value can be one of the following: `REJECTED`, `EXPIRED`, `INVALID_ARGUMENT`.
 * `status_name` - The VPC peering connection status value can be one of the following: `INITIATING`, `PENDING_ACCEPTANCE`, `FAILED`, `FINALIZING`, `AVAILABLE`, `TERMINATING`.
-* `atlas_cidr_block` - Unique identifier for an Azure AD directory.
 * `azure_directory_id` - Unique identifier for an Azure AD directory.
 * `azure_subscription_id` - Unique identifer of the Azure subscription in which the VNet resides.
 * `resource_group_name` - Name of your Azure resource group. 

--- a/website/docs/d/network_peerings.html.markdown
+++ b/website/docs/d/network_peerings.html.markdown
@@ -56,7 +56,6 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_id` - Unique identifier of the peer VPC.
 * `error_state_name` - Error state, if any. The VPC peering connection error state value can be one of the following: `REJECTED`, `EXPIRED`, `INVALID_ARGUMENT`.
 * `status_name` - The VPC peering connection status value can be one of the following: `INITIATING`, `PENDING_ACCEPTANCE`, `FAILED`, `FINALIZING`, `AVAILABLE`, `TERMINATING`.
-* `atlas_cidr_block` - Unique identifier for an Azure AD directory.
 * `azure_directory_id` - Unique identifier for an Azure AD directory.
 * `azure_subscription_id` - Unique identifer of the Azure subscription in which the VNet resides.
 * `resource_group_name` - Name of your Azure resource group. 

--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -163,7 +163,6 @@ resource "mongodbatlas_network_peering" "test" {
   azure_subscription_id = local.AZURE_SUBSCRIPTION_ID
   resource_group_name   = local.AZURE_RESOURCES_GROUP_NAME
   vnet_name             = local.AZURE_VNET_NAME
-  atlas_cidr_block      = mongodbatlas_network_container.test.atlas_cidr_block
 }
 
 # Create the cluster once the peering connection is completed
@@ -314,7 +313,6 @@ resource "mongodbatlas_network_peering" "test" {
   azure_subscription_id = local.AZURE_SUBSCRIPTION_ID
   resource_group_name   = local.AZURE_RESOURCE_GROUP_NAME
   vnet_name             = local.AZURE_VNET_NAME
-  atlas_cidr_block      = local.ATLAS_CIDR_BLOCK
 }
 ```
 


### PR DESCRIPTION
## Description

`atlas_cidr` was removed from azure network peering resource due is not necessary 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
