### PR TITLE
Relying on atlas api for unit validation on alert configuration

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -126,23 +126,6 @@ func resourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 						"units": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"RAW",
-								"BITS",
-								"BYTES",
-								"KILOBITS",
-								"KILOBYTES",
-								"MEGABITS",
-								"MEGABYTES",
-								"GIGABITS",
-								"GIGABYTES",
-								"TERABYTES",
-								"PETABYTES",
-								"MILLISECONDS",
-								"SECONDS",
-								"MINUTES",
-								"HOURS",
-								"DAYS"}, false),
 						},
 						"mode": {
 							Type:     schema.TypeString,

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -155,24 +155,7 @@ The threshold that causes an alert to be triggered. Required if `event_type_name
 
 * `threshold` - Threshold value outside of which an alert will be triggered.
 * `units` - The units for the threshold value. Depends on the type of metric.
-  Accepted values are:
-    - `RAW`
-    - `BITS`
-    - `BYTES`
-    - `KILOBITS`
-    - `KILOBYTES`
-    - `MEGABITS`
-    - `MEGABYTES`
-    - `GIGABITS`
-    - `GIGABYTES`
-    - `TERABYTES`
-    - `PETABYTES`
-    - `MILLISECONDS`
-    - `SECONDS`
-    - `MINUTES`
-    - `HOURS`
-    - `DAYS`
-
+  Refer to the [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-get-config/#request-body-parameters) for a list of accepted values.
 * `mode` - This must be set to AVERAGE. Atlas computes the current metric value as an average.
 
 ### Threshold Config (`threshold_config`)
@@ -183,23 +166,7 @@ The threshold that causes an alert to be triggered. Required if `event_type_name
 
 * `threshold` - Threshold value outside of which an alert will be triggered.
 * `units` - The units for the threshold value. Depends on the type of metric.
-    Accepted values are:
-      - `RAW`
-      - `BITS`
-      - `BYTES`
-      - `KILOBITS`
-      - `KILOBYTES`
-      - `MEGABITS`
-      - `MEGABYTES`
-      - `GIGABITS`
-      - `GIGABYTES`
-      - `TERABYTES`
-      - `PETABYTES`
-      - `MILLISECONDS`
-      - `SECONDS`
-      - `MINUTES`
-      - `HOURS`
-      - `DAYS`
+  Refer to the [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-get-config/#request-body-parameters) for a list of accepted values.
 
 ### Notifications
 Notifications to send when an alert condition is detected.

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -178,23 +178,7 @@ The threshold that causes an alert to be triggered. Required if `event_type_name
 
 * `threshold` - Threshold value outside of which an alert will be triggered.
 * `units` - The units for the threshold value. Depends on the type of metric.
-  Accepted values are:
-    - `RAW`
-    - `BITS`
-    - `BYTES`
-    - `KILOBITS`
-    - `KILOBYTES`
-    - `MEGABITS`
-    - `MEGABYTES`
-    - `GIGABITS`
-    - `GIGABYTES`
-    - `TERABYTES`
-    - `PETABYTES`
-    - `MILLISECONDS`
-    - `SECONDS`
-    - `MINUTES`
-    - `HOURS`
-    - `DAYS`
+  Refer to the [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-get-config/#request-body-parameters) for a list of accepted values.
 
 * `mode` - This must be set to AVERAGE. Atlas computes the current metric value as an average.
 
@@ -206,23 +190,7 @@ The threshold that causes an alert to be triggered. Required if `event_type_name
 
 * `threshold` - Threshold value outside of which an alert will be triggered.
 * `units` - The units for the threshold value. Depends on the type of metric.
-    Accepted values are:
-      - `RAW`
-      - `BITS`
-      - `BYTES`
-      - `KILOBITS`
-      - `KILOBYTES`
-      - `MEGABITS`
-      - `MEGABYTES`
-      - `GIGABITS`
-      - `GIGABYTES`
-      - `TERABYTES`
-      - `PETABYTES`
-      - `MILLISECONDS`
-      - `SECONDS`
-      - `MINUTES`
-      - `HOURS`
-      - `DAYS`
+  Refer to the [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-get-config/#request-body-parameters) for a list of accepted values.
 
 ### Notifications
 List of notifications to send when an alert condition is detected.


### PR DESCRIPTION
## Description
Update alert configuration to defer unit validation atlas api.
An alternative solution would've been to update the ValidateFunc to support the following values
- NANOSECONDS
- MILLION_MINUTES
- RPU
- THOUSAND_RPU
- MILLION_RPU
- WPU
- THOUSAND_WPU
- MILLION_WPU

The above values were gathered from the following documentation under `metricThreshold.units` https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-get-config/#request-path-parameters

Closes #854

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
