### PR TITLE
INTMDB-226 - Added forceNew to vpc_id in network_peering

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_network_peering.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering.go
@@ -72,6 +72,7 @@ func resourceMongoDBAtlasNetworkPeering() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"connection_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Description

The property `vpc_id` now has the flag `ForceNew: true` in order to recreate the resource when terraform try to change this value

The `vpc_id` is unique for each peering_network

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments

This is the result of the tests:
```
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasNetworkPeering_basicAWS (177.71s)
PASS
coverage: 5.4% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 180.118s        coverage: 5.4% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]
```