### PR TITLE
INTMDB-468: Hide current_certificate when X.509 Authentication Database Users are Created

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v7
         id: stale
         with:
           stale-issue-message: 'This issue has gone 30 days without any activity and meets the project’s definition of "stale". This will be auto-closed if there is no new activity over the next 30 days. If the issue is still relevant and active, you can simply comment with a "bump" to keep it open, or add the label "not_stale". Thanks for keeping our repository healthy!'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-test/deep v1.1.0
-	github.com/gruntwork-io/terratest v0.41.6
+	github.com/gruntwork-io/terratest v0.41.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/hashicorp/terraform-provider-google v1.20.1-0.20210625223728-379bcb41c06b
 	github.com/mongodb-forks/digest v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.41.6 h1:BlZOu8GUzLEA2aODnyszCXSoF/jgo2AuVhk41vsqUQI=
-github.com/gruntwork-io/terratest v0.41.6/go.mod h1:qH1xkPTTGx30XkMHw8jAVIbzqheSjIa5IyiTwSV2vKI=
+github.com/gruntwork-io/terratest v0.41.7 h1:Vc0hb7ajWHutGA++gu/a9FSkuf+IuQuGDRymiWdrA04=
+github.com/gruntwork-io/terratest v0.41.7/go.mod h1:qH1xkPTTGx30XkMHw8jAVIbzqheSjIa5IyiTwSV2vKI=
 github.com/hashicorp/aws-sdk-go-base v0.7.1 h1:7s/aR3hFn74tYPVihzDyZe7y/+BorN70rr9ZvpV3j3o=
 github.com/hashicorp/aws-sdk-go-base v0.7.1/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
@@ -102,7 +102,7 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 	projectID := d.Get("project_id").(string)
 	username := d.Get("username").(string)
 
-	var currentCertificate string
+	var serialNumber string
 
 	if expirationMonths, ok := d.GetOk("months_until_expiration"); ok {
 		res, _, err := conn.X509AuthDBUsers.CreateUserCertificate(ctx, projectID, username, expirationMonths.(int))
@@ -110,7 +110,7 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 			return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersCreate, username, projectID, err))
 		}
 
-		currentCertificate = cast.ToString(res.ID)
+		serialNumber = cast.ToString(res.ID)
 		if err := d.Set("current_certificate", cast.ToString(res.Certificate)); err != nil {
 			return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersSetting, "current_certificate", username, err))
 		}
@@ -123,9 +123,9 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 	}
 
 	d.SetId(encodeStateID(map[string]string{
-		"project_id":          projectID,
-		"username":            username,
-		"current_certificate": currentCertificate,
+		"project_id":    projectID,
+		"username":      username,
+		"serial_number": serialNumber,
 	}))
 
 	return resourceMongoDBAtlasX509AuthDBUserRead(ctx, d, meta)
@@ -137,11 +137,11 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
-	//currentCertificate := ids["current_certificate"]
 
 	var (
 		certificates []matlas.UserCertificate
 		err          error
+		serialNumber string
 	)
 
 	if username != "" {
@@ -155,15 +155,20 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 			}
 			return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersRead, username, projectID, err))
 		}
-	}
-
-	if err := d.Set("current_certificate", cast.ToString(certificates[0].Certificate)); err != nil {
-		return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersSetting, "current_certificate", username, err))
+		for _, val := range certificates {
+			serialNumber = cast.ToString(val.ID)
+		}
 	}
 
 	if err := d.Set("certificates", flattenCertificates(certificates)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersSetting, "certificates", username, err))
 	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id":    projectID,
+		"username":      username,
+		"serial_number": serialNumber,
+	}))
 
 	return nil
 }

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
@@ -110,7 +110,10 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 			return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersCreate, username, projectID, err))
 		}
 
-		currentCertificate = res.Certificate
+		currentCertificate = cast.ToString(res.ID)
+		if err := d.Set("current_certificate", cast.ToString(res.Certificate)); err != nil {
+			return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersSetting, "current_certificate", username, err))
+		}
 	} else {
 		customerX509Cas := d.Get("customer_x509_cas").(string)
 		_, _, err := conn.X509AuthDBUsers.SaveConfiguration(ctx, projectID, &matlas.CustomerX509{Cas: customerX509Cas})
@@ -134,7 +137,7 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
-	currentCertificate := ids["current_certificate"]
+	//currentCertificate := ids["current_certificate"]
 
 	var (
 		certificates []matlas.UserCertificate
@@ -154,7 +157,7 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 		}
 	}
 
-	if err := d.Set("current_certificate", cast.ToString(currentCertificate)); err != nil {
+	if err := d.Set("current_certificate", cast.ToString(certificates[0].Certificate)); err != nil {
 		return diag.FromErr(fmt.Errorf(errorX509AuthDBUsersSetting, "current_certificate", username, err))
 	}
 


### PR DESCRIPTION
## Description

Hide current_certificate when X.509 Authentication Database Users are Created. 

Resolves Issue: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/884 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
