### PR TITLE
v1.8.0 - Fix test failures

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -535,6 +535,11 @@ func clusterAdvancedConfigurationSchemaComputed() *schema.Schema {
 					Type:     schema.TypeInt,
 					Computed: true,
 				},
+				"oplog_min_retention_hours": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
 			},
 		},
 	}

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -1305,7 +1305,7 @@ func replicationSpecsHashSet(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%d", m["num_shards"].(int)))
-	buf.WriteString(fmt.Sprintf("%+v", m["region_configs"].([]interface{})))
+	buf.WriteString(fmt.Sprintf("%+v", m["region_configs"].(*schema.Set)))
 	buf.WriteString(m["zone_name"].(string))
 	return schema.HashString(buf.String())
 }


### PR DESCRIPTION
## Description

- Fixed replicationSpecsHashSet which was improperly updated to cast region_configs to a slice of interface. region_configs is a *schema.Set in all existing usages of that function.
- Added oplog_min_retention_hours property to the advancedConfigurationSchema for cluster data_source

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
