### PR TITLE
INTMDB-465 - PrivateLink Endpoint Service & Connection Strings

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -942,18 +942,15 @@ func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []*matlas.A
 
 	var tfList []map[string]interface{}
 
-	for _, apiObject := range apiObjects {
+	for i, apiObject := range apiObjects {
 		if apiObject == nil {
 			continue
 		}
 
 		var tfMapObject map[string]interface{}
 
-		for _, v := range tfMapObjects {
-			if v.(map[string]interface{})["id"] == apiObject.ID {
-				tfMapObject = v.(map[string]interface{})
-				break
-			}
+		if len(tfMapObjects) > i {
+			tfMapObject = tfMapObjects[i].(map[string]interface{})
 		}
 
 		advancedReplicationSpec, err := flattenAdvancedReplicationSpec(ctx, apiObject, tfMapObject, d, conn)

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -1147,7 +1147,7 @@ func resourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID strin
 
 		for i := range clusters.Results {
 			if clusters.Results[i].StateName != "IDLE" {
-				return clusters, clusters.Results[i].StateName, nil
+				return clusters.Results[i], "PENDING", nil
 			}
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -1107,7 +1107,9 @@ func resourceClusterAdvancedRefreshFunc(ctx context.Context, name, projectID str
 
 		if err != nil && c == nil && resp == nil {
 			return nil, "", err
-		} else if err != nil {
+		}
+
+		if err != nil {
 			if resp.StatusCode == 404 {
 				return "", "DELETED", nil
 			}
@@ -1135,7 +1137,9 @@ func resourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID strin
 
 		if err != nil && clusters == nil && resp == nil {
 			return nil, "", err
-		} else if err != nil {
+		}
+
+		if err != nil {
 			if resp.StatusCode == 404 {
 				return "", "DELETED", nil
 			}

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -31,6 +31,7 @@ const (
 	errorClusterAdvancedSetting            = "error setting `%s` for MongoDB ClusterAdvanced (%s): %s"
 	errorAdvancedClusterAdvancedConfUpdate = "error updating Advanced Configuration Option form MongoDB Cluster (%s): %s"
 	errorAdvancedClusterAdvancedConfRead   = "error reading Advanced Configuration Option form MongoDB Cluster (%s): %s"
+	errorAdvancedClusterListStatus         = "error awaiting MongoDB ClusterAdvanced List IDLE: %s"
 )
 
 var upgradeRequestCtxKey acCtxKey = "upgradeRequest"

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode.go
@@ -92,7 +92,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(ctx context.Context, 
 	log.Println("[INFO] Waiting for MongoDB Clusters' Private Endpoints to be updated")
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
+		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
 		Refresh:    resourceClusterListAdvancedRefreshFunc(ctx, projectID, conn),
 		Timeout:    1 * time.Hour,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -298,7 +298,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"NONE", "PENDING_ACCEPTANCE", "PENDING", "DELETING"},
+			Pending:    []string{"NONE", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "INITIATING"},
 			Target:     []string{"REJECTED", "DELETED", "FAILED"},
 			Refresh:    resourceServiceEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID, endpointServiceID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -200,8 +200,6 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d
 	if err != nil {
 		// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
 		log.Printf(errorAdvancedClusterListStatus, err)
-
-		err = nil
 	}
 
 	d.SetId(encodeStateID(map[string]string{
@@ -300,8 +298,8 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"NONE", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "INITIATING"},
-			Target:     []string{"REJECTED", "DELETED", "FAILED"},
+			Pending:    []string{"REPEATING", "PENDING"},
+			Target:     []string{"IDLE", "DELETED"},
 			Refresh:    resourceServiceEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID, endpointServiceID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: 5 * time.Second,
@@ -315,7 +313,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		}
 
 		clusterConf := &resource.StateChangeConf{
-			Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
+			Pending:    []string{"REPEATING", "PENDING"},
 			Target:     []string{"IDLE", "DELETED"},
 			Refresh:    resourceClusterListAdvancedRefreshFunc(ctx, projectID, conn),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
@@ -328,8 +326,6 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		if err != nil {
 			// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
 			log.Printf(errorAdvancedClusterListStatus, err)
-
-			err = nil
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -195,9 +195,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d
 		Delay:      5 * time.Minute,
 	}
 
-	_, err = clusterConf.WaitForStateContext(ctx)
-
-	if err != nil {
+	if _, err = clusterConf.WaitForStateContext(ctx); err != nil {
 		// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
 		log.Printf(errorAdvancedClusterListStatus, err)
 	}

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -195,7 +195,14 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d
 		Delay:      5 * time.Minute,
 	}
 
-	clusterConf.WaitForStateContext(ctx)
+	_, err = clusterConf.WaitForStateContext(ctx)
+
+	if err != nil {
+		// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
+		log.Printf(errorAdvancedClusterListStatus, err)
+
+		err = nil
+	}
 
 	d.SetId(encodeStateID(map[string]string{
 		"project_id":          projectID,
@@ -316,7 +323,14 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 			Delay:      5 * time.Minute,
 		}
 
-		clusterConf.WaitForStateContext(ctx)
+		_, err = clusterConf.WaitForStateContext(ctx)
+
+		if err != nil {
+			// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
+			log.Printf(errorAdvancedClusterListStatus, err)
+
+			err = nil
+		}
 	}
 
 	return nil

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -309,7 +309,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 
 		clusterConf := &resource.StateChangeConf{
 			Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
-			Target:     []string{"IDLE"},
+			Target:     []string{"IDLE", "DELETED"},
 			Refresh:    resourceClusterListAdvancedRefreshFunc(ctx, projectID, conn),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
 			MinTimeout: 5 * time.Second,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -298,8 +298,8 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
-			Target:     []string{"AVAILABLE", "REJECTED", "DELETED", "FAILED"},
+			Pending:    []string{"NONE", "PENDING_ACCEPTANCE", "PENDING", "DELETING"},
+			Target:     []string{"REJECTED", "DELETED", "FAILED"},
 			Refresh:    resourceServiceEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID, endpointServiceID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: 5 * time.Second,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -187,7 +187,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d
 	}
 
 	clusterConf := &resource.StateChangeConf{
-		Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
+		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
 		Refresh:    resourceClusterListAdvancedRefreshFunc(ctx, projectID, conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
@@ -298,8 +298,8 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"REPEATING", "PENDING"},
-			Target:     []string{"IDLE", "DELETED"},
+			Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
+			Target:     []string{"AVAILABLE", "REJECTED", "DELETED", "FAILED"},
 			Refresh:    resourceServiceEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID, endpointServiceID),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: 5 * time.Second,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -296,7 +296,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 			Pending:    []string{"NONE", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "INITIATING"},
 			Target:     []string{"REJECTED", "DELETED", "FAILED"},
 			Refresh:    resourceServiceEndpointRefreshFunc(ctx, conn, projectID, providerName, privateLinkID, endpointServiceID),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: 5 * time.Second,
 			Delay:      3 * time.Second,
 		}
@@ -311,7 +311,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 			Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
 			Target:     []string{"IDLE", "DELETED"},
 			Refresh:    resourceClusterListAdvancedRefreshFunc(ctx, projectID, conn),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: 5 * time.Second,
 			Delay:      5 * time.Minute,
 		}

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -102,11 +102,11 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy(state *terrafo
 func testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, comment string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_privatelink_endpoint_service_adl" "test" {
-			project_id   = "%[1]s"
-			endpoint_id  = "%[2]s"
-			comment      = "%[3]s"
-			type		 = "DATA_LAKE"
-			provider_name	 = "AWS"
+			project_id    = "%[1]s"
+			endpoint_id   = "%[2]s"
+			comment       = "%[3]s"
+			type          = "DATA_LAKE"
+			provider_name = "AWS"
 		}
 	`, projectID, endpointID, comment)
 }

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -19,7 +19,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceADL_basic(t *testing.T) {
 		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy,
@@ -55,7 +55,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceADL_importBasic(t *testing.T) {
 		endpointID    = "vpce-jjg5e24qp93513h03"
 		commentOrigin = "this is a comment for adl private link endpoint"
 	)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasSearchIndexDestroy,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -19,7 +19,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceADL_basic(t *testing.T) {
 		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy,
@@ -55,7 +55,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceADL_importBasic(t *testing.T) {
 		endpointID    = "vpce-jjg5e24qp93513h03"
 		commentOrigin = "this is a comment for adl private link endpoint"
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasSearchIndexDestroy,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -132,9 +132,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 		Delay:      5 * time.Minute,
 	}
 
-	_, err = clusterConf.WaitForStateContext(ctx)
-
-	if err != nil {
+	if _, err = clusterConf.WaitForStateContext(ctx); err != nil {
 		// error awaiting serverless instances to IDLE should not result in failure to apply changes to this resource
 		log.Printf(errorServerlessInstanceListStatus, err)
 	}

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -135,7 +135,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 	_, err = clusterConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
+		// error awaiting serverless instances to IDLE should not result in failure to apply changes to this resource
 		log.Printf(errorServerlessInstanceListStatus, err)
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -136,7 +136,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 
 	if err != nil {
 		// error awaiting advanced clusters IDLE should not result in failure to apply changes to this resource
-		log.Printf(errorAdvancedClusterListStatus, err)
+		log.Printf(errorServerlessInstanceListStatus, err)
 	}
 
 	d.SetId(encodeStateID(map[string]string{

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	errorServerlessInstanceListStatus = "error awaiting serverless instance list status IDLE: %s""
+	errorServerlessInstanceListStatus = "error awaiting serverless instance list status IDLE: %s"
 )
 
 func resourceMongoDBAtlasServerlessInstance() *schema.Resource {

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance.go
@@ -16,6 +16,10 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
+const (
+	errorServerlessInstanceListStatus = "error awaiting serverless instance list status IDLE: %s""
+)
+
 func resourceMongoDBAtlasServerlessInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceMongoDBAtlasServerlessInstanceCreate,

--- a/website/docs/r/privatelink_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service.html.markdown
@@ -15,7 +15,7 @@ description: |-
   * Project Owner
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
-
+-> **NOTE:** Create and delete wait for all clusters on the project to IDLE in order for their operations to complete. This ensures the latest connection strings can be retrieved following creation or deletion of this resource. Default timeout is 2hrs.
 
 ## Example with AWS
 

--- a/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
@@ -13,6 +13,7 @@ Describes a Serverless PrivateLink Endpoint Service
 This is the second of two resources required to configure PrivateLink for Serverless, the first is [mongodbatlas_privatelink_endpoint_serverless](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_serverless).
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+-> **NOTE:** Create waits for all serverless instances on the project to IDLE in order for their operations to complete. This ensures the latest connection strings can be retrieved following creation of this resource. Default timeout is 2hrs.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

Added a secondary RefreshFunc to _mongodbatlas_privatelink_endpoint_service_ to wait for all clusters to be idle. This allows us to retrieve proper connection_string information following the creation or deletion of endpoint services.

Closes INTMDB-465
Addresses HELP-39042

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
