### PR TITLE
Add support for Prometheus and Microsoft Teams third party integrations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/openlyinc/pointy v1.1.2
 	github.com/spf13/cast v1.5.0
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f
+	go.mongodb.org/atlas v0.16.0
 	go.mongodb.org/realm v0.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20210625223728-379bcb41c06b
 	github.com/mongodb-forks/digest v1.0.4
-	github.com/mwielbut/pointy v1.1.0
+	github.com/openlyinc/pointy v1.1.2
 	github.com/spf13/cast v1.5.0
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
 	go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f

--- a/go.sum
+++ b/go.sum
@@ -1228,8 +1228,8 @@ go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
-go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f h1:IvKkFdSSBLC5kqB1X87vn8CRAI7eXoMSK7u2lG+WUg8=
-go.mongodb.org/atlas v0.15.1-0.20220215171307-4b760c3c624f/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.16.0 h1:IqnDuK3XAZUgJ5lPHc4v4z4B8F6mvsS37O4ck7tOYVc=
+go.mongodb.org/atlas v0.16.0/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,6 @@ github.com/mozilla/tls-observatory v0.0.0-20210209181001-cf43108d6880/go.mod h1:
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/mwielbut/pointy v1.1.0 h1:U5/YEfoIkaGCHv0St3CgjduqXID4FNRoyZgLM1kY9vg=
-github.com/mwielbut/pointy v1.1.0/go.mod h1:MvvO+uMFj9T5DMda33HlvogsFBX7pWWKAkFIn4teYwY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=
 github.com/mwitkow/go-proto-validators v0.2.0/go.mod h1:ZfA1hW+UH/2ZHOWvQ3HnQaU0DtnpXu850MZiy+YUgcc=

--- a/mongodbatlas/data_source_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_cluster_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_trigger_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"go.mongodb.org/realm/realm"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"go.mongodb.org/realm/realm"
 )
 

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -105,6 +105,10 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Sensitive: true,
 				Computed:  true,
 			},
+			"microsoft_teams_webhook_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -109,6 +109,22 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_discovery": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"scheme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -91,6 +91,18 @@ const (
 		microsoft_teams_webhook_url = "%[4]s"
 	}
 	`
+
+	PROMETHEUS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		username = "%[4]s"
+		password = "%[5]s"
+		service_discovery = "%[6]s"
+		enabled = "%[7]t"
+	}
+	`
+
 	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	numeric  = "0123456789"
 	alphaNum = alphabet + numeric
@@ -215,6 +227,16 @@ func testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config *thirdPartyCo
 			config.ProjectID,
 			config.Integration.Type,
 			config.Integration.MicrosoftTeamsWebhookURL,
+		)
+	case "PROMETHEUS":
+		return fmt.Sprintf(PROMETHEUS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.UserName,
+			config.Integration.Password,
+			config.Integration.ServiceDiscovery,
+			config.Integration.Enabled,
 		)
 	default:
 		return fmt.Sprintf(Unknown3rdParty,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -2,12 +2,11 @@ package mongodbatlas
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"math/big"
 	"os"
 	"testing"
-
-	"crypto/rand"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -82,6 +81,14 @@ const (
 		project_id = "%[2]s"
 		type = "%[3]s"
 		url = "%[4]s"	
+	}
+	`
+
+	MICROSOFT_TEAMS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		microsoft_teams_webhook_url = "%[4]s"
 	}
 	`
 	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -201,6 +208,13 @@ func testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config *thirdPartyCo
 			config.ProjectID,
 			config.Integration.Type,
 			config.Integration.URL,
+		)
+	case "MICROSOFT_TEAMS":
+		return fmt.Sprintf(MICROSOFT_TEAMS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.MicrosoftTeamsWebhookURL,
 		)
 	default:
 		return fmt.Sprintf(Unknown3rdParty,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -64,22 +64,23 @@ func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID 
 
 func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]interface{} {
 	out := map[string]interface{}{
-		"type":         integration.Type,
-		"license_key":  integration.LicenseKey,
-		"account_id":   integration.AccountID,
-		"write_token":  integration.WriteToken,
-		"read_token":   integration.ReadToken,
-		"api_key":      integration.APIKey,
-		"region":       integration.Region,
-		"service_key":  integration.ServiceKey,
-		"api_token":    integration.APIToken,
-		"team_name":    integration.TeamName,
-		"channel_name": integration.ChannelName,
-		"routing_key":  integration.RoutingKey,
-		"flow_name":    integration.FlowName,
-		"org_name":     integration.OrgName,
-		"url":          integration.URL,
-		"secret":       integration.Secret,
+		"type":                        integration.Type,
+		"license_key":                 integration.LicenseKey,
+		"account_id":                  integration.AccountID,
+		"write_token":                 integration.WriteToken,
+		"read_token":                  integration.ReadToken,
+		"api_key":                     integration.APIKey,
+		"region":                      integration.Region,
+		"service_key":                 integration.ServiceKey,
+		"api_token":                   integration.APIToken,
+		"team_name":                   integration.TeamName,
+		"channel_name":                integration.ChannelName,
+		"routing_key":                 integration.RoutingKey,
+		"flow_name":                   integration.FlowName,
+		"org_name":                    integration.OrgName,
+		"url":                         integration.URL,
+		"secret":                      integration.Secret,
+		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
@@ -164,6 +165,10 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 
 	if secret, ok := in.GetOk("secret"); ok {
 		out.Secret = secret.(string)
+	}
+
+	if microsoftTeamsWebhookUrl, ok := in.GetOk("microsoft_teams_webhook_url"); ok {
+		out.MicrosoftTeamsWebhookURL = microsoftTeamsWebhookUrl.(string)
 	}
 
 	return out

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -81,6 +81,10 @@ func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]i
 		"url":                         integration.URL,
 		"secret":                      integration.Secret,
 		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
+		"username":                    integration.UserName,
+		"service_discovery":           integration.ServiceDiscovery,
+		"scheme":                      integration.Scheme,
+		"enabled":                     integration.Enabled,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
@@ -169,6 +173,22 @@ func schemaToIntegration(in *schema.ResourceData) (out *matlas.ThirdPartyIntegra
 
 	if microsoftTeamsWebhookUrl, ok := in.GetOk("microsoft_teams_webhook_url"); ok {
 		out.MicrosoftTeamsWebhookURL = microsoftTeamsWebhookUrl.(string)
+	}
+
+	if username, ok := in.GetOk("username"); ok {
+		out.UserName = username.(string)
+	}
+
+	if password, ok := in.GetOk("password"); ok {
+		out.Password = password.(string)
+	}
+
+	if serviceDiscovery, ok := in.GetOk("service_discovery"); ok {
+		out.ServiceDiscovery = serviceDiscovery.(string)
+	}
+
+	if enabled, ok := in.GetOk("enabled"); ok {
+		out.Enabled = enabled.(bool)
 	}
 
 	return out

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/resource_mongodbatlas_encryption_at_rest.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_encryption_at_rest_test.go
+++ b/mongodbatlas/resource_mongodbatlas_encryption_at_rest_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	"go.mongodb.org/realm/realm"
 )

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"go.mongodb.org/realm/realm"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_maintenance_window.go
+++ b/mongodbatlas/resource_mongodbatlas_maintenance_window.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
+++ b/mongodbatlas/resource_mongodbatlas_private_ip_mode.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_private_ip_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_ip_mode_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mwielbut/pointy"
+	"github.com/openlyinc/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -19,16 +19,18 @@ var integrationTypes = []string{
 	"VICTOR_OPS",
 	"FLOWDOCK",
 	"WEBHOOK",
+	"MICROSOFT_TEAMS",
 }
 
 var requiredPerType = map[string][]string{
-	"PAGER_DUTY": {"service_key"},
-	"DATADOG":    {"api_key", "region"},
-	"NEW_RELIC":  {"license_key", "account_id", "write_token", "read_token"},
-	"OPS_GENIE":  {"api_key", "region"},
-	"VICTOR_OPS": {"api_key"},
-	"FLOWDOCK":   {"flow_name", "api_token", "org_name"},
-	"WEBHOOK":    {"url"},
+	"PAGER_DUTY":      {"service_key"},
+	"DATADOG":         {"api_key", "region"},
+	"NEW_RELIC":       {"license_key", "account_id", "write_token", "read_token"},
+	"OPS_GENIE":       {"api_key", "region"},
+	"VICTOR_OPS":      {"api_key"},
+	"FLOWDOCK":        {"flow_name", "api_token", "org_name"},
+	"WEBHOOK":         {"url"},
+	"MICROSOFT_TEAMS": {"microsoft_teams_webhook_url"},
 }
 
 func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
@@ -119,6 +121,10 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+			},
+			"microsoft_teams_webhook_url": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -20,6 +20,7 @@ var integrationTypes = []string{
 	"FLOWDOCK",
 	"WEBHOOK",
 	"MICROSOFT_TEAMS",
+	"PROMETHEUS",
 }
 
 var requiredPerType = map[string][]string{
@@ -31,6 +32,7 @@ var requiredPerType = map[string][]string{
 	"FLOWDOCK":        {"flow_name", "api_token", "org_name"},
 	"WEBHOOK":         {"url"},
 	"MICROSOFT_TEAMS": {"microsoft_teams_webhook_url"},
+	"PROMETHEUS":      {"username", "password", "service_discovery", "enabled"},
 }
 
 func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
@@ -126,6 +128,28 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"service_discovery": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"scheme": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -184,7 +208,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *schem
 
 	for key, val := range integrationMap {
 		if err := d.Set(key, val); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting `%s` for third party integration (%s): %s", key, d.Id(), err))
+			return diag.FromErr(fmt.Errorf("error setting `%s` to `%s` for third party integration (%s): %s", key, val, d.Id(), err))
 		}
 	}
 

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -40,6 +40,7 @@ data "mongodbatlas_third_party_integration" "test" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * MICROSOFT_TEAMS
 
 
 ## Attributes Reference
@@ -74,5 +75,7 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `MICROSOFT_TEAMS`
+   * `microsoft_teams_webook_url` - Your Microsoft Teams incoming webhook URL.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -26,6 +26,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
 
 data "mongodbatlas_third_party_integration" "test" {
 	project_id = mongodbatlas_third_party_integration.test_flowdock.project_id
+	type       = "FLOWDOCK"
 }
 ```
 

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -41,6 +41,7 @@ data "mongodbatlas_third_party_integration" "test" {
      * FLOWDOCK
      * WEBHOOK
      * MICROSOFT_TEAMS
+     * PROMETHEUS
 
 
 ## Attributes Reference
@@ -77,5 +78,10 @@ Additional values based on Type
    * `secret` - An optional field for your webhook secret.
 * `MICROSOFT_TEAMS`
    * `microsoft_teams_webook_url` - Your Microsoft Teams incoming webhook URL.
+* `PROMETHEUS`
+   * `username` - Your Prometheus username.
+   * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+   * `scheme` - Your Prometheus protocol scheme configured for requests.
+   * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -44,8 +44,9 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
      * VICTOR_OPS
      * FLOWDOCK
      * WEBHOOK
+     * MICROSOFT_TEAMS
 
-Additional values based on Type
+Additional values based on `Type`
 
 * `PAGER_DUTY`
   * `service_key` - Your Service Key.
@@ -70,6 +71,8 @@ Additional values based on Type
 * `WEBHOOK`
    * `url` - Your webhook URL.
    * `secret` - An optional field for your webhook secret.
+* `MICROSOFT_TEAMS`
+   * `microsoft_teams_webook_url` - Your Microsoft Teams incoming webhook URL.
 
 ## Attributes Reference
 

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -45,6 +45,7 @@ resource "mongodbatlas_third_party_integration" "test_flowdock" {
      * FLOWDOCK
      * WEBHOOK
      * MICROSOFT_TEAMS
+     * PROMETHEUS
 
 Additional values based on `Type`
 
@@ -73,11 +74,20 @@ Additional values based on `Type`
    * `secret` - An optional field for your webhook secret.
 * `MICROSOFT_TEAMS`
    * `microsoft_teams_webook_url` - Your Microsoft Teams incoming webhook URL.
+* `PROMETHEUS`
+   * `username` - Your Prometheus username.
+   * `password` - Your Prometheus password.
+   * `service_discovery` - Indicates which Prometheus service discovery method is used, either `file` or `http`.
+   * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 
 * `id` - Unique identifier used by terraform for internal management, which can also be used to import.
 
+Additional values based on `Type`
+
+* `PROMETHEUS`
+   * `scheme` - Your Prometheus protocol scheme configured for requests.
 ## Import
 
 Third-Party Integration Settings can be imported using project ID and the integration type, in the format `project_id`-`type`, e.g.


### PR DESCRIPTION
## Description

Adds support within the `mongodbatlas_third_party_integration` and related resources for the Prometheus and Microsoft Teams integrations.

Also bumps `go.mongodb.org/atlas` dependency to `v0.16.0`

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
