### PR TITLE
test: skip instead of fatal for team ids missing

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
 	if len(teamsIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -50,7 +50,7 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
 	if len(teamsIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/mongodbatlas/data_source_mongodbatlas_projects_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceMongoDBAtlasProjects_basic(t *testing.T) {
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
 	if len(teamsIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -51,7 +51,7 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
 	if len(teamsIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/mongodbatlas/provider_test.go
+++ b/mongodbatlas/provider_test.go
@@ -171,7 +171,7 @@ func SkipTestExtCred(t *testing.T) {
 
 func checkTeamsIds(t *testing.T) {
 	if os.Getenv("MONGODB_ATLAS_TEAMS_IDS") == "" {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must be set for Projects acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must be set for Projects acceptance testing")
 	}
 }
 

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -24,7 +24,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 		teamsIds     = strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
 	)
 	if len(teamsIds) < 3 {
-		t.Fatal("`MONGODB_ATLAS_TEAMS_IDS` must have 3 team ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 3 team ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
## Description

A fix attempt for dependabot, it seems it doesn't have access to the env var so tests fail, I think it should be better to skip rather than fail 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

