### PR TITLE
INTMDB-547: 1005 - Enhance docs for mongodbatlas cloud_backup_schedule

### DIFF
--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -79,21 +79,21 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequency type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
   * `40` represents the last day of the month (depending on the month).

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -69,36 +69,35 @@ In addition to all arguments above, the following attributes are exported:
 ### Export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
 * `frequency_type` - Frequency associated with the export snapshot item.
+
 ### Policy Item Hourly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
+* `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
-*
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item.
-* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - Value to associate with `retention_unit`.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
+  * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
+  * `40` represents the last day of the month (depending on the month).
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/schedule/get-all-schedules/)

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -113,22 +113,23 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
   
   // This will now add the desired policy items to the existing mongodbatlas_cloud_backup_schedule resource
   policy_item_hourly {
-    frequency_interval = 1
+    frequency_interval = 1        #accepted values = 1, 2, 4, 6, 8, 12 -> every n hours
     retention_unit     = "days"
     retention_value    = 1
   }
   policy_item_daily {
-    frequency_interval = 1
+    frequency_interval = 1        #accepted values = 1 -> every 1 day
     retention_unit     = "days"
     retention_value    = 2
   }
   policy_item_weekly {
-    frequency_interval = 4
+    frequency_interval = 4        # accepted values = 1 to 7 -> every 1=Monday,2=Tuesday,3=Wednesday,4=Thursday,5=Friday,6=Saturday,7=Sunday day of the week
     retention_unit     = "weeks"
     retention_value    = 3
   }
   policy_item_monthly {
-    frequency_interval = 5
+    frequency_interval = 5        # accepted values = 1 to 28 -> 1 to 28 every nth day of the month  
+                                  # accepted values = 40 -> every last day of the month
     retention_unit     = "months"
     retention_value    = 4
   }

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 `mongodbatlas_cloud_backup_schedule` provides a cloud backup schedule resource. The resource lets you create, read, update and delete a cloud backup schedule.
 
--> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
+-> **NOTE** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
--> **API Key Access List**: This resource requires an Atlas API Access Key List to utilize this feature. This means to manage this resources you must have the IP address or CIDR block that the Terraform connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using. See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list) for details.
+-> **API Key Access List** This resource requires an Atlas API Access Key List to utilize this feature. This means to manage this resources you must have the IP address or CIDR block that the Terraform connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using. See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list) for details.
 
 In the Terraform MongoDB Atlas Provider 1.0.0 we have re-architected the way in which Cloud Backup Policies are manged with Terraform to significantly reduce the complexity. Due to this change we've provided multiple examples below to help express how this new resource functions.
 

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -158,28 +158,34 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `frequency_type` - Frequency associated with the export snapshot item.
 
 ### Policy Item Hourly
-* 
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
-*
-* `frequency_interval` - (Required) Desired frequency of the new backup policy item specified by `frequency_type`.
-* `retention_unit` - (Required) Scope of the backup policy item: days, weeks, or months.
-* `retention_value` - (Required) Value to associate with `retention_unit`.
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
+  * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
+  * `40` represents the last day of the month (depending on the month).
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 
 ## Attributes Reference

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -167,21 +167,21 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequence type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequence type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
 * `id` - Unique identifier of the backup policy item.
-* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequence type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_type` - Frequency associated with the backup policy item. For monthly policies, the frequency type is defined as `monthly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
   * `40` represents the last day of the month (depending on the month).


### PR DESCRIPTION
## Description

Updates documentation for mongodbatlas_cloud_backup_schedule by adding more information about possible values for frequency_type, frequency_interval, retention_unit and retention_value.

Fixes #1005 and [INTMDB-547](https://jira.mongodb.org/browse/INTMDB-547).

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
This is a duplicate PR of #1006. PR #1006 is for work applied to a branch from `master`, this PR is for work applied to a branch from `v1.8.0_staging`.