### PR TITLE
INTMDB-935: HELP: mongodbatlas_online_archive schedule parameter update causing crashing in terraform apply

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -452,7 +452,7 @@ func fromOnlineArchiveToMap(in *matlas.OnlineArchive) map[string]interface{} {
 	}
 
 	var schedule map[string]interface{}
-	// When schedule is not provided in CREATE/UPDATE the GET return Schedule.Type = DEFAULT
+	// When schedule is not provided in CREATE/UPDATE the GET returns Schedule.Type = DEFAULT
 	// In this case, we don't want to update the schema as there is no SCHEDULE
 	if in.Schedule != nil && in.Schedule.Type != scheduleTypeDefault {
 		schedule = map[string]interface{}{

--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -107,27 +107,23 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 					"type": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validation.StringInSlice([]string{"DAILY", "MONTHLY", "WEEKLY", "DEFAULT"}, false),
+						ValidateFunc: validation.StringInSlice([]string{"DAILY", "MONTHLY", "WEEKLY"}, false),
 					},
 					"end_hour": {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Computed: true,
 					},
 					"end_minute": {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Computed: true,
 					},
 					"start_hour": {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Computed: true,
 					},
 					"start_minute": {
 						Type:     schema.TypeInt,
 						Optional: true,
-						Computed: true,
 					},
 					"day_of_month": {
 						Type:     schema.TypeInt,

--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -553,13 +553,29 @@ func mapCriteria(d *schema.ResourceData) *matlas.OnlineArchiveCriteria {
 }
 
 func mapSchedule(d *schema.ResourceData) *matlas.OnlineArchiveSchedule {
-	scheduleTFConfigList := d.Get("schedule").([]interface{})
-	if len(scheduleTFConfigList) == 0 {
-		return nil
-	}
-	scheduleTFConfig := scheduleTFConfigList[0].(map[string]interface{})
-
+	// We have to provide schedule.type="DEFAULT" when the schedule block is not provided or removed
 	scheduleInput := &matlas.OnlineArchiveSchedule{
+		Type: scheduleTypeDefault,
+	}
+
+	scheduleTFConfigInterface := d.Get("schedule")
+	if scheduleTFConfigInterface == nil {
+		return scheduleInput
+	}
+
+	scheduleTFConfigList, ok := scheduleTFConfigInterface.([]interface{})
+	if !ok {
+		return scheduleInput
+	}
+
+	if len(scheduleTFConfigList) == 0 {
+		return &matlas.OnlineArchiveSchedule{
+			Type: scheduleTypeDefault,
+		}
+	}
+
+	scheduleTFConfig := scheduleTFConfigList[0].(map[string]interface{})
+	scheduleInput = &matlas.OnlineArchiveSchedule{
 		Type: scheduleTFConfig["type"].(string),
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -208,7 +208,7 @@ func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resour
 	}
 }
 
-func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clusterName string, start_hour int) string {
+func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clusterName string, startHour int) string {
 	return fmt.Sprintf(`
 	%s
 	resource "mongodbatlas_online_archive" "users_archive" {
@@ -256,7 +256,7 @@ func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clu
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), start_hour)
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
 }
 
 func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clusterName string) string {
@@ -345,7 +345,7 @@ func testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName
 	`, orgID, projectName, clusterName)
 }
 
-func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName string, start_hour int) string {
+func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName string, startHour int) string {
 	return fmt.Sprintf(`
 	%s
 	resource "mongodbatlas_online_archive" "users_archive" {
@@ -394,10 +394,10 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), start_hour)
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
 }
 
-func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName string, start_hour int) string {
+func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName string, startHour int) string {
 	return fmt.Sprintf(`
 	%s
 	resource "mongodbatlas_online_archive" "users_archive" {
@@ -446,5 +446,5 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), start_hour)
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
 }

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -38,7 +38,20 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, name),
+				Config: testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, name, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, name, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -56,6 +69,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckNoResourceAttr(onlineArchiveResourceName, "schedule.#"),
 				),
 			},
 		},
@@ -155,7 +169,7 @@ func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resour
 	}
 }
 
-func testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, clusterName string) string {
+func testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, clusterName string, start_hour int) string {
 	return fmt.Sprintf(`
 	%s
 	resource "mongodbatlas_online_archive" "users_archive" {
@@ -176,7 +190,7 @@ func testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, clusterN
 			type = "DAILY"
 			end_hour = 1
 			end_minute = 1
-			start_hour = 1
+			start_hour = %d
 			start_minute = 1
 		}
 	
@@ -203,7 +217,7 @@ func testAccBackupRSOnlineArchiveConfigWithSchedule(orgID, projectName, clusterN
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName))
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), start_hour)
 }
 
 func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clusterName string) string {

--- a/website/docs/d/online_archives.html.markdown
+++ b/website/docs/d/online_archives.html.markdown
@@ -50,7 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Schedule
 
-* `type`          - Type of schedule (`DEFAULT`, `DAILY`, `MONTHLY`, `WEEKLY`).
+* `type`          - Type of schedule (`DAILY`, `MONTHLY`, `WEEKLY`).
 * `start_hour`    - Hour of the day when the when the scheduled window to run one online archive starts.  
 * `end_hour`      - Hour of the day when the scheduled window to run one online archive ends.
 * `start_minute`   - Minute of the hour when the scheduled window to run one online archive starts.

--- a/website/docs/r/online_archive.html.markdown
+++ b/website/docs/r/online_archive.html.markdown
@@ -107,7 +107,7 @@ The only field required for criteria type `CUSTOM`
 
 ### Schedule
 
-* `type`          - Type of schedule (`DEFAULT`, `DAILY`, `MONTHLY`, `WEEKLY`).
+* `type`          - Type of schedule (``DAILY`, `MONTHLY`, `WEEKLY`).
 * `start_hour`    - Hour of the day when the when the scheduled window to run one online archive starts.  
 * `end_hour`      - Hour of the day when the scheduled window to run one online archive ends.
 * `start_minute`   - Minute of the hour when the scheduled window to run one online archive starts.


### PR DESCRIPTION
## Description

**Bug**:  the `mongodbatlas_online_archive` resource returns an error if the `schedule` param is not defined for the resource. 
**Why**:  The API returns `schedule.type = "DEFAULT"` when the `schedule` param is not sent in the `CREATE` or `UPDATE` operation. As a result, the `READ` retrieves the resource with `schedule.type = "DEFAULT"` and complains that `schedule` is not defined in the TF config.

**Fix**: 
- When the schedule param is not provided, `CREATE` & `UPDATE` operations will send `schedule.type = "DEFAULT"`
  - We need to update these operations to cover the scenario: the `schedule` is added during resource creation, and then it is removed
- When the `READ` operation returns `schedule.type = "DEFAULT"`, we do not add the schedule param to the schema

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1318

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

### Acceptance Test (Run against Atlas Prod since cloud-dev is broken)

- TestAccBackupRSOnlineArchive

```hcl
Running tool: /Users/andrea.angiolillo/.asdf/installs/golang/1.20.3/go/bin/go test -timeout 300000s -run ^TestAccBackupRSOnlineArchive$ github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas

ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 1051.394s
```

- TestAccBackupRSOnlineArchiveBasic
```htl
Running tool: /Users/andrea.angiolillo/.asdf/installs/golang/1.20.3/go/bin/go test -timeout 300000s -run ^TestAccBackupRSOnlineArchiveBasic$ github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas

ok  	github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas	1015.013s
```

I tested locally the following scenario:
- I used the config file provided in the help ticket
- I installed 1.10.0
- run terraform apply
- upgrade to 1.10.1
- run terraform apply
- checked that I got the same error
- build the provider binary with my changes
- run terraform apply with the provider with my changes
- the apply was successful
- I updated the config and added `schedule` to the online archive
- run terraform apply -> successful
- removed `schedule` from the online archive
- run terraform apply - successful