### PR TITLE
INTMDB-919: resource_mongodbatlas_cloud_backup_snapshot_restore_job: Extend guards for delivery type deletions

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -309,7 +309,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobDelete(ctx context.Context
 
 	shouldDelete := true
 
-	// Validate because atomated restore can not be cancelled
+	// Validate because automated restore can not be cancelled
 	if aut, _ := d.Get("delivery_type.automated").(string); aut == "true" {
 		log.Print("Automated restore cannot be cancelled")
 		shouldDelete = false
@@ -320,7 +320,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobDelete(ctx context.Context
 		shouldDelete = false
 	}
 
-	if aut, _ := d.Get("delivery_type.point_in_time").(string); aut == "true" {
+	if aut, ok := d.Get("delivery_type_config.0.point_in_time").(bool); ok && aut {
 		log.Print("Point in time restore cannot be cancelled")
 		shouldDelete = false
 	}

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -320,6 +320,11 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobDelete(ctx context.Context
 		shouldDelete = false
 	}
 
+	if aut, _ := d.Get("delivery_type.point_in_time").(string); aut == "true" {
+		log.Print("Point in time restore cannot be cancelled")
+		shouldDelete = false
+	}
+
 	if shouldDelete {
 		_, err := conn.CloudProviderSnapshotRestoreJobs.Delete(context.Background(), requestParameters)
 		if err != nil {

--- a/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
@@ -17,6 +17,9 @@ description: |-
 
 -> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your request body to create an automated restore job, Atlas removes all existing data on the target cluster prior to the restore.
 
+-> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your 
+`mongodbatlas_cloud_backup_snapshot_restore_job` resource, you won't be able to delete the snapshot resource in MongoDB Atlas as the functionality is currently not supported by the Admin API. The provider will remove TF resource from the state file but the MongoDB Atlas resource won't be destroyed.
+
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
 -> **API Key Access List**: This resource requires an Atlas API Access Key List to utilize this feature. This means to manage this resources you must have the IP address or CIDR block that the Terraform connection is coming from added to the Atlas API Key Access List of the Atlas API key you are using. See [Resources that require API Key List](https://www.mongodb.com/docs/atlas/configure-api-access/#use-api-resources-that-require-an-access-list) for details.

--- a/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/r/cloud_backup_snapshot_restore_job.html.markdown
@@ -18,7 +18,7 @@ description: |-
 -> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your request body to create an automated restore job, Atlas removes all existing data on the target cluster prior to the restore.
 
 -> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your 
-`mongodbatlas_cloud_backup_snapshot_restore_job` resource, you won't be able to delete the snapshot resource in MongoDB Atlas as the functionality is currently not supported by the Admin API. The provider will remove TF resource from the state file but the MongoDB Atlas resource won't be destroyed.
+`mongodbatlas_cloud_backup_snapshot_restore_job` resource, you won't be able to delete the snapshot resource in MongoDB Atlas as the Atlas Admin API doesn't support this. The provider will remove the Terraform resource from the state file but won't destroy the MongoDB Atlas resource.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 


### PR DESCRIPTION
## Description

Ticket: [INTMDB-919](https://jira.mongodb.org/browse/INTMDB-919), [HELP-47603](https://jira.mongodb.org/browse/HELP-47603)

Issue: Customers get the following error when trying to delete a snapshot point in time
```tf
mongodbatlas_cloud_backup_snapshot_restore_job.pitRestoreJob: Destroying... [id=Y2x1c3Rlcl9uYW1l:ZGZ0ZXN0-cHJvamVjdF9pZA==:NjNjZWY4ODZjYzZmMTY0ZWY0ZTgxMGMx-c25hcHNob3RfcmVzdG9yZV9qb2JfaWQ=:NjRhNWU0YmNhYjE5MmExOGEyOTZiZTBl]
--
╷
│ Error: error deleting a cloudProviderSnapshotRestoreJob (64a5e4bcab192a18a296be0e): DELETE https://cloud.mongodb.com/api/atlas/v1.0/groups/63cef886cc6f164ef4e810c1/clusters/dftest/backup/restoreJobs/64a5e4bcab192a18a296be0e: 400 (request "CANNOT_CANCEL_AUTOMATED_RESTORE") Automated restore cannot be cancelled.
```

Fix: Since this behaviour is correct and user s cannot delete point-in-time snapshots, this PR adds guards to skip calling the DELETE snapshot endpoint in case of point-in-time.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
### Testing
I used the main.tf file provided in [HELP-47603](https://jira.mongodb.org/browse/HELP-47603):

1. I reproduced the error
```tf
mongodbatlas_cloud_backup_schedule.test: Destruction complete after 0s
2023-07-10T10:05:49.106+0200 [ERROR] vertex "mongodbatlas_cloud_backup_snapshot_restore_job.pitRestoreJob (destroy)" error: error deleting a cloudProviderSnapshotRestoreJob (64abbbb33119147577f8d084): DELETE https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/64abb4b83119147577f8d022/clusters/dftest/backup/restoreJobs/64abbbb33119147577f8d084: 400 (request "CANNOT_CANCEL_AUTOMATED_RESTORE") Automated restore cannot be cancelled.
2023-07-10T10:05:49.112+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
╷
│ Error: error deleting a cloudProviderSnapshotRestoreJob (64abbbb33119147577f8d084): DELETE https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/64abb4b83119147577f8d022/clusters/dftest/backup/restoreJobs/64abbbb33119147577f8d084: 400 (request "CANNOT_CANCEL_AUTOMATED_RESTORE") Automated restore cannot be cancelle
```

2. I created the resources again 
```tf
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

snapshotID = "64abb97e3119147577f8d081"
```
3. I destroyed the resources and checked that the snapshot was not deleted

```tf
2023-07-10T10:37:34.897+0200 [INFO]  provider.terraform-provider-mongodbatlas: 2023/07/10 10:37:34 Point in time restore cannot be cancelled: 

timestamp=2023-07-10T10:37:34.897+0200
mongodbatlas_cloud_backup_snapshot_restore_job.pitRestoreJob: Destruction complete after 0s
2023-07-10T10:37:34.902+0200 [DEBUG] State storage *statemgr.Filesystem declined to persist a state snapshot
``` 

```tf 
2023-07-10T10:39:47.069+0200 [DEBUG] provider: plugin process exited: path=../bin/terraform-provider-mongodbatlas pid=16922
2023-07-10T10:39:47.069+0200 [DEBUG] provider: plugin exited

Destroy complete! Resources: 3 destroyed.
```