### PR TITLE
INTMDB-203: Fix IOPS restriction on NVME clusters

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -435,12 +435,6 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if providerName != "AWS" {
-		instanceName, instanceOk := d.GetOk("provider_instance_size_name")
-
-		if _, ok := d.GetOk("provider_disk_iops"); ok && instanceOk && strings.Contains(instanceName.(string), "NVME") {
-			return diag.Errorf("`provider_disk_iops` shouldn't be set when provider instance is an NVME storage")
-		}
-
 		if _, ok := d.GetOk("provider_disk_iops"); ok {
 			return diag.Errorf("`provider_disk_iops` shouldn't be set when provider name is `GCP` or `AZURE`")
 		}
@@ -1159,11 +1153,7 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 	if d.Get("provider_name") == "AWS" {
 		// Check if the Provider Disk IOS sets in the Terraform configuration and if the instance size name is not NVME.
 		// If it didn't, the MongoDB Atlas server would set it to the default for the amount of storage.
-		if _, ok := d.GetOk("provider_disk_iops"); ok && strings.Contains(providerSettings.InstanceSizeName, "NVME") {
-			return nil, fmt.Errorf("cannot set 'provider_disk_iops' when a NVME instance size has been setted")
-		}
-
-		if v, ok := d.GetOk("provider_disk_iops"); ok {
+		if v, ok := d.GetOk("provider_disk_iops"); ok && !strings.Contains(providerSettings.InstanceSizeName, "NVME") {
 			providerSettings.DiskIOPS = pointy.Int64(cast.ToInt64(v))
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -435,16 +435,13 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if providerName != "AWS" {
-
 		instanceName, instanceOk := d.GetOk("provider_instance_size_name")
 
 		if _, ok := d.GetOk("provider_disk_iops"); ok && instanceOk && strings.Contains(instanceName.(string), "NVME") {
-
 			return diag.Errorf("`provider_disk_iops` shouldn't be set when provider instance is an NVME storage")
 		}
 
 		if _, ok := d.GetOk("provider_disk_iops"); ok {
-
 			return diag.Errorf("`provider_disk_iops` shouldn't be set when provider name is `GCP` or `AZURE`")
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1168,7 +1168,7 @@ func flattenProviderSettings(d *schema.ResourceData, settings *matlas.ProviderSe
 		log.Printf(errorClusterSetting, "backing_provider_name", clusterName, err)
 	}
 
-	if settings.DiskIOPS != nil && *settings.DiskIOPS != 0 && !strings.Contains(settings.InstanceSizeName, "NVME") {
+	if settings.DiskIOPS != nil && *settings.DiskIOPS != 0 {
 		if err := d.Set("provider_disk_iops", *settings.DiskIOPS); err != nil {
 			log.Printf(errorClusterSetting, "provider_disk_iops", clusterName, err)
 		}

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -61,7 +61,6 @@ func TestAccResourceMongoDBAtlasCluster_basicAWS_simple(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCluster_basicAWS_instanceScale(t *testing.T) {
-	//SkipTest(t) // Skipped for now because of paramater provider_disk_iops breaks the terraform flow
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.test"


### PR DESCRIPTION
## Description

A restriction was added to cluster when try to update a cluster to an NVME instance and avoid to send the IOPS parameter to the API

Link to any related issue(s):[INTMDB-203](https://jira.mongodb.org/browse/INTMDB-203)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
TEST:
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasCluster_basicAWS_instanceScale (2643.25s)
PASS
coverage: 7.5% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 2645.655s       coverage: 7.5% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]
