### PR TITLE
INTMDB-579: POST Create Access List Entries for One Organization API Key endpoint supports list, but Terraform does not

### DIFF
--- a/examples/atlas-ip-access-list/README.md
+++ b/examples/atlas-ip-access-list/README.md
@@ -2,7 +2,9 @@
 This example creates a project API access list showing how to attach multiple IP addresses and CIDR Blocks.
 
 Variables Required to be set:
-- `mongodbatlas_project_id`: ID of the Atlas project
+- `project_id`: ID of the Atlas project
+- `public_key`: Atlas public key
+- `private_key`: Atlas  private key
 - `ip_address`: IP addresses you want to permit access to
 - `cidr_block`: CIDR block you want to permit access to
 - `comment`: If provider_name is tenant, the backing provider (AWS, GCP)

--- a/examples/atlas-ip-access-list/README.md
+++ b/examples/atlas-ip-access-list/README.md
@@ -1,0 +1,13 @@
+# MongoDB Atlas Provider -- Atlas IP Access List
+This example creates a project API access list showing how to attach multiple IP addresses and CIDR Blocks.
+
+Variables Required to be set:
+- `mongodbatlas_project_id`: ID of the Atlas project
+- `ip_address`: IP addresses you want to permit access to
+- `cidr_block`: CIDR block you want to permit access to
+- `comment`: If provider_name is tenant, the backing provider (AWS, GCP)
+
+
+For this example, we will setup two access ranges to show multiple IP support and multiple CIDR block.
+
+

--- a/examples/atlas-ip-access-list/main.tf
+++ b/examples/atlas-ip-access-list/main.tf
@@ -1,0 +1,52 @@
+locals {
+
+  mongodbatlas_project_id = "xx1234"
+
+  ip_address_list = [
+    {
+      ip_address = "47.225.213.178"
+      comment    = "IP Address 1"
+    },
+
+    {
+      ip_address = "47.225.214.179"
+      comment    = "IP Address 2"
+    },
+  ]
+
+  cidr_block_list = [
+    {
+      cidr_block = "10.1.0.0/16"
+      comment    = "CIDR Block 1"
+    },
+    {
+      cidr_block = "12.2.0.0/16"
+      comment    = "CIDR Block 2"
+    },
+  ]
+}
+
+
+
+
+resource "mongodbatlas_project_ip_access_list" "ip" {
+  for_each = {
+    for index, ip in local.ip_address_list :
+    ip.comment => ip
+  }
+  project_id = local.mongodbatlas_project_id
+  ip_address = each.value.ip_address
+  comment    = each.value.comment
+}
+
+
+resource "mongodbatlas_project_ip_access_list" "cidr" {
+
+  for_each = {
+    for index, cidr in local.cidr_block_list :
+    cidr.comment => cidr
+  }
+  project_id = local.mongodbatlas_project_id
+  cidr_block = each.value.cidr_block
+  comment    = each.value.comment
+}

--- a/examples/atlas-ip-access-list/main.tf
+++ b/examples/atlas-ip-access-list/main.tf
@@ -26,7 +26,6 @@ locals {
 
 
 
-
 resource "mongodbatlas_project_ip_access_list" "ip" {
   for_each = {
     for index, ip in local.ip_address_list :

--- a/examples/atlas-ip-access-list/main.tf
+++ b/examples/atlas-ip-access-list/main.tf
@@ -1,7 +1,5 @@
 locals {
 
-  mongodbatlas_project_id = "xx1234"
-
   ip_address_list = [
     {
       ip_address = "47.225.213.178"
@@ -34,7 +32,7 @@ resource "mongodbatlas_project_ip_access_list" "ip" {
     for index, ip in local.ip_address_list :
     ip.comment => ip
   }
-  project_id = local.mongodbatlas_project_id
+  project_id = var.project_id
   ip_address = each.value.ip_address
   comment    = each.value.comment
 }
@@ -46,7 +44,7 @@ resource "mongodbatlas_project_ip_access_list" "cidr" {
     for index, cidr in local.cidr_block_list :
     cidr.comment => cidr
   }
-  project_id = local.mongodbatlas_project_id
+  project_id = var.project_id
   cidr_block = each.value.cidr_block
   comment    = each.value.comment
 }

--- a/examples/atlas-ip-access-list/main.tf
+++ b/examples/atlas-ip-access-list/main.tf
@@ -25,7 +25,6 @@ locals {
 }
 
 
-
 resource "mongodbatlas_project_ip_access_list" "ip" {
   for_each = {
     for index, ip in local.ip_address_list :

--- a/examples/atlas-ip-access-list/provider.tf
+++ b/examples/atlas-ip-access-list/provider.tf
@@ -1,0 +1,4 @@
+provider "mongodbatlas" {
+  public_key  = var.public_key
+  private_key = var.private_key
+}

--- a/examples/atlas-ip-access-list/variables.tf
+++ b/examples/atlas-ip-access-list/variables.tf
@@ -1,0 +1,10 @@
+variable "public_key" {
+  description = "Public API key to authenticate to Atlas"
+}
+variable "private_key" {
+  description = "Private API key to authenticate to Atlas"
+}
+variable "project_id" {
+  description = "Atlas project name"
+  default     = ""
+}

--- a/examples/atlas-ip-access-list/versions.tf
+++ b/examples/atlas-ip-access-list/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
## Description

POST Create Access List Entries for One Organization API Key endpoint supports list, but Terraform does not

Link to any related issue(s):
[INTMDB-579](https://jira.mongodb.org/browse/INTMDB-579)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
