### PR TITLE
INTMDB-257: Changed 'hcl' markdown tag to 'terraform' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ From terraform version 0.14, we can override provider use for development purpos
 
 Just create a `.trfc` file to hold the configuration to override terraform local configuration
 
-```hcl
+```terraform
 provider_installation {
 
   dev_overrides {

--- a/website/docs/d/advanced_cluster.html.markdown
+++ b/website/docs/d/advanced_cluster.html.markdown
@@ -18,7 +18,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_advanced_cluster" "example" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"

--- a/website/docs/d/advanced_clusters.html.markdown
+++ b/website/docs/d/advanced_clusters.html.markdown
@@ -18,7 +18,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "example" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_alert_configuration" "test" {
   project_id = "<PROJECT-ID>"
   event_type = "OUTSIDE_METRIC_THRESHOLD"
@@ -53,7 +53,7 @@ data "mongodbatlas_alert_configuration" "test" {
 
 -> **NOTE:** In order to allow for a fast pace of change to alert variables some validations have been removed from this resource in order to unblock alert creation. Impacted areas have links to the MongoDB Atlas API documentation so always check it for the most current information: https://docs.atlas.mongodb.com/reference/api/alert-configurations-create-config/
 
-```hcl
+```terraform
 resource "mongodbatlas_alert_configuration" "test" {
   project_id = "<PROJECT-ID>"
   event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"

--- a/website/docs/d/auditing.html.markdown
+++ b/website/docs/d/auditing.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_auditing" "test" {
 	project_id                  = "<project-id>"
 	audit_filter                = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"

--- a/website/docs/d/cloud_backup_snapshot.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_backup_snapshot" "test" {
   group_id          = "5d0f1f73cf09a29120e173cf"
   cluster_name      = "MyClusterTest"

--- a/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
@@ -15,7 +15,7 @@ description: |-
 ## Example Usage
 First create a snapshot of the desired cluster. Then request that snapshot be restored in an automated fashion to the designated cluster and project.
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_backup_snapshot" "test" {
   project_id          = "5cf5a45a9ccf6400e60981b6"
   cluster_name      = "MyCluster"

--- a/website/docs/d/cloud_backup_snapshot_restore_jobs.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_jobs.html.markdown
@@ -15,7 +15,7 @@ description: |-
 ## Example Usage
 First create a snapshot of the desired cluster. Then request that snapshot be restored in an automated fashion to the designated cluster and project.
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_backup_snapshot" "test" {
   project_id          = "5cf5a45a9ccf6400e60981b6"
   cluster_name      = "MyCluster"

--- a/website/docs/d/cloud_backup_snapshots.html.markdown
+++ b/website/docs/d/cloud_backup_snapshots.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_backup_snapshots" "test" {
   group_id          = "5d0f1f73cf09a29120e173cf"
   cluster_name      = "MyClusterTest"

--- a/website/docs/d/cloud_provider_access.markdown
+++ b/website/docs/d/cloud_provider_access.markdown
@@ -13,7 +13,7 @@ description: |-
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
 ## Example Usage
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_access" "test_role" {
    project_id = "<PROJECT-ID>"
    provider_name = "AWS"

--- a/website/docs/d/cloud_provider_access_setup.markdown
+++ b/website/docs/d/cloud_provider_access_setup.markdown
@@ -13,7 +13,7 @@ description: |-
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
 ## Example Usage
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
    project_id = "<PROJECT-ID>"
    provider_name = "AWS"

--- a/website/docs/d/cloud_provider_snapshot.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot.html.markdown
@@ -16,7 +16,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_snapshot" "test" {
   group_id          = "5d0f1f73cf09a29120e173cf"
   cluster_name      = "MyClusterTest"

--- a/website/docs/d/cloud_provider_snapshot_backup_policy.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot_backup_policy.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"

--- a/website/docs/d/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot_restore_job.html.markdown
@@ -17,7 +17,7 @@ description: |-
 ## Example Usage
 First create a snapshot of the desired cluster. Then request that snapshot be restored in an automated fashion to the designated cluster and project.
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_snapshot" "test" {
   project_id          = "5cf5a45a9ccf6400e60981b6"
   cluster_name      = "MyCluster"

--- a/website/docs/d/cloud_provider_snapshot_restore_jobs.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot_restore_jobs.html.markdown
@@ -17,7 +17,7 @@ description: |-
 ## Example Usage
 First create a snapshot of the desired cluster. Then request that snapshot be restored in an automated fashion to the designated cluster and project.
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_snapshot" "test" {
   project_id          = "5cf5a45a9ccf6400e60981b6"
   cluster_name      = "MyCluster"

--- a/website/docs/d/cloud_provider_snapshots.html.markdown
+++ b/website/docs/d/cloud_provider_snapshots.html.markdown
@@ -16,7 +16,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_snapshot" "test" {
   group_id          = "5d0f1f73cf09a29120e173cf"
   cluster_name      = "MyClusterTest"

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -18,7 +18,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -18,7 +18,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"

--- a/website/docs/d/custom_db_role.html.markdown
+++ b/website/docs/d/custom_db_role.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_custom_db_role" "test_role" {
   project_id = "<PROJECT-ID>"
   role_name  = "myCustomRole"

--- a/website/docs/d/custom_db_roles.html.markdown
+++ b/website/docs/d/custom_db_roles.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username      = "test-acc-username"
   password      = "test-acc-password"

--- a/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
+++ b/website/docs/d/custom_dns_configuration_cluster_aws.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
 	project_id                  = "<project-id>"
 	enabled                     = true

--- a/website/docs/d/data_lake.html.markdown
+++ b/website/docs/d/data_lake.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "NAME OF THE PROJECT"
   org_id = "ORGANIZATION ID"

--- a/website/docs/d/data_lakes.html.markdown
+++ b/website/docs/d/data_lakes.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 data "mongodbatlas_data_lakes" "test" {
   project_id = "PROJECT ID"
 }

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -16,7 +16,7 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username           = "test-acc-username"
   password           = "test-acc-password"

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -16,7 +16,7 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username           = "test-acc-username"
   password           = "test-acc-password"

--- a/website/docs/d/event_trigger.html.markdown
+++ b/website/docs/d/event_trigger.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"

--- a/website/docs/d/event_triggers.html.markdown
+++ b/website/docs/d/event_triggers.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"

--- a/website/docs/d/global_cluster_config.html.markdown
+++ b/website/docs/d/global_cluster_config.html.markdown
@@ -16,7 +16,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 	resource "mongodbatlas_cluster" "test" {
 		project_id              = "<YOUR-PROJECT-ID>"
 		name                    = "<CLUSTER-NAME>"

--- a/website/docs/d/ldap_configuration.html.markdown
+++ b/website/docs/d/ldap_configuration.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "NAME OF THE PROJECT"
   org_id = "ORG ID"

--- a/website/docs/d/ldap_verify.html.markdown
+++ b/website/docs/d/ldap_verify.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "NAME OF THE PROJECT"
   org_id = "ORG ID"

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Examples Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_maintenance_window" "test" {
   project_id  = "<your-project-id>"
   day_of_week = 3
@@ -28,7 +28,7 @@ data "mongodbatlas_maintenance_window" "test" {
 ```
 
 
-```hcl
+```terraform
 resource "mongodbatlas_maintenance_window" "test" {
   project_id  = "<your-project-id>"
   start_asap  = true 

--- a/website/docs/d/network_container.html.markdown
+++ b/website/docs/d/network_container.html.markdown
@@ -19,7 +19,7 @@ description: |-
 
 ### Basic Example.
 
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<YOUR-PROJECT-ID>"
   atlas_cidr_block = "10.8.0.0/21"

--- a/website/docs/d/network_containers.html.markdown
+++ b/website/docs/d/network_containers.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 ### Basic Example.
 
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<YOUR-PROJECT-ID>"
   atlas_cidr_block = "10.8.0.0/21"

--- a/website/docs/d/network_peering.html.markdown
+++ b/website/docs/d/network_peering.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 ### Basic Example (AWS).
 
-```hcl
+```terraform
 resource "mongodbatlas_network_peering" "test" {
 	accepter_region_name	= "us-east-1"	
 	project_id    			= "<YOUR-PROJEC-ID>"

--- a/website/docs/d/network_peerings.html.markdown
+++ b/website/docs/d/network_peerings.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 ### Basic Example (AWS).
 
-```hcl
+```terraform
 resource "mongodbatlas_network_peering" "test" {
 	accepter_region_name	= "us-east-1"	
 	project_id    			= "<YOUR-PROJEC-ID>"

--- a/website/docs/d/online_archive.html.markdown
+++ b/website/docs/d/online_archive.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl 
+```terraform 
 
 data "mongodbatlas_online_archive" "test" {
     project_id   = var.project_id

--- a/website/docs/d/online_archives.html.markdown
+++ b/website/docs/d/online_archives.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl 
+```terraform 
 data "mongodbatlas_online_archives" "test" {
     project_id   = var.project_id
     cluster_name = var.cluster_name

--- a/website/docs/d/org_invitation.html.markdown
+++ b/website/docs/d/org_invitation.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_org_invitation" "test" {
   username    = "test-acc-username"
   org_id      = "<ORG-ID>"

--- a/website/docs/d/privatelink_endpoint.html.markdown
+++ b/website/docs/d/privatelink_endpoint.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = "<PROJECT-ID>"
   provider_name = "AWS"

--- a/website/docs/d/privatelink_endpoint_service.html.markdown
+++ b/website/docs/d/privatelink_endpoint_service.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example with AWS
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = "<PROJECT_ID>"
   provider_name = "AWS"
@@ -45,7 +45,7 @@ data "mongodbatlas_privatelink_endpoint_service" "test" {
 
 ## Example with Azure
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = var.project_id
   provider_name = "AZURE"

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -15,7 +15,7 @@ description: |-
 ## Example Usage
 
 ### Using project_id attribute to query
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
   org_id = "<ORG_ID>"
@@ -37,7 +37,7 @@ data "mongodbatlas_project" "test" {
 ```
 
 ### Using name attribute to query
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
   org_id = "<ORG_ID>"

--- a/website/docs/d/project_invitation.html.markdown
+++ b/website/docs/d/project_invitation.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usages
 
-```hcl
+```terraform
 resource "mongodbatlas_project_invitation" "test" {
   username    = "test-acc-username"
   project_id  = "<PROJECT-ID>"

--- a/website/docs/d/project_ip_access_list.html.markdown
+++ b/website/docs/d/project_ip_access_list.html.markdown
@@ -19,7 +19,7 @@ When you remove an entry from the access list, existing connections from the rem
 ## Example Usage
 
 ### Using CIDR Block
-```hcl
+```terraform
 resource "mongodbatlas_project_ip_access_list" "test" {
   project_id = "<PROJECT-ID>"
   cidr_block = "1.2.3.4/32"
@@ -33,7 +33,7 @@ data "mongodbatlas_project_ip_access_list" "test" {
 ```
 
 ### Using IP Address
-```hcl
+```terraform
 resource "mongodbatlas_project_ip_access_list" "test" {
   project_id = "<PROJECT-ID>"
   ip_address = "2.3.4.5"
@@ -47,7 +47,7 @@ data "mongodbatlas_project_ip_access_list" "test" {
 ```
 
 ### Using an AWS Security Group
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<PROJECT-ID>"
   atlas_cidr_block = "192.168.208.0/21"

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
   org_id = "<ORG_ID>"

--- a/website/docs/d/search_index.html.markdown
+++ b/website/docs/d/search_index.html.markdown
@@ -15,7 +15,7 @@ Describes a Search Index.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "mongodbatlas_search_index" "test" {
   index_id   = "<INDEX_ID"
   project_id = "<PROJECT_ID>"

--- a/website/docs/d/search_indexes.html.markdown
+++ b/website/docs/d/search_indexes.html.markdown
@@ -15,7 +15,7 @@ Describes a Search Indexes.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "mongodbatlas_search_index" "test" {
   project_id = "<PROJECT_ID>"
   cluster_name = "<CLUSTER_NAME>"

--- a/website/docs/d/serverless_instance.html.markdown
+++ b/website/docs/d/serverless_instance.html.markdown
@@ -19,7 +19,7 @@ For a full list of unsupported features, see [Serverless Instance Limitations](h
 ## Example Usage
 
 ### Basic
-```hcl
+```terraform
 data "mongodbatlas_serverless_instance" "test_two" {
   name        = "<SERVERLESS_INSTANCE_NAME>"
   project_id  = "<PROJECT_ID >"

--- a/website/docs/d/serverless_instances.html.markdown
+++ b/website/docs/d/serverless_instances.html.markdown
@@ -19,7 +19,7 @@ For a full list of unsupported features, see [Serverless Instance Limitations](h
 
 ## Example Usage
 
-```hcl
+```terraform
 data "mongodbatlas_serverless_instances" "data_serverless" {
   project_id = "<PROJECT_ID"
 }

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_teams" "test" {
   org_id     = "<ORGANIZATION-ID>"
   name       = "myNewTeam"
@@ -28,7 +28,7 @@ data "mongodbatlas_teams" "test" {
 
 ```
 
-```hcl
+```terraform
 resource "mongodbatlas_teams" "test" {
   org_id     = "<ORGANIZATION-ID>"
   name       = "myNewTeam"

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 
 resource "mongodbatlas_third_party_integration" "test_flowdock" {
 	project_id = "<PROJECT-ID>"

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -15,7 +15,7 @@ applied across the project.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_third_party_integration" "test_pager_duty" {
     project_id = "<PROJECT-ID>"
 	type = "PAGER_DUTY"

--- a/website/docs/d/x509_authentication_database_user.html.markdown
+++ b/website/docs/d/x509_authentication_database_user.html.markdown
@@ -15,7 +15,7 @@ description: |-
 ## Example Usages
 
 ### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "user" {
   project_id    = "<PROJECT-ID>"
   username      = "myUsername"
@@ -46,7 +46,7 @@ data "mongodbatlas_x509_authentication_database_user" "test" {
 ```
 
 ### Example Usage: Save a customer-managed X.509 configuration for an Atlas project
-```hcl
+```terraform
 resource "mongodbatlas_x509_authentication_database_user" "test" {
   project_id        = "<PROJECT-ID>"
   customer_x509_cas = <<-EOT

--- a/website/docs/guides/0.9.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/0.9.1-upgrade-guide.html.markdown
@@ -15,7 +15,7 @@ perform the following steps
 
 1. Add the new `mongodbatlas_cloud_provider_access_setup` to your configuration file 
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_access_setup" "unique" {
    project_id = "<PROJECT-ID>"
    provider_name = "AWS"
@@ -31,7 +31,7 @@ resource "mongodbatlas_cloud_provider_access_setup" "unique" {
 
 3. Add the mongodbatlas_cloud_provider_access_authorization to the configuration file
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_access_authorization" "auth" {
 
   project_id = mongodbatlas_cloud_provider_access_setup.unique.project_id

--- a/website/docs/guides/1.0.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.0.0-upgrade-guide.html.markdown
@@ -257,7 +257,7 @@ Thanks to user feedback we redesigned the `mongodbatlas_cloud_provider_snapshot_
 
 `mongodbatlas_cloud_provider_snapshot_backup_policy` Example - Previous Resource - Deprecated
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
   project_id   = mongodbatlas_cluster.my_cluster.project_id
   cluster_name = mongodbatlas_cluster.my_cluster.name
@@ -308,7 +308,7 @@ resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
 
 `mongodbatlas_cloud_backup_schedule` Example - New Resource
 
-```hcl
+```terraform
 resource "mongodbatlas_cloud_backup_schedule" "test" {
   project_id   = mongodbatlas_cluster.my_cluster.project_id
   cluster_name = mongodbatlas_cluster.my_cluster.name

--- a/website/docs/guides/1.0.1-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.0.1-upgrade-guide.html.markdown
@@ -13,7 +13,7 @@ MongoDB Atlas Provider 1.0.1: Upgrade and Information Guide
 To update from v1.0.0 to v1.0.1 you need to set `analyzers` field as a JSON string.
 
 Old Usage: 
-```hcl
+```terraform
 resource "mongodbatlas_search_index" "test" {
   project_id         = mongodbatlas_cluster.aws_conf.project_id
   cluster_name       = mongodbatlas_cluster.aws_conf.name
@@ -47,7 +47,7 @@ resource "mongodbatlas_search_index" "test" {
 ```
 
 New Usage:
-```hcl
+```terraform
 resource "mongodbatlas_search_index" "test" {
   project_id = mongodbatlas_cluster.aws_conf.project_id
   cluster_name = mongodbatlas_cluster.aws_conf.name

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -18,7 +18,7 @@ Speaking of changes, see [CHANGELOG](https://github.com/mongodb/terraform-provid
 
 ## Example Usage
 
-```hcl
+```terraform
 # Configure the MongoDB Atlas Provider
 provider "mongodbatlas" {
   public_key = var.mongodbatlas_public_key
@@ -47,7 +47,7 @@ You can also provide your credentials via the environment variables,
 `MONGODB_ATLAS_PUBLIC_KEY` and `MONGODB_ATLAS_PRIVATE_KEY`,
 for your public and private MongoDB Atlas programmatic API key pair respectively:
 
-```hcl
+```terraform
 provider "mongodbatlas" {}
 ```
 
@@ -68,7 +68,7 @@ then `MCLI_PUBLIC_API_KEY` and `MCLI_PRIVATE_API_KEY` are also supported.
 Static credentials can be provided by adding the following attributes in-line in the MongoDB Atlas provider block, 
 either directly or via input variable/local value:
 
-```hcl
+```terraform
 provider "mongodbatlas" {
   public_key = "atlas_public_api_key" #required
   private_key  = "atlas_private_api_key" #required

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_alert_configuration" "test" {
   project_id = "<PROJECT-ID>"
   event_type = "OUTSIDE_METRIC_THRESHOLD"
@@ -48,7 +48,7 @@ resource "mongodbatlas_alert_configuration" "test" {
 -> **NOTE:** In order to allow for a fast pace of change to alert variables some validations have been removed from this resource in order to unblock alert creation. Impacted areas have links to the MongoDB Atlas API documentation so always check it for the most current information: https://docs.atlas.mongodb.com/reference/api/alert-configurations-create-config/
 
 
-```hcl
+```terraform
 resource "mongodbatlas_alert_configuration" "test" {
   project_id = "<PROJECT-ID>"
   event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"

--- a/website/docs/r/auditing.html.markdown
+++ b/website/docs/r/auditing.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_auditing" "test" {
 		project_id                  = "<project-id>"
 		audit_filter                = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -19,7 +19,7 @@ In the Terraform MongoDB Atlas Provider 1.0.0 we have re-architected the way in 
 
 You can create a new cluster with `cloud_backup` enabled and then immediately overwrite the default cloud backup policy that Atlas creates by default at the same time with this example.
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"
@@ -59,7 +59,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 
 You can enable `cloud_backup` in the Cluster resource and then use the `cloud_backup_schedule` resource with no policy items to remove the default policy that Atlas creates when you enable Cloud Backup. This allows you to then create a policy when you are ready to via Terraform.
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"
@@ -88,7 +88,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 If you followed the example to Create a Cluster with Cloud Backup Enabled but No Policy Items and then want to add policy items later to the `mongodbatlas_cloud_backup_schedule` this example shows how.
 
 The cluster already exists with `cloud_backup` enabled
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"

--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -27,7 +27,7 @@ the initial configuration (create, delete operations). The second resource, `mon
 
 ## Example Usage
 
-```hcl
+```terraform
 
 resource "mongodbatlas_cloud_provider_access" "test_role" {
    project_id = "<PROJECT-ID>"
@@ -58,7 +58,7 @@ resource "mongodbatlas_cloud_provider_access" "test_role" {
 
 Once the resource is created add the field `iam_assumed_role_arn` see [Set Up Unified AWS Access](https://docs.atlas.mongodb.com/security/set-up-unified-aws-access/#set-up-unified-aws-access) , and execute a new `terraform apply` this will create a PATCH request.
 
-```hcl
+```terraform
 
 resource "mongodbatlas_cloud_provider_access" "test_role" {
    project_id = "<PROJECT-ID>"
@@ -86,7 +86,7 @@ This is the first resource in the two-resource path as described above.
 
 ## Example Usage
 
-```hcl
+```terraform
 
 resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
    project_id = "<PROJECT-ID>"
@@ -125,7 +125,7 @@ This is the second resource in the two-resource path as described above.
 `mongodbatlas_cloud_provider_access_authorization`  Allows you to authorize an AWS IAM roles in Atlas.
 
 ## Example Usage
-```hcl
+```terraform
 
 resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
    project_id = "<PROJECT-ID>"

--- a/website/docs/r/cloud_provider_snapshot.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot.html.markdown
@@ -17,7 +17,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
 
 ## Example Usage
 
-```hcl
+```terraform
   resource "mongodbatlas_cluster" "my_cluster" {
     project_id   = "5cf5a45a9ccf6400e60981b6"
     name         = "MyCluster"

--- a/website/docs/r/cloud_provider_snapshot_backup_policy.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_backup_policy.html.markdown
@@ -19,7 +19,7 @@ When Cloud Backup is enabled for a cluster MongoDB Atlas automatically creates a
 
 ## Example Usage - Create a Cluster and Modify the 4 Default Policies Simultaneously
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"
@@ -84,7 +84,7 @@ resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
 
 ## Example Usage - Create a Cluster and Modify 3 Default Policies and Remove 1 Default Policy Simultaneously
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"
@@ -151,7 +151,7 @@ resource "mongodbatlas_cloud_provider_snapshot_backup_policy" "test" {
 
 ## Example Usage - Remove 3 Default Policies Items After the Cluster Has Already Been Created and Modify One Policy
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = "<PROJECT-ID>"
   name         = "clusterTest"

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -25,7 +25,7 @@ description: |-
 
 ### Example automated delivery type.
 
-```hcl
+```terraform
   resource "mongodbatlas_cluster" "my_cluster" {
     project_id   = "5cf5a45a9ccf6400e60981b6"
     name         = "MyCluster"
@@ -60,7 +60,7 @@ description: |-
 
 ### Example download delivery type.
 
-```hcl
+```terraform
   resource "mongodbatlas_cluster" "my_cluster" {
     project_id   = "5cf5a45a9ccf6400e60981b6"
     name         = "MyCluster"

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -24,7 +24,7 @@ description: |-
 
 ### Example AWS cluster
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"
@@ -51,7 +51,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 
 ### Example Azure cluster.
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "test"
@@ -78,7 +78,7 @@ resource "mongodbatlas_cluster" "test" {
 
 ### Example GCP cluster
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "test"
@@ -105,7 +105,7 @@ resource "mongodbatlas_cluster" "test" {
 
 ### Example Multi Region cluster
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id               = "<YOUR-PROJECT-ID>"
   name                     = "cluster-test-multi-region"
@@ -144,7 +144,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 
 ### Example Global cluster
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id              = "<YOUR-PROJECT-ID>"
   name                    = "cluster-test-global"
@@ -181,7 +181,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 }
 ```
 ### Example AWS Shared Tier (M2/M5) cluster
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id              = "<YOUR-PROJECT-ID>"
   name                    = "cluster-test-global"
@@ -194,7 +194,7 @@ resource "mongodbatlas_cluster" "cluster-test" {
 }
 ```
 ### Example AWS Free Tier cluster
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id              = "<YOUR-PROJECT-ID>"
   name                    = "cluster-test-global"
@@ -208,35 +208,35 @@ resource "mongodbatlas_cluster" "cluster-test" {
 ```
 ### Example - Return a Connection String
 AWS Private Endpoint
-```hcl
+```terraform
 output "plstring" {
     value = lookup(mongodbatlas_cluster.cluster-test.connection_strings[0].private_endpoint[0].srv_connection_string, aws_vpc_endpoint.ptfe_service.id)
 }
 # Example return string: plstring = mongodb+srv://cluster-atlas-pl-0.za3fb.mongodb.net
 ```
 Azure Private Endpoint
-```hcl
+```terraform
 output "plstring" {
     value = lookup(mongodbatlas_cluster.cluster-test.connection_strings[0].private_endpoint[0].srv_connection_string, azurerm_private_endpoint.test.id)
 }
 # Example return string: plstring = mongodb+srv://cluster-atlas-pl-0.za3fb.mongodb.net
 ```
 Standard
-```hcl
+```terraform
 output "standard" {
     value = mongodbatlas_cluster.cluster-test.connection_strings[0].standard
 }
 # Example return string: standard = "mongodb://cluster-atlas-shard-00-00.ygo1m.mongodb.net:27017,cluster-atlas-shard-00-01.ygo1m.mongodb.net:27017,cluster-atlas-shard-00-02.ygo1m.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-12diht-shard-0"
 ```
 Standard srv
-```hcl
+```terraform
 output "standard_srv" {
     value = mongodbatlas_cluster.cluster-test.connection_strings[0].standard_srv
 }
 # Example return string: standard_srv = "mongodb+srv://cluster-atlas.ygo1m.mongodb.net"
 ```
 Private with Network peering and Custom DNS AWS enabled
-```hcl
+```terraform
 output "private" {
     value = mongodbatlas_cluster.cluster-test.connection_strings[0].private
 }
@@ -244,7 +244,7 @@ output "private" {
 private = "mongodb+srv://cluster-atlas-pri.ygo1m.mongodb.net"
 ```
 Private srv with Network peering and Custom DNS AWS enabled
-```hcl
+```terraform
 output "private_srv" {
     value = mongodbatlas_cluster.cluster-test.connection_strings[0].private_srv
 }
@@ -352,7 +352,7 @@ But in order to explicitly change `provider_instance_size_name` comment the `lif
 
 ### Multi-Region Cluster 
 
-```hcl
+```terraform
 //Example 3 Multi-Region block
 replication_specs {
     num_shards = 1
@@ -405,7 +405,7 @@ replication_specs {
 
 Specifies BI Connector for Atlas configuration.
  
- ```hcl
+ ```terraform
  bi_connector = {
         enabled         = true
         read_preference = secondary
@@ -433,7 +433,7 @@ Specifies BI Connector for Atlas configuration.
 
 Include **desired options** within advanced_configuration:
 
-```hcl
+```terraform
 // Nest options within advanced_configuration
  advanced_configuration {
    javascript_enabled                   = false
@@ -458,7 +458,7 @@ Include **desired options** within advanced_configuration:
 
 ### Labels
 
- ```hcl
+ ```terraform
  labels {
         key   = "Key 1"
         value = "Value 1"

--- a/website/docs/r/custom_db_role.html.markdown
+++ b/website/docs/r/custom_db_role.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_custom_db_role" "test_role" {
   project_id = "<PROJECT-ID>"
   role_name  = "myCustomRole"
@@ -48,7 +48,7 @@ resource "mongodbatlas_custom_db_role" "test_role" {
 
 ## Example Usage with inherited roles
 
-```hcl
+```terraform
 resource "mongodbatlas_custom_db_role" "inherited_role_one" {
   project_id = "<PROJECT-ID>"
   role_name  = "insertRole"

--- a/website/docs/r/custom_dns_configuration_cluster_aws.markdown
+++ b/website/docs/r/custom_dns_configuration_cluster_aws.markdown
@@ -19,7 +19,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
   project_id    = "<PROJECT-ID>"
   enabled = true

--- a/website/docs/r/data_lake.html.markdown
+++ b/website/docs/r/data_lake.html.markdown
@@ -17,7 +17,7 @@ description: |-
 ## Example Usages
 
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "NAME OF THE PROJECT"
   org_id = "ORGANIZATION ID"

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -18,7 +18,7 @@ Each user has a set of roles that provide access to the project’s databases. U
 
 ## Example Usages
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username           = "test-acc-username"
   password           = "test-acc-password"
@@ -53,7 +53,7 @@ resource "mongodbatlas_database_user" "test" {
 ```
 
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username           = "test-acc-username"
   x509_type          = "MANAGED"
@@ -77,7 +77,7 @@ resource "mongodbatlas_database_user" "test" {
 }
 ```
 
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "test" {
   username           = aws_iam_role.test.arn
   project_id         = "<PROJECT-ID>"

--- a/website/docs/r/event_trigger.html.markdown
+++ b/website/docs/r/event_trigger.html.markdown
@@ -13,7 +13,7 @@ description: |-
 ## Example Usages
 
 ### Example Usage: Database Trigger with Function
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"
@@ -45,7 +45,7 @@ EOF
 ```
 
 ### Example Usage: Database Trigger with EventBridge
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"
@@ -73,7 +73,7 @@ resource "mongodbatlas_event_trigger" "test" {
 ```
 
 ### Example Usage: Authentication Trigger
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"
@@ -87,7 +87,7 @@ resource "mongodbatlas_event_trigger" "test" {
 ```
 
 ### Example Usage: Scheduled Trigger
-```hcl
+```terraform
 resource "mongodbatlas_event_trigger" "test" {
   project_id = "PROJECT ID"
   app_id = "APPLICATION ID"

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -18,7 +18,7 @@ description: |-
 
 ### Example Global cluster
 
-```hcl
+```terraform
 	resource "mongodbatlas_cluster" "test" {
 		project_id              = "<YOUR-PROJECT-ID>"
 		name                    = "<CLUSTER-NAME>"
@@ -74,7 +74,7 @@ description: |-
 
 ### Example Global cluster config
 
-```hcl
+```terraform
 resource "mongodbatlas_cluster" "cluster-test" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "cluster-test"

--- a/website/docs/r/ldap_verify.html.markdown
+++ b/website/docs/r/ldap_verify.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
 	name   = "NAME OF THE PROJECT"
 	org_id = "ORG ID"

--- a/website/docs/r/maintenance_window.html.markdown
+++ b/website/docs/r/maintenance_window.html.markdown
@@ -22,7 +22,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 ## Example Usage
 
-```hcl
+```terraform
   resource "mongodbatlas_maintenance_window" "test" {
     project_id  = "<your-project-id>"
     day_of_week = 3
@@ -31,7 +31,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 ```
 
-```hcl
+```terraform
   resource "mongodbatlas_maintenance_window" "test" {
     project_id = "<your-project-id>"
     defer      = true

--- a/website/docs/r/network_container.html.markdown
+++ b/website/docs/r/network_container.html.markdown
@@ -23,7 +23,7 @@ The following is the maximum number of Network Peering containers per cloud prov
 
 ### Example with AWS
 
-```hcl
+```terraform
   resource "mongodbatlas_network_container" "test" {
     project_id       = "<YOUR-PROJECT-ID>"
     atlas_cidr_block = "10.8.0.0/21"
@@ -35,7 +35,7 @@ The following is the maximum number of Network Peering containers per cloud prov
 
 ### Example with GCP
 
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<YOUR-PROJECT-ID>"
   atlas_cidr_block = "10.8.0.0/21"
@@ -46,7 +46,7 @@ resource "mongodbatlas_network_container" "test" {
 
 ### Example with Azure
 
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<YOUR-PROJECT-ID>"
   atlas_cidr_block = "10.8.0.0/21"

--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -29,7 +29,7 @@ For more information see https://docs.atlas.mongodb.com/security-vpc-peering/ an
 ## Example Usage - Container & Peering Connection
 
 ### Global configuration for the following examples
-```hcl
+```terraform
 locals {
   project_id        = <your-project-id>
 
@@ -46,7 +46,7 @@ locals {
 
 ### Example with AWS
 
-```hcl
+```terraform
 # Container example provided but not always required, 
 # see network_container documentation for details. 
 resource "mongodbatlas_network_container" "test" {
@@ -78,7 +78,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 
 ### Example with GCP
 
-```hcl
+```terraform
 
 # Container example provided but not always required, 
 # see network_container documentation for details. 
@@ -149,7 +149,7 @@ resource "mongodbatlas_cluster" "test" {
 
 ### Example with Azure
 
-```hcl
+```terraform
 
 # Ensure you have created the required Azure service principal first, see
 # see https://docs.atlas.mongodb.com/security-vpc-peering/
@@ -207,7 +207,7 @@ resource "mongodbatlas_cluster" "test" {
 You can create a peering connection if an appropriate container for your cloud provider already exists in your project (see the network_container resource for more information).  A container may already exist if you have already created a cluster in your project, if so you may obtain the `container_id` from the cluster resource as shown in the examples below.
 
 ### Example with AWS
-```hcl
+```terraform
 # Create an Atlas cluster, this creates a container if one
 # does not yet exist for this AWS region
 resource "mongodbatlas_cluster" "test" {
@@ -264,7 +264,7 @@ resource "aws_vpc_peering_connection_accepter" "aws_peer" {
 ```
 
 ### Example with GCP
-```hcl
+```terraform
 # Create an Atlas cluster, this creates a container if one
 # does not yet exist for this GCP 
 resource "mongodbatlas_cluster" "test" {
@@ -317,7 +317,7 @@ resource "google_compute_network_peering" "peering" {
 
 ### Example with Azure
 
-```hcl
+```terraform
 
 # Ensure you have created the required Azure service principal first, see
 # see https://docs.atlas.mongodb.com/security-vpc-peering/

--- a/website/docs/r/online_archive.html.markdown
+++ b/website/docs/r/online_archive.html.markdown
@@ -17,7 +17,7 @@ description: |-
 ~> **IMPORTANT:** There are fields that are immutable after creation, i.e if `date_field` value does not exist in the collection, the online archive state will be pending forever, and this field cannot be updated, that means a destroy is required, known error `ONLINE_ARCHIVE_CANNOT_MODIFY_FIELD`
 
 ## Example Usages
-```hcl
+```terraform
 resource "mongodbatlas_online_archive" "test" {
     project_id   = var.project_id
     cluster_name = var.cluster_name
@@ -45,7 +45,7 @@ resource "mongodbatlas_online_archive" "test" {
 
 For custom criteria example
 
-```hcl
+```terraform
 resource "mongodbatlas_online_archive" "test" {
     project_id   = var.project_id
     cluster_name = var.cluster_name

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -22,7 +22,7 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 
 ## Example Usages
 
-```hcl
+```terraform
 resource "mongodbatlas_org_invitation" "test0" {
   username    = "test0-acc-username"
   org_id      = "<ORG-ID>"
@@ -30,7 +30,7 @@ resource "mongodbatlas_org_invitation" "test0" {
 }
 ```
 
-```hcl
+```terraform
 resource "mongodbatlas_org_invitation" "test0" {
   username    = "test0-acc-username"
   org_id      = "<ORG-ID>"
@@ -38,7 +38,7 @@ resource "mongodbatlas_org_invitation" "test0" {
 }
 ```
 
-```hcl
+```terraform
 resource "mongodbatlas_org_invitation" "test1" {
   username    = "test1-acc-username"
   org_id      = "<ORG-ID>"

--- a/website/docs/r/private_ip_mode.html.markdown
+++ b/website/docs/r/private_ip_mode.html.markdown
@@ -15,7 +15,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_private_ip_mode" "my_private_ip_mode" {
     project_id = "<YOUR PROJECT ID>"
 	enabled    = false

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -21,7 +21,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = "<PROJECT-ID>"
   provider_name = "AWS/AZURE"

--- a/website/docs/r/privatelink_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service.html.markdown
@@ -19,7 +19,7 @@ description: |-
 
 ## Example with AWS
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = "<PROJECT_ID>"
   provider_name = "AWS"
@@ -44,7 +44,7 @@ resource "mongodbatlas_privatelink_endpoint_service" "test" {
 
 ## Example with Azure
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = var.project_id
   provider_name = "AZURE"
@@ -76,7 +76,7 @@ resource "mongodbatlas_privatelink_endpoint_service" "test" {
 
 ## Example with GCP
 
-```hcl
+```terraform
 resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = var.project_id
   provider_name = "GCP"

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -14,7 +14,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_project" "test" {
   name   = "project-name"
   org_id = "<ORG_ID>"

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -25,7 +25,7 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 
 ## Example Usages
 
-```hcl
+```terraform
 resource "mongodbatlas_project_invitation" "test" {
   username    = "test-acc-username"
   project_id  = "<PROJECT-ID>"
@@ -33,7 +33,7 @@ resource "mongodbatlas_project_invitation" "test" {
 }
 ```
 
-```hcl
+```terraform
 resource "mongodbatlas_project_invitation" "test" {
   username    = "test-acc-username"
   project_id  = "<PROJECT-ID>"

--- a/website/docs/r/project_ip_access_list.html.markdown
+++ b/website/docs/r/project_ip_access_list.html.markdown
@@ -19,7 +19,7 @@ When you remove an entry from the access list, existing connections from the rem
 ## Example Usage
 
 ### Using CIDR Block
-```hcl
+```terraform
 resource "mongodbatlas_project_ip_access_list" "test" {
   project_id = "<PROJECT-ID>"
   cidr_block = "1.2.3.4/32"
@@ -28,7 +28,7 @@ resource "mongodbatlas_project_ip_access_list" "test" {
 ```
 
 ### Using IP Address
-```hcl
+```terraform
 resource "mongodbatlas_project_ip_access_list" "test" {
   project_id = "<PROJECT-ID>"
   ip_address = "2.3.4.5"
@@ -37,7 +37,7 @@ resource "mongodbatlas_project_ip_access_list" "test" {
 ```
 
 ### Using an AWS Security Group
-```hcl
+```terraform
 resource "mongodbatlas_network_container" "test" {
   project_id       = "<PROJECT-ID>"
   atlas_cidr_block = "192.168.208.0/21"

--- a/website/docs/r/search_index.html.markdown
+++ b/website/docs/r/search_index.html.markdown
@@ -13,7 +13,7 @@ Provides a Search Index resource.
 ## Example Usage
 
 ### Basic 
-```hcl
+```terraform
 resource "mongodbatlas_search_index" "test" {
   name   = "project-name"
   project_id = "<PROJECT_ID>"
@@ -29,7 +29,7 @@ resource "mongodbatlas_search_index" "test" {
 ```
 
 ### Advanced (with custom analyzers)
-```hcl
+```terraform
 resource "mongodbatlas_search_index" "test" {
   project_id = "%[1]s"
   cluster_name = "%[2]s"
@@ -137,7 +137,7 @@ EOF
 * `mappings_dynamic` - Indicates whether the index uses dynamic or static mapping. For dynamic mapping, set the value to `true`. For static mapping, specify the fields to index using `mappings_fields`
 
 * `mappings_fields` - attribute is required when `mappings_dynamic` is true. This field needs to be a JSON string in order to be decoded correctly.
-  ```hcl
+  ```terraform
     mappings_fields = <<-EOF
     {
     "address": {
@@ -183,7 +183,7 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
     * `builtin`
     * `mongodb`
 * `char_filters` - Array containing zero or more character filters. Always require a `type` field, and some take additional options as well
-  ```hcl
+  ```terraform
   "char_filters":{
    "type": "<FILTER_TYPE>",
    "ADDITIONAL_OPTION": VALUE
@@ -193,7 +193,7 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
     * [htmlStrip](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-htmlStrip-ref) - Strips out HTML constructs
         * `type` - (Required) Must be `htmlStrip`
         * `ignored_tags`- a list of HTML tags to exclude from filtering
-        ```hcl
+        ```terraform
           analyzers = <<-EOF [{
             "name": "analyzer_test",
             "char_filters":{
@@ -206,7 +206,7 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
     * [mapping](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-mapping-ref) - Applies user-specified normalization mappings to characters. Based on Lucene's [MappingCharFilter](https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/charfilter/MappingCharFilter.html)
       An object containing a comma-separated list of mappings. A mapping indicates that one character or group of characters should be substituted for another, in the format `<original> : <replacement>`
       ### Example
-        ```hcl
+        ```terraform
         analyzers = <<-EOF [{
           "name":"name_analyzer",        
           "type": "mapping",
@@ -221,7 +221,7 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
 
 
 * `tokenizer` - (Required) Tokenizer to use. Determines how Atlas Search splits up text into discrete chunks of indexing. Always require a type field, and some take additional options as well.
-    ```hcl
+    ```terraform
     "tokenizer":{
     "type": "<tokenizer-type>",
     "ADDITIONAL_OPTIONS": VALUE
@@ -255,7 +255,7 @@ An [Atlas Search analyzer](https://docs.atlas.mongodb.com/reference/atlas-search
         *  `max_token_length` - The maximum number of characters in one token.
 
 * `tokenFilters` - Array containing zero or more token filters. Always require a type field, and some take additional options as well:
-  ```hcl
+  ```terraform
   "token_filters":{
     "type": "<FILTER_TYPE>",
     "ADDITIONAL-OPTIONS": VALUE
@@ -370,7 +370,7 @@ Synonyms mapping definition to use in the index.
     * [edgeGram](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-edgegram-tf-ref) token filter
     * [shingle](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-shingle-tf-ref) token filter
 
-```hcl
+```terraform
   synonyms {
    analyzer = "lucene.simple"
    name = "synonym_test"

--- a/website/docs/r/serverless_instance.html.markdown
+++ b/website/docs/r/serverless_instance.html.markdown
@@ -17,7 +17,7 @@ For a full list of unsupported features, see [Serverless Instance Limitations](h
 ## Example Usage
 
 ### Basic
-```hcl
+```terraform
 resource "mongodbatlas_serverless_instance" "test" {
   project_id   = "<PROJECT_ID>"
   name         = "<SERVERLESS_INSTANCE_NAME>"

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -18,7 +18,7 @@ MongoDB Atlas Team limits: max 250 teams in an organization and max 100 teams pe
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "mongodbatlas_teams" "test" {
   org_id     = "<ORGANIZATION-ID>"
   name       = "myNewTeam"

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -21,7 +21,7 @@ description: |-
 
 ## Example Usage
 
-```hcl
+```terraform
 
 resource "mongodbatlas_third_party_integration" "test_flowdock" {
 	project_id = "<PROJECT-ID>"

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -20,7 +20,7 @@ description: |-
 ## Example Usages
 
 ### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user
-```hcl
+```terraform
 resource "mongodbatlas_database_user" "user" {
   project_id    = "<PROJECT-ID>"
   username      = "myUsername"
@@ -46,7 +46,7 @@ resource "mongodbatlas_x509_authentication_database_user" "test" {
 ```
 
 ### Example Usage: Save a customer-managed X.509 configuration for an Atlas project
-```hcl
+```terraform
 resource "mongodbatlas_x509_authentication_database_user" "test" {
   project_id        = "<PROJECT-ID>"
   customer_x509_cas = <<-EOT


### PR DESCRIPTION
## Description

`hcl` meta tag changed to `terraform` in documentation according to https://github.com/hashicorp/vscode-terraform/pull/225#issuecomment-650265457

Link to any related issue(s):[INTMDB-257](https://jira.mongodb.org/browse/INTMDB-257)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
