### PR TITLE
INTMDB-371: PrivateLink Endpoint Timeout

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
@@ -132,7 +132,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointCreate(ctx context.Context, d *schem
 		Pending:    []string{"INITIATING", "DELETING"},
 		Target:     []string{"WAITING_FOR_USER", "FAILED", "DELETED", "AVAILABLE"},
 		Refresh:    resourcePrivateLinkEndpointRefreshFunc(ctx, conn, projectID, providerName, privateEndpointConn.ID),
-		Timeout:    1 * time.Hour,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      3 * time.Second,
 	}
@@ -250,7 +250,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointDelete(ctx context.Context, d *schem
 		Pending:    []string{"DELETING"},
 		Target:     []string{"DELETED", "FAILED"},
 		Refresh:    resourcePrivateLinkEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID),
-		Timeout:    1 * time.Hour,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 		Delay:      3 * time.Second,
 	}

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
@@ -105,6 +105,10 @@ func resourceMongoDBAtlasPrivateLinkEndpoint() *schema.Resource {
 				},
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Hour),
+			Delete: schema.DefaultTimeout(1 * time.Hour),
+		},
 	}
 }
 

--- a/website/docs/d/privatelink_endpoint.html.markdown
+++ b/website/docs/d/privatelink_endpoint.html.markdown
@@ -33,7 +33,7 @@ data "mongodbatlas_privatelink_endpoint" "test" {
 * `project_id` - (Required) Unique identifier for the project.
 * `private_link_id` - (Required) Unique identifier of the private endpoint service that you want to retrieve.
 * `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
-* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `10m`
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
 
 
 ## Attributes Reference

--- a/website/docs/d/privatelink_endpoint.html.markdown
+++ b/website/docs/d/privatelink_endpoint.html.markdown
@@ -33,7 +33,6 @@ data "mongodbatlas_privatelink_endpoint" "test" {
 * `project_id` - (Required) Unique identifier for the project.
 * `private_link_id` - (Required) Unique identifier of the private endpoint service that you want to retrieve.
 * `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
-* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
 
 
 ## Attributes Reference

--- a/website/docs/d/privatelink_endpoint.html.markdown
+++ b/website/docs/d/privatelink_endpoint.html.markdown
@@ -33,6 +33,7 @@ data "mongodbatlas_privatelink_endpoint" "test" {
 * `project_id` - (Required) Unique identifier for the project.
 * `private_link_id` - (Required) Unique identifier of the private endpoint service that you want to retrieve.
 * `provider_name` - (Required) Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `10m`
 
 
 ## Attributes Reference
@@ -55,6 +56,6 @@ In addition to all arguments above, the following attributes are exported:
 * `private_link_service_resource_id` - Resource ID of the Azure Private Link Service that Atlas manages.
 * `endpoint_group_names` - GCP network endpoint groups corresponding to the Private Service Connect endpoint service.
 * `region_name` - GCP region for the Private Service Connect endpoint service.
-* `service_attachment_names` - Unique alphanumeric and special character strings that identify the service attachments associated with the GCP Private Service Connect endpoint service. 
+* `service_attachment_names` - Unique alphanumeric and special character strings that identify the service attachments associated with the GCP Private Service Connect endpoint service.
 
 See [MongoDB Atlas API](https://docs.atlas.mongodb.com/reference/api/private-endpoints-service-get-one/) Documentation for more information.

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -35,6 +35,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 * `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws), [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure) and [GCP regions](https://docs.atlas.mongodb.com/reference/google-gcp/#std-label-google-gcp)
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
 
 
 ## Attributes Reference

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -26,6 +26,11 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
   project_id    = "<PROJECT-ID>"
   provider_name = "AWS/AZURE"
   region        = "US_EAST_1"
+
+  timeouts {
+    create = "30m"
+    delete = "20m"
+  }
 }
 ```
 
@@ -35,7 +40,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 * `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws), [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure) and [GCP regions](https://docs.atlas.mongodb.com/reference/google-gcp/#std-label-google-gcp)
-* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
+* `timeouts`- (Optional) The duration of time to wait for private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
 
 
 ## Attributes Reference

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -40,7 +40,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 * `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws), [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure) and [GCP regions](https://docs.atlas.mongodb.com/reference/google-gcp/#std-label-google-gcp)
-* `timeouts`- (Optional) The duration of time to wait for private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
 
 
 ## Attributes Reference

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -40,7 +40,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 * `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws), [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure) and [GCP regions](https://docs.atlas.mongodb.com/reference/google-gcp/#std-label-google-gcp)
-* `timeouts`- (Optional) The duration of time to wait for Private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `1h`
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `1h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

Updated default timeout on privatelink_endpoint Create & Delete to match the state change refresh timeout for these actions.
- Timeout bumped from 20m to 60m
- Enables configuration of timeout a'la https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts
- Refresh func honors configured timeout

Link to any related issue(s):
Closes #806

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
