### PR TITLE
docs(resource/role_mapping): add link to reference of available role IDs

### DIFF
--- a/website/docs/r/federated_settings_org_role_mapping.html.markdown
+++ b/website/docs/r/federated_settings_org_role_mapping.html.markdown
@@ -43,6 +43,8 @@ resource "mongodbatlas_federated_settings_org_role_mapping" "org_group_role_mapp
 * `role_assignments` - Atlas roles and the unique identifiers of the groups and organizations associated with each role.
 * `group_id` - Unique identifier of the project to which you want the role mapping to apply.
 * `roles` - Specifies the Roles that are attached to the Role Mapping.
+  Available role IDs can be found on [the User Roles
+  Reference](https://www.mongodb.com/docs/atlas/reference/user-roles/).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

When creating `mongodbatlas_federated_settings_org_role_mapping` resources, one might wonder what are the available identifiers for the `roles` field. This adds a link to their reference.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

No relevant test to add.

## Further comments

None.
