### PR TITLE
INTMDB-938: Fix Online Archive tests

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -234,7 +234,7 @@ func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clu
 		}
 
 		partition_fields {
-			field_name = "date"
+			field_name = "last_review"
 			order = 0
 		}
 	

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -243,6 +243,11 @@ func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clu
 			order = 1
 		}
 
+		partition_fields {
+			field_name = "date"
+			order = 1
+		}
+
 		sync_creation = true
 	}
 	
@@ -283,6 +288,11 @@ func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clust
 	
 		partition_fields {
 			field_name = "name"
+			order = 1
+		}
+
+		partition_fields {
+			field_name = "date"
 			order = 1
 		}
 
@@ -381,6 +391,11 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 			order = 1
 		}
 
+		partition_fields {
+			field_name = "date"
+			order = 1
+		}
+
 		sync_creation = true
 	}
 	
@@ -430,6 +445,11 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 	
 		partition_fields {
 			field_name = "name"
+			order = 1
+		}
+
+		partition_fields {
+			field_name = "date"
 			order = 1
 		}
 

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -232,20 +232,20 @@ func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clu
 			start_hour = %d
 			start_minute = 1
 		}
-	
+
 		partition_fields {
-			field_name = "maximum_nights"
+			field_name = "date"
 			order = 0
 		}
 	
 		partition_fields {
-			field_name = "name"
+			field_name = "maximum_nights"
 			order = 1
 		}
-
+	
 		partition_fields {
-			field_name = "date"
-			order = 1
+			field_name = "name"
+			order = 2
 		}
 
 		sync_creation = true
@@ -282,18 +282,18 @@ func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clust
 		}
 
 		partition_fields {
-			field_name = "maximum_nights"
+			field_name = "date"
 			order = 0
+		}
+
+		partition_fields {
+			field_name = "maximum_nights"
+			order = 1
 		}
 	
 		partition_fields {
 			field_name = "name"
-			order = 1
-		}
-
-		partition_fields {
-			field_name = "date"
-			order = 1
+			order = 2
 		}
 
 		sync_creation = true
@@ -380,20 +380,20 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 			start_hour = %d
 			start_minute = 1
 		}
-	
+
 		partition_fields {
-			field_name = "maximum_nights"
+			field_name = "date"
 			order = 0
 		}
 	
 		partition_fields {
-			field_name = "name"
+			field_name = "maximum_nights"
 			order = 1
 		}
-
+	
 		partition_fields {
-			field_name = "date"
-			order = 1
+			field_name = "name"
+			order = 2
 		}
 
 		sync_creation = true
@@ -437,21 +437,23 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 			start_hour = %d
 			start_minute = 1
 		}
-	
+
 		partition_fields {
-			field_name = "maximum_nights"
+			field_name = "date"
 			order = 0
 		}
 	
 		partition_fields {
-			field_name = "name"
+			field_name = "maximum_nights"
 			order = 1
 		}
 
+
 		partition_fields {
-			field_name = "date"
-			order = 1
+			field_name = "name"
+			order = 2
 		}
+
 
 		sync_creation = true
 	}

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -282,7 +282,7 @@ func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clust
 		}
 
 		partition_fields {
-			field_name = "date"
+			field_name = "last_review"
 			order = 0
 		}
 
@@ -382,7 +382,7 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 		}
 
 		partition_fields {
-			field_name = "date"
+			field_name = "last_review"
 			order = 0
 		}
 	
@@ -439,7 +439,7 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 		}
 
 		partition_fields {
-			field_name = "date"
+			field_name = "last_review"
 			order = 0
 		}
 	


### PR DESCRIPTION
## Description

The online archive tests are failing because of [CLOUDP-186083](https://jira.mongodb.org/browse/CLOUDP-186083). Updating our tests to add the DATE field

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
