### PR TITLE
INTMDB-276: Added VersionReleaseSystem parameter for resource/datasource(s) of cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.4.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.14.0
+	go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1197,8 +1197,6 @@ go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
-go.mongodb.org/atlas v0.14.0 h1:g5y/ZbM+eg++qJtpjG/oxoEicf3MTx7o7JaTpoKfyYw=
-go.mongodb.org/atlas v0.14.0/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e h1:kYgaXVVngAzJFFXYrwL1x+73Y7zrJ37KQw/1huAOWJY=
 go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=

--- a/go.sum
+++ b/go.sum
@@ -1199,6 +1199,8 @@ go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsX
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
 go.mongodb.org/atlas v0.14.0 h1:g5y/ZbM+eg++qJtpjG/oxoEicf3MTx7o7JaTpoKfyYw=
 go.mongodb.org/atlas v0.14.0/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e h1:kYgaXVVngAzJFFXYrwL1x+73Y7zrJ37KQw/1huAOWJY=
+go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -306,6 +306,10 @@ func dataSourceMongoDBAtlasCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"version_release_system": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -434,6 +438,10 @@ func dataSourceMongoDBAtlasClusterRead(ctx context.Context, d *schema.ResourceDa
 
 	if err := d.Set("labels", flattenLabels(cluster.Labels)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterSetting, "labels", clusterName, err))
+	}
+
+	if err := d.Set("version_release_system", cluster.VersionReleaseSystem); err != nil {
+		return diag.FromErr(fmt.Errorf(errorClusterSetting, "version_release_system", clusterName, err))
 	}
 
 	// Get the snapshot policy and set the data

--- a/mongodbatlas/data_source_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_test.go
@@ -50,6 +50,7 @@ func TestAccDataSourceMongoDBAtlasCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "auto_scaling_compute_scale_down_enabled", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "provider_auto_scaling_compute_min_instance_size", minSizeInstance),
 					resource.TestCheckResourceAttr(dataSourceName, "provider_auto_scaling_compute_max_instance_size", maxSizeInstance),
+					resource.TestCheckResourceAttr(dataSourceName, "version_release_system", "LTS"),
 				),
 			},
 		},

--- a/mongodbatlas/data_source_mongodbatlas_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters.go
@@ -310,6 +310,10 @@ func dataSourceMongoDBAtlasClusters() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"version_release_system": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -384,6 +388,7 @@ func flattenClusters(ctx context.Context, d *schema.ResourceData, conn *matlas.C
 			"replication_specs":                               flattenReplicationSpecs(clusters[i].ReplicationSpecs),
 			"labels":                                          flattenLabels(clusters[i].Labels),
 			"snapshot_backup_policy":                          snapshotBackupPolicy,
+			"version_release_system":                          clusters[i].VersionReleaseSystem,
 		}
 		results = append(results, result)
 	}

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -44,6 +44,7 @@ func TestAccDataSourceMongoDBAtlasClusters_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "results.0.version_release_system", "LTS"),
 				),
 			},
 		},

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -40,6 +40,8 @@ func TestAccResourceMongoDBAtlasCluster_basicAWS_simple(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "pit_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "version_release_system", "LTS"),
 				),
 			},
 			{
@@ -54,6 +56,7 @@ func TestAccResourceMongoDBAtlasCluster_basicAWS_simple(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "version_release_system", "LTS"),
 				),
 			},
 		},

--- a/website/docs/d/advanced_cluster.html.markdown
+++ b/website/docs/d/advanced_cluster.html.markdown
@@ -62,7 +62,7 @@ In addition to all arguments above, the following attributes are exported:
 * `pit_enabled` - Flag that indicates if the cluster uses Continuous Cloud Backup.
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use. 
-* `version_release_system` - Method by which this cluster maintains the MongoDB versions. 
+* `version_release_system` - Release cadence that Atlas uses for this cluster.
 
 
 ### bi_connector

--- a/website/docs/d/advanced_clusters.html.markdown
+++ b/website/docs/d/advanced_clusters.html.markdown
@@ -64,7 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 * `pit_enabled` - Flag that indicates if the cluster uses Continuous Cloud Backup.
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use.
-* `version_release_system` - Method by which this cluster maintains the MongoDB versions.
+* `version_release_system` - Release cadence that Atlas uses for this cluster.
 
 
 ### bi_connector

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -120,6 +120,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `container_id` - The Network Peering Container ID.
 
+* `version_release_system` - Method by which this cluster maintains the MongoDB versions.
+
 ### BI Connector
 
 Indicates BI Connector for Atlas configuration.

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -120,7 +120,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `container_id` - The Network Peering Container ID.
 
-* `version_release_system` - Method by which this cluster maintains the MongoDB versions.
+* `version_release_system` - Release cadence that Atlas uses for this cluster.
 
 ### BI Connector
 

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -121,6 +121,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `container_id` - The Network Peering Container ID.
 
+* `version_release_system` - Method by which this cluster maintains the MongoDB versions.
 
 
 ### BI Connector

--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -121,7 +121,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `container_id` - The Network Peering Container ID.
 
-* `version_release_system` - Method by which this cluster maintains the MongoDB versions.
+* `version_release_system` - Release cadence that Atlas uses for this cluster.
 
 
 ### BI Connector

--- a/website/docs/r/advanced_cluster.html.markdown
+++ b/website/docs/r/advanced_cluster.html.markdown
@@ -129,13 +129,15 @@ This parameter defaults to false.
 * `pit_enabled` - (Optional) - Flag that indicates if the cluster uses Continuous Cloud Backup.
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - (Optional) - Certificate Authority that MongoDB Atlas clusters use. You can specify ISRGROOTX1 (for ISRG Root X1).
-* `version_release_system` - (Optional) - Method by which this cluster maintains the MongoDB versions. Valid values are `CONTINUOUS` or `LTS` (Long Term Support). This parameter defaults to `LTS`. If you set this parameter to `CONTINUOUS` and set any value for `mongo_db_major_version`, this resource returns an error.
+* `version_release_system` - (Optional) - Release cadence that Atlas uses for this cluster. This parameter defaults to `LTS`. If you set this field to `CONTINUOUS`, you must omit the `mongo_db_major_version` field. Atlas accepts:
+  - `CONTINUOUS`:  Atlas creates your cluster using the most recent MongoDB release. Atlas automatically updates your cluster to the latest major and rapid MongoDB releases as they become available.
+  - `LTS`: Atlas creates your cluster using the latest patch release of the MongoDB version that you specify in the mongoDBMajorVersion field. Atlas automatically updates your cluster to subsequent patch releases of this MongoDB version. Atlas doesn't update your cluster to newer rapid or major MongoDB releases as they become available.
 * `paused` (Optional) - Flag that indicates whether the cluster is paused or not. You can pause M10 or larger clusters.  You cannot initiate pausing for a shared/tenant tier cluster.  See [Considerations for Paused Clusters](https://docs.atlas.mongodb.com/pause-terminate-cluster/#considerations-for-paused-clusters)  
   **NOTE** Pause lasts for up to 30 days. If you don't resume the cluster within 30 days, Atlas resumes the cluster.  When the cluster resumption happens Terraform will flag the changed state.  If you wish to keep the cluster paused, reapply your Terraform configuration.   If you prefer to allow the automated change of state to unpaused use:
   `lifecycle {
   ignore_changes = [paused]
   }`
-
+ 
 
 ### bi_connector
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -355,8 +355,10 @@ But in order to explicitly change `provider_instance_size_name` comment the `lif
   ignore_changes = [paused]
   }`
 
-* `version_release_system` - (Optional) - Method by which this cluster maintains the MongoDB versions. Valid values are `CONTINUOUS` or `LTS` (Long Term Support). This parameter defaults to `LTS`. If you set this parameter to `CONTINUOUS` and set any value for `mongo_db_major_version`, this resource returns an error.
-
+* `version_release_system` - (Optional) - Release cadence that Atlas uses for this cluster. This parameter defaults to `LTS`. If you set this field to `CONTINUOUS`, you must omit the `mongo_db_major_version` field. Atlas accepts:
+  - `CONTINUOUS`:  Atlas creates your cluster using the most recent MongoDB release. Atlas automatically updates your cluster to the latest major and rapid MongoDB releases as they become available.
+  - `LTS`: Atlas creates your cluster using the latest patch release of the MongoDB version that you specify in the mongoDBMajorVersion field. Atlas automatically updates your cluster to subsequent patch releases of this MongoDB version. Atlas doesn't update your cluster to newer rapid or major MongoDB releases as they become available.
+  
 ### Multi-Region Cluster 
 
 ```terraform

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -355,33 +355,34 @@ But in order to explicitly change `provider_instance_size_name` comment the `lif
   ignore_changes = [paused]
   }`
 
+* `version_release_system` - (Optional) - Method by which this cluster maintains the MongoDB versions. Valid values are `CONTINUOUS` or `LTS` (Long Term Support). This parameter defaults to `LTS`. If you set this parameter to `CONTINUOUS` and set any value for `mongo_db_major_version`, this resource returns an error.
 
 ### Multi-Region Cluster 
 
 ```terraform
 //Example 3 Multi-Region block
 replication_specs {
-    num_shards = 1
-    regions_config {
-      region_name     = "US_EAST_1"
-      electable_nodes = 3
-      priority        = 7
-      read_only_nodes = 0
-    }
-    regions_config {
-      region_name     = "US_EAST_2"
-      electable_nodes = 2
-      priority        = 6
-      read_only_nodes = 0
-    }
-    regions_config {
-      region_name     = "US_WEST_1"
-      electable_nodes = 2
-      priority        = 5
-      read_only_nodes = 2
-    }
+  num_shards = 1
+  regions_config {
+    region_name     = "US_EAST_1"
+    electable_nodes = 3
+    priority        = 7
+    read_only_nodes = 0
+  }
+  regions_config {
+    region_name     = "US_EAST_2"
+    electable_nodes = 2
+    priority        = 6
+    read_only_nodes = 0
+  }
+  regions_config {
+    region_name     = "US_WEST_1"
+    electable_nodes = 2
+    priority        = 5
+    read_only_nodes = 2
   }
 }
+
 ```
 
 **Replication Spec**  - Configuration block for multi-region cluster.


### PR DESCRIPTION

## Description

- Added field `version_release_system` for resource and datasource(s) of cluster
- Updated docs

NOTE: Still waiting for [PR](https://github.com/mongodb/go-client-mongodb-atlas/pull/270) to be merged first then updated the vendor, so it can pass the checks.


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
