### PR TITLE
INTMDB-513: Import statements are broken in documentation and help commands in the Terraform provider are outdated.

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -521,7 +521,7 @@ func resourceMongoDBAtlasEventTriggerImportState(ctx context.Context, d *schema.
 
 	parts := strings.Split(d.Id(), "--")
 	if len(parts) != 3 {
-		return nil, errors.New("import format error: to import a MongoDB Event Trigger, use the format {project_id}-{app_id}-{trigger_id} ")
+		return nil, errors.New("import format error: to import a MongoDB Event Trigger, use the format {project_id}--{app_id}--{trigger_id} ")
 	}
 
 	projectID := parts[0]


### PR DESCRIPTION
## Description

Import statements are broken in documentation and help commands in the Terraform provider are outdated.
Correct import statement error handler to match docs

Link to any related issue(s):
#956
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
