### PR TITLE
INTMDB-384 Fix PrivateLink test flakiness

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -14,7 +14,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_basic(t *testing.T
 	var (
 		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		endpointID    = "vpce-jjg5e24qp93513h03"
+		endpointID    = "vpce-jjg5e24qp93513h04"
 		commentOrigin = "this is a comment for adl private link endpoint"
 		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
@@ -102,11 +102,11 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy(state *terrafo
 func testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, comment string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_privatelink_endpoint_service_adl" "test" {
-			project_id   = "%[1]s"
-			endpoint_id  = "%[2]s"
-			comment      = "%[3]s"
-			type		 = "DATA_LAKE"
-			provider_name	 = "AWS"
+			project_id    = "%[1]s"
+			endpoint_id   = "%[2]s"
+			comment       = "%[3]s"
+			type          = "DATA_LAKE"
+			provider_name = "AWS"
 		}
 	`, projectID, endpointID, comment)
 }

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -19,7 +19,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_basic(t *testing.T
 		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy,
@@ -52,10 +52,10 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_importBasic(t *tes
 	var (
 		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		endpointID    = "vpce-jjg5e24qp93513h03"
+		endpointID    = "vpce-jjg5e24qp93513h04"
 		commentOrigin = "this is a comment for adl private link endpoint"
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasSearchIndexDestroy,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -14,7 +14,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_basic(t *testing.T
 	var (
 		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		endpointID    = "vpce-jjg5e24qp93513h04"
+		endpointID    = "vpce-jjg5e24qp93513h03"
 		commentOrigin = "this is a comment for adl private link endpoint"
 		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
@@ -52,7 +52,7 @@ func TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL_importBasic(t *tes
 	var (
 		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		endpointID    = "vpce-jjg5e24qp93513h04"
+		endpointID    = "vpce-jjg5e24qp93513h03"
 		commentOrigin = "this is a comment for adl private link endpoint"
 	)
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Description

Updated PrivateLink tests to run in series, as they use the same project & endpoint, which could cause an issue where one test deleted a resource that another test was attempting to update.

Re-creation of the bug accomplished with the following
```
TF_ACC=1 $GO test -timeout 60m -run ^TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceADL github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas
```

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
