### PR TITLE
INTMDB-955: HELP: Error: Plugin did not respond - panic: interface conversion: interface is nil, not map[string]interface

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -87,6 +87,7 @@ jobs:
             - 'mongodbatlas/data_source_mongodbatlas_team*.go'
             - 'mongodbatlas/data_source_mongodbatlas_third_party_integration*.go'
             - 'mongodbatlas/resource_mongodbatlas_api_key*.go'
+            - 'mongodbatlas/resource_mongodbatlas_alert_configuration*.go'
             - 'mongodbatlas/resource_mongodbatlas_cloud_provider_access_setup*.go'
             - 'mongodbatlas/resource_mongodbatlas_cloud_provider_access*.go'
             - 'mongodbatlas/resource_mongodbatlas_custom_db_role*.go'

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -574,10 +574,10 @@ func expandAlertConfigurationThreshold(d *schema.ResourceData) *matlas.Threshold
 
 func expandAlertConfigurationMetricThresholdConfig(d *schema.ResourceData) *matlas.MetricThreshold {
 	if value, ok := d.GetOk("metric_threshold_config"); ok {
-		vL := value.([]interface{})
+		metricThresholdConfigLists := value.([]interface{})
 
-		if len(vL) > 0 {
-			v := vL[0].(map[string]interface{})
+		if len(metricThresholdConfigLists) == 1 && metricThresholdConfigLists[0] != nil {
+			v := metricThresholdConfigLists[0].(map[string]interface{})
 
 			return &matlas.MetricThreshold{
 				MetricName: cast.ToString(v["metric_name"]),


### PR DESCRIPTION
## Description

Ticket: [INTMDB-955](https://jira.mongodb.org/browse/INTMDB-955)

This PR fixes a bug where the provider panics if an empty `metric_threshold_config {}` is provided

Issue: #1337

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
