### PR TITLE
Support for organization API Keys

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_organization_api_key.go
+++ b/mongodbatlas/data_source_mongodbatlas_organization_api_key.go
@@ -1,0 +1,96 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceMongoDBAtlasOrganizationApiKey() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMongoDBAtlasOrganizationApiKeyRead,
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"api_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"roles": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"access_list_cidr_blocks": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceMongoDBAtlasOrganizationApiKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*MongoDBClient).Atlas
+	orgID := d.Get("org_id").(string)
+	apiKeyID := d.Get("api_key_id").(string)
+
+	apiKey, _, err := conn.APIKeys.Get(ctx, orgID, apiKeyID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	if err := d.Set("api_key_id", apiKey.ID); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	apiKeyAccessList, _, err := conn.AccessListAPIKeys.List(ctx, orgID, apiKeyID, nil)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// description
+	if err := d.Set("description", apiKey.Desc); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// roles
+	roles := []string{}
+	for i := range apiKey.Roles {
+		roles = append(roles, apiKey.Roles[i].RoleName)
+	}
+
+	if err := d.Set("roles", roles); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// access_list_cidr_blocks
+	ip_addresses := []string{}
+	for i := range apiKeyAccessList.Results {
+		ip_addresses = append(ip_addresses, apiKeyAccessList.Results[i].CidrBlock)
+	}
+
+	if err := d.Set("access_list_cidr_blocks", ip_addresses); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"org_id":     orgID,
+		"api_key_id": apiKeyID,
+	}))
+
+	return nil
+}

--- a/mongodbatlas/data_source_mongodbatlas_organization_api_key_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_organization_api_key_test.go
@@ -1,0 +1,53 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceMongoDBAtlasOrganizationApiKey_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_organization_api_key.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		role           = "ORG_OWNER"
+		accessList     = "1.1.1.1/30"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, role, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "api_key_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", desc),
+					resource.TestCheckResourceAttr(dataSourceName, "access_list_cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, role, accessList string) string {
+	return fmt.Sprintf(`
+        resource "mongodbatlas_organization_api_key" "test" {
+            org_id                  = "%s"
+            description             = "%s"
+            roles                   = ["%s"]
+            access_list_cidr_blocks = ["%s"]
+        }
+
+        data "mongodbatlas_organization_api_key" "test" {
+            org_id     = mongodbatlas_organization_api_key.test.org_id
+            api_key_id = mongodbatlas_organization_api_key.test.api_key_id
+        }
+    `, orgID, desc, role, accessList)
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -85,6 +85,7 @@ func Provider() *schema.Provider {
 			"mongodbatlas_data_lakes":                            dataSourceMongoDBAtlasDataLakes(),
 			"mongodbatlas_event_trigger":                         dataSourceMongoDBAtlasEventTrigger(),
 			"mongodbatlas_event_triggers":                        dataSourceMongoDBAtlasEventTriggers(),
+			"mongodbatlas_organization_api_key":                  dataSourceMongoDBAtlasOrganizationApiKey(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -121,6 +122,7 @@ func Provider() *schema.Provider {
 			"mongodbatlas_data_lake":                             resourceMongoDBAtlasDataLake(),
 			"mongodbatlas_event_trigger":                         resourceMongoDBAtlasEventTriggers(),
 			"mongodbatlas_cloud_backup_schedule":                 resourceMongoDBAtlasCloudBackupSchedule(),
+			"mongodbatlas_organization_api_key":                  resourceMongoDBAtlasOrganizationApiKey(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/mongodbatlas/resource_mongodbatlas_organization_api_key.go
+++ b/mongodbatlas/resource_mongodbatlas_organization_api_key.go
@@ -1,0 +1,360 @@
+package mongodbatlas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	errorOrgApiKeyCreate         = "error creating the MongoDB Organization (%s) API Key: %s"
+	errorOrgApiKeyUpdate         = "error updating the MongoDB Organization (%s) API Key (%s): %s"
+	errorOrgApiKeyRead           = "error reading the MongoDB Organization (%s) API Key (%s): %s"
+	errorOrgApiKeyDelete         = "error deleting the MongoDB Organization (%s) API Key (%s): %s"
+	errorOrgApiKeyAtLeastOneRole = "error, at least one role must be present for an API Key"
+	errorOrgApiKeyInvalidCIDR    = "error creating the MongoDB Organization (%s) API Key, invalid CIDR block %s"
+)
+
+func resourceMongoDBAtlasOrganizationApiKey() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMongoDBAtlasOrganizationApiKeyCreate,
+		ReadContext:   resourceMongoDBAtlasOrganizationApiKeyRead,
+		UpdateContext: resourceMongoDBAtlasOrganizationApiKeyUpdate,
+		DeleteContext: resourceMongoDBAtlasOrganizationApiKeyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceMongoDBAtlasOrganizationApiKeyImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"api_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"roles": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"access_list_cidr_blocks": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasOrganizationApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*MongoDBClient).Atlas
+	orgID := d.Get("org_id").(string)
+
+	// Checking there is at least one role
+	roles := expandStringListFromSetSchema(d.Get("roles").(*schema.Set))
+	if len(roles) == 0 {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyAtLeastOneRole))
+	}
+
+	// Before creating the API keys, first validating cidr blocks
+	accessList := expandStringListFromSetSchema(d.Get("access_list_cidr_blocks").(*schema.Set))
+	invalidCIDR := validateCIDRBlocks(accessList)
+	if invalidCIDR != "" {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyInvalidCIDR, orgID, invalidCIDR))
+	}
+
+	// Creating org key
+	apiKey, _, err := conn.APIKeys.Create(ctx, orgID,
+		&matlas.APIKeyInput{
+			Desc:  d.Get("description").(string),
+			Roles: roles,
+		})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyCreate, orgID, err))
+	}
+
+	// Creating API key access list
+	err = createAccessList(conn.AccessListAPIKeys, ctx, orgID, apiKey.ID, accessList)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyCreate, orgID, err))
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"org_id":     orgID,
+		"api_key_id": apiKey.ID,
+	}))
+
+	return resourceMongoDBAtlasOrganizationApiKeyRead(ctx, d, meta)
+}
+
+func resourceMongoDBAtlasOrganizationApiKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	conn := meta.(*MongoDBClient).Atlas
+
+	ids := decodeStateID(d.Id())
+	orgID := ids["org_id"]
+	apiKeyID := ids["api_key_id"]
+
+	apiKey, resp, err := conn.APIKeys.Get(context.Background(), orgID, apiKeyID)
+
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	if err := d.Set("api_key_id", apiKey.ID); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	if err := d.Set("public_key", apiKey.PublicKey); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	if err := d.Set("private_key", apiKey.PrivateKey); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	apiKeyAccessList, _, err := conn.AccessListAPIKeys.List(ctx, orgID, apiKeyID, nil)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// description
+	if err := d.Set("description", apiKey.Desc); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// roles
+	roles := []string{}
+	for i := range apiKey.Roles {
+		roles = append(roles, apiKey.Roles[i].RoleName)
+	}
+
+	if err := d.Set("roles", roles); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	// access_list_cidr_blocks
+	accessList := []string{}
+	for i := range apiKeyAccessList.Results {
+		accessList = append(accessList, apiKeyAccessList.Results[i].CidrBlock)
+	}
+
+	if err := d.Set("access_list_cidr_blocks", accessList); err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyRead, orgID, apiKeyID, err))
+	}
+
+	return nil
+}
+
+func resourceMongoDBAtlasOrganizationApiKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*MongoDBClient).Atlas
+
+	ids := decodeStateID(d.Id())
+	orgID := ids["org_id"]
+	apiKeyID := ids["api_key_id"]
+
+	// description
+	if d.HasChange("description") {
+		_, _, err := conn.APIKeys.Update(ctx, orgID, apiKeyID,
+			&matlas.APIKeyInput{
+				Desc: d.Get("description").(string),
+			})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyUpdate, orgID, apiKeyID, err))
+		}
+	}
+	// roles
+	if d.HasChange("roles") {
+		roles := expandStringListFromSetSchema(d.Get("roles").(*schema.Set))
+
+		// Checking there is at least one role
+		if len(roles) == 0 {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyAtLeastOneRole))
+		}
+
+		_, _, err := conn.APIKeys.Update(ctx, orgID, apiKeyID,
+			&matlas.APIKeyInput{
+				Roles: roles,
+			})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyUpdate, orgID, apiKeyID, err))
+		}
+	}
+
+	// access_list_cidr_blocks
+	// As of 8/20/2021, access list update (PATCH) is not supported in Atlas API
+	// https://docs.atlas.mongodb.com/reference/api/apiKeys/#organization-api-key-access-list-endpoints
+	//
+	// So, deleting the existing ones and create the new ones
+	if d.HasChange("access_list_cidr_blocks") {
+		// First, validating new CIDR blocks
+		accessList := expandStringListFromSetSchema(d.Get("access_list_cidr_blocks").(*schema.Set))
+		invalidCIDR := validateCIDRBlocks(accessList)
+		if invalidCIDR != "" {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyInvalidCIDR, orgID, invalidCIDR))
+		}
+
+		// Deleting
+		err := deleteAccessListIPs(conn.AccessListAPIKeys, ctx, orgID, apiKeyID)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyDelete, orgID, apiKeyID, err))
+		}
+		// Recreating
+		err = createAccessList(conn.AccessListAPIKeys, ctx, orgID, apiKeyID, accessList)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf(errorOrgApiKeyCreate, orgID, err))
+		}
+	}
+
+	return resourceMongoDBAtlasOrganizationApiKeyRead(ctx, d, meta)
+}
+
+func resourceMongoDBAtlasOrganizationApiKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*MongoDBClient).Atlas
+
+	ids := decodeStateID(d.Id())
+	orgID := ids["org_id"]
+	apiKeyID := ids["api_key_id"]
+
+	// Deleting access list ips
+	err := deleteAccessListIPs(conn.AccessListAPIKeys, ctx, orgID, apiKeyID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyDelete, orgID, apiKeyID, err))
+	}
+
+	// Deleting API keys
+	_, err = conn.APIKeys.Delete(ctx, orgID, apiKeyID)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorOrgApiKeyDelete, orgID, apiKeyID, err))
+	}
+
+	return nil
+}
+
+func deleteAccessListIPs(apiKeysResource matlas.AccessListAPIKeysService, ctx context.Context, orgID, apiKeyID string) error {
+	apiKeyAccessList, _, err := apiKeysResource.List(ctx, orgID, apiKeyID, nil)
+	if err != nil {
+		return err
+	}
+
+	for i := range apiKeyAccessList.Results {
+		// Atlas API stores /32 as regular IPs without the CIDR notation
+		// detecting them and stripping the "/32" part so they can be deleted
+		toDelete := apiKeyAccessList.Results[i].CidrBlock
+		if toDelete[len(toDelete)-3:] == "/32" {
+			toDelete = toDelete[:len(toDelete)-3]
+		}
+		_, err = apiKeysResource.Delete(ctx, orgID, apiKeyID, url.QueryEscape(toDelete))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCIDRBlocks(accessList []string) string {
+	for i := range accessList {
+		// Checking address is a cidr block
+		cidrBlock, _, _ := net.ParseCIDR(accessList[i])
+		if cidrBlock == nil {
+			return accessList[i]
+		}
+	}
+	return ""
+}
+
+func createAccessList(apiKeysResource matlas.AccessListAPIKeysService, ctx context.Context, orgID, apiKeyID string, accessList []string) error {
+	keyAccessList := []*matlas.AccessListAPIKeysReq{}
+	for i := range accessList {
+		keyAccessList = append(keyAccessList, &matlas.AccessListAPIKeysReq{
+			CidrBlock: accessList[i],
+		})
+	}
+
+	_, _, err := apiKeysResource.Create(ctx, orgID, apiKeyID, keyAccessList)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceMongoDBAtlasOrganizationApiKeyImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*MongoDBClient).Atlas
+
+	parts := strings.SplitN(d.Id(), "-", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("import format error: to import an API key, use the format {org_id}-{api_public_key}")
+	}
+
+	orgID := parts[0]
+	apiPublicKey := parts[1]
+
+	apiKeyList, _, err := conn.APIKeys.List(ctx, orgID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't import API key (%s) in organization (%s), error: %s", apiPublicKey, orgID, err)
+	}
+
+	var apiKey matlas.APIKey
+	for i := range apiKeyList {
+		if apiKeyList[i].PublicKey == apiPublicKey {
+			apiKey = apiKeyList[i]
+		}
+	}
+	if apiKey.ID == "" {
+		return nil, fmt.Errorf("couldn't find API key (%s) in organization (%s), error: %s", apiPublicKey, orgID, err)
+	}
+
+	if err := d.Set("org_id", orgID); err != nil {
+		log.Printf("[WARN] Error setting org_id for (%s): %s", orgID, err)
+	}
+
+	if err := d.Set("api_key_id", apiKey.ID); err != nil {
+		log.Printf("[WARN] Error setting api_key_id for (%s): %s", apiPublicKey, err)
+	}
+
+	if err := d.Set("public_key", apiPublicKey); err != nil {
+		log.Printf("[WARN] Error setting api_key_id for (%s): %s", apiPublicKey, err)
+	}
+
+	if err := d.Set("private_key", apiKey.PrivateKey); err != nil {
+		log.Printf("[WARN] Error setting api_key_id for (%s): %s", apiPublicKey, err)
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"org_id":     orgID,
+		"api_key_id": apiKey.ID,
+	}))
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/mongodbatlas/resource_mongodbatlas_organization_api_key_test.go
+++ b/mongodbatlas/resource_mongodbatlas_organization_api_key_test.go
@@ -1,0 +1,234 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccResourceMongoDBAtlasOrganizationApiKeys_basic(t *testing.T) {
+	var (
+		apiKey           matlas.APIKey
+		resourceName     = "mongodbatlas_organization_api_key.test"
+		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc             = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		descUpdate       = fmt.Sprintf("test-update-acc-%s", acctest.RandString(10))
+		roles            = []string{"ORG_OWNER"}
+		rolesUpdate      = []string{"ORG_OWNER", "ORG_READ_ONLY"}
+		accessList       = []string{"1.1.1.1/30", "10.10.10.10/32"}
+		accessListUpdate = []string{"1.1.1.1/30"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, roles, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", desc),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, descUpdate, roles, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", descUpdate),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, descUpdate, rolesUpdate, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", descUpdate),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, descUpdate, rolesUpdate, accessListUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", descUpdate),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasOrganizationApiKeys_InvalidAccessList(t *testing.T) {
+	var (
+		orgID      = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc       = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		roles      = []string{"ORG_OWNER"}
+		accessList = []string{"1.1.1.1/30", "10.10.10.10"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, roles, accessList),
+				ExpectError: regexp.MustCompile(".*error creating the MongoDB Organization .* API Key, invalid CIDR block.*"),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasOrganizationApiKeys_InvalidRoles(t *testing.T) {
+	var (
+		orgID      = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc       = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		roles      = []string{}
+		accessList = []string{"1.1.1.1/30", "10.10.10.10/20"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, roles, accessList),
+				ExpectError: regexp.MustCompile(".*at least one role must be present for an API Key.*"),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasOrganizationApiKeys_EmptyAccessList(t *testing.T) {
+	var (
+		apiKey       matlas.APIKey
+		resourceName = "mongodbatlas_organization_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		roles        = []string{"ORG_OWNER"}
+		accessList   = []string{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, roles, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", desc),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasOrganizationApiKeys_importBasic(t *testing.T) {
+	var (
+		apiKey       matlas.APIKey
+		resourceName = "mongodbatlas_organization_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		desc         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		roles        = []string{"ORG_OWNER"}
+		accessList   = []string{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc, roles, accessList),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMongoDBAtlasOrganizationApiKeyExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "description", desc),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_list_cidr_blocks.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasOrganizationApiKeyStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasOrganizationApiKeyStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["org_id"], rs.Primary.Attributes["public_key"]), nil
+	}
+}
+
+func testAccMongoDBAtlasOrganizationApiKeyExists(resourceName string, apiKey *matlas.APIKey) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		orgID := ids["org_id"]
+		api_key_id := ids["api_key_id"]
+
+		if orgID == "" && api_key_id == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] orgID: %s", orgID)
+		log.Printf("[DEBUG] apiKeyID: %s", api_key_id)
+
+		apiKeyResp, _, err := conn.APIKeys.Get(context.Background(), orgID, api_key_id)
+		if err == nil {
+			*apiKey = *apiKeyResp
+			return nil
+		}
+
+		return fmt.Errorf("API key(%s) does not exist", api_key_id)
+	}
+}
+
+func testAccMongoDBAtlasOrganizationApiKeyConfig(orgID, desc string, roles, accessList []string) string {
+	return fmt.Sprintf(`
+        resource "mongodbatlas_organization_api_key" "test" {
+            org_id                  = "%s"
+            description             = "%s"
+            roles                   = %s
+            access_list_cidr_blocks = %s
+        }
+    `, orgID, desc, strings.ReplaceAll(fmt.Sprintf("%+q", roles), " ", ","),
+		strings.ReplaceAll(fmt.Sprintf("%+q", accessList), " ", ","),
+	)
+}

--- a/website/docs/d/organization_api_key.html.markdown
+++ b/website/docs/d/organization_api_key.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: organization_api_key"
+sidebar_current: "docs-mongodbatlas-datasource-organization-api-key"
+description: |-
+    Describes an Organization API key.
+---
+
+# mongodbatlas_organization_api_key
+
+`mongodbatlas_organization_api_key` describes an Organization API key.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_organization_api_key" "test" {
+  org_id                  = "<ORGANIZATION-ID>"
+  description             = "My organization API key description"
+  roles                   = ["ORG_GROUP_CREATOR", "ORG_READ_ONLY"]
+  access_list_cidr_blocks = ["1.1.1.1/28", "10.10.10.10/32"]
+}
+
+data "mongodbatlas_organization_api_key" "test" {
+	org_id     = mongodbatlas_organization_api_key.test.org_id
+	api_key_id = mongodbatlas_organization_api_key.test.api_key_id
+}
+
+```
+
+```hcl
+resource "mongodbatlas_organization_api_key" "test2" {
+  org_id                  = "<ORGANIZATION-ID>"
+  description             = "My organization API key description"
+  roles                   = ["ORG_MEMBER"]
+}
+
+data "mongodbatlas_organization_api_key" "test2" {
+	org_id     = mongodbatlas_organization_api_key.test2.org_id
+	api_key_id = mongodbatlas_organization_api_key.test2.api_key_id
+}
+```
+
+
+## Argument Reference
+
+* `org_id` - (Required) The unique identifier for the organization you want to associate the organization API key with.
+* `description` - (Required) API key description
+* `roles` - (Required) List of organization roles, at least one required. See possible values [here](https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/)
+* `access_list_cidr_blocks` - (Optional) API key CIDR block access list. If you only want to add a single ip, then add it with block /32
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -	The Terraform's unique identifier used internally for state management.
+* `api_key_id` -  The unique identifier for the organization API key
+* `public_key` -  The public key string that for the API key
+
+See detailed information for arguments and attributes: [MongoDB API apiKeys](https://docs.atlas.mongodb.com/reference/api/apiKeys/)

--- a/website/docs/r/organization_api_key.html.markdown
+++ b/website/docs/r/organization_api_key.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: organization_api_key"
+sidebar_current: "docs-mongodbatlas-resource-organization-api-key"
+description: |-
+    Provides an Organization API key resource.
+---
+
+# mongodbatlas_organization_api_key
+
+`mongodbatlas_organization_api_key` provides an Organization API key resource. The resource lets you create, edit and delete Organization API keys.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+
+## Example Usage
+
+```hcl
+resource "mongodbatlas_organization_api_key" "test" {
+  org_id                  = "<ORGANIZATION-ID>"
+  description             = "My organization API key description"
+  roles                   = ["ORG_GROUP_CREATOR", "ORG_READ_ONLY"]
+  access_list_cidr_blocks = ["1.1.1.1/28", "10.10.10.10/32"]
+}
+```
+
+## Argument Reference
+
+* `org_id` - (Required) The unique identifier for the organization you want to associate the organization API key with.
+* `description` - (Required) API key description
+* `roles` - (Required) List of organization roles, at least one required. See possible values [here](https://docs.atlas.mongodb.com/reference/api/apiKeys-orgs-create-one/)
+* `access_list_cidr_blocks` - (Optional) API key CIDR block access list. If you only want to add a single ip, then add it with block /32
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -    The Terraform's unique identifier used internally for state management.
+* `api_key_id` -  The unique identifier for the organization API key
+* `public_key` -  The public key string that for the API key
+
+## Import
+
+Organization API keys can be imported using the organization ID and API key id (note: this is not the public key), in the format ORGID-APIKEYID, e.g.
+
+```
+$ terraform import mongodbatlas_organization_api_key.my_key 5e8973054812445d456614a5b-6123e708d013aa65f4ba4e7f
+```
+
+See detailed information for arguments and attributes: [MongoDB API apiKeys](https://docs.atlas.mongodb.com/reference/api/apiKeys/)


### PR DESCRIPTION
## Description

This PR adds support to create organization API keys: mongodbatlas_organization_api_key

This creates organization API keys with roles and access list, tests have been added covering all cases and tested with my own Atlas account, import also works.

Note that this does not support the assignments of API keys to projects, i'm working on that at this moment and will be a separate resource.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments

Please double check that i'm not missing anything in `website/mongodbatlas.erb`, i don't see all entries there so not sure if i need to add this new one.