### PR TITLE
Fix typo in import search index error

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_search_index.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index.go
@@ -89,7 +89,7 @@ func resourceMongoDBAtlasSearchIndexImportState(ctx context.Context, d *schema.R
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
-		return nil, errors.New("import format error: to import a search index, use the format {project_id}-{cluster_name}-{index_id}")
+		return nil, errors.New("import format error: to import a search index, use the format {project_id}--{cluster_name}--{index_id}")
 	}
 
 	projectID := parts[0]


### PR DESCRIPTION
## Description

Small fix for the error message related to search index import formatting.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
