### PR TITLE
INTMDB-313: Set project settings to computed to ignore when not supplied by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 ## What's Changed
 
 * INTMDB-313: Update project settings default flags by @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/778
-* 
+
+**Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.1...v1.4.2
+
 ## [v1.4.1](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.1) (2022-07-7)
 ## What's Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## [v1.4.2](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.2) (2022-07-7)
+## What's Changed
+
+* INTMDB-313: Update project settings default flags by @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/778
+* 
 ## [v1.4.1](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.1) (2022-07-7)
 ## What's Changed
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -99,22 +99,27 @@ func resourceMongoDBAtlasProject() *schema.Resource {
 			},
 			"is_collect_database_specifics_statistics_enabled": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 			"is_data_explorer_enabled": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 			"is_performance_advisor_enabled": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 			"is_realtime_performance_panel_enabled": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 			"is_schema_advisor_enabled": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 		},


### PR DESCRIPTION
## Description

Set project settings to computed to ignore when not supplied by user

Link to any related issue(s):
https://github.com/mongodb/terraform-provider-mongodbatlas/pull/741

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
