### PR TITLE
INTMDB-270: fix issue with project resource importer test

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -223,10 +223,11 @@ func TestAccResourceMongoDBAtlasProject_importBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasProjectImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"with_default_alerts_settings"},
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Fixed Project Import test, field `with_default_alerts_settings` value now is ignored on import (currently the API doesn't return this value)

Link to any related issue(s):[INTMDB-270](https://jira.mongodb.org/browse/INTMDB-270)

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasProject_importBasic (13.96s)
PASS
coverage: 2.5% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 16.563s coverage: 2.5% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]
