### PR TITLE
Fix 'pause' during cluster and advanced_cluster update

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -718,15 +718,6 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		cluster.VersionReleaseSystem = d.Get("version_release_system").(string)
 	}
 
-	// var pauseStateCurrent, pauseStateNew bool
-	// if d.HasChange("paused") {
-	// 	currentPause, newPause := d.GetChange("paused")
-	// 	pauseStateCurrent = currentPause.(bool)
-	// 	pauseStateNew = newPause.(bool)
-
-	// 	cluster.Paused = pointy.Bool(d.Get("paused").(bool))
-	// }
-
 	if d.HasChange("paused") && !d.Get("paused").(bool) {
 		cluster.Paused = pointy.Bool(d.Get("paused").(bool))
 	}
@@ -785,20 +776,6 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 			return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
 		}
 	}
-
-	// this breaks here because if cluster updated to pause=true, then we have already done that above at line 730
-	//
-	// if d.Get("paused").(bool) {
-	// if pauseStateNew {
-	// 	clusterRequest := &matlas.AdvancedCluster{
-	// 		Paused: pointy.Bool(true),
-	// 	}
-
-	// 	_, _, err := updateAdvancedCluster(ctx, conn, clusterRequest, projectID, clusterName, timeout)
-	// 	if err != nil {
-	// 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
-	// 	}
-	// }
 
 	return resourceMongoDBAtlasAdvancedClusterRead(ctx, d, meta)
 }

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -718,6 +718,10 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		cluster.VersionReleaseSystem = d.Get("version_release_system").(string)
 	}
 
+	if d.HasChange("paused") {
+		cluster.Paused = pointy.Bool(d.Get("paused").(bool))
+	}
+
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	// Has changes
@@ -772,6 +776,17 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 			return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
 		}
 	}
+
+	// if d.Get("paused").(bool) {
+	// 	clusterRequest := &matlas.AdvancedCluster{
+	// 		Paused: pointy.Bool(true),
+	// 	}
+
+	// 	_, _, err := updateAdvancedCluster(ctx, conn, clusterRequest, projectID, clusterName, timeout)
+	// 	if err != nil {
+	// 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
+	// 	}
+	// }
 
 	return resourceMongoDBAtlasAdvancedClusterRead(ctx, d, meta)
 }

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -718,7 +718,16 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		cluster.VersionReleaseSystem = d.Get("version_release_system").(string)
 	}
 
-	if d.HasChange("paused") {
+	// var pauseStateCurrent, pauseStateNew bool
+	// if d.HasChange("paused") {
+	// 	currentPause, newPause := d.GetChange("paused")
+	// 	pauseStateCurrent = currentPause.(bool)
+	// 	pauseStateNew = newPause.(bool)
+
+	// 	cluster.Paused = pointy.Bool(d.Get("paused").(bool))
+	// }
+
+	if d.HasChange("paused") && !d.Get("paused").(bool) {
 		cluster.Paused = pointy.Bool(d.Get("paused").(bool))
 	}
 
@@ -777,7 +786,10 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		}
 	}
 
+	// this breaks here because if cluster updated to pause=true, then we have already done that above at line 730
+	//
 	// if d.Get("paused").(bool) {
+	// if pauseStateNew {
 	// 	clusterRequest := &matlas.AdvancedCluster{
 	// 		Paused: pointy.Bool(true),
 	// 	}

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -304,7 +304,7 @@ func TestAccClusterAdvancedCluster_PausedToUnpaused(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
 				),
 			},
 			{
@@ -316,7 +316,7 @@ func TestAccClusterAdvancedCluster_PausedToUnpaused(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
 				),
 			},
 			{

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -230,7 +230,7 @@ func TestAccClusterAdvancedCluster_multicloudSharded(t *testing.T) {
 	})
 }
 
-func TestAccClusterAdvancedCluster_Paused(t *testing.T) {
+func TestAccClusterAdvancedCluster_UnpausedToPaused(t *testing.T) {
 	SkipTest(t)
 	var (
 		cluster      matlas.AdvancedCluster
@@ -259,6 +259,56 @@ func TestAccClusterAdvancedCluster_Paused(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_PausedToUnpaused(t *testing.T) {
+	SkipTest(t)
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckBasic(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -932,6 +932,10 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	if d.HasChange("paused") {
+		cluster.Paused = pointy.Bool(d.Get("paused").(bool))
+	}
+
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	if isUpgradeRequired(d) {
@@ -987,6 +991,27 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
+	// if !isSharedTier(d.Get("provider_instance_size_name").(string)) {
+	// 	var pause bool
+	// 	if d.Get("paused").(bool) {
+	// 		// pause it
+	// 		pause = true
+	// 	} else {
+	// 		// leave it as is and update pause to false
+
+	// 	}
+
+	// 	if d.HasChange("paused") {
+	// 		clusterRequest := &matlas.Cluster{
+	// 			Paused: pointy.Bool(GetPauseState(d)),
+	// 		}
+	// 		_, _, err := updateCluster(ctx, conn, clusterRequest, projectID, clusterName, timeout)
+	// 		if err != nil {
+	// 			return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
+	// 		}
+	// 	}
+	// }
+
 	if d.Get("paused").(bool) && !isSharedTier(d.Get("provider_instance_size_name").(string)) {
 		clusterRequest := &matlas.Cluster{
 			Paused: pointy.Bool(true),
@@ -999,6 +1024,10 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	return resourceMongoDBAtlasClusterRead(ctx, d, meta)
+}
+
+func GetPauseState(d *schema.ResourceData) bool {
+	return d.Get("paused").(bool)
 }
 
 func didErrOnPausedCluster(err error) bool {

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -932,7 +932,7 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	if d.HasChange("paused") {
+	if d.HasChange("paused") && !d.Get("paused").(bool) {
 		cluster.Paused = pointy.Bool(d.Get("paused").(bool))
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1005,10 +1005,6 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 	return resourceMongoDBAtlasClusterRead(ctx, d, meta)
 }
 
-func GetPauseState(d *schema.ResourceData) bool {
-	return d.Get("paused").(bool)
-}
-
 func didErrOnPausedCluster(err error) bool {
 	if err == nil {
 		return false

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -991,27 +991,6 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 
-	// if !isSharedTier(d.Get("provider_instance_size_name").(string)) {
-	// 	var pause bool
-	// 	if d.Get("paused").(bool) {
-	// 		// pause it
-	// 		pause = true
-	// 	} else {
-	// 		// leave it as is and update pause to false
-
-	// 	}
-
-	// 	if d.HasChange("paused") {
-	// 		clusterRequest := &matlas.Cluster{
-	// 			Paused: pointy.Bool(GetPauseState(d)),
-	// 		}
-	// 		_, _, err := updateCluster(ctx, conn, clusterRequest, projectID, clusterName, timeout)
-	// 		if err != nil {
-	// 			return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
-	// 		}
-	// 	}
-	// }
-
 	if d.Get("paused").(bool) && !isSharedTier(d.Get("provider_instance_size_name").(string)) {
 		clusterRequest := &matlas.Cluster{
 			Paused: pointy.Bool(true),

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -1265,7 +1265,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
 					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
 				),
-			}
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

Jira Ticket: https://jira.mongodb.org/browse/INTMDB-875

This Pr resolves bug from https://jira.mongodb.org/browse/HELP-46575 where we do not properly update 'pause' and 'unpause' attribute in mongodbatlas_cluster anf mongodbatlas_advanced_cluster resources.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
