### PR TITLE
INTMDB-783: Point in Time Restore is not enabled when should_copy_oplogs is set to true, when copying backups to other regions

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -597,6 +597,7 @@ func expandCopySetting(tfMap map[string]interface{}) *matlas.CopySetting {
 		Frequencies:       expandStringList(tfMap["frequencies"].(*schema.Set).List()),
 		RegionName:        pointy.String(tfMap["region_name"].(string)),
 		ReplicationSpecID: pointy.String(tfMap["replication_spec_id"].(string)),
+		ShouldCopyOplogs:  pointy.Bool(tfMap["should_copy_oplogs"].(bool)),
 	}
 	return copySetting
 }

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -264,6 +264,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
 					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.region_name", "US_EAST_1"),
+					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.should_copy_oplogs", "true"),
 				),
 			},
 		},
@@ -554,7 +555,7 @@ func testAccMongoDBAtlasCloudBackupScheduleCopySettingsConfig(projectID, cluster
 							"ON_DEMAND"]
 				region_name = "US_EAST_1"
 				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
-				should_copy_oplogs = false
+				should_copy_oplogs = true
 			  }
 		}
 	`, projectID, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -516,6 +516,7 @@ func testAccMongoDBAtlasCloudBackupScheduleCopySettingsConfig(projectID, cluster
 			provider_region_name        = "US_EAST_2"
 			provider_instance_size_name = "M10"
 			cloud_backup     = true //enable cloud provider snapshots
+			pit_enabled = true // enable point in time restore. you cannot copy oplogs when pit is not enabled.
 		}
 
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -237,7 +237,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 				Config: testAccMongoDBAtlasCloudBackupScheduleCopySettingsConfig(projectID, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
 					ReferenceHourOfDay:    pointy.Int64(3),
 					ReferenceMinuteOfHour: pointy.Int64(45),
-					RestoreWindowDays:     pointy.Int64(4),
+					RestoreWindowDays:     pointy.Int64(1),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
@@ -245,7 +245,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
 					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
-					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -100,7 +100,6 @@ In addition to all arguments above, the following attributes are exported:
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 ### Snapshot Distribution
-*
 * `cloud_provider` - Human-readable label that identifies the cloud provider that stores the snapshot copy. i.e. "AWS" "AZURE" "GCP"
 * `frequencies` - List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "ON_DEMAND"
 * `region_name` - Target region to copy snapshots belonging to replicationSpecId to. Please supply the 'Atlas Region' which can be found under https://www.mongodb.com/docs/atlas/reference/cloud-providers/ 'regions' link


### PR DESCRIPTION
## Description

Issue: #1134

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
I tested the changes locally with a local binary 
```
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

![Screenshot 2023-04-28 at 15 29 03](https://user-images.githubusercontent.com/5663078/235175991-eb9d636e-8552-4c31-a4ae-d972dddb8e61.png)


Run the acceptance test:
```bash
-----------------------------------------------------
2023-04-28T20:00:05.734+0100 [DEBUG] sdk.helper_resource: Called TestCase CheckDestroy: test_working_directory=/var/folders/nh/l2q_2qxs45z9d1jxtlkzq8c00000gp/T/plugintest4061730918 test_terraform_path=/Users/andrea.angiolillo/.asdf/shims/terraform test_step_number=1 test_name=TestAccBackupRSCloudBackupSchedule_copySettings
2023-04-28T20:00:05.738+0100 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccBackupRSCloudBackupSchedule_copySettings
--- PASS: TestAccBackupRSCloudBackupSchedule_copySettings (875.19s)
PASS
ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 875.802s
```