### PR TITLE
federated_settings_org_config import example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export TF_CLI_CONFIG_FILE=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cac
 
 #### Logs
 To help with dubbing issues, you can turn on Logs with `export TF_LOG=TRACE`. Note: this is very noisy. 
+
 To export logs to file, you can use `export TF_LOG_PATH=terraform.log`
 
 ### Running the acceptance test

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export TF_CLI_CONFIG_FILE=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cac
 
 #### Logs
 To help with dubbing issues, you can turn on Logs with `export TF_LOG=TRACE`. Note: this is very noisy. 
+To export logs to file, you can use `export TF_LOG_PATH=terraform.log`
 
 ### Running the acceptance test
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -88,7 +88,7 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
       "private_key":"secret2"
      }
 ```
-2. Create an AWS IAM Role to attach to the AWS STS (Security Token Service) generated short lived API keys. This is required since STS generated API Keys by default have restricted permissions and need to have their permissions elevated in order to authenticate with Terraform. Take note of Role ARN and ensure IAM Role has permission for “sts:AssumeRole” . For example: 
+2. Create an AWS IAM Role to attach to the AWS STS (Security Token Service) generated short lived API keys. This is required since STS generated API Keys by default have restricted permissions and need to have their permissions elevated in order to authenticate with Terraform. Take note of Role ARN and ensure IAM Role has permission for “sts:AssumeRole”. For example: 
 ```
 {
     "Version": "2012-10-17",
@@ -99,13 +99,13 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
             "Principal": {
                 "AWS": "*"
             },
-            "Action": [
-                "sts:AssumeRole"
-            ]
+            "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+In addition, you are required to also attach the AWS Managed policy of `SecretsManagerReadWrite` to this IAM role.
+
 Note: this policy may be overly broad for many use cases, feel free to adjust accordingly to your organization's needs.
 
 3. In terminal, store as environmental variables AWS API Keys (while you can also hardcode in config files these will then be stored as plain text in .tfstate file and should be avoided if possible). For example:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -99,10 +99,12 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
             "Principal": {
                 "AWS": "*"
             },
-            "Action": "sts:AssumeRole"
+            "Action": [
+                "sts:AssumeRole"
+            ]
         }
     ]
-} 
+}
 ```
 Note: this policy may be overly broad for many use cases, feel free to adjust accordingly to your organization's needs.
 

--- a/website/docs/r/federated_settings_org_config.html.markdown
+++ b/website/docs/r/federated_settings_org_config.html.markdown
@@ -49,7 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 FederatedSettingsOrgConfig must be imported using federation_settings_id-org_id, e.g.
 
 ```
-$ terraform import mongodbatlas_federated_settings_org_config.org_connection 6287a663c7f7f7f71c441c6c-627a96837f7f7f7e306f14-628ae97f7f7468ea3727
+$ terraform import mongodbatlas_federated_settings_org_config.org_connection 627a9687f7f7f7f774de306f14-627a9683ea7ff7f74de306f14
 ```
 
 For more information see: [MongoDB Atlas API Reference.](https://www.mongodb.com/docs/atlas/reference/api/federation-configuration/)


### PR DESCRIPTION
## Description

Correcting example to include only 2 parameters ( federation_settings_id and org_id) instead of 3 shown 

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
