### PR TITLE
INTMDB-221: Added projectOwnerID to project resource

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -64,6 +64,10 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 					},
 				},
 			},
+			"project_owner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -77,7 +81,15 @@ func resourceMongoDBAtlasProjectCreate(ctx context.Context, d *schema.ResourceDa
 		Name:  d.Get("name").(string),
 	}
 
-	project, _, err := conn.Projects.Create(ctx, projectReq, nil)
+	var createProjectOptions *matlas.CreateProjectOptions
+
+	if projectOwnerID, ok := d.GetOk("project_owner_id"); ok {
+		createProjectOptions = &matlas.CreateProjectOptions{
+			ProjectOwnerID: projectOwnerID.(string),
+		}
+	}
+
+	project, _, err := conn.Projects.Create(ctx, projectReq, createProjectOptions)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorProjectCreate, err))
 	}

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -115,6 +115,33 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceMongoDBAtlasProject_CreateWithProjectOwner(t *testing.T) {
+	var (
+		project        matlas.Project
+		resourceName   = "mongodbatlas_project.test"
+		projectName    = fmt.Sprintf("testacc-project-%s", acctest.RandString(10))
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceMongoDBAtlasProject_withUpdatedRole(t *testing.T) {
 	var (
 		resourceName    = "mongodbatlas_project.test"
@@ -254,8 +281,8 @@ func testAccMongoDBAtlasProjectConfig(projectName, orgID string, teams []*matlas
 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
-			name   = "%s"
-			org_id = "%s"
+			name  			 = "%s"
+			org_id 			 = "%s"
 
 			%s
 		}
@@ -274,4 +301,15 @@ func testAccMongoDBAtlasProjectConfigWithUpdatedRole(projectName, orgID, teamID,
 			}
 		}
 	`, projectName, orgID, teamID, roleName)
+}
+
+func testAccMongoDBAtlasProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+
+		   project_owner_id = "%[3]s"
+		}
+	`, projectName, orgID, projectOwnerID)
 }

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -306,10 +306,9 @@ func testAccMongoDBAtlasProjectConfigWithUpdatedRole(projectName, orgID, teamID,
 func testAccMongoDBAtlasProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
-			name   = "%[1]s"
-			org_id = "%[2]s"
-
-		   project_owner_id = "%[3]s"
+			name   			 = "%[1]s"
+			org_id 			 = "%[2]s"
+		    project_owner_id = "%[3]s"
 		}
 	`, projectName, orgID, projectOwnerID)
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -18,6 +18,7 @@ description: |-
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
   org_id = "<ORG_ID>"
+  project_owner_id = "<OWNER_ACCOUNT_ID>"
 
   teams {
     team_id    = "5e0fa8c99ccf641c722fe645"
@@ -35,6 +36,7 @@ resource "mongodbatlas_project" "test" {
 
 * `name` - (Required) The name of the project you want to create. (Cannot be changed via this Provider after creation.)
 * `org_id` - (Required) The ID of the organization you want to create the project within.
+* `project_owner_id` - (Optional) Unique 24-hexadecimal digit string that identifies the Atlas user account to be granted the [Project Owner](https://docs.atlas.mongodb.com/reference/user-roles/#mongodb-authrole-Project-Owner) role on the specified project. If you set this parameter, it overrides the default value of the oldest [Organization Owner](https://docs.atlas.mongodb.com/reference/user-roles/#mongodb-authrole-Organization-Owner).
 
 ### Teams
 Teams attribute is optional


### PR DESCRIPTION
## Description

Added ProjectOwnerID property to Project resource

Link to any related issue(s):[INTMDB-221](https://jira.mongodb.org/browse/INTMDB-221)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments
Test: 
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasProject_CreateWithProjectOwner (10.44s)
PASS
coverage: 2.7% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 12.875s coverage: 2.7% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]
