### PR TITLE
INTMDB-842 : [Terraform] Add acceptance tests for mongodbatlas_cluster_outage_simulation

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
@@ -24,7 +24,7 @@ func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_SingleRegion(projectName, orgID, clusterName),
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -38,7 +38,7 @@ func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_SingleRegion(projectName, orgID, clusterName string) string {
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"
@@ -88,7 +88,7 @@ func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_MultiRegion(projectName, orgID, clusterName),
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -102,7 +102,7 @@ func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_MultiRegion(projectName, orgID, clusterName string) string {
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"

--- a/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
@@ -1,0 +1,164 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_SingleRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_SingleRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id                  = mongodbatlas_project.outage_project.id
+   		provider_name               = "AWS"
+   		name                        = "%s"
+   		backing_provider_name       = "AWS"
+   		provider_region_name        = "US_EAST_1"
+   		provider_instance_size_name = "M10"
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+	}
+
+	data "mongodbatlas_cluster_outage_simulation" "test" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		depends_on = [
+    		mongodbatlas_cluster_outage_simulation.test_outage,
+  		]
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_MultiRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDS_MultiRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id   = mongodbatlas_project.outage_project.id
+		name         = "%s"
+		cluster_type = "REPLICASET"
+	  
+		provider_name               = "AWS"
+		provider_instance_size_name = "M10"
+	  
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_EAST_2"
+			electable_nodes = 2
+			priority        = 6
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_WEST_1"
+			electable_nodes = 2
+			priority        = 5
+			read_only_nodes = 2
+		  }
+		}
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+		outage_filters {
+			   cloud_provider = "AWS"
+			   region_name    = "US_EAST_2"
+		}
+	}
+
+	data "mongodbatlas_cluster_outage_simulation" "test" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		depends_on = [
+    		mongodbatlas_cluster_outage_simulation.test_outage,
+  		]
+	}
+	`, projectName, orgID, clusterName)
+}

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -1,0 +1,168 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		dataSourceName = "mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_SingleRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_SingleRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id                  = mongodbatlas_project.outage_project.id
+   		provider_name               = "AWS"
+   		name                        = "%s"
+   		backing_provider_name       = "AWS"
+   		provider_region_name        = "US_EAST_1"
+   		provider_instance_size_name = "M10"
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_MultiRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_MultiRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id   = mongodbatlas_project.outage_project.id
+		name         = "%s"
+		cluster_type = "REPLICASET"
+	  
+		provider_name               = "AWS"
+		provider_instance_size_name = "M10"
+	  
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_EAST_2"
+			electable_nodes = 2
+			priority        = 6
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_WEST_1"
+			electable_nodes = 2
+			priority        = 5
+			read_only_nodes = 2
+		  }
+		}
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+		outage_filters {
+			   cloud_provider = "AWS"
+			   region_name    = "US_EAST_2"
+		}
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cluster_outage_simulation" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
+		if err == nil {
+			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["tenant_name"])
+		}
+	}
+
+	return nil
+}

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -14,13 +14,13 @@ import (
 func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 	SkipTestExtCred(t)
 	var (
-		dataSourceName = "mongodbatlas_cluster_outage_simulation.test"
+		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName    = acctest.RandomWithPrefix("test-acc-project")
 		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
@@ -70,7 +70,7 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(proj
 func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 	SkipTestExtCred(t)
 	var (
-		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName    = acctest.RandomWithPrefix("test-acc-project")
 		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
@@ -160,7 +160,7 @@ func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) 
 		ids := decodeStateID(rs.Primary.ID)
 		_, _, err := conn.ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
 		if err == nil {
-			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["tenant_name"])
+			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["cluster_name"])
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -26,7 +26,7 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_SingleRegion(projectName, orgID, clusterName),
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -40,7 +40,7 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_SingleRegion(projectName, orgID, clusterName string) string {
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"
@@ -82,7 +82,7 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_MultiRegion(projectName, orgID, clusterName),
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -96,7 +96,7 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfig_MultiRegion(projectName, orgID, clusterName string) string {
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1188 to add acceptance tests for Cluster Simulation resource.

Jira ticket: [INTMDB-842](https://jira.mongodb.org/browse/INTMDB-842)

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
