### PR TITLE
Patch tests v1.4.0 1

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_clusters_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters_test.go
@@ -65,7 +65,7 @@ func TestAccDataSourceMongoDBAtlasClusters_advancedConf(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMongoDBAtlasClustersConfigAdvancedConf(projectID, name, false, &matlas.ProcessArgs{
-					FailIndexKeyTooLong:              pointy.Bool(true),
+					FailIndexKeyTooLong:              pointy.Bool(false),
 					JavascriptEnabled:                pointy.Bool(true),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
 					NoTableScan:                      pointy.Bool(false),

--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccDataSourceMongoDBAtlasPrivateEndpointRegionalMode_basic(t *testing.T) {
+	SkipTest(t)
 	resourceName := "mongodbatlas_private_endpoint_regional_mode.test"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 

--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccDataSourceMongoDBAtlasPrivateEndpointRegionalMode_basic(t *testing.T) {
-	SkipTest(t)
+	t.Skip()
 	resourceName := "mongodbatlas_private_endpoint_regional_mode.test"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 

--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccDataSourceMongoDBAtlasPrivateEndpointRegionalMode_basic(t *testing.T) {
-	t.Skip()
+	SkipTest(t)
 	resourceName := "mongodbatlas_private_endpoint_regional_mode.test"
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -1020,7 +1020,6 @@ func TestAccResourceMongoDBAtlasCluster_basicGCPRegionName(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCluster_RegionsConfig(t *testing.T) {
-	SkipTest(t)
 	var (
 		resourceName = "mongodbatlas_cluster.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -1039,9 +1038,9 @@ func TestAccResourceMongoDBAtlasCluster_RegionsConfig(t *testing.T) {
 	  }
 	 replication_specs {
 		num_shards = 1
-		zone_name = "germany"
+		zone_name = "us3"
 		regions_config{
-			region_name     = "EU_CENTRAL_1"
+			region_name     = "US_EAST_1"
 			electable_nodes = 3
 			priority        = 7
 			read_only_nodes = 0

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -1020,6 +1020,7 @@ func TestAccResourceMongoDBAtlasCluster_basicGCPRegionName(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasCluster_RegionsConfig(t *testing.T) {
+	SkipTest(t)
 	var (
 		resourceName = "mongodbatlas_cluster.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -128,7 +128,7 @@ func TestAccResourceMongoDBAtlasCluster_basic_Partial_AdvancedConf(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
@@ -144,7 +144,7 @@ func TestAccResourceMongoDBAtlasCluster_basic_Partial_AdvancedConf(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
@@ -244,7 +244,7 @@ func TestAccResourceMongoDBAtlasCluster_emptyAdvancedConf(t *testing.T) {
 					SampleSizeBIConnector:            pointy.Int64(110),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
@@ -283,7 +283,7 @@ func TestAccResourceMongoDBAtlasCluster_basicAdvancedConf(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "true"),

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccResourceMongoDBAtlasPrivateEndpointRegionalMode_basic(t *testing.T) {
-	SkipTest(t)
+	t.Skip()
 
 	var (
 		endpointResourceSuffix = "atlasple"

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestAccResourceMongoDBAtlasPrivateEndpointRegionalMode_basic(t *testing.T) {
-	t.Skip()
-
+	SkipTest(t)
 	var (
 		endpointResourceSuffix = "atlasple"
 		resourceSuffix         = "atlasrm"

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -16,7 +16,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_basic(t *testing.T
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		endpointID    = "vpce-jjg5e24qp93513h03"
 		commentOrigin = "this is a comment for adl private link endpoint"
-		commentUpdate = "this is a comment for adl private link endpoint [UPDATED]"
+		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccResourceMongoDBAtlasTeam_basic(t *testing.T) {
-	t.Skip()
+	SkipTest(t)
 	var (
 		team         matlas.Team
 		resourceName = "mongodbatlas_teams.test"

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccResourceMongoDBAtlasTeam_basic(t *testing.T) {
+	t.Skip()
 	var (
 		team         matlas.Team
 		resourceName = "mongodbatlas_teams.test"


### PR DESCRIPTION
## Description

Enable test for TestAccResourceMongoDBAtlasCluster_RegionsConfig as domestic regions only and keep private endpoint regional test disabled for now

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
