### PR TITLE
INTMDB-279: Fixes a bug where it crashes when importing a trigger

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -477,7 +477,7 @@ func expandTriggerEventProcessorAWSEventBridge(p []interface{}) map[string]inter
 
 func flattenTriggerEventProcessorAWSEventBridge(eventProcessor map[string]interface{}) []map[string]interface{} {
 	results := make([]map[string]interface{}, 0)
-	if eventProcessor != nil {
+	if eventProcessor != nil && eventProcessor["AWS_EVENTBRIDGE"] != nil {
 		event := eventProcessor["AWS_EVENTBRIDGE"].(map[string]interface{})
 		config := event["config"].(map[string]interface{})
 		mapEvent := map[string]interface{}{
@@ -488,7 +488,6 @@ func flattenTriggerEventProcessorAWSEventBridge(eventProcessor map[string]interf
 				},
 			},
 		}
-
 		results = append(results, mapEvent)
 	}
 


### PR DESCRIPTION
## Description

- Fixes a bug where it crashes when reading a trigger with an empty event bridge processor
- Added a testacc `TestAccResourceMongoDBAtlasEventTriggerFunction_basic` to show it works, the config is the similar as the issue mentioned below


Results of testacc `TestAccResourceMongoDBAtlasEventTriggerFunction_basic`
```
make testacc TESTARGS='-run=TestAccResourceMongoDBAtlasEventTriggerFunction_basic'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v /integrationtesting) -v -parallel 20 -run=TestAccResourceMongoDBAtlasEventTriggerFunction_basic -timeout 300m -cover -ldflags="-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=acc'"
?       github.com/mongodb/terraform-provider-mongodbatlas      [no test files]
=== RUN   TestAccResourceMongoDBAtlasEventTriggerFunction_basic
=== PAUSE TestAccResourceMongoDBAtlasEventTriggerFunction_basic
=== CONT  TestAccResourceMongoDBAtlasEventTriggerFunction_basic
--- PASS: TestAccResourceMongoDBAtlasEventTriggerFunction_basic (38.23s)
PASS
coverage: 4.5% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 40.348s coverage: 4.5% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```

Link to any related issue(s):
#606 
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
