### PR TITLE
Make aws field optional in federated_database_instance resource and upgrade aws provider

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_federated_database_instance_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_database_instance_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceFederatedDatabaseInstance_basic(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"aws": {
-						VersionConstraint: "4.66.1",
+						VersionConstraint: "5.1.0",
 						Source:            "hashicorp/aws",
 					},
 				},

--- a/mongodbatlas/data_source_mongodbatlas_federated_database_instances_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_database_instances_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceFederatedDatabaseInstances_basic(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"aws": {
-						VersionConstraint: "4.66.1",
+						VersionConstraint: "5.1.0",
 						Source:            "hashicorp/aws",
 					},
 				},

--- a/mongodbatlas/resource_mongodbatlas_federated_database_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_database_instance.go
@@ -50,7 +50,7 @@ func resourceMongoDBAtlasFederatedDatabaseInstance() *schema.Resource {
 			"aws": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"role_id": {

--- a/mongodbatlas/resource_mongodbatlas_federated_database_instance_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_database_instance_test.go
@@ -24,7 +24,7 @@ func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 		region       = "VIRGINIA_USA"
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
 		Steps: []resource.TestStep{

--- a/website/docs/r/federated_database_instance.html.markdown
+++ b/website/docs/r/federated_database_instance.html.markdown
@@ -64,7 +64,7 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 * `project_id` - (Required) The unique ID for the project to create a Federated Database Instance.
 * `name` - (Required) Name of the Atlas Federated Database Instance.
-* `aws` - (Required) AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket.
+* `aws` - AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket.
   * `aws.0.role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `aws.0.test_s3_bucket`.
   * `aws.0.test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `aws.0.role_id`.
   ### `data_process_region` - (Optional) The cloud provider region to which the Federated Instance routes client connections for data processing.

--- a/website/docs/r/federated_database_instance.html.markdown
+++ b/website/docs/r/federated_database_instance.html.markdown
@@ -65,8 +65,8 @@ resource "mongodbatlas_federated_database_instance" "test" {
 * `project_id` - (Required) The unique ID for the project to create a Federated Database Instance.
 * `name` - (Required) Name of the Atlas Federated Database Instance.
   ### `aws` - AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket.
-  * `aws.0.role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `aws.0.test_s3_bucket`.
-  * `aws.0.test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `aws.0.role_id`.
+  * `role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `aws.0.test_s3_bucket`.
+  * `test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `aws.0.role_id`.
   ### `data_process_region` - (Optional) The cloud provider region to which the Federated Instance routes client connections for data processing.
   * `cloud_provider` - (Required) Name of the cloud service provider. Atlas Federated Database only supports AWS.
   * `region` - (Required) Name of the region to which the Federanted Instnace routes client connections for data processing. Atlas Federated Database only supports the following regions:

--- a/website/docs/r/federated_database_instance.html.markdown
+++ b/website/docs/r/federated_database_instance.html.markdown
@@ -64,7 +64,7 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 * `project_id` - (Required) The unique ID for the project to create a Federated Database Instance.
 * `name` - (Required) Name of the Atlas Federated Database Instance.
-* `aws` - AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket.
+  ### `aws` - AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket.
   * `aws.0.role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `aws.0.test_s3_bucket`.
   * `aws.0.test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `aws.0.role_id`.
   ### `data_process_region` - (Optional) The cloud provider region to which the Federated Instance routes client connections for data processing.


### PR DESCRIPTION
## Description

Changes:
1. Based on comments [here](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1173/files#r1212475941) 'aws' should be an optional field if cloudProviderConfig is not to be specified. 
        - This should not be a required field if you are just creating a federated database instance to query a cluster. Added acceptance test for the same as well.

2. Upgrade AWS ExternalProvider version in tests to address error `Failed to marshal state to json: unsupported attribute "role_last_used` . See [AWS Terraform provider issue](https://github.com/hashicorp/terraform-provider-aws/issues/30861#issuecomment-1569019852).

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
<img width="1281" alt="Screenshot 2023-06-02 at 11 32 34" src="https://github.com/mongodb/terraform-provider-mongodbatlas/assets/122359335/5375a438-032b-4a66-b6e9-3bb54eaaf4a6">
