### PR TITLE
INTMDB-426: Alert Configuration -- Api Token erroneous changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-16)
+## [v1.6.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.6.0) (2022-11-17)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.5.0...v1.6.0)
 

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -292,7 +292,7 @@ func dataSourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "threshold_config", projectID, err))
 	}
 
-	if err := d.Set("notification", flattenAlertConfigurationNotifications(alert.Notifications)); err != nil {
+	if err := d.Set("notification", flattenAlertConfigurationNotifications(d, alert.Notifications)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "notification", projectID, err))
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -370,7 +370,7 @@ func resourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "updated", ids["id"], err))
 	}
 
-	if err := d.Set("notification", flattenAlertConfigurationNotifications(alert.Notifications)); err != nil {
+	if err := d.Set("notification", flattenAlertConfigurationNotifications(d, alert.Notifications)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "notification", ids["id"], err))
 	}
 
@@ -500,7 +500,7 @@ func resourceMongoDBAtlasAlertConfigurationImportState(ctx context.Context, d *s
 		return nil, fmt.Errorf(errorAlertConfSetting, "threshold_config", id, err)
 	}
 
-	if err := d.Set("notification", flattenAlertConfigurationNotifications(alert.Notifications)); err != nil {
+	if err := d.Set("notification", flattenAlertConfigurationNotifications(d, alert.Notifications)); err != nil {
 		return nil, fmt.Errorf(errorAlertConfSetting, "notification", id, err)
 	}
 
@@ -731,33 +731,38 @@ func expandAlertConfigurationNotification(d *schema.ResourceData) ([]matlas.Noti
 	return notifications, nil
 }
 
-func flattenAlertConfigurationNotifications(notifications []matlas.Notification) []map[string]interface{} {
+func flattenAlertConfigurationNotifications(d *schema.ResourceData, notifications []matlas.Notification) []map[string]interface{} {
+	notificationsSchema, err := expandAlertConfigurationNotification(d)
+	if err != nil {
+		return nil
+	}
+
 	nts := make([]map[string]interface{}, len(notifications))
 
 	for i := range notifications {
 		nts[i] = map[string]interface{}{
-			"api_token":                   notifications[i].APIToken,
+			"api_token":                   notificationsSchema[i].APIToken,
 			"channel_name":                notifications[i].ChannelName,
-			"datadog_api_key":             notifications[i].DatadogAPIKey,
+			"datadog_api_key":             notificationsSchema[i].DatadogAPIKey,
 			"datadog_region":              notifications[i].DatadogRegion,
 			"delay_min":                   notifications[i].DelayMin,
 			"email_address":               notifications[i].EmailAddress,
 			"email_enabled":               notifications[i].EmailEnabled,
-			"flowdock_api_token":          notifications[i].FlowdockAPIToken,
+			"flowdock_api_token":          notificationsSchema[i].FlowdockAPIToken,
 			"flow_name":                   notifications[i].FlowName,
 			"interval_min":                notifications[i].IntervalMin,
 			"mobile_number":               notifications[i].MobileNumber,
-			"ops_genie_api_key":           notifications[i].OpsGenieAPIKey,
+			"ops_genie_api_key":           notificationsSchema[i].OpsGenieAPIKey,
 			"ops_genie_region":            notifications[i].OpsGenieRegion,
 			"org_name":                    notifications[i].OrgName,
-			"service_key":                 notifications[i].ServiceKey,
+			"service_key":                 notificationsSchema[i].ServiceKey,
 			"sms_enabled":                 notifications[i].SMSEnabled,
 			"team_id":                     notifications[i].TeamID,
 			"team_name":                   notifications[i].TeamName,
 			"type_name":                   notifications[i].TypeName,
 			"username":                    notifications[i].Username,
-			"victor_ops_api_key":          notifications[i].VictorOpsAPIKey,
-			"victor_ops_routing_key":      notifications[i].VictorOpsRoutingKey,
+			"victor_ops_api_key":          notificationsSchema[i].VictorOpsAPIKey,
+			"victor_ops_routing_key":      notificationsSchema[i].VictorOpsRoutingKey,
 			"microsoft_teams_webhook_url": notifications[i].MicrosoftTeamsWebhookURL,
 			"webhook_secret":              notifications[i].WebhookSecret,
 			"webhook_url":                 notifications[i].WebhookURL,

--- a/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
@@ -38,7 +38,7 @@ resource "mongodbatlas_privatelink_endpoint_service_serverless" "test" {
 	project_id   = "<PROJECT_ID>"
 	instance_name = mongodbatlas_serverless_instance.test.name
 	endpoint_id = mongodbatlas_privatelink_endpoint_serverless.test.endpoint_id
-	cloud_endpoint_id = aws_vpc_endpoint.ptfe_service.id
+	cloud_provider_endpoint_id = aws_vpc_endpoint.ptfe_service.id
 	provider_name = "AWS"
 	comment = "New serverless endpoint"
 }
@@ -78,7 +78,7 @@ resource "mongodbatlas_privatelink_endpoint_service_serverless" "test" {
   project_id                  = mongodbatlas_privatelink_endpoint_serverless.test.project_id
   instance_name               = mongodbatlas_serverless_instance.test.name
   endpoint_id                 = mongodbatlas_privatelink_endpoint_serverless.test.endpoint_id
-  cloud_endpoint_id           = azurerm_private_endpoint.test.id 
+  cloud_provider_endpoint_id  = azurerm_private_endpoint.test.id 
   private_endpoint_ip_address = azurerm_private_endpoint.test.private_service_connection.0.private_ip_address
   provider_name               = "AZURE"
   comment                     = "test"


### PR DESCRIPTION
## Description

Alert Configuration -- Api Token erroneous changes adapt logic to ignore API returning obfuscated values for API keys

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
