### PR TITLE
INTMDB-911: [Terraform] Remove unused secret from code-health workflow

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           go-version: "1.20"
       - name: Unit Test
-        env:
-          MONGODB_ATLAS_TEAMS_IDS: ${{ secrets.MONGODB_ATLAS_TEAMS_IDS }}
         run: make test
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Ticket: [INTMDB-911](https://jira.mongodb.org/browse/INTMDB-911)

This PR removes the secret `MONGODB_ATLAS_TEAMS_IDS` from the `unit-test` as is not used.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
