### PR TITLE
chore(github): add link to contribution guidelines in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Link to any related issue(s):
 ## Required Checklist:
 
 - [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
-- [ ] I have read the Terraform contribution guidelines
+- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
 - [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
 - [ ] I have added any necessary documentation (if appropriate)
 - [ ] I have run make fmt and formatted my code


### PR DESCRIPTION
## Description

As a new contributor, I wondered where I could find the _"Terraform contribution guidelines"_ mentioned in the Pull Requests template.

I ended up guessing it's about <https://github.com/hashicorp/terraform/blob/main/.github/CONTRIBUTING.md>

Considering that the linked-above guidelines are already linked in the current repository contribution guidelines (<https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md?plain=1#L11>), this PR add a link to these guidelines and removes the "Terraform" mention.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

No relevant tests to run as far as I know.

## Further comments

None.
