### PR TITLE
INTMDB-313: Update project settings default flags to true

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -100,27 +100,22 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 			"is_collect_database_specifics_statistics_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"is_data_explorer_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"is_performance_advisor_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"is_realtime_performance_panel_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"is_schema_advisor_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 		},
 	}

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -100,27 +100,27 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 			"is_collect_database_specifics_statistics_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"is_data_explorer_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"is_performance_advisor_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"is_realtime_performance_panel_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"is_schema_advisor_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 		},
 	}

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -461,12 +461,12 @@ func testAccMongoDBAtlasProjectConfigWithFalseDefaultAdvSettings(projectName, or
 			name   			 = "%[1]s"
 			org_id 			 = "%[2]s"
 			project_owner_id = "%[3]s"
-			with_default_alerts_settings = true
-			is_collect_database_specifics_statistics_enabled = true
-			is_data_explorer_enabled = true
-			is_performance_advisor_enabled = true
-			is_realtime_performance_panel_enabled = true
-			is_schema_advisor_enabled = true
+			with_default_alerts_settings = false
+			is_collect_database_specifics_statistics_enabled = false
+			is_data_explorer_enabled = false
+			is_performance_advisor_enabled = false
+			is_realtime_performance_panel_enabled = false
+			is_schema_advisor_enabled = false
 		}
 	`, projectName, orgID, projectOwnerID)
 }

--- a/mongodbatlas/resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_test.go
@@ -461,12 +461,12 @@ func testAccMongoDBAtlasProjectConfigWithFalseDefaultAdvSettings(projectName, or
 			name   			 = "%[1]s"
 			org_id 			 = "%[2]s"
 			project_owner_id = "%[3]s"
-			with_default_alerts_settings = false
-			is_collect_database_specifics_statistics_enabled = false
-			is_data_explorer_enabled = false
-			is_performance_advisor_enabled = false
-			is_realtime_performance_panel_enabled = false
-			is_schema_advisor_enabled = false
+			with_default_alerts_settings = true
+			is_collect_database_specifics_statistics_enabled = true
+			is_data_explorer_enabled = true
+			is_performance_advisor_enabled = true
+			is_realtime_performance_panel_enabled = true
+			is_schema_advisor_enabled = true
 		}
 	`, projectName, orgID, projectOwnerID)
 }

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -35,11 +35,11 @@ resource "mongodbatlas_project" "test" {
     role_names = ["GROUP_READ_ONLY"]
   }
 
-  is_collect_database_specifics_statistics_enabled = false
-  is_data_explorer_enabled                         = false
+  is_collect_database_specifics_statistics_enabled = true
+  is_data_explorer_enabled                         = true
   is_performance_advisor_enabled                   = true
-  is_realtime_performance_panel_enabled            = false
-  is_schema_advisor_enabled                        = false
+  is_realtime_performance_panel_enabled            = true
+  is_schema_advisor_enabled                        = true
 }
 ```
 


### PR DESCRIPTION
## Description

Change default values of is_collect_database_specifics_statistics_enabled, is_data_explorer_enabled, 
			is_performance_advisor_enabled,is_realtime_performance_panel_enabled
			is_schema_advisor_enabled  
to true/enabled

Link to any related issue(s):
https://github.com/mongodb/terraform-provider-mongodbatlas/issues/772

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
