### PR TITLE
INTMDB-211: Add new advanced shard key options in global cluster resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.4.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.12.0
+	go.mongodb.org/atlas v0.12.1-0.20210914184738-151291ec6779
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -977,6 +977,8 @@ go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mI
 go.etcd.io/etcd v0.0.0-20200513171258-e048e166ab9c/go.mod h1:xCI7ZzBfRuGgBXyXO6yfWfDmlWd35khcWpUa4L0xI/k=
 go.mongodb.org/atlas v0.12.0 h1:/vnHX3rh8jdPrP8mRznuU/2VrGH+cCdz8/Esrzpvaus=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
+go.mongodb.org/atlas v0.12.1-0.20210914184738-151291ec6779 h1:UVBeNe+ntj3m47JexenCnoPTf8HGXtZx7k2cqSw1iXg=
+go.mongodb.org/atlas v0.12.1-0.20210914184738-151291ec6779/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/data_source_mongodbatlas_global_cluster_config.go
@@ -39,6 +39,16 @@ func dataSourceMongoDBAtlasGlobalCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"is_custom_shard_key_hashed": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"is_shard_key_unique": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/openlyinc/pointy"
+	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -222,7 +222,6 @@ func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.Reso
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 		}
-
 	}
 
 	return resourceMongoDBAtlasGlobalClusterRead(ctx, d, meta)

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -211,17 +211,18 @@ func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.Reso
 		remove := oldSet.Difference(newSet).List()
 		add := newSet.Difference(oldSet).List()
 
+		if len(remove) > 0 {
+			if err := removeManagedNamespaces(ctx, conn, remove, projectID, clusterName); err != nil {
+				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
+			}
+		}
+
 		if len(add) > 0 {
 			if err := addManagedNamespaces(ctx, conn, add, projectID, clusterName); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 		}
 
-		if len(remove) > 0 {
-			if err := removeManagedNamespaces(ctx, conn, remove, projectID, clusterName); err != nil {
-				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
-			}
-		}
 	}
 
 	return resourceMongoDBAtlasGlobalClusterRead(ctx, d, meta)

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -121,7 +121,7 @@ func resourceMongoDBAtlasGlobalClusterCreate(ctx context.Context, d *schema.Reso
 				addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
 			}
 
-			if isShardKeyUnique, okShard := mn["is_shard_"]; okShard {
+			if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
 				addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
 			}
 
@@ -309,7 +309,7 @@ func removeManagedNamespaces(ctx context.Context, conn *matlas.Client, remove []
 			addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
 		}
 
-		if isShardKeyUnique, okShard := mn["is_shard_"]; okShard {
+		if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
 			addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
 		}
 		_, _, err := conn.GlobalClusters.DeleteManagedNamespace(ctx, projectID, clusterName, addManagedNamespace)
@@ -336,7 +336,7 @@ func addManagedNamespaces(ctx context.Context, conn *matlas.Client, add []interf
 			addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
 		}
 
-		if isShardKeyUnique, okShard := mn["is_shard_"]; okShard {
+		if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
 			addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
 		}
 		_, _, err := conn.GlobalClusters.AddManagedNamespace(ctx, projectID, clusterName, addManagedNamespace)

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -62,10 +62,12 @@ func resourceMongoDBAtlasGlobalCluster() *schema.Resource {
 						"is_custom_shard_key_hashed": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"is_shard_key_unique": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -220,11 +220,11 @@ func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled strin
 			cluster_name = mongodbatlas_cluster.test.name
 
 			managed_namespaces {
-				db               = "mydata"
-				collection       = "publishers"
-				custom_shard_key = "city"
+				db               		   = "mydata"
+				collection       		   = "publishers"
+				custom_shard_key		   = "city"
 				is_custom_shard_key_hashed = false
-				is_shard_key_unique = false
+				is_shard_key_unique 	   = false
 			}
 
 			custom_zone_mappings {

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -36,8 +36,8 @@ func TestAccResourceMongoDBAtlasGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "is_custom_shard_key_hashed", "true"),
-					resource.TestCheckResourceAttr(resourceName, "is_shard_key_unique", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
 					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
 				),
 			},
@@ -145,7 +145,7 @@ func testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName string)
 func testAccCheckMongoDBAtlasGlobalClusterAttributes(globalCluster *matlas.GlobalCluster, managedNamespacesCount int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(globalCluster.ManagedNamespaces) != managedNamespacesCount {
-			return fmt.Errorf("bad managed namespaces: %s", globalCluster.ManagedNamespaces)
+			return fmt.Errorf("bad managed namespaces: %v", globalCluster.ManagedNamespaces)
 		}
 
 		return nil
@@ -223,8 +223,8 @@ func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled strin
 				db               = "mydata"
 				collection       = "publishers"
 				custom_shard_key = "city"
-				is_custom_shard_key_hashed = true
-				is_shard_key_unique = true
+				is_custom_shard_key_hashed = false
+				is_shard_key_unique = false
 			}
 
 			custom_zone_mappings {

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -36,6 +36,8 @@ func TestAccResourceMongoDBAtlasGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "is_custom_shard_key_hashed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_shard_key_unique", "true"),
 					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
 				),
 			},
@@ -221,6 +223,8 @@ func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled strin
 				db               = "mydata"
 				collection       = "publishers"
 				custom_shard_key = "city"
+				is_custom_shard_key_hashed = true
+				is_shard_key_unique = true
 			}
 
 			custom_zone_mappings {

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -27,7 +27,7 @@ func TestAccResourceMongoDBAtlasGlobalCluster_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasGlobalClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false"),
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
@@ -38,6 +38,24 @@ func TestAccResourceMongoDBAtlasGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "true"),
 					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
 				),
 			},
@@ -88,7 +106,7 @@ func TestAccResourceMongoDBAtlasGlobalCluster_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false"),
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "false"),
 			},
 			{
 				ResourceName:            resourceName,
@@ -178,7 +196,7 @@ func testAccCheckMongoDBAtlasGlobalClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled string) string {
+func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled, isCustomShard, isShardKeyUnique string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id              = "%s"
@@ -223,8 +241,8 @@ func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled strin
 				db               		   = "mydata"
 				collection       		   = "publishers"
 				custom_shard_key		   = "city"
-				is_custom_shard_key_hashed = false
-				is_shard_key_unique 	   = false
+				is_custom_shard_key_hashed = "%s"
+				is_shard_key_unique 	   = "%s"
 			}
 
 			custom_zone_mappings {
@@ -232,7 +250,7 @@ func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled strin
 				zone     = "Zone 1"
 			}
 		}
-	`, projectID, name, backupEnabled)
+	`, projectID, name, backupEnabled, isCustomShard, isShardKeyUnique)
 }
 
 func testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(projectID, name, backupEnabled string) string {

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -77,7 +77,7 @@ func resourceMongoDBAtlasProjectCreate(ctx context.Context, d *schema.ResourceDa
 		Name:  d.Get("name").(string),
 	}
 
-	project, _, err := conn.Projects.Create(ctx, projectReq)
+	project, _, err := conn.Projects.Create(ctx, projectReq, nil)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorProjectCreate, err))
 	}

--- a/website/docs/d/global_cluster_config.html.markdown
+++ b/website/docs/d/global_cluster_config.html.markdown
@@ -91,6 +91,8 @@ In addition to all arguments above, the following attributes are exported:
 * `collection` -	(Required) The name of the collection associated with the managed namespace.
 * `custom_shard_key` - (Required)	The custom shard key for the collection. Global Clusters require a compound shard key consisting of a location field and a user-selected second key, the custom shard key.
 * `db` - (Required) The name of the database containing the collection.
+* `is_custom_shard_key_hashed` - (Optional) Flag that specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
+* `is_shard_key_unique` - (Optional) Flag that specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
 
 
 See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/)

--- a/website/docs/d/global_cluster_config.html.markdown
+++ b/website/docs/d/global_cluster_config.html.markdown
@@ -91,8 +91,8 @@ In addition to all arguments above, the following attributes are exported:
 * `collection` -	(Required) The name of the collection associated with the managed namespace.
 * `custom_shard_key` - (Required)	The custom shard key for the collection. Global Clusters require a compound shard key consisting of a location field and a user-selected second key, the custom shard key.
 * `db` - (Required) The name of the database containing the collection.
-* `is_custom_shard_key_hashed` - (Optional) Flag that specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
-* `is_shard_key_unique` - (Optional) Flag that specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
+* `is_custom_shard_key_hashed` - Specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
+* `is_shard_key_unique` - Specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
 
 
 See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/)

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -130,8 +130,8 @@ resource "mongodbatlas_global_cluster_config" "config" {
 * `collection` -	(Required) The name of the collection associated with the managed namespace.
 * `custom_shard_key` - (Required)	The custom shard key for the collection. Global Clusters require a compound shard key consisting of a location field and a user-selected second key, the custom shard key.
 * `db` - (Required) The name of the database containing the collection.
-* `is_custom_shard_key_hashed` - (Optional) Flag that specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
-* `is_shard_key_unique` - (Optional) Flag that specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
+* `is_custom_shard_key_hashed` - (Optional) Specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
+* `is_shard_key_unique` - (Optional) Specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
 
 ### Custom Zone Mapping
 

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -61,6 +61,8 @@ description: |-
 			db 				 = "mydata"
 			collection 		 = "publishers"
 			custom_shard_key = "city"
+            is_custom_shard_key_hashed = false
+            is_shard_key_unique = false
 		}
 
 		custom_zone_mappings {
@@ -128,7 +130,8 @@ resource "mongodbatlas_global_cluster_config" "config" {
 * `collection` -	(Required) The name of the collection associated with the managed namespace.
 * `custom_shard_key` - (Required)	The custom shard key for the collection. Global Clusters require a compound shard key consisting of a location field and a user-selected second key, the custom shard key.
 * `db` - (Required) The name of the database containing the collection.
-
+* `is_custom_shard_key_hashed` - (Optional) Flag that specifies whether the custom shard key for the collection is [hashed](https://docs.mongodb.com/manual/reference/method/sh.shardCollection/#hashed-shard-keys). If omitted, defaults to `false`. If `false`, Atlas uses [ranged sharding](https://docs.mongodb.com/manual/core/ranged-sharding/). This is only available for Atlas clusters with MongoDB v4.4 and later.
+* `is_shard_key_unique` - (Optional) Flag that specifies whether the underlying index enforces a unique constraint. If omitted, defaults to false. You cannot specify true when using [hashed shard keys](https://docs.mongodb.com/manual/core/hashed-sharding/#std-label-sharding-hashed).
 
 ### Custom Zone Mapping
 


### PR DESCRIPTION
## Description

Added `isCustomShardKeyHashed` and `isShardKeyUnique` properties to RS and DS for Global_cluster

Link to any related issue(s):[INTMDB-211](https://jira.mongodb.org/browse/INTMDB-211)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
Tests:
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasGlobalCluster_basic (662.26s)
PASS
coverage: 8.3% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 664.729s        coverage: 8.3% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

