### PR TITLE
Add stronger warning against attempting a shared tier upgrade

### DIFF
--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -16,7 +16,7 @@ description: |-
 
 ~> **IMPORTANT:**
 <br> &#8226; Free tier cluster creation (M0) is not supported via API or by this Provider.
-<br> &#8226; Shared tier clusters (M2, M5) cannot be upgraded to higher tiers via API or by this Provider.
+<br> &#8226; Shared tier clusters (M2, M5) cannot be upgraded to higher tiers via API or by this Provider.  WARNING! If you attempt to upgrade from an existing shared tier cluster that you manage with this Provider to a dedicated cluster (M10+) Terraform will see it as a request to destroy the shared tier cluster and as a request to create a dedicated tier cluster, i.e. Terraform will not see it as a request to upgrade.   If you accept the plan in this case the shared tier cluster would be destroyed and you would lose the data on that cluster. Do not attempt to upgrade from the shared to dedicated tier via this Provider, it is not supported!  
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).   
 <br> &#8226; If your Atlas project contains a custom role that uses actions introduced in a specific MongoDB version, you cannot create a cluster with a MongoDB version less than that version unless you delete the custom role.
 


### PR DESCRIPTION
## Description

Users who attempt to upgrade from a shared tier cluster (M2/M5) to a dedicated tier cluster - even though it is called out as unsupported - will destroy the shared tier and create a dedicated tier.  This is due to the fact that upgrades are not supported yet Terraform will still try to make the changes it sees in the config.   Adding stronger language to the call out that this is not supported since it will result in data lost from the shared tier cluster.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
