### PR TITLE
INTMDB-298: fixes a bug where you couldn't delete a team in team resource

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -230,6 +230,7 @@ func resourceMongoDBAtlasProjectUpdate(ctx context.Context, d *schema.ResourceDa
 				if errors.As(err, &target) && target.ErrorCode != "USER_UNAUTHORIZED" {
 					return diag.Errorf("error removing team(%s) from the project(%s): %s", teamID, projectID, err)
 				}
+				log.Printf("[WARN] error removing team(%s) from the project(%s): %s", teamID, projectID, err
 			}
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -226,7 +226,10 @@ func resourceMongoDBAtlasProjectUpdate(ctx context.Context, d *schema.ResourceDa
 
 			_, err := conn.Teams.RemoveTeamFromProject(ctx, projectID, teamID)
 			if err != nil {
-				return diag.Errorf("error removing team(%s) from the project(%s): %s", teamID, projectID, err)
+				var target *matlas.ErrorResponse
+				if errors.As(err, &target) && target.ErrorCode != "USER_UNAUTHORIZED" {
+					return diag.Errorf("error removing team(%s) from the project(%s): %s", teamID, projectID, err)
+				}
 			}
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -230,7 +230,7 @@ func resourceMongoDBAtlasProjectUpdate(ctx context.Context, d *schema.ResourceDa
 				if errors.As(err, &target) && target.ErrorCode != "USER_UNAUTHORIZED" {
 					return diag.Errorf("error removing team(%s) from the project(%s): %s", teamID, projectID, err)
 				}
-				log.Printf("[WARN] error removing team(%s) from the project(%s): %s", teamID, projectID, err
+				log.Printf("[WARN] error removing team(%s) from the project(%s): %s", teamID, projectID, err)
 			}
 		}
 


### PR DESCRIPTION
## Description

- Fixes a bug when you get an error of `CANNOT_DELETE_TEAM_ASSIGNED_TO_PROJECT` when trying to delete one team in team resource

Link to any related issue(s): #662 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
