### PR TITLE
INTMDB-436: Update privatelink endpoint service resources timeout config

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"time"
 
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
@@ -90,7 +91,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessCreate(ctx context.Context
 		Refresh:    resourcePrivateLinkEndpointServerlessRefreshFunc(ctx, conn, projectID, instanceName, endPoint.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
-		Delay:      3 * time.Second,
+		Delay:      5 * time.Second,
 	}
 	// RESERVATION_REQUESTED, RESERVED, INITIATING, AVAILABLE, FAILED, DELETING.
 	// Wait, catching any errors
@@ -182,7 +183,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessDelete(ctx context.Context
 		Refresh:    resourcePrivateLinkEndpointServerlessRefreshFunc(ctx, conn, projectID, instanceName, endpointID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
-		Delay:      3 * time.Second,
+		Delay:      5 * time.Second,
 	}
 	// Wait, catching any errors
 	_, err = stateConf.WaitForStateContext(ctx)

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
@@ -53,6 +55,10 @@ func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive()
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Hour),
+			Delete: schema.DefaultTimeout(2 * time.Hour),
 		},
 	}
 }

--- a/website/docs/r/privatelink_endpoint_service_data_federation_online_archive.markdown
+++ b/website/docs/r/privatelink_endpoint_service_data_federation_online_archive.markdown
@@ -26,12 +26,13 @@ resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archi
   provider_name = "AWS"
   comment = "Test"
 }
-
+```
 ## Argument Reference
 
 * `project_id` (Required) - Unique 24-hexadecimal digit string that identifies your project. 
 * `endpoint_id` (Required) - Unique 22-character alphanumeric string that identifies the private endpoint. See [Atlas Data Lake supports Amazon Web Services private endpoints using the AWS PrivateLink feature](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/createDataFederationPrivateEndpoint:~:text=Atlas%20Data%20Lake%20supports%20Amazon%20Web%20Services%20private%20endpoints%20using%20the%20AWS%20PrivateLink%20feature).
 * `provider_name` (Required) - Human-readable label that identifies the cloud service provider. 
+* `timeouts`- (Optional) The duration of time to wait for Private Endpoint Service to be created or deleted. The timeout value is definded by a signed sequence of decimal numbers with an time unit suffix such as: `1h45m`, `300s`, `10m`, .... The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The default timeout for Private Endpoint create & delete is `2h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Enable configurable timeout, and make consistent 2 hour defaulting timeout across dedicated, serverless, and privatelink_endpoint_service_data_federation_online_archive

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-436 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
