### PR TITLE
INTMDB-269: Fix issue with default auto_scaling_disk_gb_enabled value

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_test.go
@@ -43,6 +43,7 @@ func TestAccDataSourceMongoDBAtlasCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "replication_specs.0.regions_config.#"),
 					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_disk_gb_enabled", "true"),
 				),
 			},
 		},
@@ -68,7 +69,6 @@ func testAccDataSourceMongoDBAtlasClusterConfig(projectID, name, backupEnabled s
 		    }
 
 			provider_backup_enabled      = %s
-			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "AWS"

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -372,15 +372,11 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	autoScaling := &matlas.AutoScaling{
+		DiskGBEnabled: pointy.Bool(d.Get("auto_scaling_disk_gb_enabled").(bool)),
 		Compute: &matlas.Compute{
 			Enabled:          &computeEnabled,
 			ScaleDownEnabled: &scaleDownEnabled,
 		},
-	}
-
-	diskEnable, ok := d.GetOk("auto_scaling_disk_gb_enabled")
-	if ok {
-		autoScaling.DiskGBEnabled = pointy.Bool(diskEnable.(bool))
 	}
 
 	// validate cluster_type conditional

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -418,7 +418,6 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 
 	tenantDisksize := pointy.Float64(0)
 	if providerName == "TENANT" {
-
 		if diskEnabledTenant, diskEnabledTenantOK := d.GetOk("auto_scaling_disk_gb_enabled"); diskEnabledTenantOK && diskEnabledTenant.(bool) {
 			return diag.FromErr(fmt.Errorf("`auto_scaling_disk_gb_enabled` cannot be true when provider name is TENANT"))
 		}

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -379,11 +379,6 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 		},
 	}
 
-	diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
-	if diskEnabledOK {
-		autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
-	}
-
 	// validate cluster_type conditional
 	if _, ok := d.GetOk("replication_specs"); ok {
 		if _, ok1 := d.GetOk("cluster_type"); !ok1 {

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -372,7 +372,7 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	autoScaling := &matlas.AutoScaling{
-		DiskGBEnabled: pointy.Bool(true),
+		DiskGBEnabled: pointy.Bool(d.Get("auto_scaling_disk_gb_enabled").(bool)),
 		Compute: &matlas.Compute{
 			Enabled:          &computeEnabled,
 			ScaleDownEnabled: &scaleDownEnabled,

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -63,6 +63,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"auto_scaling_disk_gb_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 			"auto_scaling_compute_enabled": {
 				Type:     schema.TypeBool,

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -63,7 +63,8 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"auto_scaling_disk_gb_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				//	DiffSuppressFunc: validateAutoScalingEnableDiff,
+				Computed: true,
+				//DiffSuppressFunc: validateAutoScalingEnableDiff,
 			},
 			"auto_scaling_compute_enabled": {
 				Type:     schema.TypeBool,
@@ -378,12 +379,12 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 			ScaleDownEnabled: &scaleDownEnabled,
 		},
 	}
-	/*
-		diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
-		if diskEnabledOK {
-			autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
-		}
-	*/
+
+	diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
+	if diskEnabledOK {
+		autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
+	}
+
 	// validate cluster_type conditional
 	if _, ok := d.GetOk("replication_specs"); ok {
 		if _, ok1 := d.GetOk("cluster_type"); !ok1 {

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -371,11 +371,16 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	autoScaling := &matlas.AutoScaling{
-		DiskGBEnabled: pointy.Bool(d.Get("auto_scaling_disk_gb_enabled").(bool)),
+		DiskGBEnabled: pointy.Bool(true),
 		Compute: &matlas.Compute{
 			Enabled:          &computeEnabled,
 			ScaleDownEnabled: &scaleDownEnabled,
 		},
+	}
+
+	diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
+	if diskEnabledOK {
+		autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
 	}
 
 	// validate cluster_type conditional
@@ -413,7 +418,8 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 
 	tenantDisksize := pointy.Float64(0)
 	if providerName == "TENANT" {
-		if diskGBEnabled := d.Get("auto_scaling_disk_gb_enabled"); diskGBEnabled.(bool) {
+
+		if diskEnabledTenant, diskEnabledTenantOK := d.GetOk("auto_scaling_disk_gb_enabled"); diskEnabledTenantOK && diskEnabledTenant.(bool) {
 			return diag.FromErr(fmt.Errorf("`auto_scaling_disk_gb_enabled` cannot be true when provider name is TENANT"))
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -63,7 +63,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"auto_scaling_disk_gb_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				//	DiffSuppressFunc: validateAutoScalingEnableDiff,
 			},
 			"auto_scaling_compute_enabled": {
 				Type:     schema.TypeBool,
@@ -372,13 +372,18 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	autoScaling := &matlas.AutoScaling{
-		DiskGBEnabled: pointy.Bool(d.Get("auto_scaling_disk_gb_enabled").(bool)),
+		DiskGBEnabled: pointy.Bool(true),
 		Compute: &matlas.Compute{
 			Enabled:          &computeEnabled,
 			ScaleDownEnabled: &scaleDownEnabled,
 		},
 	}
-
+	/*
+		diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
+		if diskEnabledOK {
+			autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
+		}
+	*/
 	// validate cluster_type conditional
 	if _, ok := d.GetOk("replication_specs"); ok {
 		if _, ok1 := d.GetOk("cluster_type"); !ok1 {
@@ -1586,4 +1591,12 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 			},
 		},
 	}
+}
+
+func validateAutoScalingEnableDiff(k, old, newStr string, d *schema.ResourceData) bool {
+	if old == "" && newStr == "true" {
+		return true
+	}
+
+	return false
 }

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -64,7 +64,6 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-				//DiffSuppressFunc: validateAutoScalingEnableDiff,
 			},
 			"auto_scaling_compute_enabled": {
 				Type:     schema.TypeBool,
@@ -1592,12 +1591,4 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 			},
 		},
 	}
-}
-
-func validateAutoScalingEnableDiff(k, old, newStr string, d *schema.ResourceData) bool {
-	if old == "" && newStr == "true" {
-		return true
-	}
-
-	return false
 }

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -379,8 +379,8 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 		},
 	}
 
-	diskEnabled, diskEnabledOK := d.GetOk("auto_scaling_disk_gb_enabled")
-	if diskEnabledOK {
+	diskEnabled := d.Get("auto_scaling_disk_gb_enabled")
+	if diskEnabled != nil {
 		autoScaling.DiskGBEnabled = pointy.Bool(diskEnabled.(bool))
 	}
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -268,6 +268,9 @@ output "private_srv" {
 * `auto_scaling_disk_gb_enabled` - (Optional) Specifies whether disk auto-scaling is enabled. The default is true.
     - Set to `true` to enable disk auto-scaling.
     - Set to `false` to disable disk auto-scaling.
+  
+-> **NOTE:** If `provider_name` is set to `TENANT`, the parameter `auto_scaling_disk_gb_enabled` will be ignored.
+
 * `auto_scaling_compute_enabled` - (Optional) Specifies whether cluster tier auto-scaling is enabled. The default is false.
     - Set to `true` to enable cluster tier auto-scaling. If enabled, you must specify a value for `providerSettings.autoScaling.compute.maxInstanceSize`.
     - Set to `false` to disable cluster tier auto-scaling.


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):[INTMDB-269](https://jira.mongodb.org/browse/INTMDB-269)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
TEST RESULT:
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasCluster_tenant (1558.34s)
PASS
coverage: 6.8% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 1560.775s       coverage: 6.8% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]