### PR TITLE
INTMDB-387: Enable Azure NVME for Atlas Dedicated clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/go-test/deep v1.0.8
-	github.com/gruntwork-io/terratest v0.40.20
+	github.com/gruntwork-io/terratest v0.40.21
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20210625223728-379bcb41c06b
 	github.com/mongodb-forks/digest v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -618,8 +618,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqC
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.40.20 h1:pco6s3b62h2Yd13N+HvHQVTAk3aPRz4sdoVwErPCBzQ=
-github.com/gruntwork-io/terratest v0.40.20/go.mod h1:JGeIGgLbxbG9/Oqm06z6YXVr76CfomdmLkV564qov+8=
+github.com/gruntwork-io/terratest v0.40.21 h1:BYN/CamnMIHPFqE2Jh+XwaFT0RSZhnlBCOXeImxWrBQ=
+github.com/gruntwork-io/terratest v0.40.21/go.mod h1:JGeIGgLbxbG9/Oqm06z6YXVr76CfomdmLkV564qov+8=
 github.com/hashicorp/aws-sdk-go-base v0.7.1 h1:7s/aR3hFn74tYPVihzDyZe7y/+BorN70rr9ZvpV3j3o=
 github.com/hashicorp/aws-sdk-go-base v0.7.1/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1148,7 +1148,7 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 		providerSettings.AutoScaling = &matlas.AutoScaling{Compute: compute}
 	}
 
-	if d.Get("provider_name") == "AWS" {
+	if d.Get("provider_name") == "AWS" || d.Get("provider_name") == "AZURE" {
 		// Check if the Provider Disk IOS sets in the Terraform configuration and if the instance size name is not NVME.
 		// If it didn't, the MongoDB Atlas server would set it to the default for the amount of storage.
 		if v, ok := d.GetOk("provider_disk_iops"); ok && !strings.Contains(providerSettings.InstanceSizeName, "NVME") {

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1148,13 +1148,20 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 		providerSettings.AutoScaling = &matlas.AutoScaling{Compute: compute}
 	}
 
-	if d.Get("provider_name") == "AWS" || d.Get("provider_name") == "AZURE" {
+	if d.Get("provider_name") == "AWS" {
 		// Check if the Provider Disk IOS sets in the Terraform configuration and if the instance size name is not NVME.
 		// If it didn't, the MongoDB Atlas server would set it to the default for the amount of storage.
 		if v, ok := d.GetOk("provider_disk_iops"); ok && !strings.Contains(providerSettings.InstanceSizeName, "NVME") {
 			providerSettings.DiskIOPS = pointy.Int64(cast.ToInt64(v))
 		}
 
+		providerSettings.EncryptEBSVolume = pointy.Bool(true)
+	}
+
+	if d.Get("provider_name") == "AZURE" {
+		if v, ok := d.GetOk("provider_disk_type_name"); ok && !strings.Contains(providerSettings.InstanceSizeName, "NVME") {
+			providerSettings.DiskTypeName = cast.ToString(v)
+		}
 		providerSettings.EncryptEBSVolume = pointy.Bool(true)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -416,13 +416,13 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 }
 
 /*
-	This assumes the project CRUD outcome will be the same for any non-zero number of dependents
+This assumes the project CRUD outcome will be the same for any non-zero number of dependents
 
-	If all dependents are deleting, wait to try and delete
-	Else consider the aggregate dependents idle.
+If all dependents are deleting, wait to try and delete
+Else consider the aggregate dependents idle.
 
-	If we get a defined error response, return that right away
-	Else retry
+If we get a defined error response, return that right away
+Else retry
 */
 func resourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {


### PR DESCRIPTION
## Description

INTMDB-387: Enable Azure NVME for Atlas Dedicated clusters

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
