### PR TITLE
INTMDB-363: [Updated Feature] Add serverless backup to mongodbatlas_serverless_instance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.5.0
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210625132053-af2d5c0ad54f
-	go.mongodb.org/atlas v0.16.1-0.20220531163122-551edbfb2f27
+	go.mongodb.org/atlas v0.16.1-0.20220823081124-819fb5448bfe
 	go.mongodb.org/realm v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1234,8 +1234,8 @@ go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQc
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
-go.mongodb.org/atlas v0.16.1-0.20220531163122-551edbfb2f27 h1:rGTb8CaE9ZKNjmdUJ58jFcHopLg6o6Kzfm9AIayq1Hw=
-go.mongodb.org/atlas v0.16.1-0.20220531163122-551edbfb2f27/go.mod h1:lQhRHIxc6jQHEK3/q9WLu/SdBkPj2fQYhjLGUF6Z3U8=
+go.mongodb.org/atlas v0.16.1-0.20220823081124-819fb5448bfe h1:jmRFnzQejpiVo7xsPSCUYOqIzltc9Z95UuLr5fy5+qM=
+go.mongodb.org/atlas v0.16.1-0.20220823081124-819fb5448bfe/go.mod h1:GUuW7/ZrHzCO0o47aiqhokN0N6i0GM3yraRyHIBTykU=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instance.go
@@ -66,6 +66,10 @@ func dataSourceMongoDBAtlasServerlessInstanceRead(ctx context.Context, d *schema
 		return diag.Errorf("error setting `state_name` for serverless instance (%s): %s", d.Id(), err)
 	}
 
+	if err := d.Set("continuous_backup_enabled", serverlessInstance.ServerlessBackupOptions.ServerlessContinuousBackupEnabled); err != nil {
+		return diag.Errorf("error setting `state_name` for serverless instance (%s): %s", d.Id(), err)
+	}
+
 	d.SetId(encodeStateID(map[string]string{
 		"project_id": projectID.(string),
 		"name":       instanceName.(string),
@@ -130,6 +134,11 @@ func returnServerlessInstanceDSSchema() map[string]*schema.Schema {
 		},
 		"state_name": {
 			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"continuous_backup_enabled": {
+			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
 		},

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
@@ -29,6 +29,7 @@ func TestAccDataSourceMongoDBAtlasServerlessInstance_byName(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "state_name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "create_date"),
 					resource.TestCheckResourceAttrSet(datasourceName, "mongo_db_version"),
+					resource.TestCheckResourceAttrSet(datasourceName, "continuous_backup_enabled"),
 				),
 			},
 		},

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instances.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instances.go
@@ -102,6 +102,7 @@ func flattenServerlessInstances(serverlessInstances []*matlas.Cluster) []map[str
 			"provider_settings_region_name":           serverlessInstances[i].ProviderSettings.RegionName,
 			"provider_settings_provider_name":         serverlessInstances[i].ProviderSettings.ProviderName,
 			"state_name":                              serverlessInstances[i].StateName,
+			"continuous_backup_enabled":               serverlessInstances[i].ServerlessBackupOptions.ServerlessContinuousBackupEnabled,
 		}
 	}
 

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instances_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instances_test.go
@@ -29,6 +29,7 @@ func TestAccDataSourceMongoDBAtlasServerlessInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.state_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.continuous_backup_enabled"),
 				),
 			},
 		},

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -416,13 +416,13 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 }
 
 /*
-	This assumes the project CRUD outcome will be the same for any non-zero number of dependents
+This assumes the project CRUD outcome will be the same for any non-zero number of dependents
 
-	If all dependents are deleting, wait to try and delete
-	Else consider the aggregate dependents idle.
+If all dependents are deleting, wait to try and delete
+Else consider the aggregate dependents idle.
 
-	If we get a defined error response, return that right away
-	Else retry
+If we get a defined error response, return that right away
+Else retry
 */
 func resourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance.go
@@ -225,6 +225,10 @@ func resourceMongoDBAtlasServerlessInstanceRead(ctx context.Context, d *schema.R
 		return diag.Errorf("error setting `state_name` for serverless instance (%s): %s", d.Id(), err)
 	}
 
+	if err := d.Set("continuous_backup_enabled", serverlessInstance.ServerlessBackupOptions.ServerlessContinuousBackupEnabled); err != nil {
+		return diag.Errorf("error setting `continuous_backup_enabled` for serverless instance (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
@@ -127,6 +127,7 @@ func testAccMongoDBAtlasServerlessInstanceConfig(projectID, name string) string 
 			provider_settings_backing_provider_name = "AWS"
 			provider_settings_provider_name = "SERVERLESS"
 			provider_settings_region_name = "US_EAST_1"
+			continuous_backup_enabled = true
 		}
 
 	`, projectID, name)

--- a/website/docs/d/serverless_instance.html.markdown
+++ b/website/docs/d/serverless_instance.html.markdown
@@ -41,5 +41,6 @@ data "mongodbatlas_serverless_instance" "test_two" {
 * `provider_settings_provider_name` - Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
 * `state_name` - Stage of deployment of this serverless instance when the resource made its request.
+* `continuous_backup_enabled` - Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
 
 For more information see: [MongoDB Atlas API - Serverless Instance](https://docs.atlas.mongodb.com/reference/api/serverless-instances/) Documentation.

--- a/website/docs/d/serverless_instances.html.markdown
+++ b/website/docs/d/serverless_instances.html.markdown
@@ -42,6 +42,7 @@ data "mongodbatlas_serverless_instances" "data_serverless" {
 * `provider_settings_provider_name` - Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
 * `state_name` - Stage of deployment of this serverless instance when the resource made its request.
+* `continuous_backup_enabled` - Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
 
 
 

--- a/website/docs/r/serverless_instance.html.markdown
+++ b/website/docs/r/serverless_instance.html.markdown
@@ -24,7 +24,6 @@ resource "mongodbatlas_serverless_instance" "test" {
   provider_settings_backing_provider_name = "AWS"
   provider_settings_provider_name = "SERVERLESS"
   provider_settings_region_name = "US_EAST_1"
-  continuous_backup_enabled = true
 }
 ```
 
@@ -36,7 +35,7 @@ resource "mongodbatlas_serverless_instance" "test" {
 * `provider_settings_provider_name` - (Required) Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - (Required) 	
   Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
-* `continuous_backup_enabled` - (Optional) Flag that indicates whether the serverless instance uses Serverless Continuous Backup. If this parameter is false, the serverless instance uses Basic Backup. 
+* `continuous_backup_enabled` - (Optional) Flag that indicates whether the serverless instance uses [Serverless Continuous Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup). If this parameter is false or not used, the serverless instance uses [Basic Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup).  
 
 ## Attributes Reference
 

--- a/website/docs/r/serverless_instance.html.markdown
+++ b/website/docs/r/serverless_instance.html.markdown
@@ -24,6 +24,7 @@ resource "mongodbatlas_serverless_instance" "test" {
   provider_settings_backing_provider_name = "AWS"
   provider_settings_provider_name = "SERVERLESS"
   provider_settings_region_name = "US_EAST_1"
+  continuous_backup_enabled = true
 }
 ```
 
@@ -35,6 +36,7 @@ resource "mongodbatlas_serverless_instance" "test" {
 * `provider_settings_provider_name` - (Required) Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - (Required) 	
   Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
+* `continuous_backup_enabled` - (Optional) Flag that indicates whether the serverless instance uses Serverless Continuous Backup. If this parameter is false, the serverless instance uses Basic Backup. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

[Updated Feature] Add serverless backup to mongodbatlas_serverless_instance

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
