### PR TITLE
Docs: fix custom_dns_configuration_cluster_aws

### DIFF
--- a/website/docs/r/custom_dns_configuration_cluster_aws.markdown
+++ b/website/docs/r/custom_dns_configuration_cluster_aws.markdown
@@ -39,4 +39,4 @@ Custom DNS Configuration for Atlas Clusters on AWS must be imported using Projec
 $ terraform import mongodbatlas_custom_dns_configuration_cluster_aws.test 1112222b3bf99403840e8934
 ```
 
-See detailed information for arguments and attributes: [MongoDB API Custom DNS Configuration for Atlas Clusters on AWS](https://docs.atlas.mongodb.com/reference/api/aws-custom-dns)
+See detailed information for arguments and attributes: [MongoDB API Custom DNS Configuration for Atlas Clusters on AWS](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Custom-DNS-for-Atlas-Clusters-Deployed-to-AWS)

--- a/website/docs/r/custom_dns_configuration_cluster_aws.markdown
+++ b/website/docs/r/custom_dns_configuration_cluster_aws.markdown
@@ -33,7 +33,7 @@ resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
 
 
 ## Import
-Custom DNS Configuration for Atlas Clusters on AWS must be imported using auditing ID, e.g.
+Custom DNS Configuration for Atlas Clusters on AWS must be imported using Project ID, e.g.
 
 ```
 $ terraform import mongodbatlas_custom_dns_configuration_cluster_aws.test 1112222b3bf99403840e8934


### PR DESCRIPTION
## Description

The import of this resource should performed using the project ID, not the auditing ID. I think the reference to the "Auditing ID" is a typo and I've been able to import this resource using the project ID (Group ID).

References:
https://www.mongodb.com/docs/atlas/reference/api/aws-custom-dns-get/
https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/custom_dns_configuration_cluster_aws


Link to any related issue(s):
N/A

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
