### PR TITLE
INTMDB-302: Ensure we handle new flow for project deletion well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ website/node_modules
 *~
 .*.swp
 .idea
+.vscode
 *.iml
 *.test
 *.iml

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -300,7 +300,7 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 	projectID := d.Id()
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"DELETING", "PENDING", "RETRY"},
+		Pending:    []string{"DELETING", "RETRY"},
 		Target:     []string{"IDLE"},
 		Refresh:    resourceProjectDependentsDeletingRefreshFunc(ctx, projectID, conn),
 		Timeout:    30 * time.Minute,

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -344,11 +344,13 @@ func resourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID
 			return nil, "RETRY", nil
 		}
 
-		if clusters.TotalCount > 0 {
-			for _, v := range clusters.Results {
-				if v.StateName != "DELETING" {
-					return dependents, "IDLE", nil
-				}
+		if dependents.AdvancedClusters.TotalCount == 0 {
+			return dependents, "IDLE", nil
+		}
+
+		for _, v := range dependents.AdvancedClusters.Results {
+			if v.StateName != "DELETING" {
+				return dependents, "IDLE", nil
 			}
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -303,7 +303,7 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 		Pending:    []string{"DELETING", "PENDING", "RETRY"},
 		Target:     []string{"IDLE"},
 		Refresh:    resourceProjectDependentsDeletingRefreshFunc(ctx, projectID, conn),
-		Timeout:    3 * time.Hour,
+		Timeout:    30 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Delay:      0,
 	}

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -319,7 +319,7 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 
 func resourceProjectClustersDeleteRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		c, resp, err := client.AdvancedClusters.List(ctx, projectID, nil)
+		clusters, resp, err := client.AdvancedClusters.List(ctx, projectID, nil)
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -327,10 +327,10 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 	This assumes the project CRUD outcome will be the same for any non-zero number of dependents
 
 	If all dependents are deleting, wait to try and delete
-	Otherwise, consider the aggregate dependents idle.
+	Else consider the aggregate dependents idle.
 
 	If we get a defined error response, return that right away
-	Otherwise retry
+	Else retry
 */
 func resourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -422,7 +422,7 @@ func testAccMongoDBAtlasProjectConfigWithFalseDefaultSettings(projectName, orgID
 		resource "mongodbatlas_project" "test" {
 			name   			 = "%[1]s"
 			org_id 			 = "%[2]s"
-		    project_owner_id = "%[3]s"
+			project_owner_id = "%[3]s"
 			with_default_alerts_settings = false
 		}
 	`, projectName, orgID, projectOwnerID)
@@ -431,9 +431,9 @@ func testAccMongoDBAtlasProjectConfigWithFalseDefaultSettings(projectName, orgID
 func testAccMongoDBAtlasProjectConfigWithAdvancedCluster(projectName, orgID, projectOwnerID, clusterName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
-			name   			 = %[1]q
-			org_id 			 = %[2]q
-		    project_owner_id = %[3]q
+			name                         = %[1]q
+			org_id                       = %[2]q
+			project_owner_id             = %[3]q
 			with_default_alerts_settings = false
 		}
 
@@ -441,21 +441,21 @@ func testAccMongoDBAtlasProjectConfigWithAdvancedCluster(projectName, orgID, pro
 			project_id   = mongodbatlas_project.test.id
 			name         = %[4]q
 			cluster_type = "REPLICASET"
-		  
+
 			replication_specs {
-			  region_configs {
-				electable_specs {
-				  instance_size = "M10"
-				  node_count    = 3
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_EAST_1"
 				}
-				analytics_specs {
-				  instance_size = "M10"
-				  node_count    = 1
-				}
-				provider_name = "AWS"
-				priority      = 7
-				region_name   = "US_EAST_1"
-			  }
 			}
 		}
 	`, projectName, orgID, projectOwnerID, clusterName)


### PR DESCRIPTION
## Description
https://jira.mongodb.org/browse/INTMDB-302

- **Current state:** Project delete works properly if the project and its clusters are managed by the state file, and you `terraform destroy` them.
- **Current state:** Project delete fails if you try to delete the project and it has clusters managed outside the state file. I'm under the impression this is expected behavior, as it may inform their decision to delete the project.
- **What this enhancement provides:** if the project is being deleted, and clusters managed outside the state file are in state `deleting`, we will wait until they are gone to attempt to delete the project.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
