### PR TITLE
fix: Mark project api key resource as destroyed if not present

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project_api_key_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_api_key_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
@@ -88,6 +90,60 @@ func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
+	var (
+		resourceName      = "mongodbatlas_project_api_key.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		descriptionPrefix = "test-acc-project-to-delete-api-key"
+		description       = fmt.Sprintf("%s-%s", descriptionPrefix, acctest.RandString(5))
+		roleName          = "GROUP_OWNER"
+	)
+
+	projectAPIKeyConfig := testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckBasic(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: projectAPIKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+				),
+			},
+			{
+				PreConfig: func() {
+					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
+						t.Fatalf("failed to manually delete API key resource: %s", err)
+					}
+				},
+				Config:             projectAPIKeyConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true, // should detect that api key has to be recreated
+			},
+		},
+	})
+}
+
+func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
+	conn := testAccProvider.Meta().(*MongoDBClient).Atlas
+	list, _, err := conn.APIKeys.List(context.Background(), orgID, &matlas.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, key := range list {
+		if strings.HasPrefix(key.Desc, descriptionPrefix) {
+			if _, err := conn.APIKeys.Delete(context.Background(), orgID, key.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {


### PR DESCRIPTION
## Description

Ticket: [INTMDB-918](https://jira.mongodb.org/browse/INTMDB-918)

Include missing logic to detect if project api key is not longer present during read operation.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

- Included acceptance test to reproduce reported issue. Create project api key resource, delete externally using Atlas API, then expect terraform to detect resource needs to be recreated.
