### PR TITLE
INTMDB-372: [Terraform] Fix failing test for testAccMongoDBAtlasAlertConfigurationConfigWithMatchers 

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration_test.go
@@ -33,8 +33,6 @@ func TestAccDataSourceMongoDBAtlaAlertConfiguration_basic(t *testing.T) {
 }
 
 func TestAccDataSourceMongoDBAtlaAlertConfiguration_withThreshold(t *testing.T) {
-	t.Skip() // TODO: Address failures in v1.4.6
-
 	var (
 		alert          = &matlas.AlertConfiguration{}
 		dataSourceName = "data.mongodbatlas_alert_configuration.test"
@@ -136,7 +134,7 @@ func testAccDSMongoDBAtlasAlertConfigurationConfigWithThreshold(projectID string
 			}
 
 			matcher {
-				field_name = "HOSTNAME_AND_PORT"
+				field_name = "REPLICA_SET_NAME"
 				operator   = "EQUALS"
 				value      = "SECONDARY"
 			}

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
@@ -74,8 +74,6 @@ func TestAccResourceMongoDBAtlasAlertConfiguration_Notifications(t *testing.T) {
 }
 
 func TestAccResourceMongoDBAtlasAlertConfiguration_WithMatchers(t *testing.T) {
-	t.Skip() // TODO: Address failures in v1.4.6
-
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -156,8 +154,6 @@ func TestAccResourceMongoDBAtlasAlertConfiguration_whitMetricUpdated(t *testing.
 }
 
 func TestAccResourceMongoDBAtlasAlertConfiguration_whitThresholdUpdated(t *testing.T) {
-	t.Skip() // TODO: Address failures in v1.4.6
-
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -497,7 +493,7 @@ func testAccMongoDBAtlasAlertConfigurationConfigWithMatchers(projectID string, e
 	return fmt.Sprintf(`
 		resource "mongodbatlas_alert_configuration" "test" {
 			project_id = "%s"
-			event_type = "NO_PRIMARY"
+			event_type = "HOST_DOWN"
 			enabled    = "%t"
 
 			notification {
@@ -608,7 +604,7 @@ func testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(projectID s
 			}
 
 			matcher {
-				field_name = "HOSTNAME_AND_PORT"
+				field_name = "REPLICA_SET_NAME"
 				operator   = "EQUALS"
 				value      = "SECONDARY"
 			}

--- a/mongodbatlas/resource_mongodbatlas_project.go
+++ b/mongodbatlas/resource_mongodbatlas_project.go
@@ -416,13 +416,13 @@ func resourceMongoDBAtlasProjectDelete(ctx context.Context, d *schema.ResourceDa
 }
 
 /*
-	This assumes the project CRUD outcome will be the same for any non-zero number of dependents
+This assumes the project CRUD outcome will be the same for any non-zero number of dependents
 
-	If all dependents are deleting, wait to try and delete
-	Else consider the aggregate dependents idle.
+If all dependents are deleting, wait to try and delete
+Else consider the aggregate dependents idle.
 
-	If we get a defined error response, return that right away
-	Else retry
+If we get a defined error response, return that right away
+Else retry
 */
 func resourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {


### PR DESCRIPTION
## Description

INTMDB-372: [Terraform] Fix failing test for testAccMongoDBAtlasAlertConfigurationConfigWithMatchers 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
