### PR TITLE
docs: `*_invitation` life cycle clarification

### DIFF
--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -21,7 +21,10 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 * ORG_MEMBER
 
 ~> **IMPORTANT:**
-This resource is specifically to mange the invitations, not the user beyond that. Once the invite is accepted, the resource will be missing from the state. Unless the `resource` block is removed, Terraform will attempt to create the invite again on the next apply.
+This resource is specifically to mange the invitations, not the user beyond that. Possible provider behavior depending on the invitee's action:
+* If the user has not yet accepted the invitation, the provider leaves the invitation as is.
+* If the user has accepted the invitation and is now an organization member, the provider will remove the invitation from the Terraform state.  The invitation must then be removed from the Terraform resource configuration.
+* If the user accepts the invitation and then leaves the organization, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.
 
 ## Example Usages
 
@@ -71,11 +74,6 @@ In addition to the arguments, this resource exports the following attributes:
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `invitation_id` - Unique 24-hexadecimal digit string that identifies the invitation in Atlas.
 * `inviter_username` - Atlas user who invited `username` to the organization.
-
-> **NOTE**: Possible provider behavior depending on the invitee's action:
->* If the user has not yet accepted the invitation, the provider leaves the invitation as is.
->* If the user has accepted the invitation and is now an organization member, the provider will remove the invitation from the Terraform state.  The invitation must then be removed from the Terraform resource configuration.
->* If the user accepts the invitation and then leaves the organization, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.
 
 ## Import
 

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -20,6 +20,9 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 * ORG_READ_ONLY
 * ORG_MEMBER
 
+~> **IMPORTANT:**
+This resource is specifically to mange the invitations, not the user beyond that. Once the invite is accepted, the resource will be missing from the state. Unless the `resource` block is removed, Terraform will attempt to create the invite again on the next apply.
+
 ## Example Usages
 
 ```terraform
@@ -75,6 +78,9 @@ In addition to the arguments, this resource exports the following attributes:
 >* If the user accepts the invitation and then leaves the organization, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.
 
 ## Import
+
+~> **IMPORTANT:**
+A project invitation can **not** be imported once it has been accepted.
 
 Import a user's invitation to an organization by separating the `org_id` and the `username` with a hyphen:
 

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -78,7 +78,7 @@ In addition to the arguments, this resource exports the following attributes:
 ## Import
 
 ~> **IMPORTANT:**
-A project invitation can **not** be imported once it has been accepted.
+An organization invitation can **not** be imported once it has been accepted.
 
 Import a user's invitation to an organization by separating the `org_id` and the `username` with a hyphen:
 

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -20,8 +20,7 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 * ORG_READ_ONLY
 * ORG_MEMBER
 
-~> **IMPORTANT:**
-This resource is specifically to mange the invitations, not the user beyond that. Possible provider behavior depending on the invitee's action:
+~> **IMPORTANT:** This resource is only for managing invitations, not for managing the Atlas User being invited. Possible provider behavior depending on the invitee's action:
 * If the user has not yet accepted the invitation, the provider leaves the invitation as is.
 * If the user has accepted the invitation and is now an organization member, the provider will remove the invitation from the Terraform state.  The invitation must then be removed from the Terraform resource configuration.
 * If the user accepts the invitation and then leaves the organization, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -23,6 +23,9 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find GROUP-ID in the official documentation.
 
+~> **IMPORTANT:**
+This resource is specifically to mange the invitations, not the user beyond that. Once the invite is accepted, the resource will be missing from the state. Unless the `resource` block is removed, Terraform will attempt to create the invite again on the next apply.
+
 ## Example Usages
 
 ```terraform
@@ -64,6 +67,9 @@ In addition to all arguments above, the following attributes are exported:
 * `inviter_username` - Atlas user who invited `username` to the project.
 
 ## Import
+
+~> **IMPORTANT:**
+A project invitation can **not** be imported once it has been accepted.
 
 Import a user's invitation to a project by separating the `project_id` and the `username` with a hyphen:
 

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -23,8 +23,10 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find GROUP-ID in the official documentation.
 
-~> **IMPORTANT:**
-This resource is specifically to mange the invitations, not the user beyond that. Once the invite is accepted, the resource will be missing from the state. Unless the `resource` block is removed, Terraform will attempt to create the invite again on the next apply.
+~> **IMPORTANT:** This resource is specifically to mange the invitations, not the user beyond that. Possible provider behavior depending on the invitee's action:
+* If the user has not yet accepted the invitation, the provider leaves the invitation as is.
+* If the user has accepted the invitation and is now a project member, the provider will remove the invitation from the Terraform state.  The invitation must then be removed from the Terraform resource configuration.
+* If the user accepts the invitation and then leaves the project, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.
 
 ## Example Usages
 

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -23,7 +23,7 @@ The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find GROUP-ID in the official documentation.
 
-~> **IMPORTANT:** This resource is specifically to mange the invitations, not the user beyond that. Possible provider behavior depending on the invitee's action:
+~> **IMPORTANT:** This resource is only for managing invitations, not for managing the Atlas User being invited. Possible provider behavior depending on the invitee's action:
 * If the user has not yet accepted the invitation, the provider leaves the invitation as is.
 * If the user has accepted the invitation and is now a project member, the provider will remove the invitation from the Terraform state.  The invitation must then be removed from the Terraform resource configuration.
 * If the user accepts the invitation and then leaves the project, the provider will re-add the invitation if the resource definition is not removed from the Terraform configuration.


### PR DESCRIPTION
## Description

Update the docs to clarify how the lifecycle of the `org_invitation` and `project_invitation` resources work. Indicating that once the invite is accepted the resource is deleted.

Link to any related issue(s):

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/633#issuecomment-993026984

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
