### PR TITLE
provider_backup_enabled deprecated to cloud_backup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: 1.18
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.1
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: v1.46.2
           args: --timeout 7m0s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v1.8.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.8.0) (2023-1-25)
+## [v1.8.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.8.0) (2023-1-26)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.7.0...v1.8.0)
 

--- a/examples/Atlas_Database_Users/atlas_cluster.tf
+++ b/examples/Atlas_Database_Users/atlas_cluster.tf
@@ -13,7 +13,7 @@ resource "mongodbatlas_cluster" "cluster" {
     }
   }
   # Provider Settings "block"
-  provider_backup_enabled      = true
+  cloud_backup                 = true
   auto_scaling_disk_gb_enabled = true
   provider_name                = "AWS"
   disk_size_gb                 = 10

--- a/examples/MongoDB-Atlas-AWS-VPC-Peering/atlas.tf
+++ b/examples/MongoDB-Atlas-AWS-VPC-Peering/atlas.tf
@@ -21,7 +21,7 @@ resource "mongodbatlas_cluster" "cluster-atlas" {
       read_only_nodes = 0
     }
   }
-  provider_backup_enabled      = true
+  cloud_backup                 = true
   auto_scaling_disk_gb_enabled = true
   mongo_db_major_version       = "5.0"
 

--- a/examples/MongoDB-Atlas-GCP-VPC-Peering/cluster.tf
+++ b/examples/MongoDB-Atlas-GCP-VPC-Peering/cluster.tf
@@ -17,7 +17,7 @@ resource "mongodbatlas_cluster" "cluster" {
     key   = "environment"
     value = "prod"
   }
-  provider_backup_enabled                 = true
+  cloud_backup                            = true
   auto_scaling_disk_gb_enabled            = true
   mongo_db_major_version                  = "4.4"
   auto_scaling_compute_enabled            = true


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
provider_backup_enabled is deprecated, replacing with cloud_backup parameter in our Examples folder per https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cluster#provider_backup_enabled 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
