### PR TITLE
Release staging v1.4.0

### DIFF
--- a/examples/MongoDB-Atlas-Third-Party-Integration/.gitignore
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/.gitignore
@@ -1,0 +1,5 @@
+iatlaspl.code-workspace
+terraform.tfvars
+.terraform/
+*.tfstate*
+

--- a/examples/MongoDB-Atlas-Third-Party-Integration/Readme.md
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/Readme.md
@@ -1,0 +1,68 @@
+# Example - A basic example configuring MongoDB Atlas Third Party Integrations and Terraform
+
+This project aims to provide a very straight-forward example of setting up Terraform with MongoDB Atlas. This will create the following resources in MongoDB Atlas:
+
+- Atlas Project
+- Microst Teams Third Party Integration
+- Prometheus Third Party Integration
+
+
+You can refer to the MongoDB Atlas documentation to know about the parameters that support Third Party Integrations.
+
+[Prometheus](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/#std-label-httpsd-prometheus-config)
+
+[Microsoft Teams](https://www.mongodb.com/docs/atlas/tutorial/integrate-msft-teams/)
+
+## Dependencies
+
+* Terraform v0.13 or greater
+* A MongoDB Atlas account 
+* provider.mongodbatlas: version = "~> 0.9.1"
+
+## Usage
+
+**1\. Ensure your MongoDB Atlas credentials are set up.**
+
+This can be done using environment variables:
+
+```bash
+export MONGODB_ATLAS_PUBLIC_KEY="xxxx"
+export MONGODB_ATLAS_PRIVATE_KEY="xxxx"
+```
+
+... or follow as in the `variables.tf` file and create **terraform.tfvars** file with all the variable values and make sure **not to commit it**.
+
+
+> **IMPORTANT** Hard-coding your MongoDB Atlas programmatic API key pair into a Terraform configuration is not recommended. Consider the risks, especially the inadvertent submission of a configuration file containing secrets to a public repository.
+
+
+**2\. Review the Terraform plan.**
+
+Execute the below command and ensure you are happy with the plan.
+
+``` bash
+$ terraform plan
+```
+
+This project currently creates the below deployments:
+
+- Atlas Project
+- Microst Teams Third Party Integration
+- Prometheus Third Party Integration
+
+**3\. Execute the Terraform apply.**
+
+Now execute the plan to provision the MongoDB Atlas resources.
+
+``` bash
+$ terraform apply
+```
+
+**4\. Destroy the resources.**
+
+Once you are finished your testing, ensure you destroy the resources to avoid unnecessary charges.
+
+``` bash
+$ terraform destroy
+```
+

--- a/examples/MongoDB-Atlas-Third-Party-Integration/project.tf
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/project.tf
@@ -1,0 +1,7 @@
+resource "mongodbatlas_project" "project" {
+  name   = var.project_name
+  org_id = var.org_id
+}
+output "project_name" {
+  value = mongodbatlas_project.project.name
+}

--- a/examples/MongoDB-Atlas-Third-Party-Integration/provider.tf
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/provider.tf
@@ -1,0 +1,4 @@
+provider "mongodbatlas" {
+  public_key  = var.public_key
+  private_key = var.private_key
+}

--- a/examples/MongoDB-Atlas-Third-Party-Integration/third-party-integration.tf
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/third-party-integration.tf
@@ -1,0 +1,15 @@
+resource "mongodbatlas_third_party_integration" "test_msteams" {
+  project_id                  = mongodbatlas_project.project.id
+  type                        = "MICROSOFT_TEAMS"
+  microsoft_teams_webhook_url = var.microsoft_teams_webhook_url
+}
+
+resource "mongodbatlas_third_party_integration" "test_prometheus" {
+  project_id        = mongodbatlas_project.project.id
+  type              = "PROMETHEUS"
+  user_name         = var.user_name
+  password          = var.password
+  service_discovery = "file"
+  scheme            = "https"
+  enabled           = true
+}

--- a/examples/MongoDB-Atlas-Third-Party-Integration/variables.tf
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/variables.tf
@@ -1,0 +1,31 @@
+variable "public_key" {
+  type        = string
+  description = "Public Programmatic API key to authenticate to Atlas"
+}
+variable "private_key" {
+  type        = string
+  description = "Private Programmatic API key to authenticate to Atlas"
+}
+variable "org_id" {
+  type        = string
+  description = "MongoDB Organization ID"
+}
+variable "project_name" {
+  type        = string
+  description = "The MongoDB Atlas Project Name"
+}
+variable "user_name" {
+  type        = string
+  description = "The Prometheus User Name"
+  default     = "puser"
+}
+variable "password" {
+  type        = string
+  description = "The Prometheus Password"
+  default     = "ppassword"
+}
+variable "microsoft_teams_webhook_url" {
+  type        = string
+  description = "The Microsoft Teams Webhook URL"
+  default     = "https://yourcompany.webhook.office.com/webhookb2/zzz@yyy/IncomingWebhook/xyz"
+}

--- a/examples/MongoDB-Atlas-Third-Party-Integration/versions.tf
+++ b/examples/MongoDB-Atlas-Third-Party-Integration/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.4.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f
+	go.mongodb.org/atlas v0.15.1-0.20220403193624-86b34ba344cd
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1221,6 +1221,10 @@ go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsX
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
 go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f h1:IvKkFdSSBLC5kqB1X87vn8CRAI7eXoMSK7u2lG+WUg8=
 go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.15.1-0.20220330015822-18ef33419ce7 h1:nJjUIAkZMJ07WCYDlvqnZPPfOkGUdKJj1m9nPOggibw=
+go.mongodb.org/atlas v0.15.1-0.20220330015822-18ef33419ce7/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.15.1-0.20220403193624-86b34ba344cd h1:JzkNgRp8xLbm16DJP28+oGf0P765Nl2Xp8yERZ8O/y0=
+go.mongodb.org/atlas v0.15.1-0.20220403193624-86b34ba344cd/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
@@ -144,3 +144,18 @@ func featureToSchema(feature *matlas.FeatureUsage) map[string]interface{} {
 		"feature_id":   feature.FeatureID,
 	}
 }
+
+func featureUsagesSchemaV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"feature_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"feature_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -105,6 +105,29 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Sensitive: true,
 				Computed:  true,
 			},
+			"microsoft_teams_webhook_url": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"user_name": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"service_discovery": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"scheme": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -84,6 +84,27 @@ const (
 		url = "%[4]s"	
 	}
 	`
+
+	MICROSOFTTEAMS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		microsoft_teams_webhook_url = "%[4]s"	
+	}
+	`
+
+	PROMETHEUS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		user_name = "%[4]s"	
+		password  = "%[5]s"
+		service_discovery = "%[6]s" 
+		scheme = "%[7]s"
+		enabled = "%[8]s"
+	}
+	`
+
 	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	numeric  = "0123456789"
 	alphaNum = alphabet + numeric
@@ -201,6 +222,24 @@ func testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config *thirdPartyCo
 			config.ProjectID,
 			config.Integration.Type,
 			config.Integration.URL,
+		)
+	case "MICROSOFTTEAMS":
+		return fmt.Sprintf(WEBHOOK,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.MicrosoftTeamsWebhookURL,
+		)
+	case "PROMETHEUS":
+		return fmt.Sprintf(WEBHOOK,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.UserName,
+			config.Integration.Password,
+			config.Integration.ServiceDiscovery,
+			config.Integration.Scheme,
+			config.Integration.Enabled,
 		)
 	default:
 		return fmt.Sprintf(Unknown3rdParty,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -64,28 +64,34 @@ func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID 
 
 func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]interface{} {
 	out := map[string]interface{}{
-		"type":         integration.Type,
-		"license_key":  integration.LicenseKey,
-		"account_id":   integration.AccountID,
-		"write_token":  integration.WriteToken,
-		"read_token":   integration.ReadToken,
-		"api_key":      integration.APIKey,
-		"region":       integration.Region,
-		"service_key":  integration.ServiceKey,
-		"api_token":    integration.APIToken,
-		"team_name":    integration.TeamName,
-		"channel_name": integration.ChannelName,
-		"routing_key":  integration.RoutingKey,
-		"flow_name":    integration.FlowName,
-		"org_name":     integration.OrgName,
-		"url":          integration.URL,
-		"secret":       integration.Secret,
+		"type":                        integration.Type,
+		"license_key":                 integration.LicenseKey,
+		"account_id":                  integration.AccountID,
+		"write_token":                 integration.WriteToken,
+		"read_token":                  integration.ReadToken,
+		"api_key":                     integration.APIKey,
+		"region":                      integration.Region,
+		"service_key":                 integration.ServiceKey,
+		"api_token":                   integration.APIToken,
+		"team_name":                   integration.TeamName,
+		"channel_name":                integration.ChannelName,
+		"routing_key":                 integration.RoutingKey,
+		"flow_name":                   integration.FlowName,
+		"org_name":                    integration.OrgName,
+		"url":                         integration.URL,
+		"secret":                      integration.Secret,
+		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
+		"user_name":                   integration.UserName,
+		"password":                    integration.Password,
+		"service_discovery":           integration.ServiceDiscovery,
+		"scheme":                      integration.Scheme,
+		"enabled":                     integration.Enabled,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
 	optionals := []string{"license_key", "account_id", "write_token",
 		"read_token", "api_key", "region", "service_key", "api_token",
-		"team_name", "channel_name", "flow_name", "org_name", "url", "secret"}
+		"team_name", "channel_name", "flow_name", "org_name", "url", "secret", "password"}
 
 	for _, attr := range optionals {
 		if val, ok := out[attr]; ok {
@@ -166,6 +172,30 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 		out.Secret = secret.(string)
 	}
 
+	if microsoftTeamsWebhookURL, ok := in.GetOk("microsoft_teams_webhook_url"); ok {
+		out.MicrosoftTeamsWebhookURL = microsoftTeamsWebhookURL.(string)
+	}
+
+	if userName, ok := in.GetOk("user_name"); ok {
+		out.UserName = userName.(string)
+	}
+
+	if password, ok := in.GetOk("password"); ok {
+		out.Password = password.(string)
+	}
+
+	if serviceDiscovery, ok := in.GetOk("service_discovery"); ok {
+		out.ServiceDiscovery = serviceDiscovery.(string)
+	}
+
+	if scheme, ok := in.GetOk("scheme"); ok {
+		out.Scheme = scheme.(string)
+	}
+
+	if enabled, ok := in.GetOk("enabled"); ok {
+		out.Enabled = enabled.(bool)
+	}
+
 	return out
 }
 
@@ -228,5 +258,29 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *matlas.Thi
 
 	if d.HasChange("secret") {
 		integration.Secret = d.Get("secret").(string)
+	}
+
+	if d.HasChange("microsoft_teams_webhook_url") {
+		integration.MicrosoftTeamsWebhookURL = d.Get("microsoft_teams_webhook_url").(string)
+	}
+
+	if d.HasChange("user_name") {
+		integration.UserName = d.Get("user_name").(string)
+	}
+
+	if d.HasChange("password") {
+		integration.Password = d.Get("password").(string)
+	}
+
+	if d.HasChange("service_discovery") {
+		integration.ServiceDiscovery = d.Get("service_discovery").(string)
+	}
+
+	if d.HasChange("scheme") {
+		integration.Scheme = d.Get("scheme").(string)
+	}
+
+	if d.HasChange("enabled") {
+		integration.Enabled = d.Get("enabled").(bool)
 	}
 }

--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -141,6 +141,18 @@ func resourceMongoDBAtlasAuditingUpdate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceMongoDBAtlasAuditingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Get the client connection.
+	conn := meta.(*MongoDBClient).Atlas
+
+	auditingReq := &matlas.Auditing{}
+
+	auditingReq.Enabled = pointy.Bool(false)
+
+	_, _, err := conn.Auditing.Configure(ctx, d.Id(), auditingReq)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorAuditingUpdate, d.Id(), err))
+	}
+
 	d.SetId("")
 
 	return nil

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket.go
@@ -157,7 +157,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotExportBucketImportState(ctx context.
 
 	d.SetId(encodeStateID(map[string]string{
 		"project_id": *projectID,
-		"name":       *id,
+		"id":         *id,
 	}))
 
 	return []*schema.ResourceData{d}, nil

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
@@ -68,6 +68,14 @@ func resourceMongoDBAtlasCloudProviderAccess() *schema.Resource {
 				Computed: true,
 			},
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceMongoDBAtlasCloudProviderAccessV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceMongoDBAtlasCloudProviderAccessStateUpgradeV0,
+				Version: 0,
+			},
+		},
 	}
 }
 
@@ -247,4 +255,54 @@ func splitCloudProviderAccessID(id string) (projectID, providerName, roleID stri
 	projectID, providerName, roleID = parts[1], parts[2], parts[3]
 
 	return
+}
+
+func resourceMongoDBAtlasCloudProviderAccessV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"provider_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"AWS"}, false),
+			},
+			"atlas_aws_account_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"atlas_assumed_role_external_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authorized_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_assumed_role_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"role_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"feature_usages": {
+				Type:     schema.TypeList,
+				Elem:     featureUsagesSchemaV0(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceMongoDBAtlasCloudProviderAccessStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	rawState["feature_usages"] = []interface{}{map[string]interface{}{}}
+	return rawState, nil
 }

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -19,16 +19,20 @@ var integrationTypes = []string{
 	"VICTOR_OPS",
 	"FLOWDOCK",
 	"WEBHOOK",
+	"MICROSOFT_TEAMS",
+	"PROMETHEUS",
 }
 
 var requiredPerType = map[string][]string{
-	"PAGER_DUTY": {"service_key"},
-	"DATADOG":    {"api_key", "region"},
-	"NEW_RELIC":  {"license_key", "account_id", "write_token", "read_token"},
-	"OPS_GENIE":  {"api_key", "region"},
-	"VICTOR_OPS": {"api_key"},
-	"FLOWDOCK":   {"flow_name", "api_token", "org_name"},
-	"WEBHOOK":    {"url"},
+	"PAGER_DUTY":      {"service_key"},
+	"DATADOG":         {"api_key", "region"},
+	"NEW_RELIC":       {"license_key", "account_id", "write_token", "read_token"},
+	"OPS_GENIE":       {"api_key", "region"},
+	"VICTOR_OPS":      {"api_key"},
+	"FLOWDOCK":        {"flow_name", "api_token", "org_name"},
+	"WEBHOOK":         {"url"},
+	"MICROSOFT_TEAMS": {"microsoft_teams_webhook_url"},
+	"PROMETHEUS":      {"user_name", "password", "service_discovery", "scheme", "enabled"},
 }
 
 func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
@@ -119,6 +123,34 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+			},
+			"microsoft_teams_webhook_url": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"user_name": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"service_discovery": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+			},
+			"scheme": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 		},
 	}

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -40,6 +40,8 @@ data "mongodbatlas_third_party_integration" "test" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * MICROSOFT_TEAMS
+     * PROMETHEUS
 
 
 ## Attributes Reference
@@ -74,5 +76,13 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `MICROSOFT_TEAMS`
+   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+ * `PROMETHEUS`
+    * `user_name` - Your Prometheus username.
+    * `password` - Your Prometheus password.
+    * `service_discovery` - Indicates which service discovery method is used, either file or http.
+    * `scheme` - Your Prometheus protocol scheme configured for requests.
+    * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -77,5 +77,13 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `MICROSOFT_TEAMS`
+   * `name` - Your Microsoft Teams incoming webhook name.
+   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+ * `PROMETHEUS`
+    * `user_name` - Your Prometheus username.
+    * `service_discovery` - Indicates which service discovery method is used, either file or http.
+    * `scheme` - Your Prometheus protocol scheme configured for requests.
+    * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-all/) Documentation for more information.

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -70,6 +70,14 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `MICROSOFT_TEAMS`
+   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+ * `PROMETHEUS`
+    * `user_name` - Your Prometheus username.
+    * `password`  - Your Prometheus password.
+    * `service_discovery` - Indicates which service discovery method is used, either file or http.
+    * `scheme` - Your Prometheus protocol scheme configured for requests.
+    * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Add Support for disable of Auditing during Terraform destroy vs just clearing item from state file
Feature Add: Prometheus and Microsoft Team to the Third Party Integration Settings
Fix for Cannot import export bucket - bad state id encoding https://github.com/mongodb/terraform-provider-mongodbatlas/issues/708
Error missing expected { when updating the provider https://github.com/mongodb/terraform-provider-mongodbatlas/issues/697


Link to any related issue(s):
 INTMDB-310: Potential bug when disabling auditing #705 
 INTMDB-311: Feature Add: Prometheus and Microsoft Team to the Third Party Integration Settings #706 
 INTMDB-315: Correct import function for snapshot export bucket #714 #715 
 INTMDB-309: Add support for schema migration #717 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
