### PR TITLE
INTMDB-5: added parameter team name for alert configurations 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.4.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e
+	go.mongodb.org/atlas v0.14.1-0.20220104180936-6afea6036494
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1211,6 +1211,8 @@ go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsX
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
 go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e h1:kYgaXVVngAzJFFXYrwL1x+73Y7zrJ37KQw/1huAOWJY=
 go.mongodb.org/atlas v0.14.1-0.20211130093552-cb00594ec51e/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.14.1-0.20220104180936-6afea6036494 h1:nRJ7gjh1nNLKdQ1cCgppSoYZl1rAhwrLOzv4tNHYrQc=
+go.mongodb.org/atlas v0.14.1-0.20220104180936-6afea6036494/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -198,6 +198,10 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"team_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"type_name": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -270,6 +270,10 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"team_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"type_name": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -748,6 +752,7 @@ func flattenAlertConfigurationNotifications(notifications []matlas.Notification)
 			"service_key":            notifications[i].ServiceKey,
 			"sms_enabled":            notifications[i].SMSEnabled,
 			"team_id":                notifications[i].TeamID,
+			"team_name":              notifications[i].TeamName,
 			"type_name":              notifications[i].TypeName,
 			"username":               notifications[i].Username,
 			"victor_ops_api_key":     notifications[i].VictorOpsAPIKey,

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -221,6 +221,7 @@ Notifications to send when an alert condition is detected.
 * `service_key` - PagerDuty service key. Required for the PAGER_DUTY notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `sms_enabled` - Flag indicating if text message notifications should be sent. Configurable for `ORG`, `GROUP`, and `USER` notifications types.
 * `team_id` - Unique identifier of a team.
+* `team_name` - Label for the team that receives this notification.
 * `type_name` - Type of alert notification.
   Accepted values are:
     - `DATADOG`

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -244,6 +244,7 @@ List of notifications to send when an alert condition is detected.
 * `service_key` - PagerDuty service key. Required for the PAGER_DUTY notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `sms_enabled` - Flag indicating if text message notifications should be sent. Configurable for `ORG`, `GROUP`, and `USER` notifications types.
 * `team_id` - Unique identifier of a team.
+* `team_name` - Label for the team that receives this notification.
 * `type_name` - Type of alert notification.
   Accepted values are:
     - `DATADOG`


### PR DESCRIPTION
## Description

- Added `team_name` for alert configurations resource and datasource

Awaiting [PR](https://github.com/mongodb/go-client-mongodb-atlas/pull/272) to be merged and then update the vendor.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
