### PR TITLE
INTMDB-310:  Potential bug when disabling auditing

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -141,6 +141,19 @@ func resourceMongoDBAtlasAuditingUpdate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceMongoDBAtlasAuditingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	// Get the client connection.
+	conn := meta.(*MongoDBClient).Atlas
+
+	auditingReq := &matlas.Auditing{}
+
+	auditingReq.Enabled = pointy.Bool(false)
+
+	_, _, err := conn.Auditing.Configure(ctx, d.Id(), auditingReq)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorAuditingUpdate, d.Id(), err))
+	}
+
 	d.SetId("")
 
 	return nil

--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -141,7 +141,6 @@ func resourceMongoDBAtlasAuditingUpdate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceMongoDBAtlasAuditingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	// Get the client connection.
 	conn := meta.(*MongoDBClient).Atlas
 


### PR DESCRIPTION
## Description

Add Support for disable of Auditing during Terraform destroy vs just clearing item from state file 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
