### PR TITLE
INTMDB-237: fix word in private_endpoint resource documentation

### DIFF
--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -32,7 +32,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 ## Argument Reference
 
 * `project_id` - Required 	Unique identifier for the project.
-* `providerName` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS` or `AZURE`.
+* `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS` or `AZURE`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws) and [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure)
   


### PR DESCRIPTION
## Description

Changed `providerName` ->. `provider_name` in documentation. This word was searched in other documentation files but, the error was only in the resource documentation

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
