### PR TITLE
INTMDB-521: AWS Secrets Manager to Auth into Terraform Atlas Provider

### DIFF
--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	PrivateKey   string
 	BaseURL      string
 	RealmBaseURL string
+	AssumeRole   *AssumeRole
 }
 
 // MongoDBClient client

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -292,9 +293,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 }
 
 func configureCredentialsSTS(config *Config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken string) (Config, error) {
+	ep, _ := endpoints.GetSTSRegionalEndpoint("regional")
 	sess := session.Must(session.NewSession(&aws.Config{
-		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, awsSessionToken),
+		Region:              aws.String(region),
+		Credentials:         credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, awsSessionToken),
+		STSRegionalEndpoint: ep,
 	}))
 
 	creds := stscreds.NewCredentials(sess, config.AssumeRole.RoleARN)

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -351,8 +351,6 @@ func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secr
 				fmt.Println(aerr.Error())
 			}
 		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
 			fmt.Println(err.Error())
 		}
 		return ""
@@ -569,14 +567,12 @@ func assumeRoleSchema() *schema.Schema {
 					Description: "Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.",
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
-						//ValidateFunc: verify.ValidARN,
 					},
 				},
 				"role_arn": {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "Amazon Resource Name (ARN) of an IAM Role to assume prior to making API calls.",
-					//ValidateFunc: verify.ValidARN,
 				},
 				"session_name": {
 					Type:         schema.TypeString,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -33,6 +33,8 @@ The [MongoDB Atlas documentation](https://docs.atlas.mongodb.com/tutorial/manage
 
 **Role**: If unsure of which role level to grant your key, we suggest creating an organization API Key with an Organization Owner role. This ensures that you have sufficient access for all actions.
 
+**API Key Access List**: Some Atlas API resources such as Cloud Backup Restores, Cloud Backup Snapshots, and Cloud Backup Schedules **require** an Atlas API Key Access List to utilize these feature.  Hence, if using Terraform, or any other programmatic control, to manage these resources you must have the IP address or CIDR block that the connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using.   See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list)
+
 ## Configure MongoDB Atlas for Government
 
 In order to enable the Terraform MongoDB Atlas Provider for use with MongoDB Atlas for Government add is_mongodbgov_cloud = true to your provider configuration:
@@ -47,36 +49,6 @@ provider "mongodbatlas" {
 ```
 Also see [`Atlas for Government Considerations`](https://www.mongodb.com/docs/atlas/government/api/#atlas-for-government-considerations).  
 
-## Configure MongoDB Atlas using AWS Secrets Manager
-
-In order to enable the Terraform MongoDB Atlas Provider to use AWS Secret Manager for API Keys add secret to AWS Secret Manager with a basic key with a raw value like 
-
-``` 
-     {
-      "public_key": "iepubky",
-      "private_key":"prvkey"
-     }
-```
-
-add assume_role block wih role_arn = arn::aws::iam::xxxxxx:role/role-name set secret_name = secretName, and region = "us-xxx-1" to match region secret is present in to your provider configuration:
-```terraform
-# Configure the MongoDB Atlas Provider for MongoDB Atlas for Government
-provider "mongodbatlas" {
-  assume_role {
-    role_arn = "arn:aws:iam::476xxx451:role/mdbsts"
-  }
-  secret_name           = "mongodbsecret"
-  aws_access_key_id     = "ASIXXBNEK"
-  aws_secret_access_key = "ZUZgVb8XYZWEXXEDURGFHFc5Au"
-  aws_session_token     = "IQoXX3+Q="
-  region                = "us-east-2"
-}
-# Create the resources
-```
-**Note: aws_access_key_id, aws_secret_access_key, aws_session_token, region are also passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID TF_VAR_AWS_ACCESS_KEY_ID 
-as a default value in place of value in a terraform file variable
-
-**API Key Access List**: Some Atlas API resources such as Cloud Backup Restores, Cloud Backup Snapshots, and Cloud Backup Schedules **require** an Atlas API Key Access List to utilize these feature.  Hence, if using Terraform, or any other programmatic control, to manage these resources you must have the IP address or CIDR block that the connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using.   See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list)
 ## Authenticate the Provider
 
 The MongoDB Atlas provider offers a flexible means of providing credentials for authentication.
@@ -103,6 +75,33 @@ $ terraform plan
 As an alternative to `MONGODB_ATLAS_PUBLIC_KEY` and `MONGODB_ATLAS_PRIVATE_KEY`
 if you are using [MongoDB CLI](https://docs.mongodb.com/mongocli/stable/) 
 then `MCLI_PUBLIC_API_KEY` and `MCLI_PRIVATE_API_KEY` are also supported.
+
+### AWS Secrets Manager
+AWS Secrets Manager (AWS SM) helps to manage, retrieve, and rotate database credentials, API keys, and other secrets throughout their lifecycles. See [product page](https://aws.amazon.com/secrets-manager/) and [documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/what-is-systems-manager.html) for more details.
+
+In order to enable the Terraform MongoDB Atlas Provider to use AWS SM, first create Atlas API Keys and add them as a secret to AWS SM with a basic key with a raw value. See below example:  
+``` 
+     {
+      "public_key": "iepubky",
+      "private_key":"prvkey"
+     }
+```
+
+Next, add assume_role block wih `role_arn`, `secret_name`, and AWS `region` to match the AWS region where secret is stored with AWS SM. See below example:
+```terraform
+# Configure the MongoDB Atlas Provider to Authenticate with AWS Secrets Manager 
+provider "mongodbatlas" {
+  assume_role {
+    role_arn = "arn:aws:iam::476xxx451:role/mdbsts"
+  }
+  secret_name           = "mongodbsecret"
+  aws_access_key_id     = "ASIXXBNEK"
+  aws_secret_access_key = "ZUZgVb8XYZWEXXEDURGFHFc5Au"
+  aws_session_token     = "IQoXX3+Q="
+  region                = "us-east-2"
+}
+```
+** Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.
 
 ### Static Credentials
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -102,7 +102,7 @@ provider "mongodbatlas" {
   sts_endpoint          = "https://sts.us-east-2.amazonaws.com/"
 }
 ```
-** Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.
+**Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.
 
 ### Static Credentials
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -47,6 +47,30 @@ provider "mongodbatlas" {
 ```
 Also see [`Atlas for Government Considerations`](https://www.mongodb.com/docs/atlas/government/api/#atlas-for-government-considerations).  
 
+## Configure MongoDB Atlas using AWS Secrets Manager
+
+In order to enable the Terraform MongoDB Atlas Provider to use AWS Secret Manager for API Keys add secret to AWS Secret Manager with a basic key with a raw value like 
+
+``` 
+     {
+      "public_key": "iepubky",
+      "private_key":"prvkey"
+     }
+```
+
+add assume_role block wih role_arn = arn::aws::iam::xxxxxx:role/role-name set secret_name = secretName, and region = "us-xxx-1" to match region secret is present in to your provider configuration:
+```terraform
+# Configure the MongoDB Atlas Provider for MongoDB Atlas for Government
+provider "mongodbatlas" {
+  assume_role {
+    role_arn = "arn:aws:iam::476xxx451:role/mdbsts"
+  }
+  secret_name = "mongodbsecret"
+  region = "us-east-2"
+}
+# Create the resources
+```
+
 **API Key Access List**: Some Atlas API resources such as Cloud Backup Restores, Cloud Backup Snapshots, and Cloud Backup Schedules **require** an Atlas API Key Access List to utilize these feature.  Hence, if using Terraform, or any other programmatic control, to manage these resources you must have the IP address or CIDR block that the connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using.   See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list)
 ## Authenticate the Provider
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -102,7 +102,7 @@ provider "mongodbatlas" {
   sts_endpoint          = "https://sts.us-east-2.amazonaws.com/"
 }
 ```
-**Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.
+Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.
 
 ### Static Credentials
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -99,6 +99,7 @@ provider "mongodbatlas" {
   aws_secret_access_key = "ZUZgVb8XYZWEXXEDURGFHFc5Au"
   aws_session_token     = "IQoXX3+Q="
   region                = "us-east-2"
+  sts_endpoint          = "https://sts.us-east-2.amazonaws.com/"
 }
 ```
 ** Note: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `region` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -87,7 +87,7 @@ In order to enable the Terraform MongoDB Atlas Provider to use AWS SM, first cre
      }
 ```
 
-Next, add assume_role block wih `role_arn`, `secret_name`, and AWS `region` to match the AWS region where secret is stored with AWS SM. See below example:
+Next, add assume_role block with `role_arn`, `secret_name`, and AWS `region` to match the AWS region where secret is stored with AWS SM. See below example:
 ```terraform
 # Configure the MongoDB Atlas Provider to Authenticate with AWS Secrets Manager 
 provider "mongodbatlas" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -65,11 +65,16 @@ provider "mongodbatlas" {
   assume_role {
     role_arn = "arn:aws:iam::476xxx451:role/mdbsts"
   }
-  secret_name = "mongodbsecret"
-  region = "us-east-2"
+  secret_name           = "mongodbsecret"
+  aws_access_key_id     = "ASIXXBNEK"
+  aws_secret_access_key = "ZUZgVb8XYZWEXXEDURGFHFc5Au"
+  aws_session_token     = "IQoXX3+Q="
+  region                = "us-east-2"
 }
 # Create the resources
 ```
+**Note: aws_access_key_id, aws_secret_access_key, aws_session_token, region are also passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID TF_VAR_AWS_ACCESS_KEY_ID 
+as a default value in place of value in a terraform file variable
 
 **API Key Access List**: Some Atlas API resources such as Cloud Backup Restores, Cloud Backup Snapshots, and Cloud Backup Schedules **require** an Atlas API Key Access List to utilize these feature.  Hence, if using Terraform, or any other programmatic control, to manage these resources you must have the IP address or CIDR block that the connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using.   See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list)
 ## Authenticate the Provider


### PR DESCRIPTION
## Description

INTMDB-521: AWS Secrets Manager to Auth into Terraform Atlas Provider

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
