### PR TITLE
INTMDB-323 Remove beta requirement for serverless

### DIFF
--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -136,6 +136,8 @@ func getDataSourcesMap() map[string]*schema.Resource {
 		"mongodbatlas_federated_settings_org_configs":        dataSourceMongoDBAtlasFederatedSettingsOrganizationConfigs(),
 		"mongodbatlas_federated_settings_org_role_mapping":   dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMapping(),
 		"mongodbatlas_federated_settings_org_role_mappings":  dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMappings(),
+		"mongodbatlas_serverless_instance":                   dataSourceMongoDBAtlasServerlessInstance(),
+		"mongodbatlas_serverless_instances":                  dataSourceMongoDBAtlasServerlessInstances(),
 	}
 	return dataSourcesMap
 }
@@ -187,16 +189,13 @@ func getResourcesMap() map[string]*schema.Resource {
 		"mongodbatlas_federated_settings_org_config":         resourceMongoDBAtlasFederatedSettingsOrganizationConfig(),
 		"mongodbatlas_federated_settings_org_role_mapping":   resourceMongoDBAtlasFederatedSettingsOrganizationRoleMapping(),
 		"mongodbatlas_federated_settings_identity_provider":  resourceMongoDBAtlasFederatedSettingsIdentityProvider(),
+		"mongodbatlas_serverless_instance":                   resourceMongoDBAtlasServerlessInstance(),
 	}
 	return resourcesMap
 }
 
 func addBetaFeatures(provider *schema.Provider) {
 	if ProviderEnableBeta {
-		provider.ResourcesMap["mongodbatlas_serverless_instance"] = resourceMongoDBAtlasServerlessInstance()
-
-		provider.DataSourcesMap["mongodbatlas_serverless_instance"] = dataSourceMongoDBAtlasServerlessInstance()
-		provider.DataSourcesMap["mongodbatlas_serverless_instances"] = dataSourceMongoDBAtlasServerlessInstances()
 	}
 }
 

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -196,8 +196,6 @@ func getResourcesMap() map[string]*schema.Resource {
 
 func addBetaFeatures(provider *schema.Provider) {
 	if ProviderEnableBeta {
-		// provider.ResourcesMap["mongodbatlas_example"] = resourceMongoDBAtlasExample)
-		// provider.DataSourcesMap["mongodbatlas_example"] = dataSourceMongoDBAtlasExample()
 		return
 	}
 }

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -196,6 +196,9 @@ func getResourcesMap() map[string]*schema.Resource {
 
 func addBetaFeatures(provider *schema.Provider) {
 	if ProviderEnableBeta {
+		// provider.ResourcesMap["mongodbatlas_example"] = resourceMongoDBAtlasExample)
+		// provider.DataSourcesMap["mongodbatlas_example"] = dataSourceMongoDBAtlasExample()
+		return
 	}
 }
 

--- a/website/docs/d/serverless_instance.html.markdown
+++ b/website/docs/d/serverless_instance.html.markdown
@@ -11,7 +11,6 @@ Provides a Serverless Instance.
 `mongodbatlas_serverless_instance` describe a single serverless instance. This represents a single serverless instance that have been created.
 > **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
-> In order to use this datasource in Terraform you'll need to set the environment variable `MONGODB_ATLAS_ENABLE_BETA=true`.
  
 
 > **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.

--- a/website/docs/d/serverless_instance.html.markdown
+++ b/website/docs/d/serverless_instance.html.markdown
@@ -9,7 +9,7 @@ Provides a Serverless Instance.
 # mongodbatlas_serverless_instance
 
 `mongodbatlas_serverless_instance` describe a single serverless instance. This represents a single serverless instance that have been created.
-> **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
+> **NOTE:**  Serverless instances do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
  
 

--- a/website/docs/d/serverless_instances.html.markdown
+++ b/website/docs/d/serverless_instances.html.markdown
@@ -10,7 +10,7 @@ Describes a Serverless Instances.
 
 `mongodbatlas_serverless_instances` describe all serverless instances. This represents serverless instances that have been created for the specified group id.
 
-> **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
+> **NOTE:**  Serverless instances do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
 
 > **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.

--- a/website/docs/d/serverless_instances.html.markdown
+++ b/website/docs/d/serverless_instances.html.markdown
@@ -12,7 +12,6 @@ Describes a Serverless Instances.
 
 > **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
-> In order to use this datasource in Terraform you'll need to set the environment variable `MONGODB_ATLAS_ENABLE_BETA=true`.
 
 > **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 

--- a/website/docs/r/serverless_instance.html.markdown
+++ b/website/docs/r/serverless_instance.html.markdown
@@ -10,7 +10,7 @@ Provides a Serverless Instance resource.
 
 `mongodbatlas_serverless_instance` provides a Serverless Instance resource. This allows serverless instances to be created.
 
-> **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
+> **NOTE:**  Serverless instances do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
 
 ## Example Usage

--- a/website/docs/r/serverless_instance.html.markdown
+++ b/website/docs/r/serverless_instance.html.markdown
@@ -12,7 +12,6 @@ Provides a Serverless Instance resource.
 
 > **NOTE:**  Serverless instances are in a preview release and do not support some Atlas features at this time.
 For a full list of unsupported features, see [Serverless Instance Limitations](https://docs.atlas.mongodb.com/reference/serverless-instance-limitations/).
-> In order to use this resource in Terraform you'll need to set the environment variable `MONGODB_ATLAS_ENABLE_BETA=true`.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

Removed the requirement to set `MONGODB_ATLAS_ENABLE_BETA` to use serverless and update the docs to match.

Internal ticket [INTMDB-323](https://jira.mongodb.org/browse/INTMDB-323)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
