### PR TITLE
INTMDB-386 Defer project_invitation role validation to api

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project_invitation.go
+++ b/mongodbatlas/resource_mongodbatlas_project_invitation.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -54,14 +53,6 @@ func resourceMongoDBAtlasProjectInvitation() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"GROUP_OWNER",
-						"GROUP_CLUSTER_MANAGER",
-						"GROUP_READ_ONLY",
-						"GROUP_DATA_ACCESS_ADMIN",
-						"GROUP_DATA_ACCESS_READ_WRITE",
-						"GROUP_DATA_ACCESS_READ_ONLY",
-					}, false),
 				},
 			},
 		},

--- a/website/docs/d/project_invitation.html.markdown
+++ b/website/docs/d/project_invitation.html.markdown
@@ -41,6 +41,6 @@ In addition to the arguments, this data source exports the following attributes:
 * `created_at` - Timestamp in ISO 8601 date and time format in UTC when Atlas sent the invitation.
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `inviter_username` - Atlas user who invited `username` to the project.
-* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them.
+* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. Refer to the [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#project-roles) for information on valid roles.
 
 See the [MongoDB Atlas Administration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) documentation for more information.

--- a/website/docs/d/project_invitation.html.markdown
+++ b/website/docs/d/project_invitation.html.markdown
@@ -41,12 +41,6 @@ In addition to the arguments, this data source exports the following attributes:
 * `created_at` - Timestamp in ISO 8601 date and time format in UTC when Atlas sent the invitation.
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `inviter_username` - Atlas user who invited `username` to the project.
-* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The following options are available:
-  * GROUP_OWNER
-  * GROUP_CLUSTER_MANAGER
-  * GROUP_READ_ONLY
-  * GROUP_DATA_ACCESS_ADMIN
-  * GROUP_DATA_ACCESS_READ_WRITE
-  * GROUP_DATA_ACCESS_READ_ONLY
+* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them.
 
-See the [MongoDB Atlas Administration API](https://docs.atlas.mongodb.com/reference/api/project-get-one-invitation/) documentation for more information.
+See the [MongoDB Atlas Administration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) documentation for more information.

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 Each invitation for an Atlas user includes roles that Atlas grants the user when they accept the invitation.
 
-The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles) describes the roles a user can have, the [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) denotes the acceptable values.
+The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#project-roles) describes the roles which can be assigned to a user.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find GROUP-ID in the official documentation.
 
@@ -43,7 +43,7 @@ resource "mongodbatlas_project_invitation" "test" {
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies the project to which you want to invite a user.
 * `username` - (Required) Email address to which Atlas sent the invitation. The user uses this email address as their Atlas username if they accept this invitation.
-* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. Refer to the [Atlas Docs](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) for the list of acceptable roles.
+* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them.
 
 ## Attributes Reference
 
@@ -54,6 +54,8 @@ In addition to all arguments above, the following attributes are exported:
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `invitation_id` - Unique 24-hexadecimal digit string that identifies the invitation in Atlas.
 * `inviter_username` - Atlas user who invited `username` to the project.
+
+See the [MongoDB Atlas Administration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) documentation for more information.
 
 ## Import
 

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -12,14 +12,7 @@ description: |-
 
 Each invitation for an Atlas user includes roles that Atlas grants the user when they accept the invitation.
 
-The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles) describes the roles a user can have, which map to:
-
-* GROUP_OWNER
-* GROUP_CLUSTER_MANAGER
-* GROUP_READ_ONLY
-* GROUP_DATA_ACCESS_ADMIN
-* GROUP_DATA_ACCESS_READ_WRITE
-* GROUP_DATA_ACCESS_READ_ONLY
+The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#project-roles) describes the roles a user can have, the [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) denotes the acceptable values.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find GROUP-ID in the official documentation.
 
@@ -50,13 +43,7 @@ resource "mongodbatlas_project_invitation" "test" {
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies the project to which you want to invite a user.
 * `username` - (Required) Email address to which Atlas sent the invitation. The user uses this email address as their Atlas username if they accept this invitation.
-* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. Atlas accepts the following roles:
-  * GROUP_OWNER
-  * GROUP_CLUSTER_MANAGER
-  * GROUP_READ_ONLY
-  * GROUP_DATA_ACCESS_ADMIN
-  * GROUP_DATA_ACCESS_READ_WRITE
-  * GROUP_DATA_ACCESS_READ_ONLY
+* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. Refer to the [Atlas Docs](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#operation/inviteOneMongoDBCloudUserToJoinOneProject) for the list of acceptable roles.
 
 ## Attributes Reference
 

--- a/website/docs/r/project_invitation.html.markdown
+++ b/website/docs/r/project_invitation.html.markdown
@@ -43,7 +43,7 @@ resource "mongodbatlas_project_invitation" "test" {
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies the project to which you want to invite a user.
 * `username` - (Required) Email address to which Atlas sent the invitation. The user uses this email address as their Atlas username if they accept this invitation.
-* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them.
+* `roles` - (Required) List of Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. Refer to the [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#project-roles) for information on valid roles.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Defer project_invitation role validation to the atlas api, updated the documentation to match

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
