### PR TITLE
INTMDB-369: Updated validation logic for cloud_backup_snapshot_restore_job

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -457,15 +457,15 @@ func validateDeliveryType(dt []interface{}) error {
 
 	pointTimeUTC, pointTimeUTCOk := v["point_in_time_utc_seconds"]
 	isPITSet := pointTimeUTCOk && pointTimeUTC != nil && (pointTimeUTC.(int) > 0)
-	oplogTs, oplogTsOk := v["oplog_ts"]
-	isOpTsSet := oplogTsOk && oplogTs != nil && (oplogTs.(int) > 0)
+	oplogTS, oplogTSOk := v["oplog_ts"]
+	isOpTSSet := oplogTSOk && oplogTS != nil && (oplogTS.(int) > 0)
 	oplogInc, oplogIncOk := v["oplog_inc"]
 	isOpIncSet := oplogIncOk && oplogInc != nil && (oplogInc.(int) > 0)
 
-	if !isPITSet && !(isOpTsSet && isOpIncSet) {
+	if !isPITSet && !(isOpTSSet && isOpIncSet) {
 		return fmt.Errorf("%q point_in_time_utc_seconds or oplog_ts and oplog_inc must be set", key)
 	}
-	if isPITSet && (isOpTsSet || isOpIncSet) {
+	if isPITSet && (isOpTSSet || isOpIncSet) {
 		return fmt.Errorf("%q you can't use both point_in_time_utc_seconds and oplog_ts or oplog_inc", key)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -409,58 +409,64 @@ func splitSnapshotRestoreJobImportID(id string) (projectID, clusterName, snapsho
 	return
 }
 
-func validateDeliveryType(d []interface{}) error {
-	if len(d) != 0 {
-		v := d[0].(map[string]interface{})
-		key := "delivery_type_config"
+func validateDeliveryType(dt []interface{}) error {
+	if len(dt) == 0 {
+		return nil
+	}
 
-		_, automated := v["automated"]
-		_, download := v["download"]
-		_, pointInTime := v["point_in_time"]
+	v := dt[0].(map[string]interface{})
+	key := "delivery_type_config"
 
-		if (v["automated"] == true && v["download"] == true && v["point_in_time"] == true) ||
-			(v["automated"] == false && v["download"] == false && v["point_in_time"] == false) ||
-			(!automated && !download && !pointInTime) {
-			return fmt.Errorf("%q you can only submit one type of restore job: automated, download or point_in_time", key)
+	a, aOk := v["automated"]
+	automated := aOk && a != nil && a.(bool)
+	d, dOk := v["download"]
+	download := dOk && d != nil && d.(bool)
+	p, pOk := v["point_in_time"]
+	pointInTime := pOk && p != nil && p.(bool)
+
+	hasDeliveryType := automated || download || pointInTime
+
+	if !hasDeliveryType ||
+		(automated && download) ||
+		(automated && pointInTime) ||
+		(download && pointInTime) {
+		return fmt.Errorf("%q you must submit exactly one type of restore job: automated, download or point_in_time", key)
+	}
+
+	if automated || pointInTime {
+		if targetClusterName, ok := v["target_cluster_name"]; !ok || targetClusterName == "" {
+			return fmt.Errorf("%q target_cluster_name must be set", key)
 		}
-		if v["automated"] == true && (v["download"] == false || !download) {
-			if targetClusterName, ok := v["target_cluster_name"]; !ok || targetClusterName == "" {
-				return fmt.Errorf("%q target_cluster_name must be set", key)
-			}
-			if targetGroupID, ok := v["target_project_id"]; !ok || targetGroupID == "" {
-				return fmt.Errorf("%q target_project_id must be set", key)
-			}
+
+		if targetProjectID, ok := v["target_project_id"]; !ok || targetProjectID == "" {
+			return fmt.Errorf("%q target_project_id must be set", key)
 		}
-		if v["download"] == true && (v["automated"] == false || !automated) &&
-			(v["point_in_time"] == false || !pointInTime) {
-			if targetClusterName, ok := v["target_cluster_name"]; ok && targetClusterName != "" {
-				return fmt.Errorf("%q it's not necessary implement target_cluster_name when you are using download delivery type", key)
-			}
-			if targetGroupID, ok := v["target_project_id"]; ok && targetGroupID != "" {
-				return fmt.Errorf("%q it's not necessary implement target_project_id when you are using download delivery type", key)
-			}
+	} else {
+		if targetClusterName, ok := v["target_cluster_name"]; ok && len(targetClusterName.(string)) > 0 {
+			return fmt.Errorf("%q it's not necessary implement target_cluster_name when you are using download delivery type", key)
 		}
-		if v["point_in_time"] == true && (v["download"] == false || !download) &&
-			(v["automated"] == false || !automated) {
-			_, oplogTS := v["oplog_ts"]
-			_, pointTimeUTC := v["point_in_time_utc_seconds"]
-			_, oplogInc := v["oplog_inc"]
-			if targetClusterName, ok := v["target_cluster_name"]; !ok || targetClusterName == "" {
-				return fmt.Errorf("%q target_cluster_name must be set", key)
-			}
-			if targetGroupID, ok := v["target_project_id"]; !ok || targetGroupID == "" {
-				return fmt.Errorf("%q target_project_id must be set", key)
-			}
-			if !pointTimeUTC && !oplogTS && !oplogInc {
-				return fmt.Errorf("%q point_in_time_utc_seconds or oplog_ts and oplog_inc must be set", key)
-			}
-			if (oplogTS && !oplogInc) || (!oplogTS && oplogInc) {
-				return fmt.Errorf("%q if oplog_ts or oplog_inc is provided, oplog_inc and oplog_ts must be set", key)
-			}
-			if pointTimeUTC && (oplogTS || oplogInc) {
-				return fmt.Errorf("%q you can't use both point_in_time_utc_seconds and oplog_ts or oplog_inc", key)
-			}
+
+		if targetProjectID, ok := v["target_project_id"]; ok && len(targetProjectID.(string)) > 0 {
+			return fmt.Errorf("%q it's not necessary implement target_project_id when you are using download delivery type", key)
 		}
+	}
+
+	if automated || download {
+		return nil
+	}
+
+	pointTimeUTC, pointTimeUTCOk := v["point_in_time_utc_seconds"]
+	isPITSet := pointTimeUTCOk && pointTimeUTC != nil && (pointTimeUTC.(int) > 0)
+	oplogTs, oplogTsOk := v["oplog_ts"]
+	isOpTsSet := oplogTsOk && oplogTs != nil && (oplogTs.(int) > 0)
+	oplogInc, oplogIncOk := v["oplog_inc"]
+	isOpIncSet := oplogIncOk && oplogInc != nil && (oplogInc.(int) > 0)
+
+	if !isPITSet && !(isOpTsSet && isOpIncSet) {
+		return fmt.Errorf("%q point_in_time_utc_seconds or oplog_ts and oplog_inc must be set", key)
+	}
+	if isPITSet && (isOpTsSet || isOpIncSet) {
+		return fmt.Errorf("%q you can't use both point_in_time_utc_seconds and oplog_ts or oplog_inc", key)
 	}
 
 	return nil

--- a/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
@@ -60,7 +60,7 @@ In addition to all arguments above, the following attributes are exported:
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.

--- a/website/docs/d/cloud_backup_snapshot_restore_jobs.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_jobs.html.markdown
@@ -67,7 +67,7 @@ In addition to all arguments above, the following attributes are exported:
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.

--- a/website/docs/d/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot_restore_job.html.markdown
@@ -62,7 +62,7 @@ In addition to all arguments above, the following attributes are exported:
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.

--- a/website/docs/d/cloud_provider_snapshot_restore_jobs.html.markdown
+++ b/website/docs/d/cloud_provider_snapshot_restore_jobs.html.markdown
@@ -69,7 +69,7 @@ In addition to all arguments above, the following attributes are exported:
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.

--- a/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: mongodbatlas_cloud_backup_snapshot_restore_job
 
-`mongodbatlas_cloud_backup_snapshot_restore_job` provides a resource to create a new restore job from a cloud backup snapshot of a specified cluster. The restore job can be one of three types: 
+`mongodbatlas_cloud_backup_snapshot_restore_job` provides a resource to create a new restore job from a cloud backup snapshot of a specified cluster. The restore job must define one of three delivery types: 
 * **automated:** Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId.
 
 * **download:** Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. The contents of the archive contain the data files for your Atlas cluster.
@@ -92,17 +92,23 @@ description: |-
 * `project_id` - (Required) The unique identifier of the project for the Atlas cluster whose snapshot you want to restore.
 * `cluster_name` - (Required) The name of the Atlas cluster whose snapshot you want to restore.
 * `snapshot_id` - (Required) Unique identifier of the snapshot to restore.
-* `delivery_type_config` - (Required) Type of restore job to create. Possible values are: **download** or **automated**, only one must be set it in ``true``.
+* `delivery_type_config` - (Required) Type of restore job to create. Possible configurations are: **download**, **automated**, or **pointInTime** only one must be set it in ``true``.
+* `delivery_type_config.automated` - Set to `true` to use the automated configuration.
+* `delivery_type_config.download` - Set to `true` to use the download configuration.
+* `delivery_type_config.pointInTime` - Set to `true` to use the pointInTime configuration.
+* `delivery_type_config.target_cluster_name` - Name of the target Atlas cluster to which the restore job restores the snapshot. Required for **automated** and **pointInTime**.
+* `delivery_type_config.target_project_id` - Name of the target Atlas cluster to which the restore job restores the snapshot. Required for **automated** and **pointInTime**.
+* `delivery_type_config.oplog_ts` - Optional setting for **pointInTime** configuration. Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
+* `delivery_type_config.oplog_inc` - Optional setting for **pointInTime** configuration. Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp. Used in conjunction with `oplog_ts`.
+* `delivery_type_config.point_in_time_utc_seconds` - Optional setting for **pointInTime** configuration. Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot. Used instead of oplog settings.
 
 ### Download
 Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. 
 
 ### Automated
-Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId. if you want to use automated delivery type, you must to set the following arguments:
+Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetProjectId. if you want to use automated delivery type, you must to set the arguments for the afformentioned properties.
 
-* `target_cluster_name` - (Required) 	Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
-* `target_group_id` - (Required) 	Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
-
+### Point in time
 
 ## Attributes Reference
 
@@ -119,7 +125,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` -	The Terraform's unique identifier used internally for state management.
 * `links` -	One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot.

--- a/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot_restore_job.html.markdown
@@ -104,7 +104,7 @@ Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId.
 Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId. if you want to use automated delivery type, you must to set the following arguments:
 
 * `target_cluster_name` - (Required) 	Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
-* `target_group_id` - (Required) 	Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+* `target_project_id` - (Required) 	Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
 
 
 ## Attributes Reference
@@ -122,7 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` -	The Terraform's unique identifier used internally for state management.
 * `links` -	One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
-* `target_group_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
+* `target_project_id` -	Name of the target Atlas project of the restore job. Only visible if deliveryType is automated.
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot.


### PR DESCRIPTION
## Description

Fixes an issue with `mongodbatlas_cloud_backup_snapshot_restore_job.delivery_type_config`, where the provider had incorrect logic when validating the delivery configuration

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
