### PR TITLE
v1.6.1 - Conditionally ignore serverless connection string changes

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -15,7 +15,7 @@ func TestAccNetworkDSPrivateEndpointRegionalMode_basic(t *testing.T) {
 	resourceName := "mongodbatlas_private_endpoint_regional_mode.test"
 	projectID := os.Getenv("MONGODB_ATLAS_NETWORK_PROJECT_ID")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
@@ -46,5 +46,5 @@ func testAccMongoDBAtlasServerlessInstanceDSConfig(projectID, name string) strin
 			project_id  = mongodbatlas_serverless_instance.test.project_id
 		}
 
-	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name))
+	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name, false))
 }

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instance_test.go
@@ -46,5 +46,5 @@ func testAccMongoDBAtlasServerlessInstanceDSConfig(projectID, name string) strin
 			project_id  = mongodbatlas_serverless_instance.test.project_id
 		}
 
-	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name, false))
+	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name, true))
 }

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instances_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instances_test.go
@@ -44,5 +44,5 @@ func testAccMongoDBAtlasServerlessInstancesDSConfig(projectID, name string) stri
 		data "mongodbatlas_serverless_instances" "data_serverless" {
 			project_id         = mongodbatlas_serverless_instance.test.project_id
 		}
-	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name))
+	`, testAccMongoDBAtlasServerlessInstanceConfig(projectID, name, true))
 }

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -39,7 +39,7 @@ func TestAccNetworkRSPrivateEndpointRegionalMode_conn(t *testing.T) {
 
 	dependencies := []string{clusterResource, clusterDataSource, endpointResources}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy,
@@ -76,7 +76,7 @@ func TestAccNetworkRSPrivateEndpointRegionalMode_basic(t *testing.T) {
 		projectID = os.Getenv("MONGODB_ATLAS_NETWORK_PROJECT_ID")
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy,

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance.go
@@ -107,7 +107,6 @@ func returnServerlessInstanceSchema() map[string]*schema.Schema {
 		"connection_strings_private_endpoint_srv": {
 			Type:     schema.TypeList,
 			Computed: true,
-			Optional: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
@@ -25,7 +25,7 @@ func TestAccClusterRSServerlessInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasServerlessInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasServerlessInstanceConfig(projectID, instanceName, false),
+				Config: testAccMongoDBAtlasServerlessInstanceConfig(projectID, instanceName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasServerlessInstanceExists(resourceName, &serverlessInstance),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -50,7 +50,7 @@ func TestAccClusterRSServerlessInstance_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasServerlessInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasServerlessInstanceConfig(projectID, instanceName, false),
+				Config: testAccMongoDBAtlasServerlessInstanceConfig(projectID, instanceName, true),
 			},
 			{
 				ResourceName:      resourceName,
@@ -135,7 +135,7 @@ func testAccMongoDBAtlasServerlessInstanceConfig(projectID, name string, ignoreC
 	resource "mongodbatlas_serverless_instance" "test" {
 		project_id   = "%[1]s"
 		name         = "%[2]s"
-		
+
 		provider_settings_backing_provider_name = "AWS"
 		provider_settings_provider_name = "SERVERLESS"
 		provider_settings_region_name = "US_EAST_1"

--- a/website/docs/r/cloud_provider_snapshot.html.markdown
+++ b/website/docs/r/cloud_provider_snapshot.html.markdown
@@ -54,7 +54,7 @@ On-demand snapshots happen immediately, unlike scheduled snapshots which occur a
 * `cluster_name` - (Required) The name of the Atlas cluster that contains the snapshots you want to retrieve.
 * `description` - (Required) Description of the on-demand snapshot.
 * `retention_in_days` - (Required) The number of days that Atlas should retain the on-demand snapshot. Must be at least 1.
-* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `10m`
+* `timeout`- (Optional) The duration of time to wait to finish the on-demand snapshot. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Default value for the timeout is `10m`
 
 ## Attributes Reference
 

--- a/website/docs/r/privatelink_endpoint.html.markdown
+++ b/website/docs/r/privatelink_endpoint.html.markdown
@@ -40,7 +40,7 @@ resource "mongodbatlas_privatelink_endpoint" "test" {
 * `provider_name` - (Required) Name of the cloud provider for which you want to create the private endpoint service. Atlas accepts `AWS`, `AZURE` or `GCP`.
 * `region` - (Required) Cloud provider region in which you want to create the private endpoint connection.
 Accepted values are: [AWS regions](https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws), [AZURE regions](https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure) and [GCP regions](https://docs.atlas.mongodb.com/reference/google-gcp/#std-label-google-gcp)
-* `timeouts`- (Optional) The duration of time to wait for Private Endpoint to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `1h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint to be created or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `1h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 
 ## Attributes Reference

--- a/website/docs/r/privatelink_endpoint_serverless.html.markdown
+++ b/website/docs/r/privatelink_endpoint_serverless.html.markdown
@@ -24,7 +24,7 @@ resource "mongodbatlas_privatelink_endpoint_serverless" "test" {
 	instance_name = mongodbatlas_serverless_instance.test.name
 	provider_name = "AWS"
 }
-	  
+
 resource "mongodbatlas_serverless_instance" "test" {
 	project_id   = "<PROJECT_ID>"
 	name         = "test-db"
@@ -51,7 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider_endpoint_id` - Unique string that identifies the private endpoint's network interface.
 * `comment` - Human-readable string to associate with this private endpoint.
 * `status` - Human-readable label that indicates the current operating status of the private endpoint. Values include: RESERVATION_REQUESTED, RESERVED, INITIATING, AVAILABLE, FAILED, DELETING.
-* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 ## Import
 

--- a/website/docs/r/privatelink_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service.html.markdown
@@ -154,7 +154,7 @@ resource "mongodbatlas_privatelink_endpoint_service" "test" {
 * `private_endpoint_ip_address` - (Optional) Private IP address of the private endpoint network interface you created in your Azure VNet. Only for `AZURE`.
 * `gcp_project_id` - (Optional) Unique identifier of the GCP project in which you created your endpoints. Only for `GCP`.
 * `endpoints` - (Optional) Collection of individual private endpoints that comprise your endpoint group. Only for `GCP`. See below.
-* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 ### `endpoints`
 * `ip_address` - (Optional) Private IP address of the endpoint you created in GCP.

--- a/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service_serverless.html.markdown
@@ -104,7 +104,7 @@ resource "mongodbatlas_serverless_instance" "test" {
 * `private_endpoint_ip_address` - (Optional) IPv4 address of the private endpoint in your Azure VNet that someone added to this private endpoint service.
 * `provider_name` - (Required) Cloud provider for which you want to create a private endpoint. Atlas accepts `AWS`, `AZURE`.
 * `comment` - (Optional) Human-readable string to associate with this private endpoint.
-* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Because of how the dependency chains works on serverless, serverless privatelink endpoints, and serverless privatelink endpoint services, serverless instance connection strings state cannot be determined on the initial `terraform apply`.

When these tests run, they do a `terraform refresh` and see unexpected pending changes to those connection strings.

Now the config can conditionally ignore changes to those connection strings, which we do in certain first applications of these resources to avoid these test failures.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
