### PR TITLE
Add prometheus third party integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.5.0
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f
+	go.mongodb.org/atlas v0.16.0
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1229,8 +1229,8 @@ go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
-go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f h1:IvKkFdSSBLC5kqB1X87vn8CRAI7eXoMSK7u2lG+WUg8=
-go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.16.0 h1:IqnDuK3XAZUgJ5lPHc4v4z4B8F6mvsS37O4ck7tOYVc=
+go.mongodb.org/atlas v0.16.0/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -100,6 +100,11 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"secret": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
 			"username": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -116,11 +121,6 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-			},
-			"secret": {
-				Type:      schema.TypeString,
-				Sensitive: true,
-				Computed:  true,
 			},
 		},
 	}

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -100,6 +100,23 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"service_discovery": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"secret": {
 				Type:      schema.TypeString,
 				Sensitive: true,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -81,9 +81,21 @@ const (
 	resource "mongodbatlas_third_party_integration" "%[1]s" {
 		project_id = "%[2]s"
 		type = "%[3]s"
-		url = "%[4]s"	
+		url = "%[4]s"
 	}
 	`
+
+	PROMETHEUS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		username = "%[4]s"
+		password = "%[5]s"
+		service_discovery = "%[6]s"
+		enabled = "%[7]t"
+	}
+	`
+
 	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	numeric  = "0123456789"
 	alphaNum = alphabet + numeric
@@ -201,6 +213,16 @@ func testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config *thirdPartyCo
 			config.ProjectID,
 			config.Integration.Type,
 			config.Integration.URL,
+		)
+	case "PROMETHEUS":
+		return fmt.Sprintf(PROMETHEUS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.UserName,
+			config.Integration.Password,
+			config.Integration.ServiceDiscovery,
+			config.Integration.Enabled,
 		)
 	default:
 		return fmt.Sprintf(Unknown3rdParty,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -64,28 +64,33 @@ func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID 
 
 func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]interface{} {
 	out := map[string]interface{}{
-		"type":         integration.Type,
-		"license_key":  integration.LicenseKey,
-		"account_id":   integration.AccountID,
-		"write_token":  integration.WriteToken,
-		"read_token":   integration.ReadToken,
-		"api_key":      integration.APIKey,
-		"region":       integration.Region,
-		"service_key":  integration.ServiceKey,
-		"api_token":    integration.APIToken,
-		"team_name":    integration.TeamName,
-		"channel_name": integration.ChannelName,
-		"routing_key":  integration.RoutingKey,
-		"flow_name":    integration.FlowName,
-		"org_name":     integration.OrgName,
-		"url":          integration.URL,
-		"secret":       integration.Secret,
+		"type":              integration.Type,
+		"license_key":       integration.LicenseKey,
+		"account_id":        integration.AccountID,
+		"write_token":       integration.WriteToken,
+		"read_token":        integration.ReadToken,
+		"api_key":           integration.APIKey,
+		"region":            integration.Region,
+		"service_key":       integration.ServiceKey,
+		"api_token":         integration.APIToken,
+		"team_name":         integration.TeamName,
+		"channel_name":      integration.ChannelName,
+		"routing_key":       integration.RoutingKey,
+		"flow_name":         integration.FlowName,
+		"org_name":          integration.OrgName,
+		"url":               integration.URL,
+		"username":          integration.UserName,
+		"password":          integration.Password,
+		"service_discovery": integration.ServiceDiscovery,
+		"enabled":           integration.Enabled,
+		"secret":            integration.Secret,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
 	optionals := []string{"license_key", "account_id", "write_token",
 		"read_token", "api_key", "region", "service_key", "api_token",
-		"team_name", "channel_name", "flow_name", "org_name", "url", "secret"}
+		"team_name", "channel_name", "flow_name", "org_name", "url",
+		"username", "password", "service_discovery", "enabled", "secret"}
 
 	for _, attr := range optionals {
 		if val, ok := out[attr]; ok {
@@ -162,6 +167,22 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 		out.URL = url.(string)
 	}
 
+	if userName, ok := in.GetOk("username"); ok {
+		out.UserName = userName.(string)
+	}
+
+	if password, ok := in.GetOk("password"); ok {
+		out.Password = password.(string)
+	}
+
+	if serviceDiscovery, ok := in.GetOk("service_discovery"); ok {
+		out.ServiceDiscovery = serviceDiscovery.(string)
+	}
+
+	if enabled, ok := in.GetOk("enabled"); ok {
+		out.Enabled = enabled.(bool)
+	}
+
 	if secret, ok := in.GetOk("secret"); ok {
 		out.Secret = secret.(string)
 	}
@@ -224,6 +245,22 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *matlas.Thi
 
 	if d.HasChange("url") {
 		integration.URL = d.Get("url").(string)
+	}
+
+	if d.HasChange("username") {
+		integration.UserName = d.Get("username").(string)
+	}
+
+	if d.HasChange("password") {
+		integration.Password = d.Get("password").(string)
+	}
+
+	if d.HasChange("service_discovery") {
+		integration.ServiceDiscovery = d.Get("service_discovery").(string)
+	}
+
+	if d.HasChange("enabled") {
+		integration.Enabled = d.Get("enabled").(bool)
 	}
 
 	if d.HasChange("secret") {

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -79,18 +79,18 @@ func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]i
 		"flow_name":         integration.FlowName,
 		"org_name":          integration.OrgName,
 		"url":               integration.URL,
+		"secret":            integration.Secret,
 		"username":          integration.UserName,
 		"password":          integration.Password,
 		"service_discovery": integration.ServiceDiscovery,
 		"enabled":           integration.Enabled,
-		"secret":            integration.Secret,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
 	optionals := []string{"license_key", "account_id", "write_token",
 		"read_token", "api_key", "region", "service_key", "api_token",
 		"team_name", "channel_name", "flow_name", "org_name", "url",
-		"username", "password", "service_discovery", "enabled", "secret"}
+		"secret", "username", "password", "service_discovery", "enabled"}
 
 	for _, attr := range optionals {
 		if val, ok := out[attr]; ok {
@@ -167,6 +167,10 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 		out.URL = url.(string)
 	}
 
+	if secret, ok := in.GetOk("secret"); ok {
+		out.Secret = secret.(string)
+	}
+
 	if userName, ok := in.GetOk("username"); ok {
 		out.UserName = userName.(string)
 	}
@@ -181,10 +185,6 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 
 	if enabled, ok := in.GetOk("enabled"); ok {
 		out.Enabled = enabled.(bool)
-	}
-
-	if secret, ok := in.GetOk("secret"); ok {
-		out.Secret = secret.(string)
 	}
 
 	return out
@@ -247,6 +247,10 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *matlas.Thi
 		integration.URL = d.Get("url").(string)
 	}
 
+	if d.HasChange("secret") {
+		integration.Secret = d.Get("secret").(string)
+	}
+
 	if d.HasChange("username") {
 		integration.UserName = d.Get("username").(string)
 	}
@@ -261,9 +265,5 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *matlas.Thi
 
 	if d.HasChange("enabled") {
 		integration.Enabled = d.Get("enabled").(bool)
-	}
-
-	if d.HasChange("secret") {
-		integration.Secret = d.Get("secret").(string)
 	}
 }

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -19,6 +19,7 @@ var integrationTypes = []string{
 	"VICTOR_OPS",
 	"FLOWDOCK",
 	"WEBHOOK",
+	"PROMETHEUS",
 }
 
 var requiredPerType = map[string][]string{
@@ -29,6 +30,7 @@ var requiredPerType = map[string][]string{
 	"VICTOR_OPS": {"api_key"},
 	"FLOWDOCK":   {"flow_name", "api_token", "org_name"},
 	"WEBHOOK":    {"url"},
+	"PROMETHEUS": {"username", "password", "service_discovery", "enabled"},
 }
 
 func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
@@ -113,6 +115,23 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 			},
 			"url": {
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"service_discovery": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 			"secret": {

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -117,6 +117,11 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"secret": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
 			"username": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -133,11 +138,6 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-			},
-			"secret": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
 			},
 		},
 	}

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -40,6 +40,7 @@ data "mongodbatlas_third_party_integration" "test" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * PROMETHEUS
 
 
 ## Attributes Reference
@@ -74,5 +75,10 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+   * `username` - Your Prometheus username.
+   * `password` - Your Prometheus password.
+   * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+   * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -40,7 +40,6 @@ data "mongodbatlas_third_party_integration" "test" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
-     * PROMETHEUS
 
 
 ## Attributes Reference
@@ -56,7 +55,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -75,10 +74,5 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
-* `PROMETHEUS`
-  * `username` - Your Prometheus username.
-  * `password` - Your Prometheus password.
-  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
-  * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -40,6 +40,7 @@ data "mongodbatlas_third_party_integration" "test" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * PROMETHEUS
 
 
 ## Attributes Reference
@@ -55,7 +56,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -74,5 +75,10 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+  * `username` - Your Prometheus username.
+  * `password` - Your Prometheus password.
+  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+  * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -9,7 +9,7 @@ description: |-
 # mongodbatlas_third_party_integrations
 
 `mongodbatlas_third_party_integrations` describe all Third-Party Integration Settings. This represents two Third-Party services `PAGER_DUTY` and `FLOWDOCK`
-applied across the project. 
+applied across the project.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
@@ -21,7 +21,7 @@ resource "mongodbatlas_third_party_integration" "test_pager_duty" {
 	type = "PAGER_DUTY"
 	service_key = "<PAGER-DUTY-SERVICE-KEY>"
 }
-	
+
 resource "mongodbatlas_third_party_integration" "test_flowdock" {
 	project_id = "<PROJECT-ID>"
 	type = "FLOWDOCK"
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `results` - A list where each represents a Third-Party service integration.
 
 
-### Third-Party Service Integration 
+### Third-Party Service Integration
 
 * `project_id`  - (Required) ID of the Atlas project the Third-Party Service Integration belongs to.
 * `type`        - (Required) Thirt-Party service integration type.
@@ -58,7 +58,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -76,6 +76,10 @@ Additional values based on Type
    * `org_name` - Your Flowdock organization name.
 * `WEBHOOK`
    * `url` - Your webhook URL.
-   * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+  * `username` - Your Prometheus username.
+  * `password` - Your Prometheus password.
+  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+  * `enabled` - Whether your cluster has Prometheus enabled.  * `secret` - An optional field for your webhook secret.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-all/) Documentation for more information.

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -9,7 +9,7 @@ description: |-
 # mongodbatlas_third_party_integrations
 
 `mongodbatlas_third_party_integrations` describe all Third-Party Integration Settings. This represents two Third-Party services `PAGER_DUTY` and `FLOWDOCK`
-applied across the project.
+applied across the project. 
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
@@ -21,7 +21,7 @@ resource "mongodbatlas_third_party_integration" "test_pager_duty" {
 	type = "PAGER_DUTY"
 	service_key = "<PAGER-DUTY-SERVICE-KEY>"
 }
-
+	
 resource "mongodbatlas_third_party_integration" "test_flowdock" {
 	project_id = "<PROJECT-ID>"
 	type = "FLOWDOCK"
@@ -47,7 +47,7 @@ In addition to all arguments above, the following attributes are exported:
 * `results` - A list where each represents a Third-Party service integration.
 
 
-### Third-Party Service Integration
+### Third-Party Service Integration 
 
 * `project_id`  - (Required) ID of the Atlas project the Third-Party Service Integration belongs to.
 * `type`        - (Required) Thirt-Party service integration type.
@@ -58,7 +58,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -76,10 +76,6 @@ Additional values based on Type
    * `org_name` - Your Flowdock organization name.
 * `WEBHOOK`
    * `url` - Your webhook URL.
-* `PROMETHEUS`
-  * `username` - Your Prometheus username.
-  * `password` - Your Prometheus password.
-  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
-  * `enabled` - Whether your cluster has Prometheus enabled.  * `secret` - An optional field for your webhook secret.
+   * `secret` - An optional field for your webhook secret.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-all/) Documentation for more information.

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -77,5 +77,10 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+   * `username` - Your Prometheus username.
+   * `password` - Your Prometheus password.
+   * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+   * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-all/) Documentation for more information.

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -36,7 +36,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to get all Third-Party service integrations
-* `type`       - (Required) Third-Party Integration Settings type
+* `type`       - (Required) Third-Party Integration Settings type 
      * PAGER_DUTY
      * DATADOG
      * NEW_RELIC
@@ -44,7 +44,6 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
-     * PROMETHEUS
 
 Additional values based on Type
 
@@ -52,7 +51,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -71,11 +70,6 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
-* `PROMETHEUS`
-  * `username` - Your Prometheus username.
-  * `password` - Your Prometheus password.
-  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
-  * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -36,7 +36,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to get all Third-Party service integrations
-* `type`       - (Required) Third-Party Integration Settings type 
+* `type`       - (Required) Third-Party Integration Settings type
      * PAGER_DUTY
      * DATADOG
      * NEW_RELIC
@@ -44,6 +44,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * PROMETHEUS
 
 Additional values based on Type
 
@@ -51,7 +52,7 @@ Additional values based on Type
   * `service_key` - Your Service Key.
 * `DATADOG`
    * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.
 * `NEW_RELIC`
    * `license_key` - Your License Key.
    * `account_id`  - Unique identifier of your New Relic account.
@@ -70,6 +71,11 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+  * `username` - Your Prometheus username.
+  * `password` - Your Prometheus password.
+  * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+  * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -44,6 +44,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * PROMETHEUS
 
 Additional values based on Type
 
@@ -70,6 +71,11 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `PROMETHEUS`
+   * `username` - Your Prometheus username.
+   * `password` - Your Prometheus password.
+   * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+   * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

In this pull request I added support for the third party [prometheus integration](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/). 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments

The change itself will not break something, but I had to upgrade `go.mongodb.org/atlas` to  **v0.16.0**, because it introduces support for the prometheus integration. 
