### PR TITLE
fixes failing snapshots because timeout is too short

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
@@ -84,6 +84,7 @@ func resourceMongoDBAtlasCloudProviderSnapshot() *schema.Resource {
 			"timeout": {
 				Type:     schema.TypeString,
 				Required: false,
+				Default:  "10m",
 			},
 		},
 	}
@@ -167,8 +168,7 @@ func resourceMongoDBAtlasCloudProviderSnapshotCreate(ctx context.Context, d *sch
 
 	timeout, err := time.ParseDuration(d.Get("timeout").(string))
 	if err != nil {
-		// sets default timeout if the timeout cannot be parsed
-		timeout = 10 * time.Minute
+		return diag.FromErr(err)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot.go
@@ -83,7 +83,8 @@ func resourceMongoDBAtlasCloudProviderSnapshot() *schema.Resource {
 			},
 			"timeout": {
 				Type:     schema.TypeString,
-				Required: false,
+				Optional: true,
+				ForceNew: true,
 				Default:  "10m",
 			},
 		},

--- a/website/docs/r/cloud_provider_snapshot.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot.html.markdown
@@ -52,7 +52,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
 * `cluster_name` - (Required) The name of the Atlas cluster that contains the snapshots you want to retrieve.
 * `description` - (Required) Description of the on-demand snapshot.
 * `retention_in_days` - (Required) The number of days that Atlas should retain the on-demand snapshot. Must be at least 1.
-* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. Default is 10m
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `10m`
 
 ## Attributes Reference
 

--- a/website/docs/r/cloud_provider_snapshot.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot.html.markdown
@@ -33,6 +33,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
     cluster_name      = mongodbatlas_cluster.my_cluster.name
     description       = "myDescription"
     retention_in_days = 1
+    timeout           = "10m"
   }
   
   resource "mongodbatlas_cloud_provider_snapshot_restore_job" "test" {
@@ -51,6 +52,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
 * `cluster_name` - (Required) The name of the Atlas cluster that contains the snapshots you want to retrieve.
 * `description` - (Required) Description of the on-demand snapshot.
 * `retention_in_days` - (Required) The number of days that Atlas should retain the on-demand snapshot. Must be at least 1.
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. Default is 10m
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

If the cloud provider snapshot takes longer than 10minutes, terraform apply will fail. This pull request make the timeout configurable.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
