### PR TITLE
Docs: Normalize the space indentation in third_party_integration

### DIFF
--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -56,33 +56,33 @@ Additional values based on Type
 * `PAGER_DUTY`
   * `service_key` - Your Service Key.
 * `DATADOG`
-   * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+  * `api_key` - Your API Key.
+  * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
-   * `license_key` - Your License Key.
-   * `account_id`  - Unique identifier of your New Relic account.
-   * `write_token` - Your Insights Insert Key.
-   * `read_token`  - Your Insights Query Key.
+  * `license_key` - Your License Key.
+  * `account_id`  - Unique identifier of your New Relic account.
+  * `write_token` - Your Insights Insert Key.
+  * `read_token`  - Your Insights Query Key.
 * `OPS_GENIE`
-   * `api_key` - Your API Key.
-   * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
+  * `api_key` - Your API Key.
+  * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
 * `VICTOR_OPS`
-   * `api_key` - 	Your API Key.
-   * `routing_key` - An optional field for your Routing Key.
+  * `api_key` - 	Your API Key.
+  * `routing_key` - An optional field for your Routing Key.
 * `FLOWDOCK`
-   * `flow_name` - Your Flowdock Flow name.
-   * `api_token` - Your API Token.
-   * `org_name` - Your Flowdock organization name.
+  * `flow_name` - Your Flowdock Flow name.
+  * `api_token` - Your API Token.
+  * `org_name` - Your Flowdock organization name.
 * `WEBHOOK`
-   * `url` - Your webhook URL.
-   * `secret` - An optional field for your webhook secret.
+  * `url` - Your webhook URL.
+  * `secret` - An optional field for your webhook secret.
 * `MICROSOFT_TEAMS`
-   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
- * `PROMETHEUS`
-    * `user_name` - Your Prometheus username.
-    * `password` - Your Prometheus password.
-    * `service_discovery` - Indicates which service discovery method is used, either file or http.
-    * `scheme` - Your Prometheus protocol scheme configured for requests.
-    * `enabled` - Whether your cluster has Prometheus enabled.
+  * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+* `PROMETHEUS`
+  * `user_name` - Your Prometheus username.
+  * `password` - Your Prometheus password.
+  * `service_discovery` - Indicates which service discovery method is used, either file or http.
+  * `scheme` - Your Prometheus protocol scheme configured for requests.
+  * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-one/) Documentation for more information.

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -57,33 +57,33 @@ Additional values based on Type
 * `PAGER_DUTY`
   * `service_key` - Your Service Key.
 * `DATADOG`
-   * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+  * `api_key` - Your API Key.
+  * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
-   * `license_key` - Your License Key.
-   * `account_id`  - Unique identifier of your New Relic account.
-   * `write_token` - Your Insights Insert Key.
-   * `read_token`  - Your Insights Query Key.
+  * `license_key` - Your License Key.
+  * `account_id`  - Unique identifier of your New Relic account.
+  * `write_token` - Your Insights Insert Key.
+  * `read_token`  - Your Insights Query Key.
 * `OPS_GENIE`
-   * `api_key` - Your API Key.
-   * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
+  * `api_key` - Your API Key.
+  * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
 * `VICTOR_OPS`
-   * `api_key` - 	Your API Key.
-   * `routing_key` - An optional field for your Routing Key.
+  * `api_key` - 	Your API Key.
+  * `routing_key` - An optional field for your Routing Key.
 * `FLOWDOCK`
-   * `flow_name` - Your Flowdock Flow name.
-   * `api_token` - Your API Token.
-   * `org_name` - Your Flowdock organization name.
+  * `flow_name` - Your Flowdock Flow name.
+  * `api_token` - Your API Token.
+  * `org_name` - Your Flowdock organization name.
 * `WEBHOOK`
-   * `url` - Your webhook URL.
-   * `secret` - An optional field for your webhook secret.
+  * `url` - Your webhook URL.
+  * `secret` - An optional field for your webhook secret.
 * `MICROSOFT_TEAMS`
-   * `name` - Your Microsoft Teams incoming webhook name.
-   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
- * `PROMETHEUS`
-    * `user_name` - Your Prometheus username.
-    * `service_discovery` - Indicates which service discovery method is used, either file or http.
-    * `scheme` - Your Prometheus protocol scheme configured for requests.
-    * `enabled` - Whether your cluster has Prometheus enabled.
+  * `name` - Your Microsoft Teams incoming webhook name.
+  * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+* `PROMETHEUS`
+  * `user_name` - Your Prometheus username.
+  * `service_discovery` - Indicates which service discovery method is used, either file or http.
+  * `scheme` - Your Prometheus protocol scheme configured for requests.
+  * `enabled` - Whether your cluster has Prometheus enabled.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/third-party-integration-settings-get-all/) Documentation for more information.

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -50,34 +50,34 @@ Additional values based on Type
 * `PAGER_DUTY`
   * `service_key` - Your Service Key.
 * `DATADOG`
-   * `api_key` - Your API Key.
-   * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
+  * `api_key` - Your API Key.
+  * `region` - Indicates which API URL to use, either US or EU. Datadog will use US by default.    
 * `NEW_RELIC`
-   * `license_key` - Your License Key.
-   * `account_id`  - Unique identifier of your New Relic account.
-   * `write_token` - Your Insights Insert Key.
-   * `read_token`  - Your Insights Query Key.
+  * `license_key` - Your License Key.
+  * `account_id`  - Unique identifier of your New Relic account.
+  * `write_token` - Your Insights Insert Key.
+  * `read_token`  - Your Insights Query Key.
 * `OPS_GENIE`
-   * `api_key` - Your API Key.
-   * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
+  * `api_key` - Your API Key.
+  * `region` -  Indicates which API URL to use, either US or EU. Opsgenie will use US by default.
 * `VICTOR_OPS`
-   * `api_key` - 	Your API Key.
-   * `routing_key` - An optional field for your Routing Key.
+  * `api_key` - 	Your API Key.
+  * `routing_key` - An optional field for your Routing Key.
 * `FLOWDOCK`
-   * `flow_name` - Your Flowdock Flow name.
-   * `api_token` - Your API Token.
-   * `org_name` - Your Flowdock organization name.
+  * `flow_name` - Your Flowdock Flow name.
+  * `api_token` - Your API Token.
+  * `org_name` - Your Flowdock organization name.
 * `WEBHOOK`
-   * `url` - Your webhook URL.
-   * `secret` - An optional field for your webhook secret.
+  * `url` - Your webhook URL.
+  * `secret` - An optional field for your webhook secret.
 * `MICROSOFT_TEAMS`
-   * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
- * `PROMETHEUS`
-    * `user_name` - Your Prometheus username.
-    * `password`  - Your Prometheus password.
-    * `service_discovery` - Indicates which service discovery method is used, either file or http.
-    * `scheme` - Your Prometheus protocol scheme configured for requests.
-    * `enabled` - Whether your cluster has Prometheus enabled.
+  * `microsoft_teams_webhook_url` -  Your Microsoft Teams incoming webhook URL.
+* `PROMETHEUS`
+  * `user_name` - Your Prometheus username.
+  * `password`  - Your Prometheus password.
+  * `service_discovery` - Indicates which service discovery method is used, either file or http.
+  * `scheme` - Your Prometheus protocol scheme configured for requests.
+  * `enabled` - Whether your cluster has Prometheus enabled.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

The current documentation has a space indentation issue which results in bad rendering on [registry.hashicorp.io](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/third_party_integration#PROMETHEUS)
This PR aims at fixing this for a proper rendering.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
