### PR TITLE
Don't force recreation of `mongodbatlas_project_ip_access_list` on comment update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [v1.4.6-pre.1](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.6-pre.1) (2022-09-15)
+## [v1.4.6](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.6) (2022-09-19)
 
-[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.5...v1.4.6-pre.1)
+[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.5...v1.4.6)
 
 **Fixed**
 - INTMDB-387 - [Terraform] Enable Azure NVME for Atlas Dedicated clusters [\#833](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/833)

--- a/mongodbatlas/resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/resource_mongodbatlas_project_ip_access_list.go
@@ -84,7 +84,6 @@ func resourceMongoDBAtlasProjectIPAccessList() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 		},


### PR DESCRIPTION
## Description

When trying to update the comment in a `mongodbatlas_project_ip_access_list` the provider is recreating the resource even though the Atlas UI allows updating the comment of an existing IP access list.

Link to any related issue(s):

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
