### PR TITLE
INTMDB-547: Enhance docs for mongodbatlas cloud_backup_schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export TF_CLI_CONFIG_FILE=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cac
 
 #### Logs
 To help with dubbing issues, you can turn on Logs with `export TF_LOG=TRACE`. Note: this is very noisy. 
+
 To export logs to file, you can use `export TF_LOG_PATH=terraform.log`
 
 ### Running the acceptance test

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ export TF_CLI_CONFIG_FILE=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cac
 
 #### Logs
 To help with dubbing issues, you can turn on Logs with `export TF_LOG=TRACE`. Note: this is very noisy. 
+To export logs to file, you can use `export TF_LOG_PATH=terraform.log`
 
 ### Running the acceptance test
 

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -295,7 +295,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		awsSecretAccessKey := d.Get("aws_secret_access_key").(string)
 		awsSessionToken := d.Get("aws_session_token").(string)
 		endpoint := d.Get("sts_endpoint").(string)
-		config, _ = configureCredentialsSTS(&config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint)
+		var err error
+		config, err = configureCredentialsSTS(&config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
 	}
 
 	return config.NewClient(ctx)
@@ -305,6 +309,7 @@ func configureCredentialsSTS(config *Config, secret, region, awsAccessKeyID, aws
 	ep, err := endpoints.GetSTSRegionalEndpoint("regional")
 	if err != nil {
 		fmt.Printf("GetSTSRegionalEndpoint error: %s", err)
+		return *config, err
 	}
 
 	sess := session.Must(session.NewSession(&aws.Config{
@@ -318,25 +323,31 @@ func configureCredentialsSTS(config *Config, secret, region, awsAccessKeyID, aws
 
 	_, err = sess.Config.Credentials.Get()
 	if err != nil {
-		fmt.Printf("Session get credentils error: %s", err)
+		fmt.Printf("Session get credentials error: %s", err)
+		return *config, err
 	}
 	_, err = creds.Get()
 	if err != nil {
 		fmt.Printf("STS get credentials error: %s", err)
+		return *config, err
 	}
-	secretString := secretsManagerGetSecretValue(sess, &aws.Config{Credentials: creds, Region: aws.String(region)}, secret)
+	secretString, err := secretsManagerGetSecretValue(sess, &aws.Config{Credentials: creds, Region: aws.String(region)}, secret)
+	if err != nil {
+		fmt.Printf("Get Secrets error: %s", err)
+		return *config, err
+	}
 
 	var secretData SecretData
 	err = json.Unmarshal([]byte(secretString), &secretData)
 	if err != nil {
-		return *config, nil
+		return *config, err
 	}
 	config.PublicKey = secretData.PublicKey
 	config.PrivateKey = secretData.PrivateKey
 	return *config, nil
 }
 
-func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secret string) string {
+func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secret string) (string, error) {
 	svc := secretsmanager.New(sess, creds)
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String(secret),
@@ -363,11 +374,11 @@ func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secr
 		} else {
 			fmt.Println(err.Error())
 		}
-		return ""
+		return "", err
 	}
 
 	fmt.Println(result)
-	return *result.SecretString
+	return *result.SecretString, err
 }
 
 func encodeStateID(values map[string]string) string {

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -69,36 +69,35 @@ In addition to all arguments above, the following attributes are exported:
 ### Export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
 * `frequency_type` - Frequency associated with the export snapshot item.
+
 ### Policy Item Hourly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
+* `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
+  * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
+  * `40` represents the last day of the month (depending on the month).
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/schedule/get-all-schedules/)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -117,7 +117,7 @@ export AWS_SECRET_ACCESS_KEY="secret”
 
 Note: AWS STS secrets are short lived by default, use the ` --duration-seconds` flag to specify longer duration as needed 
 
-5. Store each of the 3 new created secrets from AWS STS as environment variables. For example: 
+5. Store each of the 3 new created secrets from AWS STS as environment variables (hardcoding secrets into config file with additional risk is also supported). For example: 
 ```
 export AWS_ACCESS_KEY_ID="ASIAYBYSK3S5FZEKLETV"
 export AWS_SECRET_ACCESS_KEY="lgT6kL9lr1fxM6mCEwJ33MeoJ1M6lIzgsiW23FGH"
@@ -132,6 +132,7 @@ provider "mongodbatlas" {
     role_arn = "arn:aws:iam::476xxx451:role/mdbsts"
   }
   secret_name           = "mongodbsecret"
+  // fully qualified secret_name ARN also supported as input "arn:aws:secretsmanager:af-south-1:553552370874:secret:test789-TO06Hy" 
   region                = "us-east-2"
   
   aws_access_key_id     = "ASIXXBNEK"
@@ -140,7 +141,13 @@ provider "mongodbatlas" {
   sts_endpoint          = "https://sts.us-east-2.amazonaws.com/"
 }
 ```
-Note: `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable. Also `sts_endpoint` will be generated on behalf of user if not provider. 
+Note: `aws_access_key_id`, `aws_secret_access_key`, and `aws_session_token` can also be passed in using environment variables i.e. aws_access_key_id will accept AWS_ACCESS_KEY_ID and TF_VAR_AWS_ACCESS_KEY_ID as a default value in place of value in a terraform file variable. 
+
+Note: Fully qualified `secret_name` ARN as input is REQUIRED for cross-AWS account secrets. For more detatils see:
+* https://aws.amazon.com/blogs/security/how-to-access-secrets-across-aws-accounts-by-attaching-resource-based-policies/ 
+* https://aws.amazon.com/premiumsupport/knowledge-center/secrets-manager-share-between-accounts/
+
+Note: `sts_endpoint` parameter is REQUIRED for cross-AWS region secrets. 
 
 7. In terminal, `terraform init` 
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -88,7 +88,7 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
       "private_key":"secret2"
      }
 ```
-2. Create an AWS IAM Role to attach to the AWS STS (Security Token Service) generated short lived API keys. This is required since STS generated API Keys by default have restricted permissions and need to have their permissions elevated in order to authenticate with Terraform. Take note of Role ARN and ensure IAM Role has permission for “sts:AssumeRole” . For example: 
+2. Create an AWS IAM Role to attach to the AWS STS (Security Token Service) generated short lived API keys. This is required since STS generated API Keys by default have restricted permissions and need to have their permissions elevated in order to authenticate with Terraform. Take note of Role ARN and ensure IAM Role has permission for “sts:AssumeRole”. For example: 
 ```
 {
     "Version": "2012-10-17",
@@ -99,13 +99,13 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
             "Principal": {
                 "AWS": "*"
             },
-            "Action": [
-                "sts:AssumeRole"
-            ]
+            "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+In addition, you are required to also attach the AWS Managed policy of `SecretsManagerReadWrite` to this IAM role.
+
 Note: this policy may be overly broad for many use cases, feel free to adjust accordingly to your organization's needs.
 
 3. In terminal, store as environmental variables AWS API Keys (while you can also hardcode in config files these will then be stored as plain text in .tfstate file and should be avoided if possible). For example:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -99,10 +99,12 @@ In order to enable the Terraform MongoDB Atlas Provider with AWS SM, please foll
             "Principal": {
                 "AWS": "*"
             },
-            "Action": "sts:AssumeRole"
+            "Action": [
+                "sts:AssumeRole"
+            ]
         }
     ]
-} 
+}
 ```
 Note: this policy may be overly broad for many use cases, feel free to adjust accordingly to your organization's needs.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -147,7 +147,7 @@ Note: Fully qualified `secret_name` ARN as input is REQUIRED for cross-AWS accou
 * https://aws.amazon.com/blogs/security/how-to-access-secrets-across-aws-accounts-by-attaching-resource-based-policies/ 
 * https://aws.amazon.com/premiumsupport/knowledge-center/secrets-manager-share-between-accounts/
 
-Note: `sts_endpoint` parameter is REQUIRED for cross-AWS region secrets. 
+Note: `sts_endpoint` parameter is REQUIRED for cross-AWS region or cross-AWS account secrets. 
 
 7. In terminal, `terraform init` 
 

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -113,22 +113,23 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
   
   // This will now add the desired policy items to the existing mongodbatlas_cloud_backup_schedule resource
   policy_item_hourly {
-    frequency_interval = 1
+    frequency_interval = 1        #accepted values = 1, 2, 4, 6, 8, 12 -> every n hours
     retention_unit     = "days"
     retention_value    = 1
   }
   policy_item_daily {
-    frequency_interval = 1
+    frequency_interval = 1        #accepted values = 1 -> every 1 day
     retention_unit     = "days"
     retention_value    = 2
   }
   policy_item_weekly {
-    frequency_interval = 4
+    frequency_interval = 4        # accepted values = 1 to 7 -> every 1=Monday,2=Tuesday,3=Wednesday,4=Thursday,5=Friday,6=Saturday,7=Sunday day of the week
     retention_unit     = "weeks"
     retention_value    = 3
   }
   policy_item_monthly {
-    frequency_interval = 5
+    frequency_interval = 5        # accepted values = 1 to 28 -> 1 to 28 every nth day of the month  
+                                  # accepted values = 40 -> every last day of the month
     retention_unit     = "months"
     retention_value    = 4
   }

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 `mongodbatlas_cloud_backup_schedule` provides a cloud backup schedule resource. The resource lets you create, read, update and delete a cloud backup schedule.
 
--> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
+-> **NOTE** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
--> **API Key Access List**: This resource requires an Atlas API Access Key List to utilize this feature. This means to manage this resources you must have the IP address or CIDR block that the Terraform connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using. See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list) for details.
+-> **API Key Access List** This resource requires an Atlas API Access Key List to utilize this feature. This means to manage this resources you must have the IP address or CIDR block that the Terraform connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using. See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list) for details.
 
 In the Terraform MongoDB Atlas Provider 1.0.0 we have re-architected the way in which Cloud Backup Policies are manged with Terraform to significantly reduce the complexity. Due to this change we've provided multiple examples below to help express how this new resource functions.
 

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -158,28 +158,34 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `frequency_type` - Frequency associated with the export snapshot item.
 
 ### Policy Item Hourly
-* 
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
+  * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
+  * `40` represents the last day of the month (depending on the month).
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

Updates documentation for mongodbatlas_cloud_backup_schedule by adding more information about possible values for frequency_type, frequency_interval, retention_unit and retention_value.

Fixes #1005 and [INTMDB-547](https://jira.mongodb.org/browse/INTMDB-547).

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
Branched off from `master` for the work done. Please advise if changes should be applied to a branch from `v1.8.0_staging` instead and PR recreated since there is other work in this PR.