### PR TITLE
INTMDB-896: add MicrosoftTeamsWebhookURL to values that are based on schema vs API

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -754,6 +754,7 @@ func flattenAlertConfigurationNotifications(d *schema.ResourceData, notification
 			notifications[i].WebhookSecret = notificationsSchema[i].WebhookSecret
 			notifications[i].SMSEnabled = notificationsSchema[i].SMSEnabled
 			notifications[i].EmailEnabled = notificationsSchema[i].EmailEnabled
+			notifications[i].MicrosoftTeamsWebhookURL = notificationsSchema[i].MicrosoftTeamsWebhookURL
 		}
 	}
 


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
Add MicrosoftTeamsWebhookURL to values that are based on schema vs API
Link to any related issue(s):
https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1275

[INTMDB-896](https://jira.mongodb.org/browse/INTMDB-896): add MicrosoftTeamsWebhookURL to values that are based on schema vs API

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
