### PR TITLE
INTMDB-287: Fixes the issues in project api keys

### DIFF
--- a/.github/workflows/automated-test-acceptances.yml
+++ b/.github/workflows/automated-test-acceptances.yml
@@ -81,4 +81,5 @@ jobs:
           MONGODB_ATLAS_ENABLE_BETA: ${{ secrets.MONGODB_ATLAS_ENABLE_BETA }}
           ACCTEST_TIMEOUT: ${{ secrets.ACCTEST_TIMEOUT }}
           PAGER_DUTY_SERVICE_KEY: ${{ secrets.PAGER_DUTY_SERVICE_KEY }}
+          MONGODB_ATLAS_API_KEYS_IDS: ${{ secrets.MONGODB_ATLAS_API_KEYS_IDS }}
         run: make testacc

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -41,7 +41,7 @@ func TestAccDataSourceMongoDBAtlasClusters_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.replication_specs.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.name"),
-					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_min_instance_size", minSizeInstance),

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -44,8 +44,6 @@ func TestAccDataSourceMongoDBAtlasClusters_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_min_instance_size", minSizeInstance),
-					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_max_instance_size", maxSizeInstance),
 				),
 			},
 		},

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -43,7 +43,7 @@ func TestAccDataSourceMongoDBAtlasClusters_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_min_instance_size", minSizeInstance),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_max_instance_size", maxSizeInstance),
 				),

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -42,7 +42,7 @@ func TestAccDataSourceMongoDBAtlasClusters_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.replication_specs.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.labels.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.auto_scaling_compute_scale_down_enabled", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_min_instance_size", minSizeInstance),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.provider_auto_scaling_compute_max_instance_size", maxSizeInstance),

--- a/mongodbatlas/data_source_mongodbatlas_project.go
+++ b/mongodbatlas/data_source_mongodbatlas_project.go
@@ -97,7 +97,7 @@ func getProjectAPIKeys(ctx context.Context, conn *matlas.Client, orgID, projectI
 		for _, role := range key.Roles {
 			// ProjectAPIKeys.List returns all API keys of the Project, including the org and project roles
 			// For more details: https://docs.atlas.mongodb.com/reference/api/projectApiKeys/get-all-apiKeys-in-one-project/
-			if !strings.HasPrefix(role.RoleName, "ORG_") {
+			if !strings.HasPrefix(role.RoleName, "ORG_") && role.GroupID == projectID {
 				roles = append(roles, role.RoleName)
 			}
 		}

--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
 	if len(apiKeysIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -66,6 +66,9 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+	if len(apiKeysIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/mongodbatlas/data_source_mongodbatlas_project_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_test.go
@@ -54,6 +54,7 @@ func TestAccDataSourceMongoDBAtlasProject_byID(t *testing.T) {
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -103,6 +104,7 @@ func TestAccDataSourceMongoDBAtlasProject_byName(t *testing.T) {
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/mongodbatlas/data_source_mongodbatlas_projects_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects_test.go
@@ -2,7 +2,6 @@ package mongodbatlas
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"testing"
@@ -114,7 +113,6 @@ func testAccMongoDBAtlasProjectsConfigWithDS(projectName, orgID string, teams []
 		%s
 		data "mongodbatlas_projects" "test" {}
 	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams, apiKeys))
-	log.Printf("[DEBUG] config: %s", config)
 	return config
 }
 

--- a/mongodbatlas/data_source_mongodbatlas_projects_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects_test.go
@@ -54,6 +54,7 @@ func TestAccDataSourceMongoDBAtlasProjects_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -103,6 +104,7 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
 					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/mongodbatlas/data_source_mongodbatlas_projects_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_projects_test.go
@@ -20,6 +20,9 @@ func TestAccDataSourceMongoDBAtlasProjects_basic(t *testing.T) {
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
 	}
+	if len(apiKeysIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t); checkTeamsIds(t) },
@@ -64,6 +67,9 @@ func TestAccDataSourceMongoDBAtlasProjects_withPagination(t *testing.T) {
 	apiKeysIds := strings.Split(os.Getenv("MONGODB_ATLAS_API_KEYS_IDS"), ",")
 	if len(teamsIds) < 2 {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+	if len(apiKeysIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -76,6 +76,7 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 			"api_keys": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"api_key_id": {

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -28,7 +28,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 3 team ids for this acceptance testing")
 	}
 	if len(apiKeysIds) < 2 {
-		t.Fatal("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
+		t.Skip("`MONGODB_ATLAS_API_KEYS_IDS` must have 2 api key ids for this acceptance testing")
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -103,7 +103,6 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
@@ -136,7 +135,6 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID, []*matlas.ProjectTeam{}, []*apiKey{}),
@@ -147,7 +145,6 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -66,6 +66,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
@@ -102,6 +103,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
@@ -134,6 +136,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID, []*matlas.ProjectTeam{}, []*apiKey{}),
@@ -144,6 +147,7 @@ func TestAccResourceMongoDBAtlasProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
## Description

- Added validation to get the roles of a project id instead of all of not related to project id
- Added env var for api keys in workflow yaml
- Changed fatal to skip to avoid crashing in automated test

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
