### PR TITLE
INTMDB-600: Add support for conditional timeout for search index build

### DIFF
--- a/website/docs/r/access_list_api_key.html.markdown
+++ b/website/docs/r/access_list_api_key.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Provides an Access List API Key resource.
 ---
 
-# Resource: mongodbatlas_project_ip_access_list
+# Resource: mongodbatlas_project_ip_access_list_key
 
 `mongodbatlas_access_list_api_key` provides an IP Access List entry resource. The access list grants access from IPs, CIDRs or AWS Security Groups (if VPC Peering is enabled) to clusters within the Project.
 

--- a/website/docs/r/search_index.html.markdown
+++ b/website/docs/r/search_index.html.markdown
@@ -103,6 +103,8 @@ EOF
 * `name` - (Required) The name of the search index you want to create.
 * `project_id` - (Required) The ID of the organization or project you want to create the search index within.
 * `cluster_name` - (Required) The name of the cluster where you want to create the search index within.
+* `wait_for_index_build_completion` - (Optional) Wait for search index to acheive Active status before terraform considers resource built.
+* `timeouts`- (Optional) The duration of time to wait for Search Index to be created, updated, or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Serach Index create & update is `3h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 
 * `analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when creating the index. Defaults to [lucene.standard](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/standard/#std-label-ref-standard-analyzer)

--- a/website/docs/r/search_index.html.markdown
+++ b/website/docs/r/search_index.html.markdown
@@ -103,7 +103,7 @@ EOF
 * `name` - (Required) The name of the search index you want to create.
 * `project_id` - (Required) The ID of the organization or project you want to create the search index within.
 * `cluster_name` - (Required) The name of the cluster where you want to create the search index within.
-* `wait_for_index_build_completion` - (Optional) Wait for search index to acheive Active status before terraform considers resource built.
+* `wait_for_index_build_completion` - (Optional) Wait for search index to achieve Active status before terraform considers resource built.
 * `timeouts`- (Optional) The duration of time to wait for Search Index to be created, updated, or deleted. The timeout value is defined by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Serach Index create & update is `3h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 


### PR DESCRIPTION
## Description

Search_index error handling delay option to test for build status

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
