### PR TITLE
INTMDB-251: Update search rs and ds to use go-client v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.3.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.11.0
+	go.mongodb.org/atlas v0.12.0
 	go.mongodb.org/realm v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -977,6 +977,8 @@ go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mI
 go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6yfWfDmlWd35khcWpUa4L0xI/k=
 go.mongodb.org/atlas v0.11.0 h1:fVVh+lFlqpGaUw2GhtETnQehV4ftucXksx6CRVdE+hI=
 go.mongodb.org/atlas v0.11.0/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
+go.mongodb.org/atlas v0.12.0 h1:/vnHX3rh8jdPrP8mRznuU/2VrGH+cCdz8/Esrzpvaus=
+go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
 go.mongodb.org/realm v0.0.1 h1:qh47ZkEMvlukKiKqcDDox5Lmx1Tk3krxwC7W9LhVGcc=
 go.mongodb.org/realm v0.0.1/go.mod h1:4LzdATHVci61HSpYuqmRPISks5WQdB92u/aJRHNz9/0=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/go.sum
+++ b/go.sum
@@ -975,7 +975,6 @@ go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6yfWfDmlWd35khcWpUa4L0xI/k=
-go.mongodb.org/atlas v0.11.0 h1:fVVh+lFlqpGaUw2GhtETnQehV4ftucXksx6CRVdE+hI=
 go.mongodb.org/atlas v0.11.0/go.mod h1:MMWDsc2akjTDSG4tVQrxv/82p3QbBnqeELbtTl45sbg=
 go.mongodb.org/atlas v0.12.0 h1:/vnHX3rh8jdPrP8mRznuU/2VrGH+cCdz8/Esrzpvaus=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=

--- a/mongodbatlas/data_source_mongodbatlas_search_index_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_search_index_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceMongoDBAtlasSearchIndexes_byID(t *testing.T) {
+func TestAccDataSourceMongoDBAtlasSearchIndex_byID(t *testing.T) {
 	var (
 		clusterName    = acctest.RandomWithPrefix("test-acc-global")
 		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/data_source_mongodbatlas_search_indexes.go
+++ b/mongodbatlas/data_source_mongodbatlas_search_indexes.go
@@ -102,14 +102,8 @@ func flattenSearchIndexes(searchIndexes []*matlas.SearchIndex) ([]map[string]int
 	searchIndexesMap = make([]map[string]interface{}, len(searchIndexes))
 
 	for i := range searchIndexes {
-		searchIndexCustomAnalyzers, err := flattenSearchIndexCustomAnalyzers(searchIndexes[i].Analyzers)
-		if err != nil {
-			return nil, err
-		}
-
 		searchIndexesMap[i] = map[string]interface{}{
 			"analyzer":         searchIndexes[i].Analyzer,
-			"analyzers":        searchIndexCustomAnalyzers,
 			"collection_name":  searchIndexes[i].CollectionName,
 			"database":         searchIndexes[i].Database,
 			"index_id":         searchIndexes[i].IndexID,
@@ -120,11 +114,19 @@ func flattenSearchIndexes(searchIndexes []*matlas.SearchIndex) ([]map[string]int
 		}
 
 		if searchIndexes[i].Mappings.Fields != nil {
-			searchIndexMappingFields, err := marshallSearchIndexMappingFields(*searchIndexes[i].Mappings.Fields)
+			searchIndexMappingFields, err := marshallSearchIndexMappingsField(*searchIndexes[i].Mappings.Fields)
 			if err != nil {
 				return nil, err
 			}
 			searchIndexesMap[i]["mappings_fields"] = searchIndexMappingFields
+		}
+
+		if len(searchIndexes[i].Analyzers) > 0 {
+			searchIndexAnalyzers, err := marshallSearchIndexAnalyzers(searchIndexes[i].Analyzers)
+			if err != nil {
+				return nil, err
+			}
+			searchIndexesMap[i]["analyzers"] = searchIndexAnalyzers
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_search_index.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index.go
@@ -181,7 +181,8 @@ func resourceMongoDBAtlasSearchIndexUpdate(ctx context.Context, d *schema.Resour
 	}
 
 	if d.HasChange("mappings_fields") {
-		searchIndex.Mappings.Fields = unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
+		mappingFields := unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
+		searchIndex.Mappings.Fields = &mappingFields
 	}
 
 	searchIndex.IndexID = ""
@@ -292,7 +293,7 @@ func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.Resour
 
 	clusterName := d.Get("cluster_name").(string)
 
-	var indexMapping *map[string]interface{}
+	var indexMapping map[string]interface{}
 	indexMapping = unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
 
 	searchIndexRequest := &matlas.SearchIndex{
@@ -302,7 +303,7 @@ func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.Resour
 		Database:       d.Get("database").(string),
 		Mappings: &matlas.IndexMapping{
 			Dynamic: d.Get("mappings_dynamic").(bool),
-			Fields:  indexMapping,
+			Fields:  &indexMapping,
 		},
 		Name:           d.Get("name").(string),
 		SearchAnalyzer: d.Get("search_analyzer").(string),
@@ -373,12 +374,12 @@ func validateSearchAnalyzersDiff(k, old, newStr string, d *schema.ResourceData) 
 	return true
 }
 
-func unmarshalSearchIndexMappingFields(mappingString string) *map[string]interface{} {
+func unmarshalSearchIndexMappingFields(mappingString string) map[string]interface{} {
 	if mappingString == "" {
 		return nil
 	}
 
-	var fields *map[string]interface{}
+	var fields map[string]interface{}
 
 	if err := json.Unmarshal([]byte(mappingString), &fields); err != nil {
 		log.Printf("[ERROR] cannot unmarshal search index mapping fields: %v", err)

--- a/mongodbatlas/resource_mongodbatlas_search_index.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -48,9 +47,10 @@ func returnSearchIndexSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"analyzers": {
-			Type:     schema.TypeList,
+			Type:     schema.TypeString,
 			Optional: true,
-			Elem:     customAnalyzersSchema(),
+			//Elem:     customAnalyzersSchema(),
+			DiffSuppressFunc: validateSearchAnalyzersDiff,
 		},
 		"collection_name": {
 			Type:     schema.TypeString,
@@ -81,149 +81,6 @@ func returnSearchIndexSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
-		},
-	}
-}
-
-func customAnalyzersSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"char_filters": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"ignore_tags": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"mappings": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: validateSearchIndexMappingDiff,
-						},
-					},
-				},
-			},
-			"tokenizer": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"max_token_length": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"min_gram": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"max_gram": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"pattern": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"group": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"token_filters": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"original_tokens": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"min": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"max": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"normalization_form": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"min_gram": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"max_gram": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"terms_not_in_bounds": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"min_shingle_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"max_shingle_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"pattern": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"replacement": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"matches": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"stemmer_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"tokens": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"ignore_case": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-			},
 		},
 	}
 }
@@ -300,7 +157,7 @@ func resourceMongoDBAtlasSearchIndexUpdate(ctx context.Context, d *schema.Resour
 	}
 
 	if d.HasChange("analyzers") {
-		searchIndex.Analyzers = expandCustomAnalyzers(d.Get("analyzers").([]interface{}))
+		searchIndex.Analyzers = unmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string))
 	}
 
 	if d.HasChange("collection_name") {
@@ -324,10 +181,7 @@ func resourceMongoDBAtlasSearchIndexUpdate(ctx context.Context, d *schema.Resour
 	}
 
 	if d.HasChange("mappings_fields") {
-		var indexMapping *map[string]matlas.IndexField
-		indexMappingResult := unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
-		indexMapping = &indexMappingResult
-		searchIndex.Mappings.Fields = indexMapping
+		searchIndex.Mappings.Fields = unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
 	}
 
 	searchIndex.IndexID = ""
@@ -368,13 +222,15 @@ func resourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resource
 		return diag.Errorf("error setting `analyzer` for search index (%s): %s", d.Id(), err)
 	}
 
-	searchIndexCustomAnalyzers, err := flattenSearchIndexCustomAnalyzers(searchIndex.Analyzers)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	if len(searchIndex.Analyzers) > 0 {
+		searchIndexMappingFields, err := marshallSearchIndexAnalyzers(searchIndex.Analyzers)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	if err := d.Set("analyzers", searchIndexCustomAnalyzers); err != nil {
-		return diag.Errorf("error setting `analyzer` for search index (%s): %s", d.Id(), err)
+		if err := d.Set("analyzers", searchIndexMappingFields); err != nil {
+			return diag.Errorf("error setting `analyzer` for search index (%s): %s", d.Id(), err)
+		}
 	}
 
 	if err := d.Set("collection_name", searchIndex.CollectionName); err != nil {
@@ -398,7 +254,7 @@ func resourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resource
 	}
 
 	if searchIndex.Mappings.Fields != nil {
-		searchIndexMappingFields, err := marshallSearchIndexMappingFields(*searchIndex.Mappings.Fields)
+		searchIndexMappingFields, err := marshallSearchIndexMappingsField(*searchIndex.Mappings.Fields)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -411,7 +267,7 @@ func resourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func marshallSearchIndexMappingFields(fields map[string]matlas.IndexField) (string, error) {
+func marshallSearchIndexAnalyzers(fields []map[string]interface{}) (string, error) {
 	if len(fields) == 0 {
 		return "", nil
 	}
@@ -420,182 +276,13 @@ func marshallSearchIndexMappingFields(fields map[string]matlas.IndexField) (stri
 	return string(mappingFieldJSON), err
 }
 
-func marshallSearchIndexCharFilterMappingFields(fields map[string]string) (interface{}, error) {
+func marshallSearchIndexMappingsField(fields map[string]interface{}) (string, error) {
 	if len(fields) == 0 {
 		return "", nil
 	}
 
 	mappingFieldJSON, err := json.Marshal(fields)
-
 	return string(mappingFieldJSON), err
-}
-
-func flattenSearchIndexCustomAnalyzers(analyzers []*matlas.CustomAnalyzer) ([]map[string]interface{}, error) {
-	if len(analyzers) == 0 {
-		return nil, nil
-	}
-
-	mapAnalyzers := make([]map[string]interface{}, len(analyzers))
-
-	for i, analyzer := range analyzers {
-		tokenizer, err := flattenSearchIndexTokenizer(analyzer.Tokenizer)
-		if err != nil {
-			return nil, err
-		}
-
-		mapAnalyzers[i] = map[string]interface{}{
-			"name":      analyzer.Name,
-			"tokenizer": tokenizer,
-		}
-
-		if len(analyzer.CharFilters) > 0 {
-			searchIndexCharFilters, err := flattenSearchIndexCharFilters(analyzer.CharFilters)
-			if err != nil {
-				return nil, err
-			}
-			mapAnalyzers[i]["char_filters"] = searchIndexCharFilters
-		}
-
-		if len(analyzer.TokenFilters) > 0 {
-			mapAnalyzers[i]["token_filters"] = flattenSearchIndexTokenFilters(analyzer.TokenFilters)
-		}
-	}
-	return mapAnalyzers, nil
-}
-
-func flattenSearchIndexTokenizer(tokenizer *matlas.AnalyzerTokenizer) ([]map[string]interface{}, error) {
-	tokenList := make([]map[string]interface{}, 0)
-
-	mapTokenizer := map[string]interface{}{}
-
-	if tokenizer.Type != "" {
-		mapTokenizer["type"] = tokenizer.Type
-	}
-
-	if tokenizer.MaxTokenLength != nil {
-		mapTokenizer["max_token_length"] = *tokenizer.MaxTokenLength
-	}
-
-	if tokenizer.MinGram != nil {
-		mapTokenizer["min_gram"] = *tokenizer.MinGram
-	}
-	if tokenizer.MaxGram != nil {
-		mapTokenizer["max_gram"] = *tokenizer.MaxGram
-	}
-	if tokenizer.Pattern != "" {
-		mapTokenizer["pattern"] = tokenizer.Pattern
-	}
-	if tokenizer.Group != nil {
-		mapTokenizer["group"] = *tokenizer.Group
-	}
-
-	tokenList = append(tokenList, mapTokenizer)
-
-	return tokenList, nil
-}
-
-func flattenSearchIndexTokenFilters(filters []*matlas.AnalyzerTokenFilters) []map[string]interface{} {
-	if len(filters) == 0 {
-		return nil
-	}
-
-	mapCharFilters := make([]map[string]interface{}, len(filters))
-
-	for i, filter := range filters {
-		mapCharFilters[i] = map[string]interface{}{
-			"type": filter.Type,
-		}
-
-		if filter.OriginalTokens != "" {
-			mapCharFilters[i]["original_tokens"] = filter.OriginalTokens
-		}
-		//
-
-		if filter.Min != nil {
-			mapCharFilters[i]["min"] = *filter.Min
-		}
-
-		if filter.Max != nil {
-			mapCharFilters[i]["max"] = *filter.Max
-		}
-
-		if filter.NormalizationForm != "" {
-			mapCharFilters[i]["normalization_form"] = filter.NormalizationForm
-		}
-
-		if filter.MinGram != nil {
-			mapCharFilters[i]["min_gram"] = *filter.MinGram
-		}
-
-		if filter.MaxGram != nil {
-			mapCharFilters[i]["max_gram"] = *filter.MaxGram
-		}
-
-		if filter.TermsNotInBounds != "" {
-			mapCharFilters[i]["terms_not_in_bounds"] = filter.TermsNotInBounds
-		}
-
-		if filter.MinShingleSize != nil {
-			mapCharFilters[i]["min_shingle_size"] = *filter.MinShingleSize
-		}
-
-		if filter.MaxShingleSize != nil {
-			mapCharFilters[i]["max_shingle_size"] = *filter.MaxShingleSize
-		}
-
-		if filter.Pattern != "" {
-			mapCharFilters[i]["pattern"] = filter.Pattern
-		}
-
-		if filter.Replacement != "" {
-			mapCharFilters[i]["replacement"] = filter.Replacement
-		}
-
-		if filter.Matches != "" {
-			mapCharFilters[i]["matches"] = filter.Matches
-		}
-
-		if filter.StemmerName != "" {
-			mapCharFilters[i]["stemmer_name"] = filter.StemmerName
-		}
-
-		if len(filter.Tokens) > 0 {
-			mapCharFilters[i]["tokens"] = filter.Tokens
-		}
-
-		if filter.IgnoreCase != nil {
-			mapCharFilters[i]["ignore_case"] = *filter.IgnoreCase
-		}
-	}
-	return mapCharFilters
-}
-
-func flattenSearchIndexCharFilters(filters []*matlas.AnalyzerCharFilter) ([]map[string]interface{}, error) {
-	if len(filters) == 0 {
-		return nil, nil
-	}
-
-	mapCharFilters := make([]map[string]interface{}, len(filters))
-
-	for i, filter := range filters {
-		mapCharFilters[i] = map[string]interface{}{
-			"type": filter.Type,
-		}
-
-		if len(filter.IgnoreTags) > 0 {
-			mapCharFilters[i]["ignore_tags"] = filter.IgnoreTags
-		}
-
-		if filter.Mappings != nil {
-			searchIndexCharFilterMappingFields, err := marshallSearchIndexCharFilterMappingFields(*filter.Mappings)
-			if err != nil {
-				return nil, err
-			}
-
-			mapCharFilters[i]["mappings"] = searchIndexCharFilterMappingFields
-		}
-	}
-	return mapCharFilters, nil
 }
 
 func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -605,13 +292,12 @@ func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.Resour
 
 	clusterName := d.Get("cluster_name").(string)
 
-	var indexMapping *map[string]matlas.IndexField
-	indexMappingResult := unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
-	indexMapping = &indexMappingResult
+	var indexMapping *map[string]interface{}
+	indexMapping = unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
 
 	searchIndexRequest := &matlas.SearchIndex{
 		Analyzer:       d.Get("analyzer").(string),
-		Analyzers:      expandCustomAnalyzers(d.Get("analyzers").([]interface{})),
+		Analyzers:      unmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string)),
 		CollectionName: d.Get("collection_name").(string),
 		Database:       d.Get("database").(string),
 		Mappings: &matlas.IndexMapping{
@@ -635,196 +321,6 @@ func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.Resour
 	}))
 
 	return resourceMongoDBAtlasSearchIndexRead(ctx, d, meta)
-}
-
-func expandCustomAnalyzers(analyzers []interface{}) []*matlas.CustomAnalyzer {
-	if len(analyzers) == 0 {
-		return nil
-	}
-
-	var analyzersList []*matlas.CustomAnalyzer
-
-	for _, analyzerObj := range analyzers {
-		analyzerInterface := analyzerObj.(map[string]interface{})
-
-		analyzer := &matlas.CustomAnalyzer{
-			Name: analyzerInterface["name"].(string),
-		}
-
-		charFiltersMap, ok := analyzerInterface["char_filters"]
-		if ok {
-			analyzer.CharFilters = expandIndexCharFilters(charFiltersMap.([]interface{}))
-		}
-
-		tokenizer, ok := analyzerInterface["tokenizer"]
-		if ok {
-			analyzer.Tokenizer = expandIndexTokenizer(tokenizer.([]interface{}))
-		}
-
-		tokenFiltersMap, ok := analyzerInterface["token_filters"]
-		if ok {
-			analyzer.TokenFilters = expandIndexTokenFilters(tokenFiltersMap.([]interface{}))
-		}
-
-		analyzersList = append(analyzersList, analyzer)
-	}
-
-	return analyzersList
-}
-
-func expandIndexTokenFilters(tokenFilters []interface{}) []*matlas.AnalyzerTokenFilters {
-	var analyzerTokenFilters []*matlas.AnalyzerTokenFilters
-	//TODO: here occurrs the change
-	if len(tokenFilters) == 0 {
-		return nil
-	}
-
-	for _, tf := range tokenFilters {
-		tokenFilterMap := tf.(map[string]interface{})
-
-		tokenFilter := &matlas.AnalyzerTokenFilters{}
-
-		tokenFilter.Type = tokenFilterMap["type"].(string)
-
-		if originalToken, ok := tokenFilterMap["original_tokens"]; ok {
-			tokenFilter.OriginalTokens = originalToken.(string)
-		}
-
-		if min, ok := tokenFilterMap["min"].(int); ok && min > 0 {
-			tokenFilter.Min = pointy.Int(min)
-		}
-
-		if max, ok := tokenFilterMap["max"].(int); ok && max > 0 {
-			tokenFilter.Max = pointy.Int(max)
-		}
-
-		if normalizationForm, ok := tokenFilterMap["normalization_form"]; ok {
-			tokenFilter.NormalizationForm = normalizationForm.(string)
-		}
-
-		if minGram, ok := tokenFilterMap["min_gram"].(int); ok && minGram > 0 {
-			tokenFilter.MinGram = pointy.Int(minGram)
-		}
-
-		if maxGram, ok := tokenFilterMap["max_gram"].(int); ok && maxGram > 0 {
-			tokenFilter.MinGram = pointy.Int(maxGram)
-		}
-
-		if termsNotInBounds, ok := tokenFilterMap["terms_not_in_bounds"]; ok {
-			tokenFilter.TermsNotInBounds = termsNotInBounds.(string)
-		}
-
-		if minShingleSize, ok := tokenFilterMap["min_shingle_size"].(int); ok && minShingleSize > 0 {
-			tokenFilter.MinShingleSize = pointy.Int(minShingleSize)
-		}
-
-		if maxShingleSize, ok := tokenFilterMap["max_shingle_size"].(int); ok && maxShingleSize > 0 {
-			tokenFilter.MaxShingleSize = pointy.Int(maxShingleSize)
-		}
-
-		if pattern, ok := tokenFilterMap["pattern"]; ok {
-			tokenFilter.Pattern = pattern.(string)
-		}
-
-		if replacement, ok := tokenFilterMap["replacement"]; ok {
-			tokenFilter.Replacement = replacement.(string)
-		}
-
-		if matches, ok := tokenFilterMap["matches"]; ok {
-			tokenFilter.Matches = matches.(string)
-		}
-
-		if stemmerName, ok := tokenFilterMap["stemmer_name"]; ok {
-			tokenFilter.StemmerName = stemmerName.(string)
-		}
-
-		if tokens, ok := tokenFilterMap["tokens"]; ok {
-			tokenFilter.Tokens = expandIndexTokens(tokens)
-		}
-
-		if ignoreCase, ok := tokenFilterMap["ignore_case"].(bool); ok {
-			tokenFilter.IgnoreCase = pointy.Bool(ignoreCase)
-		}
-
-		analyzerTokenFilters = append(analyzerTokenFilters, tokenFilter)
-	}
-
-	return analyzerTokenFilters
-}
-
-func expandIndexTokens(tokens interface{}) []string {
-	tokensInterfaces := tokens.([]interface{})
-	tokensList := make([]string, len(tokensInterfaces))
-
-	for i, token := range tokensInterfaces {
-		tokensList[i] = token.(string)
-	}
-	return tokensList
-}
-
-func expandIndexTokenizer(tokenizers []interface{}) *matlas.AnalyzerTokenizer {
-	if len(tokenizers) == 0 {
-		return nil
-	}
-
-	analyzerTokenizer := &matlas.AnalyzerTokenizer{}
-
-	tokenizer := tokenizers[0].(map[string]interface{})
-
-	analyzerTokenizer.Type = tokenizer["type"].(string)
-
-	if maxTokenLength, ok := tokenizer["max_token_length"].(int); ok && maxTokenLength > 0 {
-		analyzerTokenizer.MaxTokenLength = pointy.Int(maxTokenLength)
-	}
-
-	if minGram, ok := tokenizer["min_gram"].(int); ok && minGram > 0 {
-		analyzerTokenizer.MinGram = pointy.Int(minGram)
-	}
-
-	if maxGram, ok := tokenizer["max_gram"].(int); ok && maxGram > 0 {
-		analyzerTokenizer.MaxGram = pointy.Int(maxGram)
-	}
-
-	if pattern, ok := tokenizer["pattern"]; ok {
-		analyzerTokenizer.Pattern = pattern.(string)
-	}
-
-	if group, ok := tokenizer["group"].(int); ok {
-		analyzerTokenizer.Group = pointy.Int(group)
-	}
-
-	return analyzerTokenizer
-}
-
-func expandIndexCharFilters(charFilters []interface{}) []*matlas.AnalyzerCharFilter {
-	var analyzerCharFilters []*matlas.AnalyzerCharFilter
-
-	if len(charFilters) == 0 {
-		return nil
-	}
-
-	for _, tf := range charFilters {
-		charFilterMap := tf.(map[string]interface{})
-
-		charFilter := &matlas.AnalyzerCharFilter{
-			Type: charFilterMap["type"].(string),
-		}
-
-		if ignoreTags, ok := charFilterMap["ignoreTags"].([]string); ok {
-			charFilter.IgnoreTags = ignoreTags
-		}
-
-		if mappings, ok := charFilterMap["mappings"]; ok {
-			var charFilterMapping *map[string]string
-			charFilters := unmarshalSearchIndexCharFilterMapping(mappings.(string))
-			charFilterMapping = &charFilters
-			charFilter.Mappings = charFilterMapping
-		}
-
-		analyzerCharFilters = append(analyzerCharFilters, charFilter)
-	}
-
-	return analyzerCharFilters
 }
 
 func validateSearchIndexMappingDiff(k, old, newStr string, d *schema.ResourceData) bool {
@@ -852,12 +348,37 @@ func validateSearchIndexMappingDiff(k, old, newStr string, d *schema.ResourceDat
 	return true
 }
 
-func unmarshalSearchIndexMappingFields(mappingString string) map[string]matlas.IndexField {
+func validateSearchAnalyzersDiff(k, old, newStr string, d *schema.ResourceData) bool {
+	var j, j2 interface{}
+
+	if old == "" {
+		old = "{}"
+	}
+
+	if newStr == "" {
+		newStr = "{}"
+	}
+
+	if err := json.Unmarshal([]byte(old), &j); err != nil {
+		log.Printf("[ERROR] cannot unmarshal old search index analyzer json %v", err)
+	}
+	if err := json.Unmarshal([]byte(newStr), &j2); err != nil {
+		log.Printf("[ERROR] cannot unmarshal new search index analyzer json %v", err)
+	}
+	if diff := deep.Equal(&j, &j2); diff != nil {
+		log.Printf("[DEBUG] deep equal not passed: %v", diff)
+		return false
+	}
+
+	return true
+}
+
+func unmarshalSearchIndexMappingFields(mappingString string) *map[string]interface{} {
 	if mappingString == "" {
 		return nil
 	}
 
-	var fields map[string]matlas.IndexField
+	var fields *map[string]interface{}
 
 	if err := json.Unmarshal([]byte(mappingString), &fields); err != nil {
 		log.Printf("[ERROR] cannot unmarshal search index mapping fields: %v", err)
@@ -867,11 +388,17 @@ func unmarshalSearchIndexMappingFields(mappingString string) map[string]matlas.I
 	return fields
 }
 
-func unmarshalSearchIndexCharFilterMapping(mappingString string) map[string]string {
-	var fields map[string]string
-	if err := json.Unmarshal([]byte(mappingString), &fields); err != nil {
-		log.Printf("[ERROR] json.Unmarshal %v", err)
+func unmarshalSearchIndexAnalyzersFields(mappingString string) []map[string]interface{} {
+	if mappingString == "" {
 		return nil
 	}
+
+	var fields []map[string]interface{}
+
+	if err := json.Unmarshal([]byte(mappingString), &fields); err != nil {
+		log.Printf("[ERROR] cannot unmarshal search index mapping fields: %v", err)
+		return nil
+	}
+
 	return fields
 }

--- a/mongodbatlas/resource_mongodbatlas_search_index.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index.go
@@ -47,9 +47,8 @@ func returnSearchIndexSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"analyzers": {
-			Type:     schema.TypeString,
-			Optional: true,
-			//Elem:     customAnalyzersSchema(),
+			Type:             schema.TypeString,
+			Optional:         true,
 			DiffSuppressFunc: validateSearchAnalyzersDiff,
 		},
 		"collection_name": {
@@ -293,8 +292,7 @@ func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.Resour
 
 	clusterName := d.Get("cluster_name").(string)
 
-	var indexMapping map[string]interface{}
-	indexMapping = unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
+	indexMapping := unmarshalSearchIndexMappingFields(d.Get("mappings_fields").(string))
 
 	searchIndexRequest := &matlas.SearchIndex{
 		Analyzer:       d.Get("analyzer").(string),

--- a/mongodbatlas/resource_mongodbatlas_search_index_test.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index_test.go
@@ -61,7 +61,6 @@ func TestAccResourceMongoDBAtlasSearchIndex_withMapping(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "analyzer", updatedAnalyzer),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -236,27 +235,27 @@ func testAccMongoDBAtlasSearchIndexConfigAdvanced(projectID, clusterName string)
    			EOF
 			name = "name_test"
 			search_analyzer = "lucene.standard"
-			analyzers {
-				name = "index_analyzer_test_name"
-				char_filters {
-					type = "mapping"
-					mappings = <<-EOF
-					{"\\" : "/"}
-					EOF
+			analyzers = <<-EOF
+						[{
+				"name": "index_analyzer_test_name",
+				"char_filters": {
+					"type": "mapping",
+					"mappings": {"\\" : "/"}
+				},
+				"tokenizer": {
+					"type": "nGram",
+					"min_gram": 2,
+					"max_gram": 5
+				},
+				"token_filters": {
+				"type": "length",
+				"min": 20,
+				"max": 33
 				}
-				tokenizer {
-					type = "nGram"
-					min_gram = 2
-					max_gram = 5
-				}
-
-			token_filters {
-				type = "length"
-				min = 20
-				max = 33
-			}
+			}]
+			EOF
 		}
-	}
+	
 	
 	`, projectID, clusterName)
 }

--- a/website/docs/guides/1.0.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.0.1-upgrade-guide.html.markdown
@@ -1,0 +1,92 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas Provider 1.0.1: Upgrade and Information Guide"
+sidebar_current: "docs-mongodbatlas-guides-101-upgrade-guide"
+description: |-
+MongoDB Atlas Provider 1.0.1: Upgrade and Information Guide
+---
+
+# MongoDB Atlas Provider v1.0.1: Upgrade and Information Guide
+
+## Upgrading Search Index Resource and Datasource
+
+To update from v1.0.0 to v1.0.1 you need to set `analyzers` field as a JSON string.
+
+Old Usage: 
+```hcl
+resource "mongodbatlas_search_index" "test" {
+  project_id         = mongodbatlas_cluster.aws_conf.project_id
+  cluster_name       = mongodbatlas_cluster.aws_conf.name
+  analyzer = "lucene.simple"
+  collection_name = "collection_test"
+  database = "database_test"
+  mappings_dynamic = true
+  name = "name_test"
+  search_analyzer = "lucene.standard"
+  
+  analyzers {
+    name = "index_analyzer_test_name"
+    char_filters {
+      type = "mapping"
+      mappings = <<-EOF
+	  {"\\" : "/"}
+	  EOF
+    }
+    tokenizer {
+      type = "nGram"
+      min_gram = 2
+      max_gram = 5
+    }
+    token_filters {
+      type = "length"
+      min = 20
+      max = 33
+    }
+  }
+}
+```
+
+New Usage:
+```hcl
+resource "mongodbatlas_search_index" "test" {
+  project_id = mongodbatlas_cluster.aws_conf.project_id
+  cluster_name = mongodbatlas_cluster.aws_conf.name
+  analyzer = "lucene.simple"
+  collection_name = "collection_test"
+  database = "database_test"
+  mappings_dynamic = true
+  name = "name_test"
+  search_analyzer = "lucene.standard"
+  
+  analyzers = <<-EOF
+    [{
+    "name": "index_analyzer_test_name",
+    "char_filters": {
+     "type": "mapping",
+    	"mappings": {"\\" : "/"}
+    	},
+    "tokenizer": {
+      "type": "nGram",
+      "min_gram": 2,
+	  "max_gram": 5
+	  },
+    "token_filters": {
+      "type": "length",
+	  "min": 20,
+	  "max": 33
+    }
+  }]
+  EOF
+}
+```
+
+**NOTE** Doc links for [mongodbatlas_search_index](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/search_index)
+
+
+### Helpful Links
+
+* [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)
+
+* [Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+* [Contact Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.

--- a/website/docs/r/search_index.html.markdown
+++ b/website/docs/r/search_index.html.markdown
@@ -71,26 +71,25 @@ resource "mongodbatlas_search_index" "test" {
 EOF
  name = "name_test"
  searchAnalyzer = "lucene.standard"
- analyzers {
-  name = "index_analyzer_test_name"
-  char_filters {
-   type = "mapping"
-   mappings = <<EOF
-   {"\\" : "/"}
-   EOF
-   }
-   tokenizer { 
-    type = "nGram"
-    min_gram = 2
-    max_gram = 5
-   }
-   token_filters = {
-    type = "length"
-    min = 20
-    max = 33
-   }
-  }
-}
+ analyzers = <<-EOF
+  [{
+  "name": "index_analyzer_test_name",
+  "char_filters": {
+	"type": "mapping",
+	"mappings": {"\\" : "/"}
+    	},
+  "tokenizer": {
+  "type": "nGram",
+  "min_gram": 2,
+  "max_gram": 5
+		},
+  "token_filters": {
+	"type": "length",
+	"min": 20,
+	"max": 33
+    	}
+  }]
+EOF
 ```
 
 ## Argument Reference
@@ -102,7 +101,28 @@ EOF
 
 * `analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when creating the index. Defaults to [lucene.standard](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/standard/#std-label-ref-standard-analyzer)
 
-* `analyzers` - [Custom analyzers](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-custom-analyzers) to use in this index (this is an array of objects).
+* `analyzers` - [Custom analyzers](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-custom-analyzers) to use in this index. This is an array of JSON objects.
+```
+analyzers = <<-EOF
+  [{
+  "name": "index_analyzer_test_name",
+  "char_filters": {
+	"type": "mapping",
+	"mappings": {"\\" : "/"}
+    	},
+  "tokenizer": {
+  "type": "nGram",
+  "min_gram": 2,
+  "max_gram": 5
+	},
+  "token_filters": {
+	"type": "length",
+	"min": 20,
+	"max": 33
+    	}
+  }]
+EOF
+```
 
 * `collection_name` - (Required) Name of the collection the index is on.
 
@@ -158,9 +178,9 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
     * `mongodb`
 * `char_filters` - Array containing zero or more character filters. Always require a `type` field, and some take additional options as well
   ```hcl
-  char_filters{
-   type = "<FILTER_TYPE>"
-   ADDITIONAL_OPTION = VALUE
+  "char_filters":{
+   "type": "<FILTER_TYPE>",
+   "ADDITIONAL_OPTION": VALUE
   }
   ```
   Atlas search supports four `types` of character filters:
@@ -168,26 +188,27 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
         * `type` - (Required) Must be `htmlStrip`
         * `ignored_tags`- a list of HTML tags to exclude from filtering
         ```hcl
-          analyzers{
-            name = "analyzer_test"
-            char_filters={
-              type = "htmlStrip"
-              ignored_tags = ["a"]
+          analyzers = <<-EOF [{
+            "name": "analyzer_test",
+            "char_filters":{
+              "type": "htmlStrip",
+              "ignored_tags": ["a"]
               }   
-            } 
+            }] 
        ```
     * [icuNormalize](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-icuNormalize-ref) - Normalizes text with the [ICU](http://site.icu-project.org/) Normalizer. Based on Lucene's [ICUNormalizer2CharFilter](https://lucene.apache.org/core/8_3_0/analyzers-icu/org/apache/lucene/analysis/icu/ICUNormalizer2CharFilter.html)
     * [mapping](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-mapping-ref) - Applies user-specified normalization mappings to characters. Based on Lucene's [MappingCharFilter](https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/charfilter/MappingCharFilter.html)
       An object containing a comma-separated list of mappings. A mapping indicates that one character or group of characters should be substituted for another, in the format `<original> : <replacement>`
-      >Note: this field needs to be in a JSON format using `EOF` tags
       ### Example
         ```hcl
-        analyzers{
-          type= "mapping"
-          mappings =<<-EOF
+        analyzers = <<-EOF [{
+          "name":"name_analyzer",        
+          "type": "mapping",
+          "mappings":  
           {
              "\\" : "/"
           }
+          }]
           EOF 
       ```
     * [persian](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-persian-ref) - Replaces instances of [zero-width non-joiners](https://en.wikipedia.org/wiki/Zero-width_non-joiner) with ordinary space. Based on Lucene's [PersianCharFilter](https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/fa/PersianCharFilter.html)
@@ -195,9 +216,9 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
 
 * `tokenizer` - (Required) Tokenizer to use. Determines how Atlas Search splits up text into discrete chunks of indexing. Always require a type field, and some take additional options as well.
     ```hcl
-    tokenizer{
-    type = "<tokenizer-type>"
-    ADDITIONAL_OPTIONS = VALUE
+    "tokenizer":{
+    "type": "<tokenizer-type>",
+    "ADDITIONAL_OPTIONS": VALUE
     }
     ```
   Atlas Search supports the following tokenizer options:
@@ -229,9 +250,9 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
 
 * `tokenFilters` - Array containing zero or more token filters. Always require a type field, and some take additional options as well:
   ```hcl
-  token_filters{
-    type = "<FILTER_TYPE>"
-    ADDITIONAL-OPTIONS = VALUE
+  "token_filters":{
+    "type": "<FILTER_TYPE>",
+    "ADDITIONAL-OPTIONS": VALUE
   }
   ```
   Atlas Search supports the following token filters:


### PR DESCRIPTION
## Description

Search Index Resource and Data Source was updated in order to use the new go-client release (v0.12.0)

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
Tests Results:
```
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasSearchIndex_withMapping (589.53s)
PASS
coverage: 8.4% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 592.030s        coverage: 8.4% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]


--- PASS: TestAccResourceMongoDBAtlasSearchIndex_basic (701.34s)
PASS
coverage: 7.7% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 703.770s        coverage: 7.7% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```