### PR TITLE
INTMDB-290: Added advanced configuration for datasource/resource of advanced cluster

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_cluster.go
@@ -17,6 +17,7 @@ func dataSourceMongoDBAtlasAdvancedCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"advanced_configuration": clusterAdvancedConfigurationSchemaComputed(),
 			"backup_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -266,6 +267,18 @@ func dataSourceMongoDBAtlasAdvancedClusterRead(ctx context.Context, d *schema.Re
 
 	if err := d.Set("version_release_system", cluster.VersionReleaseSystem); err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedSetting, "version_release_system", clusterName, err))
+	}
+
+	/*
+		Get the advaced configuration options and set up to the terraform state
+	*/
+	processArgs, _, err := conn.Clusters.GetProcessArgs(ctx, projectID, clusterName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorAdvancedConfRead, clusterName, err))
+	}
+
+	if err := d.Set("advanced_configuration", flattenProcessArgs(processArgs)); err != nil {
+		return diag.FromErr(fmt.Errorf(errorClusterAdvancedSetting, "advanced_configuration", clusterName, err))
 	}
 
 	d.SetId(cluster.ID)

--- a/mongodbatlas/data_source_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_cluster_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -72,6 +73,46 @@ func TestAccDataSourceMongoDBAtlasAdvancedCluster_multicloud(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf(t *testing.T) {
+	var (
+		cluster        matlas.AdvancedCluster
+		resourceName   = "mongodbatlas_advanced_cluster.test"
+		dataSourceName = "data.mongodbatlas_advanced_cluster.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name           = acctest.RandomWithPrefix("test-acc")
+		processArgs    = &matlas.ProcessArgs{
+			FailIndexKeyTooLong:              pointy.Bool(true),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_1",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, name, processArgs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceMongoDBAtlasAdvancedClusterConfig(projectID, name string) string {
 	return fmt.Sprintf(`
 %s
@@ -92,4 +133,15 @@ data "mongodbatlas_advanced_cluster" "test" {
   name 	     = mongodbatlas_advanced_cluster.test.name
 }
 	`, testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(projectID, name))
+}
+
+func testAccDataSourceMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, name string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+%s
+
+data "mongodbatlas_advanced_cluster" "test" {
+  project_id = mongodbatlas_advanced_cluster.test.project_id
+  name 	     = mongodbatlas_advanced_cluster.test.name
+}
+	`, testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, name, p))
 }

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
@@ -223,7 +223,6 @@ func flattenAdvancedClusters(ctx context.Context, d *schema.ResourceData, conn *
 	results := make([]map[string]interface{}, 0)
 
 	for i := range clusters {
-
 		processArgs, _, err := conn.Clusters.GetProcessArgs(ctx, clusters[i].GroupID, clusters[i].Name)
 		log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", clusters[i].ID, err)
 

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -24,6 +25,7 @@ func dataSourceMongoDBAtlasAdvancedClusters() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"advanced_configuration": clusterAdvancedConfigurationSchemaComputed(),
 						"backup_enabled": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -221,7 +223,12 @@ func flattenAdvancedClusters(ctx context.Context, d *schema.ResourceData, conn *
 	results := make([]map[string]interface{}, 0)
 
 	for i := range clusters {
+
+		processArgs, _, err := conn.Clusters.GetProcessArgs(ctx, clusters[i].GroupID, clusters[i].Name)
+		log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", clusters[i].ID, err)
+
 		result := map[string]interface{}{
+			"advanced_configuration":      flattenProcessArgs(processArgs),
 			"backup_enabled":              clusters[i].BackupEnabled,
 			"bi_connector":                flattenBiConnectorConfig(clusters[i].BiConnector),
 			"cluster_type":                clusters[i].ClusterType,

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
@@ -212,19 +212,21 @@ func dataSourceMongoDBAtlasAdvancedClustersRead(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf("error reading advanced cluster list for project(%s): %s", projectID, err))
 	}
 
-	if err := d.Set("results", flattenAdvancedClusters(ctx, d, conn, clusters.Results)); err != nil {
+	if err := d.Set("results", flattenAdvancedClusters(ctx, conn, clusters.Results)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedSetting, "results", d.Id(), err))
 	}
 
 	return nil
 }
 
-func flattenAdvancedClusters(ctx context.Context, d *schema.ResourceData, conn *matlas.Client, clusters []*matlas.AdvancedCluster) []map[string]interface{} {
+func flattenAdvancedClusters(ctx context.Context, conn *matlas.Client, clusters []*matlas.AdvancedCluster) []map[string]interface{} {
 	results := make([]map[string]interface{}, 0)
 
 	for i := range clusters {
 		processArgs, _, err := conn.Clusters.GetProcessArgs(ctx, clusters[i].GroupID, clusters[i].Name)
-		log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", clusters[i].ID, err)
+		if err != nil {
+			log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", clusters[i].ID, err)
+		}
 
 		result := map[string]interface{}{
 			"advanced_configuration":      flattenProcessArgs(processArgs),

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -26,6 +27,48 @@ func TestAccDataSourceMongoDBAtlasAdvancedClusters_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMongoDBAtlasAdvancedClustersConfig(projectID, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf(t *testing.T) {
+	var (
+		cluster        matlas.AdvancedCluster
+		resourceName   = "mongodbatlas_advanced_cluster.test"
+		dataSourceName = "data.mongodbatlas_advanced_clusters.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name           = acctest.RandomWithPrefix("test-acc")
+		processArgs    = &matlas.ProcessArgs{
+			FailIndexKeyTooLong:              pointy.Bool(true),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_1",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasAdvancedClustersConfigAdvancedConf(projectID, name, processArgs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, name),
@@ -94,4 +137,14 @@ data "mongodbatlas_advanced_clusters" "test" {
   project_id = mongodbatlas_advanced_cluster.test.project_id
 }
 	`, testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(projectID, name))
+}
+
+func testAccDataSourceMongoDBAtlasAdvancedClustersConfigAdvancedConf(projectID, name string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+%s
+
+data "mongodbatlas_advanced_clusters" "test" {
+  project_id = mongodbatlas_advanced_cluster.test.project_id
+}
+	`, testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, name, p))
 }

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -580,11 +580,11 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 	}
 
 	/*
-		Check if advanced configuration option has a changes to update it
+		Update advanced configuration options if needed
 	*/
 	if d.HasChange("advanced_configuration") {
 		ac := d.Get("advanced_configuration")
-		if aclist, ok1 := ac.([]interface{}); ok1 && len(aclist) > 0 {
+		if aclist, ok := ac.([]interface{}); ok && len(aclist) > 0 {
 			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
 			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
 				_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -22,11 +22,13 @@ import (
 )
 
 const (
-	errorClusterAdvancedCreate  = "error creating MongoDB ClusterAdvanced: %s"
-	errorClusterAdvancedRead    = "error reading MongoDB ClusterAdvanced (%s): %s"
-	errorClusterAdvancedDelete  = "error deleting MongoDB ClusterAdvanced (%s): %s"
-	errorClusterAdvancedUpdate  = "error updating MongoDB ClusterAdvanced (%s): %s"
-	errorClusterAdvancedSetting = "error setting `%s` for MongoDB ClusterAdvanced (%s): %s"
+	errorClusterAdvancedCreate             = "error creating MongoDB ClusterAdvanced: %s"
+	errorClusterAdvancedRead               = "error reading MongoDB ClusterAdvanced (%s): %s"
+	errorClusterAdvancedDelete             = "error deleting MongoDB ClusterAdvanced (%s): %s"
+	errorClusterAdvancedUpdate             = "error updating MongoDB ClusterAdvanced (%s): %s"
+	errorClusterAdvancedSetting            = "error setting `%s` for MongoDB ClusterAdvanced (%s): %s"
+	errorAdvancedClusterAdvancedConfUpdate = "error updating Advanced Configuration Option form MongoDB Cluster (%s): %s"
+	errorAdvancedClusterAdvancedConfRead   = "error reading Advanced Configuration Option form MongoDB Cluster (%s): %s"
 )
 
 func resourceMongoDBAtlasAdvancedCluster() *schema.Resource {
@@ -244,6 +246,7 @@ func resourceMongoDBAtlasAdvancedCluster() *schema.Resource {
 				Default:      "LTS",
 				ValidateFunc: validation.StringInSlice([]string{"LTS", "CONTINUOUS"}, false),
 			},
+			"advanced_configuration": clusterAdvancedConfigurationSchema(),
 		},
 	}
 }
@@ -325,6 +328,14 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 		request.VersionReleaseSystem = v.(string)
 	}
 
+	// We need to validate the oplog_size_mb attr of the advanced configuration option to show the error
+	// before that the cluster is created
+	if oplogSizeMB, ok := d.GetOkExists("advanced_configuration.0.oplog_size_mb"); ok {
+		if cast.ToInt64(oplogSizeMB) <= 0 {
+			return diag.FromErr(fmt.Errorf("`advanced_configuration.oplog_size_mb` cannot be <= 0"))
+		}
+	}
+
 	cluster, _, err := conn.AdvancedClusters.Create(ctx, projectID, request)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedCreate, err))
@@ -343,6 +354,22 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedCreate, err))
+	}
+
+	/*
+		So far, the cluster has created correctly, so we need to set up
+		the advanced configuration option to attach it
+	*/
+	ac, ok := d.GetOk("advanced_configuration")
+	if aclist, ok1 := ac.([]interface{}); ok1 && len(aclist) > 0 {
+		advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
+
+		if ok {
+			_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, cluster.Name, advancedConfReq)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf(errorAdvancedClusterAdvancedConfUpdate, cluster.Name, err))
+			}
+		}
 	}
 
 	// To pause a cluster
@@ -457,6 +484,18 @@ func resourceMongoDBAtlasAdvancedClusterRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedSetting, "version_release_system", clusterName, err))
 	}
 
+	/*
+		Get the advaced configuration options and set up to the terraform state
+	*/
+	processArgs, _, err := conn.Clusters.GetProcessArgs(ctx, projectID, clusterName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorAdvancedClusterAdvancedConfRead, clusterName, err))
+	}
+
+	if err := d.Set("advanced_configuration", flattenProcessArgs(processArgs)); err != nil {
+		return diag.FromErr(fmt.Errorf(errorClusterAdvancedSetting, "advanced_configuration", clusterName, err))
+	}
+
 	return nil
 }
 
@@ -537,6 +576,22 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
+		}
+	}
+
+	/*
+		Check if advanced configuration option has a changes to update it
+	*/
+	if d.HasChange("advanced_configuration") {
+		ac := d.Get("advanced_configuration")
+		if aclist, ok1 := ac.([]interface{}); ok1 && len(aclist) > 0 {
+			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
+			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
+				_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf(errorAdvancedClusterAdvancedConfUpdate, clusterName, err))
+				}
+			}
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -247,6 +248,70 @@ func TestAccResourceMongoDBAtlasAdvancedCluster_Paused(t *testing.T) {
 	})
 }
 
+func TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		rName        = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated = acctest.RandomWithPrefix("test-acc")
+		processArgs  = &matlas.ProcessArgs{
+			FailIndexKeyTooLong:              pointy.Bool(true),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_1",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+		}
+		processArgsUpdated = &matlas.ProcessArgs{
+			FailIndexKeyTooLong:              pointy.Bool(true),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_2",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, rName, processArgs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, rNameUpdated, processArgsUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName string, cluster *matlas.AdvancedCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*MongoDBClient).Atlas
@@ -446,4 +511,44 @@ resource "mongodbatlas_advanced_cluster" "test" {
   }
 }
 	`, projectID, name, paused)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(projectID, name string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id             = %[1]q
+  name                   = %[2]q
+  cluster_type           = "REPLICASET"
+  mongo_db_major_version = "4.0"
+
+   replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+
+  advanced_configuration  {
+    fail_index_key_too_long              = %[3]t
+    javascript_enabled                   = %[4]t
+    minimum_enabled_tls_protocol         = %[5]q
+    no_table_scan                        = %[6]t
+    oplog_size_mb                        = %[7]d
+    sample_size_bi_connector			 = %[8]d
+    sample_refresh_interval_bi_connector = %[9]d
+  }
+}
+
+	`, projectID, name,
+		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
+		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector)
 }

--- a/website/docs/d/advanced_cluster.html.markdown
+++ b/website/docs/d/advanced_cluster.html.markdown
@@ -63,7 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use. 
 * `version_release_system` - Release cadence that Atlas uses for this cluster.
-* `advanced_advanced_configurationconfiguration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
+* `advanced_configuration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
 
 
 ### bi_connector

--- a/website/docs/d/advanced_cluster.html.markdown
+++ b/website/docs/d/advanced_cluster.html.markdown
@@ -63,6 +63,7 @@ In addition to all arguments above, the following attributes are exported:
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use. 
 * `version_release_system` - Release cadence that Atlas uses for this cluster.
+* `advanced_advanced_configurationconfiguration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
 
 
 ### bi_connector
@@ -115,6 +116,22 @@ Key-value pairs that tag and categorize the cluster. Each key and value has a ma
 * `compute_min_instance_size` - Minimum instance size to which your cluster can automatically scale (such as M10). 
 * `compute_max_instance_size` - Maximum instance size to which your cluster can automatically scale (such as M40). 
 
+#### Advanced Configuration
+
+* `default_read_concern` - [Default level of acknowledgment requested from MongoDB for read operations](https://docs.mongodb.com/manual/reference/read-concern/) set for this cluster. MongoDB 4.4 clusters default to [available](https://docs.mongodb.com/manual/reference/read-concern-available/).
+* `default_write_concern` -  [Default level of acknowledgment requested from MongoDB for write operations](https://docs.mongodb.com/manual/reference/write-concern/) set for this cluster. MongoDB 4.4 clusters default to [1](https://docs.mongodb.com/manual/reference/write-concern/).
+* `fail_index_key_too_long` - When true, documents can only be updated or inserted if, for all indexed fields on the target collection, the corresponding index entries do not exceed 1024 bytes. When false, mongod writes documents that exceed the limit but does not index them.
+* `javascript_enabled` - When true, the cluster allows execution of operations that perform server-side executions of JavaScript. When false, the cluster disables execution of those operations.
+* `minimum_enabled_tls_protocol` - Sets the minimum Transport Layer Security (TLS) version the cluster accepts for incoming connections.Valid values are:
+
+  - TLS1_0
+  - TLS1_1
+  - TLS1_2
+
+* `no_table_scan` - When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
+* `oplog_size_mb` - The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
+* `sample_size_bi_connector` - Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
+* `sample_refresh_interval_bi_connector` - Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 
 ## Attributes Reference
 

--- a/website/docs/d/advanced_clusters.html.markdown
+++ b/website/docs/d/advanced_clusters.html.markdown
@@ -65,6 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 * `replication_specs` - Configuration for cluster regions and the hardware provisioned in them. See [below](#replication_specs)
 * `root_cert_type` - Certificate Authority that MongoDB Atlas clusters use.
 * `version_release_system` - Release cadence that Atlas uses for this cluster.
+* `advanced_configuration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
 
 
 ### bi_connector
@@ -116,6 +117,23 @@ Key-value pairs that tag and categorize the cluster. Each key and value has a ma
 * `compute_scale_down_enabled` - Flag that indicates whether the instance size may scale down.
 * `compute_min_instance_size` - Minimum instance size to which your cluster can automatically scale (such as M10).
 * `compute_max_instance_size` - Maximum instance size to which your cluster can automatically scale (such as M40).
+
+#### Advanced Configuration
+
+* `default_read_concern` - [Default level of acknowledgment requested from MongoDB for read operations](https://docs.mongodb.com/manual/reference/read-concern/) set for this cluster. MongoDB 4.4 clusters default to [available](https://docs.mongodb.com/manual/reference/read-concern-available/).
+* `default_write_concern` -  [Default level of acknowledgment requested from MongoDB for write operations](https://docs.mongodb.com/manual/reference/write-concern/) set for this cluster. MongoDB 4.4 clusters default to [1](https://docs.mongodb.com/manual/reference/write-concern/).
+* `fail_index_key_too_long` - When true, documents can only be updated or inserted if, for all indexed fields on the target collection, the corresponding index entries do not exceed 1024 bytes. When false, mongod writes documents that exceed the limit but does not index them.
+* `javascript_enabled` - When true, the cluster allows execution of operations that perform server-side executions of JavaScript. When false, the cluster disables execution of those operations.
+* `minimum_enabled_tls_protocol` - Sets the minimum Transport Layer Security (TLS) version the cluster accepts for incoming connections.Valid values are:
+
+  - TLS1_0
+  - TLS1_1
+  - TLS1_2
+
+* `no_table_scan` - When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
+* `oplog_size_mb` - The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
+* `sample_size_bi_connector` - Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
+* `sample_refresh_interval_bi_connector` - Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
 
 
 ## Attributes Reference

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -122,7 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version_release_system` - Release cadence that Atlas uses for this cluster.
 
-* `advanced_configuration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
+* `advanced_advanced_configurationconfiguration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
 
 ### BI Connector
 

--- a/website/docs/d/cluster.html.markdown
+++ b/website/docs/d/cluster.html.markdown
@@ -122,7 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version_release_system` - Release cadence that Atlas uses for this cluster.
 
-* `advanced_advanced_configurationconfiguration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
+* `advanced_configuration` - Get the advanced configuration options. See [Advanced Configuration](#advanced-configuration) below for more details.
 
 ### BI Connector
 

--- a/website/docs/r/advanced_cluster.html.markdown
+++ b/website/docs/r/advanced_cluster.html.markdown
@@ -163,6 +163,37 @@ Specifies BI Connector for Atlas configuration.
 
   - Set to "analytics" to have BI Connector for Atlas read from an analytics node. Default if the cluster contains analytics nodes.
 
+### Advanced Configuration Options
+
+-> **NOTE:** Prior to setting these options please ensure you read https://docs.atlas.mongodb.com/cluster-config/additional-options/.
+
+-> **NOTE:** This argument has been changed to type list make sure you have the proper syntax. The list can have only one  item maximum.
+
+Include **desired options** within advanced_configuration:
+
+```terraform
+// Nest options within advanced_configuration
+ advanced_configuration {
+   javascript_enabled                   = false
+   minimum_enabled_tls_protocol         = "TLS1_2"
+ }
+```
+
+* `default_read_concern` - (Optional) [Default level of acknowledgment requested from MongoDB for read operations](https://docs.mongodb.com/manual/reference/read-concern/) set for this cluster. MongoDB 4.4 clusters default to [available](https://docs.mongodb.com/manual/reference/read-concern-available/).
+* `default_write_concern` - (Optional) [Default level of acknowledgment requested from MongoDB for write operations](https://docs.mongodb.com/manual/reference/write-concern/) set for this cluster. MongoDB 4.4 clusters default to [1](https://docs.mongodb.com/manual/reference/write-concern/).
+* `fail_index_key_too_long` - (Optional) When true, documents can only be updated or inserted if, for all indexed fields on the target collection, the corresponding index entries do not exceed 1024 bytes. When false, mongod writes documents that exceed the limit but does not index them.
+* `javascript_enabled` - (Optional) When true, the cluster allows execution of operations that perform server-side executions of JavaScript. When false, the cluster disables execution of those operations.
+* `minimum_enabled_tls_protocol` - (Optional) Sets the minimum Transport Layer Security (TLS) version the cluster accepts for incoming connections.Valid values are:
+
+  - TLS1_0
+  - TLS1_1
+  - TLS1_2
+
+* `no_table_scan` - (Optional) When true, the cluster disables the execution of any query that requires a collection scan to return results. When false, the cluster allows the execution of those operations.
+* `oplog_size_mb` - (Optional) The custom oplog size of the cluster. Without a value that indicates that the cluster uses the default oplog size calculated by Atlas.
+* `sample_size_bi_connector` - (Optional) Number of documents per database to sample when gathering schema information. Defaults to 100. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
+* `sample_refresh_interval_bi_connector` - (Optional) Interval in seconds at which the mongosqld process re-samples data to create its relational schema. The default value is 300. The specified value must be a positive integer. Available only for Atlas deployments in which BI Connector for Atlas is enabled.
+
 
 ### labels
 


### PR DESCRIPTION
## Description

- Added parameter `advanced_configuration` for resource and datasource of `advanced_cluster`
- Added docs and tests

Results of tests

Resource
Advanced cluster
```
make testacc TESTARGS='-run=TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf'   [15:28:46]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v /integrationtesting) -v -parallel 20 -run=TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf -timeout 300m -cover -ldflags="-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=acc'"
?       github.com/mongodb/terraform-provider-mongodbatlas      [no test files]
=== RUN   TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf
=== PAUSE TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf
=== CONT  TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf
--- PASS: TestAccResourceMongoDBAtlasAdvancedCluster_advancedConf (1401.44s)
PASS
coverage: 5.6% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 1404.113s       coverage: 5.6% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```
Datasource
Advanced cluster
```
make testacc TESTARGS='-run=TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v /integrationtesting) -v -parallel 20 -run=TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf -timeout 300m -cover -ldflags="-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=acc'"
?       github.com/mongodb/terraform-provider-mongodbatlas      [no test files]
=== RUN   TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf
=== PAUSE TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf
=== CONT  TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf
--- PASS: TestAccDataSourceMongoDBAtlasAdvancedCluster_advancedConf (746.11s)
PASS
coverage: 6.3% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 750.576s        coverage: 6.3% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```

Advanced clusters
```
make testacc TESTARGS='-run=TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... | grep -v /integrationtesting) -v -parallel 20 -run=TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf -timeout 300m -cover -ldflags="-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=acc'"
?       github.com/mongodb/terraform-provider-mongodbatlas      [no test files]
=== RUN   TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf
=== PAUSE TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf
=== CONT  TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf
--- PASS: TestAccDataSourceMongoDBAtlasAdvancedClusters_advancedConf (682.70s)
PASS
coverage: 6.2% of statements
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 689.151s        coverage: 6.2% of statements
?       github.com/mongodb/terraform-provider-mongodbatlas/version      [no test files]

```
Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
