### PR TITLE
Fix backup option from provider_backup_enabled to cloud_backup

### DIFF
--- a/examples/starter/atlas_cluster.tf
+++ b/examples/starter/atlas_cluster.tf
@@ -13,7 +13,7 @@ resource "mongodbatlas_cluster" "cluster" {
     }
   }
   # Provider Settings "block"
-  provider_backup_enabled      = true
+  cloud_backup                 = true
   auto_scaling_disk_gb_enabled = true
   provider_name                = var.cloud_provider
   provider_instance_size_name  = "M10"


### PR DESCRIPTION

## Description

provider_backup_enabled is deprecated

>  25:   provider_backup_enabled      = true
> 
> This field is deprecated,please use cloud_backup instead

Use cloud_backup, Instead of provider_backup_enabled 

Thanks :) 

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
