### PR TITLE
fix: null pointer in resource_mongodbatlas_cloud_backup_schedule.go

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -534,7 +534,10 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client,
 		req.UseOrgAndGroupNamesInExportPrefix = pointy.Bool(d.Get("use_org_and_group_names_in_export_prefix").(bool))
 	}
 
-	policy.ID = resp.Policies[0].ID
+	if len(resp.Policies) == 1 {
+		policy.ID = resp.Policies[0].ID
+	}
+
 	policy.PolicyItems = policiesItem
 	if len(policiesItem) > 0 {
 		req.Policies = []matlas.Policy{policy}


### PR DESCRIPTION
## Description

This error came up as part of the help ticket https://jira.mongodb.org/browse/HELP-48422

Link to any related issue(s): [INTMDB-966](https://jira.mongodb.org/browse/INTMDB-966)


Null pointer error:

```bash
panic: runtime error: invalid memory address or nil pointer dereference
--
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1a15e30]
 
goroutine 37 [running]:
github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas.cloudBackupScheduleCreateOrUpdate({0x20338c8, 0xc000c8e300}, 0xc000a74000, 0xc000000001?, {0xc00003c4e0, 0x18}, {0xc0007ae190, 0xa})
github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go:537 +0xc70
github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas.resourceMongoDBAtlasCloudBackupScheduleCreate({0x20338c8, 0xc000c8e300}, 0x0?, {0x1b956c0?, 0xc000a37b80?})
github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go:287 +0x125
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0008c1420, {0x2033900, 0xc000bf6d50}, 0xd?, {0x1b956c0, 0xc000a37b80})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:733 +0x12e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0008c1420, {0x2033900, 0xc000bf6d50}, 0xc00014ca90, 0xc000bf2f00, {0x1b956c0, 0xc000a37b80})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:864 +0xa7e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000245d28, {0x2033900?, 0xc000bf6c30?}, 0xc000172460)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/grpc_provider.go:1024 +0xe8d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0001af400, {0x2033900?, 0xc000bf6240?}, 0xc000be8070)
github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/tf5server/server.go:821 +0x574
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1c98780?, 0xc0001af400}, {0x2033900, 0xc000bf6240}, 0xc000be8000, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.16.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:422 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000262000, {0x20384c0, 0xc0006024e0}, 0xc0007be120, 0xc0008af590, 0x2705ca0, 0x0)
google.golang.org/grpc@v1.56.0/server.go:1337 +0xdf3
google.golang.org/grpc.(*Server).handleStream(0xc000262000, {0x20384c0, 0xc0006024e0}, 0xc0007be120, 0x0)
google.golang.org/grpc@v1.56.0/server.go:1714 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.1()
google.golang.org/grpc@v1.56.0/server.go:959 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
google.golang.org/grpc@v1.56.0/server.go:957 +0x18c


```

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
