### PR TITLE
INTMDB-904: HELP: mongodbatlas_org_invitation is missing ORG_BILLING_READ_ONLY role support

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_org_invitation.go
+++ b/mongodbatlas/resource_mongodbatlas_org_invitation.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -59,13 +58,6 @@ func resourceMongoDBAtlasOrgInvitation() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"ORG_OWNER",
-						"ORG_GROUP_CREATOR",
-						"ORG_BILLING_ADMIN",
-						"ORG_READ_ONLY",
-						"ORG_MEMBER",
-					}, false),
 				},
 			},
 		},

--- a/website/docs/d/org_invitation.html.markdown
+++ b/website/docs/d/org_invitation.html.markdown
@@ -40,6 +40,6 @@ In addition to the arguments, this data source exports the following attributes:
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `inviter_username` - Atlas user who invited `username` to the organization.
 * `teams_ids` - An array of unique 24-hexadecimal digit strings that identify the teams that the user was invited to join.
-* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
+* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 See the [MongoDB Atlas Administration API](https://docs.atlas.mongodb.com/reference/api/organization-get-one-invitation/) documentation for more information.

--- a/website/docs/d/org_invitation.html.markdown
+++ b/website/docs/d/org_invitation.html.markdown
@@ -40,11 +40,6 @@ In addition to the arguments, this data source exports the following attributes:
 * `expires_at` - Timestamp in ISO 8601 date and time format in UTC when the invitation expires. Users have 30 days to accept an invitation.
 * `inviter_username` - Atlas user who invited `username` to the organization.
 * `teams_ids` - An array of unique 24-hexadecimal digit strings that identify the teams that the user was invited to join.
-* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The following options are available:
-  * ORG_OWNER
-  * ORG_GROUP_CREATOR
-  * ORG_BILLING_ADMIN
-  * ORG_READ_ONLY
-  * ORG_MEMBER
+* `roles` - Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 See the [MongoDB Atlas Administration API](https://docs.atlas.mongodb.com/reference/api/organization-get-one-invitation/) documentation for more information.

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -12,7 +12,7 @@ description: |-
 
 Each invitation for an Atlas user includes roles that Atlas grants the user when they accept the invitation.
 
-The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
+The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 ~> **IMPORTANT:** This resource is only for managing invitations, not for managing the Atlas User being invited. Possible provider behavior depending on the invitee's action:
 * If the user has not yet accepted the invitation, the provider leaves the invitation as is.

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -12,13 +12,7 @@ description: |-
 
 Each invitation for an Atlas user includes roles that Atlas grants the user when they accept the invitation.
 
-The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have, which map to:
-
-* ORG_OWNER
-* ORG_GROUP_CREATOR
-* ORG_BILLING_ADMIN
-* ORG_READ_ONLY
-* ORG_MEMBER
+The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 ~> **IMPORTANT:** This resource is only for managing invitations, not for managing the Atlas User being invited. Possible provider behavior depending on the invitee's action:
 * If the user has not yet accepted the invitation, the provider leaves the invitation as is.
@@ -57,12 +51,7 @@ resource "mongodbatlas_org_invitation" "test1" {
 * `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization to which you want to invite a user.
 * `username` - (Required) Email address of the invited user. This is the address to which Atlas sends the invite. If the user accepts the invitation, they log in to Atlas with this username.
 * `teams_ids` - (Optional) An array of unique 24-hexadecimal digit strings that identify the teams that the user was invited to join.
-* `roles` - (Required) Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The following options are available:
-  * ORG_OWNER
-  * ORG_GROUP_CREATOR
-  * ORG_BILLING_ADMIN
-  * ORG_READ_ONLY
-  * ORG_MEMBER
+* `roles` - (Required) Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 ## Attributes Reference
 

--- a/website/docs/r/org_invitation.html.markdown
+++ b/website/docs/r/org_invitation.html.markdown
@@ -51,7 +51,7 @@ resource "mongodbatlas_org_invitation" "test1" {
 * `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization to which you want to invite a user.
 * `username` - (Required) Email address of the invited user. This is the address to which Atlas sends the invite. If the user accepts the invitation, they log in to Atlas with this username.
 * `teams_ids` - (Optional) An array of unique 24-hexadecimal digit strings that identify the teams that the user was invited to join.
-* `roles` - (Required) Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://docs.atlas.mongodb.com/reference/user-roles/#organization-roles) describes the roles a user can have.
+* `roles` - (Required) Atlas roles to assign to the invited user. If the user accepts the invitation, Atlas assigns these roles to them. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the roles a user can have.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description
Ticket: [INTMDB-904](https://jira.mongodb.org/browse/INTMDB-904)
Link to any related issue(s): #1280

This PR removes the hardcoded validation on the roles field. We will rely on the API from now on.



## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
