### PR TITLE
INTMDB-235: Added example of ldap configuration docs

### DIFF
--- a/website/docs/r/ldap_configuration.html.markdown
+++ b/website/docs/r/ldap_configuration.html.markdown
@@ -12,19 +12,43 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
-	name   = "NAME OF THE PROJECT"
-	org_id = "ORG ID"
+  name   = "NAME OF THE PROJECT"
+  org_id = "ORG ID"
 }
 
 resource "mongodbatlas_ldap_configuration" "test" {
-	project_id                  = mongodbatlas_project.test.id
-	authentication_enabled      = true
-	hostname 					= "HOSTNAME"
-	port                     	= 636
-	bind_username               = "USERNAME"
-	bind_password               = "PASSWORD"
+  project_id             = mongodbatlas_project.test.id
+  authentication_enabled = true
+  hostname               = "HOSTNAME"
+  port                   = 636
+  bind_username          = "USERNAME"
+  bind_password          = "PASSWORD"
+}
+```
+
+## Example Usage of LDAP with user to DN mapping
+
+```terraform
+resource "mongodbatlas_project" "test" {
+  name   = "NAME OF THE PROJECT"
+  org_id = "ORG ID"
+}
+
+resource "mongodbatlas_ldap_configuration" "test" {
+  project_id             = mongodbatlas_project.test.id
+  authentication_enabled = true
+  hostname               = "HOSTNAME"
+  port                   = 636
+  bind_username          = "USERNAME"
+  bind_password          = "PASSWORD"
+  ca_certificate         = "CA CERTIFICATE"
+  authz_query_template   = "{USER}?memberOf?base"
+  user_to_dn_mapping {
+    match      = "(.+)"
+    ldap_query = "DC=example,DC=com??sub?(userPrincipalName={0})"
+  }
 }
 ```
 


### PR DESCRIPTION
## Description

- Added another example in terraform when you pass the user DN mapping along the CA certificated and authz query

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
