### PR TITLE
INTMDB-472: Update_snapshots doesn't save at TF state with mongodbatlas_cloud_backup_schedule resource

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -289,10 +289,6 @@ func resourceMongoDBAtlasCloudBackupScheduleRead(ctx context.Context, d *schema.
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "restore_window_days", clusterName, err)
 	}
 
-	if err := d.Set("update_snapshots", backupPolicy.UpdateSnapshots); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "update_snapshots", clusterName, err)
-	}
-
 	if err := d.Set("next_snapshot", backupPolicy.NextSnapshot); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "next_snapshot", clusterName, err)
 	}

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -145,7 +145,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `restore_window_days` - (Optional) Number of days back in time you can restore to with point-in-time accuracy. Must be a positive, non-zero integer.
 * `update_snapshots` - (Optional) Specify true to apply the retention changes in the updated backup policy to snapshots that Atlas took previously. 
   
-  **Note** This parameter is not updated on return from API
+  **Note** This parameter does not return updates on return from API, this is a feature of the MongoDB Atlas Admin API itself and not Terraform.  For more details about this resource see: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Cloud-Backup-Schedule
 
 * `policy_item_hourly` - (Optional) Hourly policy item
 * `policy_item_daily` - (Optional) Daily policy item

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -143,7 +143,10 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `reference_hour_of_day` - (Optional) UTC Hour of day between 0 and 23, inclusive, representing which hour of the day that Atlas takes snapshots for backup policy items.
 * `reference_minute_of_hour` - (Optional) UTC Minutes after `reference_hour_of_day` that Atlas takes snapshots for backup policy items. Must be between 0 and 59, inclusive.
 * `restore_window_days` - (Optional) Number of days back in time you can restore to with point-in-time accuracy. Must be a positive, non-zero integer.
-* `update_snapshots` - (Optional) Specify true to apply the retention changes in the updated backup policy to snapshots that Atlas took previously.
+* `update_snapshots` - (Optional) Specify true to apply the retention changes in the updated backup policy to snapshots that Atlas took previously. 
+  
+  **Note** This parameter is not updated on return from API
+
 * `policy_item_hourly` - (Optional) Hourly policy item
 * `policy_item_daily` - (Optional) Daily policy item
 * `policy_item_weekly` - (Optional) Weekly policy item


### PR DESCRIPTION
## Description

Update_snapshots doesn't save at TF state with mongodbatlas_cloud_backup_schedule resource workaround skip update_snapshots on read as API does not return current value

Link to any related issue(s):
https://github.com/mongodb/terraform-provider-mongodbatlas/issues/904

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
