### PR TITLE
INTMDB-570: ERROR: Pager Duty API key must consist of 32 hexadecimal digits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global rule
 *	@themantissa
 
-# Maintained by the MongoDB APIx1 team
-* @mongodb/APIx1
+# Maintained by the MongoDB APIx-Integrations team
+* @mongodb/APIx-Integrations

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -254,20 +254,23 @@ func testAccCreateThirdPartyIntegrationConfig() *matlas.ThirdPartyIntegration {
 		APIKey: testGenString(40, alphaNum),
 		Region: "EU",
 
-		AccountID:                account,
-		WriteToken:               "write-test-" + testGenString(20, alphaNum),
-		ReadToken:                "read-test-" + testGenString(20, alphaNum),
-		RoutingKey:               testGenString(40, alphaNum),
-		FlowName:                 "MongoFlow test" + account,
-		OrgName:                  "MongoOrgTest " + account,
-		URL:                      "https://www.mongodb.com/webhook",
-		Secret:                   account,
-		UserName:                 "PROM_USER",
-		Password:                 "PROM_PASSWORD",
-		ServiceDiscovery:         "http",
-		Scheme:                   "https",
-		Enabled:                  false,
-		MicrosoftTeamsWebhookURL: "https://apps.webhook.office.com/webhookb2/c9c5fafc-d9fe-4ffb-9773-77d804ea4372@c96563a8-841b-4ef9-af16-33548fffc958/IncomingWebhook/484cccf0a678fffff86388b63203110a/42a0070b-5f35-ffff-be83-ac7e7f55d7d3",
+		AccountID:        account,
+		WriteToken:       "write-test-" + testGenString(20, alphaNum),
+		ReadToken:        "read-test-" + testGenString(20, alphaNum),
+		RoutingKey:       testGenString(40, alphaNum),
+		FlowName:         "MongoFlow test" + account,
+		OrgName:          "MongoOrgTest " + account,
+		URL:              "https://www.mongodb.com/webhook",
+		Secret:           account,
+		UserName:         "PROM_USER",
+		Password:         "PROM_PASSWORD",
+		ServiceDiscovery: "http",
+		Scheme:           "https",
+		Enabled:          false,
+		MicrosoftTeamsWebhookURL: "https://apps.webhook.office.com/webhookb2/" +
+			"c9c5fafc-d9fe-4ffb-9773-77d804ea4372@c9656" +
+			"3a8-841b-4ef9-af16-33548fffc958/IncomingWebhook" +
+			"/484cccf0a678fffff86388b63203110a/42a0070b-5f35-ffff-be83-ac7e7f55d7d3",
 	}
 }
 

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -94,6 +94,9 @@ func integrationToSchema(d *schema.ResourceData, integration *matlas.ThirdPartyI
 	if integrationSchema.UserName == "" {
 		integrationSchema.APIKey = integration.UserName
 	}
+	if integrationSchema.URL == "" {
+		integrationSchema.URL = integration.URL
+	}
 
 	out := map[string]interface{}{
 		"type":                        integration.Type,
@@ -110,7 +113,7 @@ func integrationToSchema(d *schema.ResourceData, integration *matlas.ThirdPartyI
 		"routing_key":                 integrationSchema.RoutingKey,
 		"flow_name":                   integration.FlowName,
 		"org_name":                    integration.OrgName,
-		"url":                         integration.URL,
+		"url":                         integrationSchema.URL,
 		"secret":                      integrationSchema.Secret,
 		"microsoft_teams_webhook_url": integration.MicrosoftTeamsWebhookURL,
 		"user_name":                   integrationSchema.UserName,
@@ -248,9 +251,7 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *matlas.Thi
 		integration.ReadToken = d.Get("read_token").(string)
 	}
 
-	if d.HasChange("api_key") {
-		integration.APIKey = d.Get("api_key").(string)
-	}
+	integration.APIKey = d.Get("api_key").(string)
 
 	if d.HasChange("region") {
 		integration.Region = d.Get("region").(string)

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -429,7 +429,7 @@ func resourceMongoDBAtlasAlertConfigurationUpdate(ctx context.Context, d *schema
 		req.Threshold = expandAlertConfigurationThresholdConfig(d)
 	}
 
-	//Always refresh structure to handle service keys being obfuscated coming back from read API call
+	// Always refresh structure to handle service keys being obfuscated coming back from read API call
 	notifications, err := expandAlertConfigurationNotification(d)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorUpdateAlertConf, err))

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -374,6 +374,10 @@ func resourceMongoDBAtlasAlertConfigurationRead(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "notification", ids["id"], err))
 	}
 
+	if err := d.Set("metric_threshold_config", flattenAlertConfigurationMetricThresholdConfig(alert.MetricThreshold)); err != nil {
+		return diag.FromErr(fmt.Errorf(errorAlertConfSetting, "metric_threshold_config", ids["id"], err))
+	}
+
 	return nil
 }
 
@@ -425,13 +429,12 @@ func resourceMongoDBAtlasAlertConfigurationUpdate(ctx context.Context, d *schema
 		req.Threshold = expandAlertConfigurationThresholdConfig(d)
 	}
 
-	if d.HasChange("notification") {
-		notifications, err := expandAlertConfigurationNotification(d)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorUpdateAlertConf, err))
-		}
-		req.Notifications = notifications
+	//Always refresh structure to handle service keys being obfuscated coming back from read API call
+	notifications, err := expandAlertConfigurationNotification(d)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf(errorUpdateAlertConf, err))
 	}
+	req.Notifications = notifications
 
 	// Cannot enable/disable ONLY via update (if only send enable as changed field server returns a 500 error) so have to use different method to change enabled.
 	if reflect.DeepEqual(req, &matlas.AlertConfiguration{Enabled: pointy.Bool(true)}) ||

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
@@ -650,7 +650,7 @@ resource "mongodbatlas_alert_configuration" "test" {
   }
 
   matcher {
-    field_name = "HOSTNAME_AND_PORT"
+    field_name = "REPLICA_SET_NAME"
     operator   = "EQUALS"
     value      = "SECONDARY"
   }

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration_test.go
@@ -16,12 +16,14 @@ func TestAccConfigRSThirdPartyIntegration_basic(t *testing.T) {
 	var (
 		targetIntegration = matlas.ThirdPartyIntegration{}
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
 		config            = testAccCreateThirdPartyIntegrationConfig()
 		testExecutionName = "test_3rd_party_" + config.AccountID
 		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
 	)
 
 	config.Type = "OPS_GENIE"
+	config.APIKey = apiKey
 
 	seedConfig := thirdPartyConfig{
 		Name:        testExecutionName,
@@ -53,12 +55,14 @@ func TestAccConfigRSThirdPartyIntegration_importBasic(t *testing.T) {
 	var (
 		targetIntegration = matlas.ThirdPartyIntegration{}
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
 		config            = testAccCreateThirdPartyIntegrationConfig()
 		testExecutionName = "test_3rd_party_" + config.AccountID
 		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
 	)
 
 	config.Type = "OPS_GENIE"
+	config.APIKey = apiKey
 
 	seedConfig := thirdPartyConfig{
 		Name:        testExecutionName,
@@ -76,7 +80,6 @@ func TestAccConfigRSThirdPartyIntegration_importBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
 					resource.TestCheckResourceAttr(resourceName, "type", config.Type),
-					resource.TestCheckResourceAttr(resourceName, "api_key", config.APIKey),
 					resource.TestCheckResourceAttr(resourceName, "region", config.Region),
 				),
 			},
@@ -84,7 +87,7 @@ func TestAccConfigRSThirdPartyIntegration_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccCheckMongoDBAtlasThirdPartyIntegrationImportStateIDFunc(resourceName),
 				ImportState:       true,
-				ImportStateVerify: true,
+				ImportStateVerify: false, // API Obfuscation will always make import mismatch
 			},
 		},
 	},
@@ -96,6 +99,7 @@ func TestAccConfigRSThirdPartyIntegration_updateBasic(t *testing.T) {
 	var (
 		targetIntegration = matlas.ThirdPartyIntegration{}
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
 		config            = testAccCreateThirdPartyIntegrationConfig()
 		updatedConfig     = testAccCreateThirdPartyIntegrationConfig()
 		testExecutionName = "test_3rd_party_" + config.AccountID
@@ -106,6 +110,8 @@ func TestAccConfigRSThirdPartyIntegration_updateBasic(t *testing.T) {
 	config.Type = "OPS_GENIE"
 	updatedConfig.Type = "OPS_GENIE"
 	updatedConfig.Region = "US"
+	config.APIKey = apiKey
+	updatedConfig.APIKey = apiKey
 
 	seedInitialConfig := thirdPartyConfig{
 		Name:        testExecutionName,


### PR DESCRIPTION
## Description

ERROR: Pager Duty API key must consist of 32 hexadecimal digits

Link to any related issue(s):

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1049

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
