### PR TITLE
Workaround to handle serverless endpoint tests failing due to provider name missing from API

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
@@ -225,6 +225,16 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessImportState(ctx context.Co
 		log.Printf("[WARN] Error setting endpoint_service_name for (%s): %s", endpointID, err)
 	}
 
+	if privateLinkResponse.PrivateLinkServiceResourceID != "" {
+		if err := d.Set("provider_name", "AZURE"); err != nil {
+			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
+		}
+	} else {
+		if err := d.Set("provider_name", "AWS"); err != nil {
+			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
+		}
+	}
+
 	d.SetId(encodeStateID(map[string]string{
 		"project_id":    projectID,
 		"instance_name": instanceName,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -226,7 +226,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 	instanceName := parts[1]
 	endpointID := parts[2]
 
-	_, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	privateLinkResponse, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import serverless private link endpoint (%s) in projectID (%s) , error: %s", endpointID, projectID, err)
 	}
@@ -238,8 +238,19 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 	if err := d.Set("endpoint_id", endpointID); err != nil {
 		log.Printf("[WARN] Error setting endpoint_id for (%s): %s", endpointID, err)
 	}
+
 	if err := d.Set("instance_name", instanceName); err != nil {
 		log.Printf("[WARN] Error setting instance_name for (%s): %s", endpointID, err)
+	}
+
+	if privateLinkResponse.PrivateLinkServiceResourceID != "" {
+		if err := d.Set("provider_name", "AZURE"); err != nil {
+			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
+		}
+	} else {
+		if err := d.Set("provider_name", "AWS"); err != nil {
+			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
+		}
 	}
 
 	d.SetId(encodeStateID(map[string]string{


### PR DESCRIPTION


## Description

Workaround to handle serverless endpoint tests failing due to provider name missing from API

```
TF_ACC=1 go test -run ^TestAccResourceMongoDBAtlasPrivateLinkEndpointServerless_importBasic$ -timeout 900m
PASS

ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 566.910s
TF_ACC=1 go test -run ^TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceServerless_importBasic$ -timeout 900m
PASS

TF_ACC=1 go test -run ^TestAccResourceMongoDBAtlasPrivateLinkEndpointServiceServerless_basic$ -timeout 900m
PASS
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 575.201s

TF_ACC=1 go test -run ^TestAccResourceMongoDBAtlasPrivateLinkEndpointServerless_basic$ -timeout 900m
PASS   
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 273.872s

```

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
