### PR TITLE
INTMDB 508 - Configurable Timeouts for Resources dependent on Advanced Cluster IDLE

### DIFF
--- a/website/docs/r/private_endpoint_regional_mode.html.markdown
+++ b/website/docs/r/private_endpoint_regional_mode.html.markdown
@@ -123,6 +123,7 @@ resource "aws_vpc_endpoint" "test_east" {
    * More than one private endpoint in one region and one private endpoint in one or more regions.
 You can create only sharded clusters when you enable the regionalized private endpoint setting. You can't create replica sets.
 
+* `timeouts`- (Optional) The duration of time to wait for Cluster to be created, updated, or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint Regional Mode operations is `3h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 ## Additional Reference
 


### PR DESCRIPTION
## Description
For resources which wait for advanced clusters to IDLE, allow users to specify timeout period. Also up'd default timeout to 3 hours.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
