### PR TITLE
INTMDB-382: Improve the importing of default alert configurations for a project

### DIFF
--- a/examples/atlas-alert-configurations/.gitignore
+++ b/examples/atlas-alert-configurations/.gitignore
@@ -1,0 +1,2 @@
+*.sh
+alert-configurations.tf

--- a/examples/atlas-alert-configurations/README.md
+++ b/examples/atlas-alert-configurations/README.md
@@ -1,3 +1,10 @@
+## Using the data source
+Example exists in `alert-configurations-data.tf`. To use this example exactly:
+- Copy directory to local disk
+- Add a `terraform.tfvars`
+- Add your `project_id`
+- Run `terraform apply`
+
 ### Create alert resources and import them into state file
 ```
 terraform output -raw alert_imports > import-alerts.sh

--- a/examples/atlas-alert-configurations/README.md
+++ b/examples/atlas-alert-configurations/README.md
@@ -1,0 +1,25 @@
+### Create alert resources and import them into state file
+```
+terraform output -raw alert_imports > import-alerts.sh
+terraform output -raw alert_resources > alert-configurations.tf
+chmod +x ./import-alerts.sh
+./import-alerts.sh
+terraform apply
+```
+
+## Contingency Plans
+If unhappy with the resource file or imports, here are some things that can be done:
+
+### Remove targeted resources from the appropriate files and remove the alet_configuration from state
+- Manually remove the resource (ex: `mongodbatlas_alert_configuration.CLUSTER_MONGOS_IS_MISSING_2`) from the `tf` file, and then remove it from state, ex:
+```
+terraform state rm mongodbatlas_alert_configuration.CLUSTER_MONGOS_IS_MISSING_2
+```
+
+### Remove all alert_configurations from state
+- Delete the `tf` file that was used for import, and then:
+```
+terraform state list | grep ^mongodbatlas_alert_configuration. | awk '{print "terraform state rm " $1}' > state-rm-alerts.sh
+chmod +x state-rm-alerts.sh
+./state-rm-alerts.sh
+```

--- a/examples/atlas-alert-configurations/alert-configurations-data.tf
+++ b/examples/atlas-alert-configurations/alert-configurations-data.tf
@@ -1,0 +1,29 @@
+data "mongodbatlas_alert_configurations" "import" {
+  project_id = var.project_id
+
+  output_type = ["resource_hcl", "resource_import"]
+}
+
+locals {
+  alerts = data.mongodbatlas_alert_configurations.import.results
+
+  alert_resources = compact([
+    for i, alert in local.alerts :
+    alert.output == null ? null :
+    length(alert.output) < 1 == null ? null : alert.output[0].value
+  ])
+
+  alert_imports = compact([
+    for i, alert in local.alerts :
+    alert.output == null ? null :
+    length(alert.output) < 2 == null ? null : alert.output[1].value
+  ])
+}
+
+output "alert_resources" {
+  value = join("\n", local.alert_resources)
+}
+
+output "alert_imports" {
+  value = join("", local.alert_imports)
+}

--- a/examples/atlas-alert-configurations/alert-configurations-data.tf
+++ b/examples/atlas-alert-configurations/alert-configurations-data.tf
@@ -27,3 +27,10 @@ output "alert_resources" {
 output "alert_imports" {
   value = join("", local.alert_imports)
 }
+
+data "mongodbatlas_alert_configurations" "test" {
+  project_id = "%s"
+  list_options {
+    page_num = 0
+  }
+}

--- a/examples/atlas-alert-configurations/alert-configurations-data.tf
+++ b/examples/atlas-alert-configurations/alert-configurations-data.tf
@@ -27,10 +27,3 @@ output "alert_resources" {
 output "alert_imports" {
   value = join("", local.alert_imports)
 }
-
-data "mongodbatlas_alert_configurations" "test" {
-  project_id = "%s"
-  list_options {
-    page_num = 0
-  }
-}

--- a/examples/atlas-alert-configurations/provider.tf
+++ b/examples/atlas-alert-configurations/provider.tf
@@ -1,0 +1,4 @@
+provider "mongodbatlas" {
+  public_key  = var.public_key
+  private_key = var.private_key
+}

--- a/examples/atlas-alert-configurations/variables.tf
+++ b/examples/atlas-alert-configurations/variables.tf
@@ -1,0 +1,10 @@
+variable "public_key" {
+  description = "Public API key to authenticate to Atlas"
+}
+variable "private_key" {
+  description = "Private API key to authenticate to Atlas"
+}
+variable "project_id" {
+  description = "Atlas project name"
+  default     = ""
+}

--- a/examples/atlas-alert-configurations/versions.tf
+++ b/examples/atlas-alert-configurations/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/zclconf/go-cty/cty"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
@@ -245,6 +249,23 @@ func dataSourceMongoDBAtlasAlertConfiguration() *schema.Resource {
 					},
 				},
 			},
+			"output": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"resource_hcl", "resource_import"}, false),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -296,10 +317,189 @@ func dataSourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "notification", projectID, err))
 	}
 
+	if dOutput := d.Get("output"); dOutput != nil {
+		types := make([]string, len(dOutput.([]interface{})))
+
+		for _, o := range dOutput.([]map[string]interface{}) {
+			types = append(types, o["type"].(string))
+		}
+
+		if err := d.Set("output", computeOutput(alert, types)); err != nil {
+			return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "output", projectID, err))
+		}
+	}
+
 	d.SetId(encodeStateID(map[string]string{
 		"id":         alert.ID,
 		"project_id": projectID,
 	}))
 
 	return nil
+}
+
+func computeOutput(alert *matlas.AlertConfiguration, types []string) []map[string]interface{} {
+	if types == nil || len(types) == 0 {
+		return nil
+	}
+
+	output := make([]map[string]interface{}, 0)
+
+	for _, oType := range types {
+		var value string
+
+		if oType == "resource_hcl" {
+			value = outputAlertConfigurationResourceHcl(alert)
+		} else if oType == "resource_import" {
+			value = outputAlertConfigurationResourceImport(alert)
+		}
+
+		if value == "" {
+			continue
+		}
+
+		output = append(output, map[string]interface{}{
+			"type":  oType,
+			"value": value,
+		})
+	}
+
+	return output
+}
+
+func outputAlertConfigurationResourceHcl(alert *matlas.AlertConfiguration) string {
+	f := hclwrite.NewEmptyFile()
+	root := f.Body()
+	resource := root.AppendNewBlock("resource", []string{"mongodbatlas_alert_configurations", alert.EventTypeName}).Body()
+
+	resource.SetAttributeValue("project_id", cty.StringVal(alert.GroupID))
+	resource.SetAttributeValue("alert_configuration_id", cty.StringVal(alert.ID))
+	resource.SetAttributeValue("event_type", cty.StringVal(alert.EventTypeName))
+	resource.SetAttributeValue("created", cty.StringVal(alert.Created))
+	resource.SetAttributeValue("updated", cty.StringVal(alert.Updated))
+
+	if alert.Enabled != nil {
+		resource.SetAttributeValue("enabled", cty.BoolVal(*alert.Enabled))
+	}
+
+	for _, matcher := range alert.Matchers {
+		values := convertMatcherToCtyValues(matcher)
+
+		appendBlockWithCtyValues(resource, "matcher", []string{}, values)
+	}
+
+	if alert.MetricThreshold != nil {
+		values := convertMetricThresholdToCtyValues(*alert.MetricThreshold)
+
+		appendBlockWithCtyValues(resource, "metric_threshold_config", []string{}, values)
+	}
+
+	if alert.Threshold != nil {
+		values := convertThresholdToCtyValues(*alert.Threshold)
+
+		appendBlockWithCtyValues(resource, "threshold_config", []string{}, values)
+	}
+
+	for _, notification := range alert.Notifications {
+		values := convertNotificationToCtyValues(notification)
+
+		appendBlockWithCtyValues(resource, "notification", []string{}, values)
+	}
+
+	return string(f.Bytes())
+}
+
+func outputAlertConfigurationResourceImport(alert *matlas.AlertConfiguration) string {
+	return fmt.Sprintf("terraform import mongodbatlas_alert_configuration.%s %s-%s\n", alert.EventTypeName, alert.GroupID, alert.ID)
+}
+
+func convertMatcherToCtyValues(matcher matlas.Matcher) map[string]cty.Value {
+	return map[string]cty.Value{
+		"field_name": cty.StringVal(matcher.FieldName),
+		"operator":   cty.StringVal(matcher.Operator),
+		"value":      cty.StringVal(matcher.Value),
+	}
+}
+
+func convertMetricThresholdToCtyValues(metric matlas.MetricThreshold) map[string]cty.Value {
+	return map[string]cty.Value{
+		"metric_name": cty.StringVal(metric.MetricName),
+		"operator":    cty.StringVal(metric.Operator),
+		"threshold":   cty.NumberFloatVal(metric.Threshold),
+		"units":       cty.StringVal(metric.Units),
+		"mode":        cty.StringVal(metric.Mode),
+	}
+}
+
+func convertThresholdToCtyValues(threshold matlas.Threshold) map[string]cty.Value {
+	return map[string]cty.Value{
+		"operator":  cty.StringVal(threshold.Operator),
+		"units":     cty.StringVal(threshold.Units),
+		"threshold": cty.NumberFloatVal(threshold.Threshold),
+	}
+}
+
+func convertNotificationToCtyValues(notification matlas.Notification) map[string]cty.Value {
+	values := map[string]cty.Value{}
+
+	if notification.ChannelName != "" {
+		values["channel_name"] = cty.StringVal(notification.ChannelName)
+	}
+
+	if notification.DatadogRegion != "" {
+		values["datadog_region"] = cty.StringVal(notification.DatadogRegion)
+	}
+
+	if notification.EmailAddress != "" {
+		values["email_address"] = cty.StringVal(notification.EmailAddress)
+	}
+
+	if notification.FlowName != "" {
+		values["flow_name"] = cty.StringVal(notification.FlowName)
+	}
+
+	if notification.IntervalMin > 0 {
+		values["interval_min"] = cty.NumberIntVal(int64(notification.IntervalMin))
+	}
+
+	if notification.MobileNumber != "" {
+		values["mobile_number"] = cty.StringVal(notification.MobileNumber)
+	}
+
+	if notification.OpsGenieRegion != "" {
+		values["ops_genie_region"] = cty.StringVal(notification.OpsGenieRegion)
+	}
+
+	if notification.OrgName != "" {
+		values["org_name"] = cty.StringVal(notification.OrgName)
+	}
+
+	if notification.TeamID != "" {
+		values["team_id"] = cty.StringVal(notification.TeamID)
+	}
+
+	if notification.TeamName != "" {
+		values["team_name"] = cty.StringVal(notification.TeamName)
+	}
+
+	if notification.TypeName != "" {
+		values["type_name"] = cty.StringVal(notification.TypeName)
+	}
+
+	if notification.Username != "" {
+		values["username"] = cty.StringVal(notification.Username)
+	}
+
+	if notification.DelayMin != nil && *notification.DelayMin > 0 {
+		values["delay_min"] = cty.NumberIntVal(int64(*notification.DelayMin))
+	}
+
+	if notification.EmailEnabled != nil && *notification.EmailEnabled {
+		values["email_enabled"] = cty.BoolVal(*notification.EmailEnabled)
+	}
+
+	if notification.SMSEnabled != nil && *notification.SMSEnabled {
+		values["sms_enabled"] = cty.BoolVal(*notification.SMSEnabled)
+	}
+
+	return values
 }

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -338,7 +338,7 @@ func dataSourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema
 }
 
 func computeOutput(alert *matlas.AlertConfiguration, types []string) []map[string]interface{} {
-	if types == nil || len(types) == 0 {
+	if len(types) == 0 {
 		return nil
 	}
 
@@ -399,8 +399,8 @@ func outputAlertConfigurationResourceHcl(alert *matlas.AlertConfiguration) strin
 		appendBlockWithCtyValues(resource, "threshold_config", []string{}, values)
 	}
 
-	for _, notification := range alert.Notifications {
-		values := convertNotificationToCtyValues(notification)
+	for i := 0; i < len(alert.Notifications); i++ {
+		values := convertNotificationToCtyValues(&alert.Notifications[i])
 
 		appendBlockWithCtyValues(resource, "notification", []string{}, values)
 	}
@@ -438,7 +438,7 @@ func convertThresholdToCtyValues(threshold matlas.Threshold) map[string]cty.Valu
 	}
 }
 
-func convertNotificationToCtyValues(notification matlas.Notification) map[string]cty.Value {
+func convertNotificationToCtyValues(notification *matlas.Notification) map[string]cty.Value {
 	values := map[string]cty.Value{}
 
 	if notification.ChannelName != "" {

--- a/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configuration.go
@@ -322,7 +322,7 @@ func dataSourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema
 	}
 
 	if dOutput := d.Get("output"); dOutput != nil {
-		if err := d.Set("output", computeAlertConfigurationOutput(alert, dOutput.([]map[string]interface{}), alert.EventTypeName)); err != nil {
+		if err := d.Set("output", computeAlertConfigurationOutput(alert, dOutput.([]interface{}), alert.EventTypeName)); err != nil {
 			return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "output", projectID, err))
 		}
 	}
@@ -335,10 +335,11 @@ func dataSourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema
 	return nil
 }
 
-func computeAlertConfigurationOutput(alert *matlas.AlertConfiguration, outputConfigurations []map[string]interface{}, defaultLabel string) []map[string]interface{} {
+func computeAlertConfigurationOutput(alert *matlas.AlertConfiguration, outputConfigurations []interface{}, defaultLabel string) []map[string]interface{} {
 	output := make([]map[string]interface{}, 0)
 
-	for _, config := range outputConfigurations {
+	for i := 0; i < len(outputConfigurations); i++ {
+		config := outputConfigurations[i].(map[string]interface{})
 		var o = map[string]interface{}{
 			"type": config["type"],
 		}

--- a/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
@@ -127,18 +127,18 @@ func flattenAlertConfigurations(ctx context.Context, conn *matlas.Client, alerts
 		}
 	}
 
-	for _, alert := range alerts {
+	for i := 0; i < len(alerts); i++ {
 		results = append(results, map[string]interface{}{
-			"alert_configuration_id":  alert.ID,
-			"event_type":              alert.EventTypeName,
-			"created":                 alert.Created,
-			"updated":                 alert.Updated,
-			"enabled":                 alert.Enabled,
-			"matcher":                 flattenAlertConfigurationMatchers(alert.Matchers),
-			"metric_threshold_config": flattenAlertConfigurationMetricThresholdConfig(alert.MetricThreshold),
-			"threshold_config":        flattenAlertConfigurationThresholdConfig(alert.Threshold),
-			"notification":            flattenAlertConfigurationNotifications(d, alert.Notifications),
-			"output":                  computeOutput(&alert, outputTypes),
+			"alert_configuration_id":  alerts[i].ID,
+			"event_type":              alerts[i].EventTypeName,
+			"created":                 alerts[i].Created,
+			"updated":                 alerts[i].Updated,
+			"enabled":                 alerts[i].Enabled,
+			"matcher":                 flattenAlertConfigurationMatchers(alerts[i].Matchers),
+			"metric_threshold_config": flattenAlertConfigurationMetricThresholdConfig(alerts[i].MetricThreshold),
+			"threshold_config":        flattenAlertConfigurationThresholdConfig(alerts[i].Threshold),
+			"notification":            flattenAlertConfigurationNotifications(d, alerts[i].Notifications),
+			"output":                  computeOutput(&alerts[i], outputTypes),
 		})
 	}
 

--- a/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
@@ -1,0 +1,130 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func resourceListOptions() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"page_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+			"items_per_page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  100,
+			},
+			"include_count": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func readListOptions(listOptionsArr []interface{}) *matlas.ListOptions {
+	var listOptions map[string]interface{}
+
+	if len(listOptionsArr) > 0 {
+		listOptions = listOptionsArr[0].(map[string]interface{})
+	} else {
+		listOptions = map[string]interface{}{
+			"page_num":       0,
+			"items_per_page": 100,
+			"include_count":  false,
+		}
+	}
+
+	return &matlas.ListOptions{
+		PageNum:      listOptions["page_num"].(int),
+		ItemsPerPage: listOptions["items_per_page"].(int),
+		IncludeCount: listOptions["include_count"].(bool),
+	}
+}
+
+func dataSourceMongoDBAtlasAlertConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMongoDBAtlasAlertConfigurationsRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"list_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     resourceListOptions(),
+			},
+			"results": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     dataSourceMongoDBAtlasAlertConfiguration(),
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMongoDBAtlasAlertConfigurationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Get client connection.
+	conn := meta.(*MongoDBClient).Atlas
+	projectID := d.Get("project_id").(string)
+	listOptions := d.Get("list_options").([]interface{})
+
+	alerts, _, err := conn.AlertConfigurations.List(ctx, projectID, readListOptions(listOptions))
+
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorReadAlertConf, err))
+	}
+
+	results := flattenAlertConfigurations(ctx, conn, alerts, d)
+
+	if err := d.Set("results", results); err != nil {
+		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "results", projectID, err))
+	}
+
+	if err := d.Set("list_options", listOptions); err != nil {
+		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "list_options", projectID, err))
+	}
+
+	d.SetId(encodeStateID(map[string]string{
+		"project_id": projectID,
+	}))
+
+	return nil
+}
+
+func flattenAlertConfigurations(ctx context.Context, conn *matlas.Client, alerts []matlas.AlertConfiguration, d *schema.ResourceData) []map[string]interface{} {
+	results := make([]map[string]interface{}, len(alerts))
+
+	for _, alert := range alerts {
+		results = append(results, map[string]interface{}{
+			"alert_configuration_id":  alert.ID,
+			"event_type":              alert.EventTypeName,
+			"created":                 alert.Created,
+			"updated":                 alert.Updated,
+			"enabled":                 alert.Enabled,
+			"matcher":                 flattenAlertConfigurationMatchers(alert.Matchers),
+			"metric_threshold":        flattenAlertConfigurationMetricThreshold(alert.MetricThreshold),
+			"threshold":               flattenAlertConfigurationThreshold(alert.Threshold),
+			"metric_threshold_config": flattenAlertConfigurationMetricThresholdConfig(alert.MetricThreshold),
+			"threshold_config":        flattenAlertConfigurationThresholdConfig(alert.Threshold),
+			"notification":            flattenAlertConfigurationNotifications(d, alert.Notifications),
+		})
+	}
+
+	return results
+}

--- a/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configurations.go
@@ -117,7 +117,7 @@ func dataSourceMongoDBAtlasAlertConfigurationsRead(ctx context.Context, d *schem
 }
 
 func flattenAlertConfigurations(ctx context.Context, conn *matlas.Client, alerts []matlas.AlertConfiguration, d *schema.ResourceData) []map[string]interface{} {
-	var outputConfigurations []map[string]interface{}
+	var outputConfigurations []interface{}
 
 	results := make([]map[string]interface{}, 0)
 

--- a/mongodbatlas/data_source_mongodbatlas_alert_configurations_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_alert_configurations_test.go
@@ -1,0 +1,79 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSAlertConfigurations_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_alert_configurations.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfiguration(projectID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationsCount(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAlertConfigurations(projectID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_alert_configurations" "test" {
+			project_id = "%s"
+
+			list_options {
+				page_num = 0
+			}
+		}
+	`, projectID)
+}
+
+func testAccCheckMongoDBAtlasAlertConfigurationsCount(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+
+		alertResp, _, err := conn.AlertConfigurations.List(context.Background(), projectID, &matlas.ListOptions{
+			PageNum:      0,
+			ItemsPerPage: 100,
+			IncludeCount: true,
+		})
+
+		if err != nil {
+			return fmt.Errorf("the Alert Configurations List for project (%s) could not be read", projectID)
+		}
+
+		if len(rs.Primary.Attributes["results"]) != len(alertResp) {
+			return fmt.Errorf("%s results count did not match that of current Alert Configurations", resourceName)
+		}
+
+		return nil
+	}
+}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -164,6 +164,7 @@ func getDataSourcesMap() map[string]*schema.Resource {
 		"mongodbatlas_teams":                                    dataSourceMongoDBAtlasTeam(),
 		"mongodbatlas_global_cluster_config":                    dataSourceMongoDBAtlasGlobalCluster(),
 		"mongodbatlas_alert_configuration":                      dataSourceMongoDBAtlasAlertConfiguration(),
+		"mongodbatlas_alert_configurations":                     dataSourceMongoDBAtlasAlertConfigurations(),
 		"mongodbatlas_x509_authentication_database_user":        dataSourceMongoDBAtlasX509AuthDBUser(),
 		"mongodbatlas_private_endpoint_regional_mode":           dataSourceMongoDBAtlasPrivateEndpointRegionalMode(),
 		"mongodbatlas_privatelink_endpoint":                     dataSourceMongoDBAtlasPrivateLinkEndpoint(),

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -527,6 +527,27 @@ func HashCodeString(s string) int {
 	return 0
 }
 
+func appendBlockWithCtyValues(body *hclwrite.Body, name string, labels []string, values map[string]cty.Value) {
+	if len(values) == 0 {
+		return
+	}
+
+	keys := make([]string, 0, len(values))
+
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	body.AppendNewline()
+	block := body.AppendNewBlock(name, labels).Body()
+
+	for _, k := range keys {
+		block.SetAttributeValue(k, values[k])
+	}
+}
+
 // assumeRoleSchema From aws provider.go
 func assumeRoleSchema() *schema.Schema {
 	return &schema.Schema{

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -690,16 +690,3 @@ func expandAssumeRole(tfMap map[string]interface{}) *AssumeRole {
 
 	return &assumeRole
 }
-
-func appendBlockWithCtyValues(body *hclwrite.Body, name string, labels []string, values map[string]cty.Value) {
-	if len(values) == 0 {
-		return
-	}
-
-	body.AppendNewline()
-	block := body.AppendNewBlock(name, labels).Body()
-
-	for k, v := range values {
-		block.SetAttributeValue(k, v)
-	}
-}

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -22,11 +22,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
+	"github.com/zclconf/go-cty/cty"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -687,4 +689,17 @@ func expandAssumeRole(tfMap map[string]interface{}) *AssumeRole {
 	}
 
 	return &assumeRole
+}
+
+func appendBlockWithCtyValues(body *hclwrite.Body, name string, labels []string, values map[string]cty.Value) {
+	if len(values) == 0 {
+		return
+	}
+
+	body.AppendNewline()
+	block := body.AppendNewBlock(name, labels).Body()
+
+	for k, v := range values {
+		block.SetAttributeValue(k, v)
+	}
 }

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -689,7 +689,17 @@ func flattenAlertConfigurationThresholdConfig(m *matlas.Threshold) []interface{}
 }
 
 func expandAlertConfigurationNotification(d *schema.ResourceData) ([]matlas.Notification, error) {
-	notifications := make([]matlas.Notification, len(d.Get("notification").([]interface{})))
+	notificationCount := 0
+
+	if notifications, ok := d.GetOk("notification"); ok {
+		notificationCount = len(notifications.([]interface{}))
+	}
+
+	notifications := make([]matlas.Notification, notificationCount)
+
+	if notificationCount == 0 {
+		return notifications, nil
+	}
 
 	for i, value := range d.Get("notification").([]interface{}) {
 		v := value.(map[string]interface{})

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -90,18 +90,18 @@ data "mongodbatlas_alert_configuration" "test" {
 Utilize data_source to generate resource hcl and import statement. Useful if you have a specific alert_configuration_id and are looking to manage it as is in state. To import all alerts, refer to the documentation on [data_source_mongodbatlas_alert_configurations](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/alert_configurations)
 ```
 data "mongodbatlas_alert_configuration" "test" {
-	project_id             = var.project_id
-	alert_configuration_id = var.alert_configuration_id
+    project_id             = var.project_id
+    alert_configuration_id = var.alert_configuration_id
 
-  output {
-    type = "resource_hcl"
-    label = "test"
-  }
+    output {
+        type = "resource_hcl"
+        label = "test"
+    }
 
-  output {
-    type = "resource_import"
-    label = "test"
-  }
+    output {
+        type = "resource_import"
+        label = "test"
+    }
 }
 ```
 

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -87,6 +87,24 @@ data "mongodbatlas_alert_configuration" "test" {
 }
 ```
 
+Utilize data_source to generate resource hcl and import statement. Useful if you have a specific alert_configuration_id and are looking to manage it as is in state. To import all alerts, refer to the documentation on [data_source_mongodbatlas_alert_configurations](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/alert_configurations)
+```
+data "mongodbatlas_alert_configuration" "test" {
+	project_id             = var.project_id
+	alert_configuration_id = var.alert_configuration_id
+
+  output {
+    type = "resource_hcl"
+    label = "test"
+  }
+
+  output {
+    type = "resource_import"
+    label = "test"
+  }
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) The ID of the project where the alert configuration will create.

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -91,12 +91,14 @@ data "mongodbatlas_alert_configuration" "test" {
 
 * `project_id` - (Required) The ID of the project where the alert configuration will create.
 * `alert_configuration_id` - (Required) Unique identifier for the alert configuration.
+* `output` - (Optional) List of formatted output requested for this alert configuration
+* `output.#.type` - (Required) If the output is requested, you must specify its type. The format is computed as `output.#.value`, the following are the supported types:
+- `resource_hcl`: This string is used to define the resource as it exists in MongoDB Atlas.
+- `resource_import`: This string is used to import the existing resource into the state file.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
-
-* `group_id` - Unique identifier of the project that owns this alert configuration.
 * `created` - Timestamp in ISO 8601 date and time format in UTC when this alert configuration was created.
 * `updated` - Timestamp in ISO 8601 date and time format in UTC when this alert configuration was last updated.
 * `enabled` - If set to true, the alert configuration is enabled. If enabled is not exported it is set to false.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas: Alert Configurations"
+sidebar_current: "docs-mongodbatlas-datasource-alert-configurations"
+description: |-
+    Describe all Alert Configurations in Project.
+---
+
+# Data Source: mongodbatlas_alert_configurations
+
+`mongodbatlas_alert_configurations` describes all Alert Configurations by the provided project_id. The data source requires your Project ID.
+
+-> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
+
+## Example Usage
+
+```terraform
+data "mongodbatlas_alert_configurations" "import" {
+  project_id = var.project_id
+
+  output_type = ["resource_hcl", "resource_import"]
+}
+
+locals {
+  alerts = data.mongodbatlas_alert_configurations.import.results
+
+  outputs = flatten([
+    for i, alert in local.alerts :
+    alert.output == null ? [] : alert.output
+  ])
+
+  output_values = compact([for i, o in local.outputs : o.value])
+}
+
+output "alert_output" {
+  value = join("\n", local.output_values)
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) The unique ID for the project to get the alert configurations.
+* `list_options` - (Optional) Arguments that dictate how many and which results are returned by the data source
+* `list_options.page_num` - Which page of results to retrieve (default to first page)
+* `list_options.items_per_page` - How many alerts to retrieve per page (default 100)
+* `list_options.include_count` - Whether to include total count of results in the response (default false)
+* `output_type` - (Optional) List of requested string formatted output to be included on each individual result. Options are `resource_hcl` and `resource_import`. Available to make it easy to gather resource statements for existing alert configurations, and corresponding import statements to import said resource state into the statefile.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `total_count` - Total count of results
+* `results` - A list of alert configurations for the project_id, constrained by the `list_options`.
+
+### Alert Configuration
+
+* `project_id` - The ID of the project where the alert configuration exists
+* `alert_configuration_id` - The ID of the alert configuration
+* `created` - Timestamp in ISO 8601 date and time format in UTC when this alert configuration was created.
+* `updated` - Timestamp in ISO 8601 date and time format in UTC when this alert configuration was last updated.
+* `enabled` - If set to true, the alert configuration is enabled. If enabled is not exported it is set to false.
+* `event_type` - The type of event that will trigger an alert.
+* `matcher` - Rules to apply when matching an object against this alert configuration
+* `metric_threshold_config` - The threshold that causes an alert to be triggered. Required if `event_type_name` : `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`
+* `threshold_config` - 	 Threshold that triggers an alert. Required if `event_type_name` is any value other than `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`.
+* `notifications` - List of notifications to send when an alert condition is detected.
+* `output` - Requested output string format for the alert configuration
+
+For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/alert-configurations/)
+Or refer to the individual resource or data_source documentation on alert configuration.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -37,6 +37,9 @@ output "alert_output" {
 }
 ```
 
+Refer to the following for a full example on using this data_source as a tool to import all resources:
+* [atlas-alert-configurations](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-alert-configurations)
+
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to get the alert configurations.


### PR DESCRIPTION
## Description

Add functionality to make it easier to import the default alert configurations for a project.

This was accomplished by:
- Adding a `data_source_alert_configurations` which reads in the alert configurations for a given `project_id`
- Supporting a couple formatted `output`s on `data_source_alert_configuration` (`resource_hcl` and `resource_import`)

By utilizing the following configuration (present in the new docs example) users can get a list of alert configuration resources and import statements for the given project.
```
data "mongodbatlas_alert_configurations" "import" {
  project_id = var.project_id

  output_type = ["resource_hcl", "resource_import"]
}

locals {
  alerts = data.mongodbatlas_alert_configurations.import.results

  outputs = flatten([
    for i, alert in local.alerts :
    alert.output == null ? [] : alert.output
  ])

  output_values = compact([for i, o in local.outputs : o.value])
}

output "alert_output" {
  value = join("\n", local.output_values)
}
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
