### PR TITLE
INTMDB-283: Fixes a bug about optional parameters in Cloud Backup Schedule

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -416,9 +416,16 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client,
 		req.Policies = []matlas.Policy{policy}
 	}
 
-	req.ReferenceHourOfDay = pointy.Int64(cast.ToInt64(d.Get("reference_hour_of_day")))
-	req.ReferenceMinuteOfHour = pointy.Int64(cast.ToInt64(d.Get("reference_minute_of_hour")))
-	req.RestoreWindowDays = pointy.Int64(cast.ToInt64(d.Get("restore_window_days")))
+	if v, ok := d.GetOk("reference_hour_of_day"); ok {
+		req.ReferenceHourOfDay = pointy.Int64(cast.ToInt64(v))
+	}
+	if v, ok := d.GetOk("reference_minute_of_hour"); ok {
+		req.ReferenceMinuteOfHour = pointy.Int64(cast.ToInt64(v))
+	}
+	if v, ok := d.GetOk("restore_window_days"); ok {
+		req.RestoreWindowDays = pointy.Int64(cast.ToInt64(v))
+	}
+
 	value := pointy.Bool(d.Get("update_snapshots").(bool))
 	if *value {
 		req.UpdateSnapshots = value
@@ -426,7 +433,7 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client,
 
 	_, _, err = conn.CloudProviderSnapshotBackupPolicies.Update(context.Background(), projectID, clusterName, req)
 	if err != nil {
-		return fmt.Errorf(errorSnapshotBackupScheduleUpdate, err)
+		return err
 	}
 
 	return nil

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -416,13 +416,13 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client,
 		req.Policies = []matlas.Policy{policy}
 	}
 
-	if v, ok := d.GetOk("reference_hour_of_day"); ok {
+	if v, ok := d.GetOkExists("reference_hour_of_day"); ok {
 		req.ReferenceHourOfDay = pointy.Int64(cast.ToInt64(v))
 	}
-	if v, ok := d.GetOk("reference_minute_of_hour"); ok {
+	if v, ok := d.GetOkExists("reference_minute_of_hour"); ok {
 		req.ReferenceMinuteOfHour = pointy.Int64(cast.ToInt64(v))
 	}
-	if v, ok := d.GetOk("restore_window_days"); ok {
+	if v, ok := d.GetOkExists("restore_window_days"); ok {
 		req.RestoreWindowDays = pointy.Int64(cast.ToInt64(v))
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -26,6 +26,58 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 1,
+					RetentionUnit:     "days",
+					RetentionValue:    1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 2,
+					RetentionUnit:     "days",
+					RetentionValue:    3,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasCloudBackupSchedule_noPolicies(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
 				Config: testAccMongoDBAtlasCloudBackupScheduleConfigNoPolicies(projectID, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
 					ReferenceHourOfDay:    pointy.Int64(3),
 					ReferenceMinuteOfHour: pointy.Int64(45),
@@ -397,4 +449,31 @@ func testAccMongoDBAtlasCloudBackupScheduleNewPoliciesConfig(projectID, clusterN
 			}
 		}
 	`, projectID, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName string, policy *matlas.PolicyItem) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = %[1]q
+  name         = %[2]q
+  disk_size_gb = 5
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "EU_CENTRAL_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true //enable cloud provider snapshots
+}
+
+resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+  project_id   = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+
+  policy_item_hourly {
+    frequency_interval = %[3]d
+    retention_unit     = %[4]q
+    retention_value    = %[5]d
+  }
+}
+	`, projectID, clusterName, policy.FrequencyInterval, policy.RetentionUnit, policy.RetentionValue)
 }

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -26,58 +26,6 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
-					FrequencyInterval: 1,
-					RetentionUnit:     "days",
-					RetentionValue:    1,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
-				),
-			},
-			{
-				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
-					FrequencyInterval: 2,
-					RetentionUnit:     "days",
-					RetentionValue:    3,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "3"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccResourceMongoDBAtlasCloudBackupSchedule_noPolicies(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
-		Steps: []resource.TestStep{
-			{
 				Config: testAccMongoDBAtlasCloudBackupScheduleConfigNoPolicies(projectID, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
 					ReferenceHourOfDay:    pointy.Int64(3),
 					ReferenceMinuteOfHour: pointy.Int64(45),
@@ -240,6 +188,58 @@ func TestAccResourceMongoDBAtlasCloudBackupScheduleImport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasCloudBackupSchedule_azure(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 1,
+					RetentionUnit:     "days",
+					RetentionValue:    1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 2,
+					RetentionUnit:     "days",
+					RetentionValue:    3,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "3"),
 				),
 			},
 			{
@@ -456,11 +456,10 @@ func testAccMongoDBAtlasCloudBackupScheduleBasicConfig(projectID, clusterName st
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
 
   // Provider Settings "block"
-  provider_name               = "AWS"
-  provider_region_name        = "EU_CENTRAL_1"
+  provider_name               = "AZURE"
+  provider_region_name        = "US_EAST_2"
   provider_instance_size_name = "M10"
   cloud_backup                = true //enable cloud provider snapshots
 }


### PR DESCRIPTION

## Description

- Fixes a bug where it should be or not set in request if it's using or not for parameters in cloud backup schedule and avoid the error `(request "INVALID_RESTORE_WINDOW") The restore window days should be a positive number`
- Added a testacc `TestAccResourceMongoDBAtlasCloudBackupSchedule_azure`

Link to any related issue(s):
#625 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
