### PR TITLE
INTMDB-335 and INTMDB-348: backup - Add option for multiple weekly monthly schedules and fix autoexport 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
 * INTMDB-348: autoexport parameter not being set via provider [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
 * INTMDB-323: Removed the requirement to set `MONGODB_ATLAS_ENABLE_BETA` to use serverless and update the docs to match. [\#783](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/783)
+* Fix typo in custom_db_role documentation [\#780](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/780)
+* Fix typo in federated_settings_org_configs documentation [\#779](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/779)
  
 **Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.2...v1.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## [v1.4.3](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.3) (2022-07-12)
+## Fixed
+
+* INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784
+* INTMDB-348: autoexport parameter not being set via provider https://jira.mongodb.org/browse/INTMDB-348
+
+**Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.1...v1.4.2
+
+## [v1.4.2](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.2) (2022-07-7)
+## What's Changed
+
+* INTMDB-313: Update project settings default flags by @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/778
+
+**Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.1...v1.4.2
+
 ## [v1.4.1](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.1) (2022-07-7)
 ## What's Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 ## [v1.4.3](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.3) (2022-07-12)
 ## Fixed
 
-* INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784
-* INTMDB-348: autoexport parameter not being set via provider https://jira.mongodb.org/browse/INTMDB-348
-
+* INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
+* INTMDB-348: autoexport parameter not being set via provider [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
+* INTMDB-323: Removed the requirement to set `MONGODB_ATLAS_ENABLE_BETA` to use serverless and update the docs to match. [\#783](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/783)
+ 
 **Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.2...v1.4.3
 
 ## [v1.4.2](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.2) (2022-07-7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
 * INTMDB-348: autoexport parameter not being set via provider [\#784](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784)
 * INTMDB-323: Removed the requirement to set `MONGODB_ATLAS_ENABLE_BETA` to use serverless and update the docs to match. [\#783](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/783)
+* INTMDB-330 Fixed Serverless Instance Import Documentation. Closes [\#754](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/754)
 * Fix typo in custom_db_role documentation [\#780](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/780)
 * Fix typo in federated_settings_org_configs documentation [\#779](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/779)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * INTMDB-335: Add option for multiple weekly monthly schedules @martinstibbe in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/784
 * INTMDB-348: autoexport parameter not being set via provider https://jira.mongodb.org/browse/INTMDB-348
 
-**Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.1...v1.4.2
+**Full Changelog**: https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.2...v1.4.3
 
 ## [v1.4.2](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.2) (2022-07-7)
 ## What's Changed

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -64,6 +64,7 @@ func resourceMongoDBAtlasCloudBackupSchedule() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"export_bucket_id": {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -125,7 +125,7 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "20"),
 					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "5"),
-					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -18,9 +18,6 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-		policyName   = acctest.RandomWithPrefix("test-acc")
-		roleName     = acctest.RandomWithPrefix("test-acc")
-		bucketName   = os.Getenv("AWS_S3_BUCKET")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,6 +113,25 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.retention_value", "4"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccResourceMongoDBAtlasCloudBackupSchedule_export(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		bucketName   = os.Getenv("AWS_S3_BUCKET")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+
+		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasCloudBackupScheduleExportPoliciesConfig(projectID, clusterName, policyName, roleName, bucketName),
 				Check: resource.ComposeTestCheckFunc(
@@ -135,7 +151,6 @@ func TestAccResourceMongoDBAtlasCloudBackupSchedule_basic(t *testing.T) {
 		},
 	})
 }
-
 func TestAccResourceMongoDBAtlasCloudBackupSchedule_onepolicy(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -133,7 +136,21 @@ func resourceMongoDBAtlasCloudBackupSnapshotExportBucketDelete(ctx context.Conte
 	projectID := ids["project_id"]
 	bucketID := ids["id"]
 
-	_, err := conn.CloudProviderSnapshotExportBuckets.Delete(ctx, projectID, bucketID)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING", "REPEATING"},
+		Target:     []string{"DELETED"},
+		Refresh:    resourceCloudBackupSnapshotExportBucketRefreshFunc(ctx, conn, projectID, bucketID),
+		Timeout:    1 * time.Hour,
+		MinTimeout: 5 * time.Second,
+		Delay:      3 * time.Second,
+	}
+	// Wait, catching any errors
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error deleting snapshot export bucket %s %s", projectID, err)
+	}
+
+	_, err = conn.CloudProviderSnapshotExportBuckets.Delete(ctx, projectID, bucketID)
 
 	if err != nil {
 		return diag.Errorf("error deleting snapshot export bucket (%s): %s", bucketID, err)
@@ -176,4 +193,63 @@ func splitCloudBackupSnapshotExportBucketImportID(id string) (projectID, bucketI
 	bucketID = &parts[2]
 
 	return
+}
+
+func resourceCloudBackupSnapshotExportBucketRefreshFunc(ctx context.Context, client *matlas.Client, projectID, exportBucketID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		clusters, resp, err := client.Clusters.List(ctx, projectID, nil)
+		if err != nil {
+			// For our purposes, no clusters is equivalent to all changes having been APPLIED
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return "", "APPLIED", nil
+			}
+			return nil, "REPEATING", err
+		}
+
+		for i := range clusters {
+			backupPolicy, _, err := client.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusters[i].Name)
+			if err != nil {
+				continue
+			}
+			// find cluster that has export id attached to its config
+			if backupPolicy.Export != nil {
+				if backupPolicy.Export.ExportBucketID == exportBucketID {
+					if clusters[i].StateName == "IDLE" {
+						return clusters, "PENDING", nil
+					}
+					if clusters[i].StateName == "UPDATING" {
+						return clusters, "PENDING", nil
+					}
+
+					s, resp, err := client.Clusters.Status(ctx, projectID, clusters[i].Name)
+
+					if err != nil && strings.Contains(err.Error(), "reset by peer") {
+						return nil, "REPEATING", nil
+					}
+
+					if err != nil {
+						if resp != nil && resp.StatusCode == http.StatusNotFound {
+							return "", "DELETED", nil
+						}
+
+						if resp.StatusCode == 404 {
+							// The cluster no longer exists, consider this equivalent to status APPLIED
+							continue
+						}
+						if resp.StatusCode == 503 {
+							return "", "PENDING", nil
+						}
+						return nil, "REPEATING", err
+					}
+
+					if s.ChangeStatus == matlas.ChangeStatusPending {
+						return clusters, "PENDING", nil
+					}
+				}
+			}
+		}
+
+		// If all clusters were properly read, and none are PENDING, all changes have been APPLIED.
+		return clusters, "DELETED", nil
+	}
 }


### PR DESCRIPTION
Fix missing auto_export_enabled flag setting add test for export example

## Description

Includes Fix for missing auto_export_enabled [INTMDB-348](https://jira.mongodb.org/browse/INTMDB-348)

Link to any related issue(s):
mongodbatlas_cloud_backup_schedule does not support multiple weekly/monthly policies https://github.com/mongodb/terraform-provider-mongodbatlas/issues/748

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
