### PR TITLE
INTMDB-256: Fixes a bug for updated a role in cloud access authorization

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization_test.go
@@ -1,0 +1,96 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceMongoDBAtlasCloudProviderAccessAuthorization_basic(t *testing.T) {
+	var (
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		policyName      = acctest.RandomWithPrefix("tf-acc")
+		roleName        = acctest.RandomWithPrefix("tf-acc")
+		roleNameUpdated = acctest.RandomWithPrefix("tf-acc")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		// same as regular cloud provider access resource
+		CheckDestroy: testAccCheckMongoDBAtlasProviderAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, policyName, roleName),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, policyName, roleNameUpdated),
+			},
+		},
+	},
+	)
+}
+
+func testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, roleName, policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[2]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[3]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+  project_id    = %[1]q
+  provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+  project_id = %[1]q
+  role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+  aws {
+    iam_assumed_role_arn = aws_iam_role.test_role.arn
+  }
+}
+	`, projectID, policyName, roleName)
+}

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_authorization_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccResourceMongoDBAtlasCloudProviderAccessAuthorization_basic(t *testing.T) {
+	SkipTestExtCred(t)
 	var (
 		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		policyName      = acctest.RandomWithPrefix("tf-acc")


### PR DESCRIPTION
## Description
- Migrated the `aws` with a state migrator because it was mistaken as deprecated, since it's already released with sdk migration, a state migrator it's better idea instead of deprecated this time in case if some user has been using the resource in 0.9.1 and upgraded to 1.0.0 or newer
- Fixed a bug when it wants to update a role in cloud access authorization
- Added a test to show it passes, see below for the result

Result of test
```
--- PASS: TestAccResourceMongoDBAtlasCloudProviderAccessAuthorization_basic (50.89s)
PASS
coverage: 4.2% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 50.943s coverage: 4.2% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```

Link to any related issue(s):
#565  #554 
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
INTMDB-255 is related to this PR because of the same error