### PR TITLE
INTMDB-281: Fix realm event trigger issue

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -271,6 +271,9 @@ func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.Reso
 	if v, ok := d.GetOk("config_full_document"); ok {
 		eventTriggerConfig.FullDocument = pointy.Bool(v.(bool))
 	}
+	if v, ok := d.GetOk("config_full_document_before"); ok {
+		eventTriggerConfig.FullDocumentBeforeChange = pointy.Bool(v.(bool))
+	}
 	if oksch {
 		eventTriggerConfig.Schedule = sche.(string)
 	}
@@ -364,9 +367,11 @@ func resourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.Resour
 	if err = d.Set("config_full_document", resp.Config.FullDocument); err != nil {
 		return diag.FromErr(fmt.Errorf(errorEventTriggersSetting, "config_full_document", projectID, appID, err))
 	}
+
 	if err = d.Set("config_full_document_before", resp.Config.FullDocumentBeforeChange); err != nil {
-		return diag.FromErr(fmt.Errorf(errorEventTriggersSetting, "config_full_document_before", projectID, appID, err))
+		return diag.FromErr(fmt.Errorf(errorEventTriggersSetting, "config_full_document", projectID, appID, err))
 	}
+
 	if err = d.Set("config_schedule", resp.Config.Schedule); err != nil {
 		return diag.FromErr(fmt.Errorf(errorEventTriggersSetting, "config_schedule", projectID, appID, err))
 	}
@@ -411,6 +416,7 @@ func resourceMongoDBAtlasEventTriggersUpdate(ctx context.Context, d *schema.Reso
 		eventTriggerConfig.Match = cast.ToStringMap(d.Get("config_match").(string))
 		eventTriggerConfig.Project = cast.ToStringMap(d.Get("config_project").(string))
 		eventTriggerConfig.FullDocument = pointy.Bool(d.Get("config_full_document").(bool))
+		eventTriggerConfig.FullDocumentBeforeChange = pointy.Bool(d.Get("config_full_document_before").(bool))
 	}
 	if typeTrigger == "AUTHENTICATION" {
 		eventTriggerConfig.OperationType = d.Get("config_operation_type").(string)

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -45,7 +45,6 @@ func TestAccResourceMongoDBAtlasEventTriggerDatabase_basic(t *testing.T) {
 			Database:       "sample_airbnb",
 			Collection:     "listingsAndReviews",
 			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
-			FullDocument:   pointy.Bool(false),
 		},
 	}
 
@@ -55,14 +54,14 @@ func TestAccResourceMongoDBAtlasEventTriggerDatabase_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasEventTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE"`, &event),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE"`, &event, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, &eventUpdated),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, &eventUpdated, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -500,7 +499,7 @@ func testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName string) 
 	}
 }
 
-func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest) string {
+func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest, fullDoc, fullDocBefore bool) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_event_trigger" "test" {
 			project_id = %[1]q
@@ -513,6 +512,8 @@ func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, ope
 			config_database = %[8]q
 			config_collection = %[9]q
 			config_service_id = %[10]q
+			config_full_document = %[11]t
+			config_full_document_before = %[12]t
 			config_match = <<-EOF
 			{
 			  "updateDescription.updatedFields": {
@@ -523,7 +524,7 @@ func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, ope
 }
 	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled, operationTypes,
 		eventTrigger.Config.Database, eventTrigger.Config.Collection,
-		eventTrigger.Config.ServiceID)
+		eventTrigger.Config.ServiceID, fullDoc, fullDocBefore)
 }
 
 func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, operationTypes, awsAccID, awsRegion string, eventTrigger *realm.EventTriggerRequest) string {


### PR DESCRIPTION
## Description

Fix issue with event trigger resource (wasn't sending the `config_full_document_before` property to the go-client

Link to any related issue(s):[INTMDB-281](https://jira.mongodb.org/browse/INTMDB-281) and issue [#616](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/616)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

```
TEST:
-----------------------------------------------------
--- PASS: TestAccResourceMongoDBAtlasEventTriggerDatabase_basic (44.60s)
PASS
coverage: 4.7% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 46.825s coverage: 4.7% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]
```