### PR TITLE
INTMDB-519: mongodbatlas_third_party_integration - api_token keeps updating on every apply

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -144,7 +144,7 @@ func dataSourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *sch
 		return diag.FromErr(fmt.Errorf("error getting third party integration for type %s %w", queryType, err))
 	}
 
-	fieldMap := integrationToSchema(integration)
+	fieldMap := integrationToSchema(d, integration)
 
 	for property, value := range fieldMap {
 		if err = d.Set(property, value); err != nil {

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -91,6 +91,9 @@ func integrationToSchema(d *schema.ResourceData, integration *matlas.ThirdPartyI
 	if integrationSchema.Password == "" {
 		integrationSchema.APIKey = integration.Password
 	}
+	if integrationSchema.UserName == "" {
+		integrationSchema.APIKey = integration.UserName
+	}
 
 	out := map[string]interface{}{
 		"type":                        integration.Type,
@@ -110,7 +113,7 @@ func integrationToSchema(d *schema.ResourceData, integration *matlas.ThirdPartyI
 		"url":                         integration.URL,
 		"secret":                      integrationSchema.Secret,
 		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
-		"user_name":                   integration.UserName,
+		"user_name":                   integrationSchema.UserName,
 		"password":                    integrationSchema.Password,
 		"service_discovery":           integration.ServiceDiscovery,
 		"scheme":                      integration.Scheme,

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -37,7 +37,7 @@ func dataSourceMongoDBAtlasThirdPartyIntegrationsRead(ctx context.Context, d *sc
 		return diag.FromErr(fmt.Errorf("error getting third party integration list: %s", err))
 	}
 
-	if err = d.Set("results", flattenIntegrations(integrations, projectID)); err != nil {
+	if err = d.Set("results", flattenIntegrations(d, integrations, projectID)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting results for third party integrations %s", err))
 	}
 
@@ -46,7 +46,7 @@ func dataSourceMongoDBAtlasThirdPartyIntegrationsRead(ctx context.Context, d *sc
 	return nil
 }
 
-func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID string) (list []map[string]interface{}) {
+func flattenIntegrations(d *schema.ResourceData, integrations *matlas.ThirdPartyIntegrations, projectID string) (list []map[string]interface{}) {
 	if len(integrations.Results) == 0 {
 		return
 	}
@@ -54,7 +54,7 @@ func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID 
 	list = make([]map[string]interface{}, 0, len(integrations.Results))
 
 	for _, integration := range integrations.Results {
-		service := integrationToSchema(integration)
+		service := integrationToSchema(d, integration)
 		service["project_id"] = projectID
 		list = append(list, service)
 	}
@@ -62,27 +62,56 @@ func flattenIntegrations(integrations *matlas.ThirdPartyIntegrations, projectID 
 	return
 }
 
-func integrationToSchema(integration *matlas.ThirdPartyIntegration) map[string]interface{} {
+func integrationToSchema(d *schema.ResourceData, integration *matlas.ThirdPartyIntegration) map[string]interface{} {
+	integrationSchema := schemaToIntegration(d)
+	if integrationSchema.LicenseKey == "" {
+		integrationSchema.APIKey = integration.LicenseKey
+	}
+	if integrationSchema.WriteToken == "" {
+		integrationSchema.APIKey = integration.WriteToken
+	}
+	if integrationSchema.ReadToken == "" {
+		integrationSchema.APIKey = integration.ReadToken
+	}
+	if integrationSchema.APIKey == "" {
+		integrationSchema.APIKey = integration.APIKey
+	}
+	if integrationSchema.ServiceKey == "" {
+		integrationSchema.APIKey = integration.ServiceKey
+	}
+	if integrationSchema.APIToken == "" {
+		integrationSchema.APIKey = integration.APIToken
+	}
+	if integrationSchema.RoutingKey == "" {
+		integrationSchema.APIKey = integration.RoutingKey
+	}
+	if integrationSchema.Secret == "" {
+		integrationSchema.APIKey = integration.Secret
+	}
+	if integrationSchema.Password == "" {
+		integrationSchema.APIKey = integration.Password
+	}
+
 	out := map[string]interface{}{
 		"type":                        integration.Type,
-		"license_key":                 integration.LicenseKey,
+		"license_key":                 integrationSchema.LicenseKey,
 		"account_id":                  integration.AccountID,
-		"write_token":                 integration.WriteToken,
-		"read_token":                  integration.ReadToken,
-		"api_key":                     integration.APIKey,
+		"write_token":                 integrationSchema.WriteToken,
+		"read_token":                  integrationSchema.ReadToken,
+		"api_key":                     integrationSchema.APIKey,
 		"region":                      integration.Region,
-		"service_key":                 integration.ServiceKey,
-		"api_token":                   integration.APIToken,
+		"service_key":                 integrationSchema.ServiceKey,
+		"api_token":                   integrationSchema.APIToken,
 		"team_name":                   integration.TeamName,
 		"channel_name":                integration.ChannelName,
-		"routing_key":                 integration.RoutingKey,
+		"routing_key":                 integrationSchema.RoutingKey,
 		"flow_name":                   integration.FlowName,
 		"org_name":                    integration.OrgName,
 		"url":                         integration.URL,
-		"secret":                      integration.Secret,
+		"secret":                      integrationSchema.Secret,
 		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
 		"user_name":                   integration.UserName,
-		"password":                    integration.Password,
+		"password":                    integrationSchema.Password,
 		"service_discovery":           integration.ServiceDiscovery,
 		"scheme":                      integration.Scheme,
 		"enabled":                     integration.Enabled,

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -746,6 +746,8 @@ func flattenAlertConfigurationNotifications(d *schema.ResourceData, notification
 			notifications[i].ServiceKey = notificationsSchema[i].ServiceKey
 			notifications[i].VictorOpsAPIKey = notificationsSchema[i].VictorOpsAPIKey
 			notifications[i].VictorOpsRoutingKey = notificationsSchema[i].VictorOpsRoutingKey
+			notifications[i].WebhookURL = notificationsSchema[i].WebhookURL
+			notifications[i].WebhookSecret = notificationsSchema[i].WebhookSecret
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -206,7 +206,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *schem
 		return diag.FromErr(fmt.Errorf("error getting third party integration resource info %s %w", integrationType, err))
 	}
 
-	integrationMap := integrationToSchema(integration)
+	integrationMap := integrationToSchema(d, integration)
 
 	for key, val := range integrationMap {
 		if err := d.Set(key, val); err != nil {


### PR DESCRIPTION
## Description

mongodbatlas_third_party_integration - api_token keeps updating on every apply use Terraform values for API keys ... etc to keep state from drifting

Link to any related issue(s):
https://github.com/mongodb/terraform-provider-mongodbatlas/issues/963 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
