### PR TITLE
CHANGELOG and UpgradeGuide Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 **Fixed**
 
-ENHANCEMENTS: 
-- INTMDB-444 Feature add: Termination Protection for Advanced Cluster/Cluster/Serverless Instances [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
-- INTMDB-364 Feature add: AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
+NEW FEATURES: 
+- INTMDB-444 Termination Protection for Advanced Cluster/Cluster/Serverless Instances [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
+- INTMDB-364 AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 
 **Merged Pull Requests**
 - docs(website): fix federated_settings_org_config resource name by removing the misleading trailing s [\#908](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/908)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ENHANCEMENTS: 
 - INTMDB-364 Feature add: AWS Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
-- INTMDB-444 Feature add: Cluster Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
+- INTMDB-444 Feature add: Advanced Cluster/Cluster/Serverless Instance Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 
 ## [v1.5.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.5.0) (2022-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ ENHANCEMENTS:
 **Merged Pull Requests**
 - docs(website): fix federated_settings_org_config resource name by removing the misleading trailing s [\#908](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/908)
 - chore(github): add link to contribution guidelines in PR template [\#910](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/910#issuecomment-1310007413)
+- docs(resource/role_mapping): indent sub-elements of role_assignments [\#918](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/918)
 - docs(resource/role_mapping): add link to reference of available role IDs [\#919](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/919)
 - federated settings plural fix [\#914](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/914)  
 - Chore(deps): Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.0 to 2.24.1 [\#922](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/922)
 - Chore(deps): Bump golangci/golangci-lint-action from 3.3.0 to 3.3.1 [\#925](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/925)
-- docs(resource/role_mapping): indent sub-elements of role_assignments [\#918](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/918)
 - Chore(deps): Bump github.com/gruntwork-io/terratest from 0.40.24 to 0.41.0 [\#923](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/923)
 - Workaround to handle serverless endpoint tests failing due to provider name missing from API [\#927](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/927)
 - Release staging v1.6.0 [\#921](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/921)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ ENHANCEMENTS:
 - INTMDB-364 Feature add: AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 
 **Merged Pull Requests**
-- chore(github): add link to contribution guidelines in PR template [\#910](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/910#issuecomment-1310007413)
 - docs(website): fix federated_settings_org_config resource name by removing the misleading trailing s [\#908](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/908)
+- chore(github): add link to contribution guidelines in PR template [\#910](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/910#issuecomment-1310007413)
+- docs(resource/role_mapping): add link to reference of available role IDs [\#919](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/919)
+- federated settings plural fix [\#914](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/914)  
+- Chore(deps): Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.0 to 2.24.1 [\#922](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/922)
+- Chore(deps): Bump golangci/golangci-lint-action from 3.3.0 to 3.3.1 [\#925](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/925)
+- docs(resource/role_mapping): indent sub-elements of role_assignments [\#918](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/918)
+- Chore(deps): Bump github.com/gruntwork-io/terratest from 0.40.24 to 0.41.0 [\#923](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/923)
 - Workaround to handle serverless endpoint tests failing due to provider name missing from API [\#927](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/927)
-- Chore(deps): Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.0 to 2.24.1 [\922](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/922)
-- Chore(deps): Bump golangci/golangci-lint-action from 3.3.0 to 3.3.1 [\925](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/925)
-- docs(resource/role_mapping): indent sub-elements of role_assignments [\918](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/918)
-- Release staging v1.6.0 [\921](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/921)
-- Chore(deps): Bump github.com/gruntwork-io/terratest from 0.40.24 to 0.41.0 [\923](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/923)
-- docs(resource/role_mapping): add link to reference of available role IDs [\919](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/919)
-- federated settings plural fix [\914](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/914)  
+- Release staging v1.6.0 [\#921](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/921)
 
 ## [v1.5.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.5.0) (2022-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-14)
+## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-11)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ ENHANCEMENTS:
 - INTMDB-364 Feature add: AWS Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 - INTMDB-444 Feature add: Advanced Cluster/Cluster/Serverless Instance Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 
+**Merged Pull Requests**
+- chore(github): add link to contribution guidelines in PR template [\#910](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/910#issuecomment-1310007413)
+- docs(website): fix federated_settings_org_config resource name by removing the misleading trailing s [\#908](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/908)
+
 ## [v1.5.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.5.0) (2022-11-07)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.6...v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,24 @@
-## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-11)
+## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-16)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
 
 **Fixed**
 
 ENHANCEMENTS: 
+- INTMDB-444 Feature add: Termination Protection for Advanced Cluster/Cluster/Serverless Instances [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 - INTMDB-364 Feature add: AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
-- INTMDB-444 Feature add: Advanced Cluster/Cluster/Serverless Instance Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 
 **Merged Pull Requests**
 - chore(github): add link to contribution guidelines in PR template [\#910](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/910#issuecomment-1310007413)
 - docs(website): fix federated_settings_org_config resource name by removing the misleading trailing s [\#908](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/908)
+- Workaround to handle serverless endpoint tests failing due to provider name missing from API [\#927](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/927)
+- Chore(deps): Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.24.0 to 2.24.1 [\922](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/922)
+- Chore(deps): Bump golangci/golangci-lint-action from 3.3.0 to 3.3.1 [\925](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/925)
+- docs(resource/role_mapping): indent sub-elements of role_assignments [\918](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/918)
+- Release staging v1.6.0 [\921](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/921)
+- Chore(deps): Bump github.com/gruntwork-io/terratest from 0.40.24 to 0.41.0 [\923](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/923)
+- docs(resource/role_mapping): add link to reference of available role IDs [\919](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/919)
+- federated settings plural fix [\914](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/914)  
 
 ## [v1.5.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.5.0) (2022-11-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
 
-**NEW FEATURES: ** 
+**NEW FEATURES:** 
 - INTMDB-444 Termination Protection for Advanced Cluster/Cluster/Serverless Instances [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 - INTMDB-364 AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
 
-**Fixed**
-
-NEW FEATURES: 
+**NEW FEATURES: ** 
 - INTMDB-444 Termination Protection for Advanced Cluster/Cluster/Serverless Instances [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 - INTMDB-364 AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ ENHANCEMENTS:
 - INTMDB-224	Support AtlasGov with Terraform [\#865](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/865)
 - INTMDB-314	Feature add: Add ability to upgrade shared/TENANT tiers for clusters and advanced clusters [\#874](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/874)
 - INTMDB-349  New AtlasGov parameter to tell the provider to use the Atlas gov base URL [\#865](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/865)
-- INTMDB-364	Add support for serverless private endpoints (AWS) [\#314](https://github.com/mongodb/go-client-mongodb-atlas/pull/314)
 - INTMDB-373	Add new notification parameters to the mongodbatlas_alert_config resource [\#883](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/883)	
 - INTMDB-378	Document for users how to get a pre-existing container id [\#883](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/883)
 - INTMDB-377	Release 1.5 (both pre and then GA) [\#887](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/887)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-14)
+
+[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
+
+**Fixed**
+
+ENHANCEMENTS: 
+- INTMDB-364 Feature add: AWS Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
+- INTMDB-444 Feature add: Cluster Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
+
 ## [v1.5.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.5.0) (2022-11-07)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.4.6...v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Fixed**
 
 ENHANCEMENTS: 
-- INTMDB-364 Feature add: AWS Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
+- INTMDB-364 Feature add: AWS/Azure Serverless Private Endpoints [\#913](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/913)
 - INTMDB-444 Feature add: Advanced Cluster/Cluster/Serverless Instance Termination Protection [\#912](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/912)
 
 **Merged Pull Requests**

--- a/website/docs/guides/1.5.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.5.0-upgrade-guide.html.markdown
@@ -11,7 +11,6 @@ MongoDB Atlas Provider 1.5.0: Upgrade and Information Guide
 The Terraform MongoDB Atlas Provider version 1.5.0 has a number of new and exciting features and changes.
 
 New Features:
-* You can now manage AWS Serverless Private Endpoints [`mongodbatlas_serverless_private_endpoints`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/serverless_private_endpoints)
 * You can now manage AtlasGov Projects [`mongodbatlas_project`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/project)
   * To enable the Terraform MongoDB Atlas Provider for use with AtlasGov see [`Getting Started Guide`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#configure-mongodb-atlas-for-government) 
 * You can now manage Microsoft Teams Alert Notifications with [`mongodbatlas_alert_configuration`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/alert_configuration)

--- a/website/docs/guides/1.6.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.6.0-upgrade-guide.html.markdown
@@ -12,7 +12,7 @@ The Terraform MongoDB Atlas Provider version 1.6.0 has several new and exciting 
 
 New Features:
 * You can now manage AWS Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)
-* You can now manage Cluster Termination Protection [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster) 
+* You can now manage Advanced Cluster/Cluster/Serverless Instance Termination Protection [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster), [`mongodbatlas_serverless_instance`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/serverless_instance)  
 
 
 See the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for more specific information.

--- a/website/docs/guides/1.6.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.6.0-upgrade-guide.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide"
+sidebar_current: "docs-mongodbatlas-guides-160-upgrade-guide"
+description: |-
+MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
+---
+
+# MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
+
+The Terraform MongoDB Atlas Provider version 1.6.0 has a number of new and exciting features and changes.
+
+New Features:
+* You can now manage AWS Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)
+* You can now manage Cluster Termination Protection [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster) 
+
+
+See the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for more specific information.
+
+
+### Helpful Links
+
+* [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)
+
+* [Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+* [Contact Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.

--- a/website/docs/guides/1.6.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.6.0-upgrade-guide.html.markdown
@@ -8,7 +8,7 @@ MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
 
 # MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
 
-The Terraform MongoDB Atlas Provider version 1.6.0 has a number of new and exciting features and changes.
+The Terraform MongoDB Atlas Provider version 1.6.0 has several new and exciting features.
 
 New Features:
 * You can now manage AWS Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)

--- a/website/docs/guides/1.6.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.6.0-upgrade-guide.html.markdown
@@ -11,7 +11,7 @@ MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
 The Terraform MongoDB Atlas Provider version 1.6.0 has several new and exciting features.
 
 New Features:
-* You can now manage AWS Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)
+* You can now manage AWS/Azure Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)
 * You can now manage Advanced Cluster/Cluster/Serverless Instance Termination Protection [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster), [`mongodbatlas_serverless_instance`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/serverless_instance)  
 
 

--- a/website/docs/guides/1.6.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.6.0-upgrade-guide.html.markdown
@@ -11,8 +11,9 @@ MongoDB Atlas Provider 1.6.0: Upgrade and Information Guide
 The Terraform MongoDB Atlas Provider version 1.6.0 has several new and exciting features.
 
 New Features:
+* You can now manage Termination Protection for Advanced Cluster/Cluster/Serverless Instances [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster), [`mongodbatlas_serverless_instance`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/serverless_instance)  
 * You can now manage AWS/Azure Serverless Private Endpoints [`mongodbatlas_privatelink_endpoint_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless), [`mongodbatlas_privatelink_endpoint_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service_serverless)
-* You can now manage Advanced Cluster/Cluster/Serverless Instance Termination Protection [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster), [`mongodbatlas_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster), [`mongodbatlas_serverless_instance`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/serverless_instance)  
+
 
 
 See the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for more specific information.


### PR DESCRIPTION
## Description

- Add AWS Serverless Private Endpoints + Cluster Termination Protection in v1.6.0
- Remove mention of AWS Serverless Private Endpoints in v1.5.0

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the Terraform contribution guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
