### PR TITLE
Fix failing cluster paused test

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -1134,9 +1134,7 @@ func getUpgradeRequest(d *schema.ResourceData) *matlas.Cluster {
 	updatedRegion := updatedSpecs[0].RegionConfigs[0]
 	currentSize := currentRegion.ElectableSpecs.InstanceSize
 
-	if currentRegion.ElectableSpecs.InstanceSize == updatedRegion.ElectableSpecs.InstanceSize || !(currentSize == "M0" ||
-		currentSize == "M2" ||
-		currentSize == "M5") {
+	if currentRegion.ElectableSpecs.InstanceSize == updatedRegion.ElectableSpecs.InstanceSize || !isSharedTier(currentSize) {
 		return nil
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -953,7 +953,7 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if d.Get("paused").(bool) && !isSharedTier(d.Get("provider_instnace_size_name").(string)) {
+	if d.Get("paused").(bool) && !isSharedTier(d.Get("provider_instance_size_name").(string)) {
 		clusterRequest := &matlas.Cluster{
 			Paused: pointy.Bool(true),
 		}

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1243,11 +1243,7 @@ func isSharedTier(instanceSize string) bool {
 func isUpgradeRequired(d *schema.ResourceData) bool {
 	currentSize, updatedSize := d.GetChange("provider_instance_size_name")
 
-	if currentSize == updatedSize {
-		return false
-	}
-
-	return isSharedTier(currentSize.(string))
+	return currentSize != updatedSize && isSharedTier(currentSize.(string))
 }
 
 func expandReplicationSpecs(d *schema.ResourceData) ([]matlas.ReplicationSpec, error) {


### PR DESCRIPTION
## Description

Fixed logic around when clusters are paused.
This addresses an issue introduced by a code change to the following line https://github.com/mongodb/terraform-provider-mongodbatlas/pull/874/files#diff-1cbe1b335d9da05cf01d8c31dee39fa427feef7828c67c160c729c24cf81afc5L945

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
