### PR TITLE
INTMDB-922: mongodbatlas_event_trigger is not updated if config_match is added

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -110,9 +110,11 @@ func resourceMongoDBAtlasEventTriggers() *schema.Resource {
 					var j, j2 interface{}
 					if err := json.Unmarshal([]byte(old), &j); err != nil {
 						log.Printf("[ERROR] json.Unmarshal %v", err)
+						return false
 					}
 					if err := json.Unmarshal([]byte(new), &j2); err != nil {
 						log.Printf("[ERROR] json.Unmarshal %v", err)
+						return false
 					}
 					if diff := deep.Equal(&j, &j2); diff != nil {
 						log.Printf("[DEBUG] deep equal not passed: %v", diff)
@@ -130,9 +132,11 @@ func resourceMongoDBAtlasEventTriggers() *schema.Resource {
 					var j, j2 interface{}
 					if err := json.Unmarshal([]byte(old), &j); err != nil {
 						log.Printf("[ERROR] json.Unmarshal %v", err)
+						return false
 					}
 					if err := json.Unmarshal([]byte(new), &j2); err != nil {
 						log.Printf("[ERROR] json.Unmarshal %v", err)
+						return false
 					}
 					if diff := deep.Equal(&j, &j2); diff != nil {
 						log.Printf("[DEBUG] deep equal not passed: %v", diff)


### PR DESCRIPTION
## Description
Ticket: [INTMDB-922](https://jira.mongodb.org/browse/INTMDB-922)

Bug:
`DiffSuppressFunc` returns true if provided invalid JSON is provided for the `config_match` and `config_project` (FYI: unfortunately the function cannot return an error) which means that TF did not find any changes between the previous state and the current state. This led to updating the resource without adding those fields in case the provided JSON was not valid. 

Fix:
By setting the return value to false in `DiffSuppressFunc` when the provided JSON is not valid, we rely on the API call error message in the response to provide an error message to the user

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1302

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

### Testing
I used the config provided in https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1302 and checked that, before my changes, TF was creating a resource without the `config_match` if the JSON was not valid. After my changes, the resource correctly contains all the fields with invalid JSON.