### PR TITLE
Removed disk_size_gb settings from tests

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule_test.go
@@ -88,8 +88,7 @@ func testAccDataSourceMongoDBAtlasCloudBackupScheduleConfig(projectID, clusterNa
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -119,8 +118,7 @@ func testAccDataSourceMongoDBAtlasCloudBackupScheduleWithPoliciesConfig(projectI
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
@@ -42,8 +42,7 @@ func testAccMongoDBAtlasDataSourceCloudBackupSnapshotRestoreJobConfig(projectID,
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "US_EAST_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_jobs_test.go
@@ -69,8 +69,7 @@ func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobsConfig(projectID, clusterN
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "EU_CENTRAL_1"
@@ -106,8 +105,7 @@ func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobsConfigWithPagination(proje
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_test.go
@@ -42,8 +42,7 @@ func testAccMongoDBAtlasDataSourceCloudBackupSnapshotConfig(projectID, clusterNa
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "US_EAST_2"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshots_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshots_test.go
@@ -64,8 +64,7 @@ func testAccMongoDBAtlasDataSourceCloudBackupSnapshotsConfig(projectID, clusterN
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "EU_CENTRAL_1"
@@ -92,8 +91,7 @@ func testAccMongoDBAtlasDataSourceCloudBackupSnapshotsConfigWithPagination(proje
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
@@ -34,8 +34,7 @@ func testAccMongoDBAtlasDataSourceCloudProviderSnapshotBackupPolicyConfig(projec
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -42,8 +42,7 @@ func testAccMongoDBAtlasDataSourceCloudProviderSnapshotRestoreJobConfig(projectI
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_restore_jobs_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_restore_jobs_test.go
@@ -69,8 +69,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobsConfig(projectID, cluste
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -106,8 +105,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobsConfigWithPagination(pro
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshot_test.go
@@ -42,8 +42,7 @@ func testAccMongoDBAtlasDataSourceCloudProviderSnapshotConfig(projectID, cluster
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshots_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_snapshots_test.go
@@ -64,8 +64,7 @@ func testAccMongoDBAtlasDataSourceCloudProviderSnapshotsConfig(projectID, cluste
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -92,8 +91,7 @@ func testAccMongoDBAtlasDataSourceCloudProviderSnapshotsConfigWithPagination(pro
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/data_source_mongodbatlas_ldap_verify_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_ldap_verify_test.go
@@ -57,8 +57,7 @@ func testAccMongoDBAtlasDataSourceLDAPVerifyConfig(projectName, orgID, clusterNa
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = mongodbatlas_project.test.id
 			name         = "%[3]s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -382,8 +382,7 @@ func testAccMongoDBAtlasCloudBackupScheduleConfigNoPolicies(projectID, clusterNa
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -407,8 +406,7 @@ func testAccMongoDBAtlasCloudBackupScheduleDefaultConfig(projectID, clusterName 
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -453,8 +451,7 @@ func testAccMongoDBAtlasCloudBackupScheduleOnePolicyConfig(projectID, clusterNam
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -484,8 +481,7 @@ func testAccMongoDBAtlasCloudBackupScheduleNewPoliciesConfig(projectID, clusterN
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -556,8 +552,7 @@ func testAccMongoDBAtlasCloudBackupScheduleAdvancedPoliciesConfig(projectID, clu
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -623,8 +618,7 @@ provider "aws" {
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-	  
+  	  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "US_WEST_2"

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
@@ -188,8 +188,7 @@ func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigAutomated(projectID, 
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   // Provider Settings "block"
   provider_name               = "AWS"
   provider_region_name        = "US_EAST_1"
@@ -223,8 +222,7 @@ func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigDownload(projectID, c
 resource "mongodbatlas_cluster" "my_cluster" {
   project_id   = %[1]q
   name         = %[2]q
-  disk_size_gb = 5
-
+  
   provider_name               = "AWS"
   provider_region_name        = "US_EAST_1"
   provider_instance_size_name = "M10"

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_backup_policy_test.go
@@ -201,8 +201,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotBackupPolicyConfig(projectID, clust
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"
@@ -260,8 +259,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotBackupPolicyConfigWithoutRestoreDay
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "EU_CENTRAL_1"

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_snapshot_restore_job_test.go
@@ -189,8 +189,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigAutomated(projectID
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%[1]s"
 			name         = "%[2]s"
-			disk_size_gb = 5
-
+			
 		// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_1"
@@ -224,8 +223,7 @@ func testAccMongoDBAtlasCloudProviderSnapshotRestoreJobConfigDownload(projectID,
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "%s"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_1"
 			provider_instance_size_name = "M10"

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -1768,8 +1768,7 @@ func testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegi
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%[3]s"
 			name         = "%[6]s"
-			disk_size_gb = 5
-
+			
             cluster_type = "REPLICASET"
 		    replication_specs {
 			  num_shards = 1
@@ -1840,9 +1839,8 @@ func testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretK
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%[3]s"
 			name         = "%[4]s"
-			disk_size_gb = 5
-
-            cluster_type = "REPLICASET"
+			
+			cluster_type = "REPLICASET"
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
@@ -1897,10 +1895,9 @@ func testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion,
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%[3]s"
 			name         = "%[4]s"
-			disk_size_gb = 5
-
+			
             cluster_type = "REPLICASET"
-		    replication_specs {
+			replication_specs {
 			  num_shards = 1
 			  regions_config {
 			     region_name     = "%[6]s"

--- a/mongodbatlas/resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_database_user_test.go
@@ -841,8 +841,7 @@ func testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, 
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = "${mongodbatlas_project.test.id}"
 			name         = "%s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"

--- a/mongodbatlas/resource_mongodbatlas_ldap_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_configuration_test.go
@@ -221,8 +221,7 @@ func testAccMongoDBAtlasLDAPConfigurationWithVerifyConfig(projectName, orgID, cl
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = mongodbatlas_project.test.id
 			name         = "%[3]s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"

--- a/mongodbatlas/resource_mongodbatlas_ldap_verify_test.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_verify_test.go
@@ -197,8 +197,7 @@ func testAccMongoDBAtlasLDAPVerifyConfig(projectName, orgID, clusterName, hostna
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = mongodbatlas_project.test.id
 			name         = "%[3]s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"
@@ -226,8 +225,7 @@ func testAccMongoDBAtlasLDAPVerifyWithConfigurationConfig(projectName, orgID, cl
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = mongodbatlas_project.test.id
 			name         = "%[3]s"
-			disk_size_gb = 5
-
+			
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_region_name        = "US_EAST_2"


### PR DESCRIPTION
## Description

Disk size in tests was set to too low of an amount, removing the optional param to allow it to use an acceptable default.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
