### PR TITLE
INTMDB-259: Fix issue when create a tenant cluster without auto_scaling_disk_gb

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -413,7 +413,7 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 
 	tenantDisksize := pointy.Float64(0)
 	if providerName == "TENANT" {
-		if diskGBEnabled := d.Get("auto_scaling_disk_gb_enabled"); diskGBEnabled.(bool) { //TODO: here's the error
+		if diskGBEnabled := d.Get("auto_scaling_disk_gb_enabled"); diskGBEnabled.(bool) {
 			return diag.FromErr(fmt.Errorf("`auto_scaling_disk_gb_enabled` cannot be true when provider name is TENANT"))
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -62,7 +62,6 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			},
 			"auto_scaling_disk_gb_enabled": {
 				Type:     schema.TypeBool,
-				Default:  true,
 				Optional: true,
 			},
 			"auto_scaling_compute_enabled": {
@@ -414,13 +413,12 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 
 	tenantDisksize := pointy.Float64(0)
 	if providerName == "TENANT" {
-		if diskGBEnabled := d.Get("auto_scaling_disk_gb_enabled"); diskGBEnabled.(bool) {
+		if diskGBEnabled := d.Get("auto_scaling_disk_gb_enabled"); diskGBEnabled.(bool) { //TODO: here's the error
 			return diag.FromErr(fmt.Errorf("`auto_scaling_disk_gb_enabled` cannot be true when provider name is TENANT"))
 		}
 
-		autoScaling = &matlas.AutoScaling{
-			DiskGBEnabled: pointy.Bool(false),
-		}
+		autoScaling = nil
+
 		if instanceSizeName, ok := d.GetOk("provider_instance_size_name"); ok {
 			if instanceSizeName == "M2" {
 				if diskSizeGB, ok := d.GetOk("disk_size_gb"); ok {

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -1553,7 +1553,6 @@ func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskS
 		provider_instance_size_name  = "%s"
 		//These must be the following values
  	 	mongo_db_major_version = "%s"
-		auto_scaling_disk_gb_enabled = false
 	  }
 	`, projectID, name, diskSize, instanceSize, majorDBVersion)
 }


### PR DESCRIPTION
## Description

Fixed issue when trying to create a TENANT cluster without `auto_scaling_disk_gb_enabled` parameter, this parameter had a `true` value by default

Link to any related issue(s):[INTMDB-259](https://jira.mongodb.org/browse/INTMDB-259)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
TEST:
abnergarcia@AbnerGarcia-MacBook-Pro terraform-provider-mongodbatlas % TF_LOG=DEBUG make testacc TESTARGS='-run=testAccMongoDBAtlasClusterConfigTenant' | tee log.txt
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v /integrationtesting) -v -parallel 20 -run=testAccMongoDBAtlasClusterConfigTenant -timeout 300m -cover -ldflags="-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=acc'"
?       github.com/mongodb/terraform-provider-mongodbatlas      [no test files]
testing: warning: no tests to run
PASS
coverage: 1.9% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 2.393s  coverage: 1.9% of statements [no tests to run]
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

