### PR TITLE
Fix typo in custom_db_role documentation

### DIFF
--- a/website/docs/d/custom_db_role.html.markdown
+++ b/website/docs/d/custom_db_role.html.markdown
@@ -59,7 +59,7 @@ Each object in the actions array represents an individual privilege action grant
 
 * `resources` - (Required) Contains information on where the action is granted. Each object in the array either indicates a database and collection on which the action is granted, or indicates that the action is granted on the cluster resource.
 
-* `resources.#.collection` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
+* `resources.#.collection_name` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
 
 * `resources.#.database_name`	Database on which the action is granted.
 

--- a/website/docs/d/custom_db_roles.html.markdown
+++ b/website/docs/d/custom_db_roles.html.markdown
@@ -55,7 +55,7 @@ Each object in the actions array represents an individual privilege action grant
 
 * `resources` - (Required) Contains information on where the action is granted. Each object in the array either indicates a database and collection on which the action is granted, or indicates that the action is granted on the cluster resource.
 
-* `resources.#.collection` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
+* `resources.#.collection_name` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
 
 * `resources.#.database_name`	Database on which the action is granted.
 

--- a/website/docs/r/custom_db_role.html.markdown
+++ b/website/docs/r/custom_db_role.html.markdown
@@ -127,7 +127,7 @@ Each object in the actions array represents an individual privilege action grant
 
 * `resources` - (Required) Contains information on where the action is granted. Each object in the array either indicates a database and collection on which the action is granted, or indicates that the action is granted on the cluster resource.
 
-* `resources.#.collection` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
+* `resources.#.collection_name` - (Optional) Collection on which the action is granted. If this value is an empty string, the action is granted on all collections within the database specified in the actions.resources.db field.
 
 	-> **NOTE** This field is mutually exclusive with the `actions.resources.cluster` field.
 


### PR DESCRIPTION
## Description

The Example Usage section in the documentation correctly uses `actions.resources.#.collection_name` as an attribute name, but the Actions section of the Arguments reference refers to `resources.#.collection`. The Example Usage section is correct as per https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/mongodbatlas/resource_mongodbatlas_custom_db_role.go#L66 .

Link to any related issue(s): #775

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

Note: tests and make fmt seem not applicable here, since this PR contains no code changes.

## Further comments
