### PR TITLE
INTMDB-405: [Terraform] Add cluster label to advanced clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [v1.4.6-pre.1](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.6-pre.1) (2022-09-15)
+## [v1.4.6](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.4.6) (2022-09-19)
 
-[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.5...v1.4.6-pre.1)
+[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.5...v1.4.6)
 
 **Fixed**
 - INTMDB-387 - [Terraform] Enable Azure NVME for Atlas Dedicated clusters [\#833](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/833)

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -315,14 +315,10 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 		request.EncryptionAtRestProvider = v.(string)
 	}
 
-	if _, ok := d.GetOk("labels"); ok {
-		if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
-			return diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
-		}
-		request.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
-	} else {
-		request.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
+	if _, ok := d.GetOk("labels"); ok && containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
+		return diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
 	}
+	request.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
 
 	if v, ok := d.GetOk("mongo_db_major_version"); ok {
 		request.MongoDBMajorVersion = formatMongoDBMajorVersion(v.(string))

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -320,6 +320,8 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 			return diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
 		}
 		request.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
+	} else {
+		request.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
 	}
 
 	if v, ok := d.GetOk("mongo_db_major_version"); ok {

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -48,6 +48,7 @@ func TestAccResourceMongoDBAtlasAdvancedCluster_basicTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
## Description

INTMDB-405: [Terraform] Add cluster label to advanced clusters
Change logic to append default label even if no labels supplied

Link to any related issue(s):


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
