### PR TITLE
deprecate: marking cloud_provider_access resource and data source as deprecated

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
@@ -16,7 +16,8 @@ const (
 
 func dataSourceMongoDBAtlasCloudProviderAccessList() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCloudProviderAccessRead,
+		ReadContext:        dataSourceMongoDBAtlasCloudProviderAccessRead,
+		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
@@ -17,7 +17,7 @@ const (
 func dataSourceMongoDBAtlasCloudProviderAccessList() *schema.Resource {
 	return &schema.Resource{
 		ReadContext:        dataSourceMongoDBAtlasCloudProviderAccessRead,
-		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access"),
+		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access_setup"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
@@ -28,7 +28,7 @@ func resourceMongoDBAtlasCloudProviderAccess() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceMongoDBAtlasCloudProviderAccessImportState,
 		},
-		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access"),
+		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access_setup and mongodbatlas_cloud_provider_access_authorization"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
@@ -28,6 +28,7 @@ func resourceMongoDBAtlasCloudProviderAccess() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceMongoDBAtlasCloudProviderAccessImportState,
 		},
+		DeprecationMessage: fmt.Sprintf(DeprecationMessage, "v1.14.0", "mongodbatlas_cloud_provider_access"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/website/docs/d/cloud_provider_access.markdown
+++ b/website/docs/d/cloud_provider_access.markdown
@@ -6,6 +6,8 @@ description: |-
     Allows you to get the list of cloud provider access roles
 ---
 
+**WARNING:** The data source `mongodbatlas_cloud_provider_access` is deprecated and will be removed in version v1.14.0, use the data source `mongodbatlas_cloud_provider_access_setup` instead.
+
 # Data Source: mongodbatlas_cloud_provider_access
 
 `mongodbatlas_cloud_provider_access` allows you to get the list of cloud provider access roles, currently only AWS is supported.

--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -11,6 +11,7 @@ description: |-
 The Terraform MongoDB Atlas Provider offers two either-or/mutually exclusive paths to perform an authorization for a cloud provider role -
 
 * A Single Resource path: using the `mongodbatlas_cloud_provider_access` that at provision time sets up all the required configuration for a given provider, then with a subsequent update it can perform the authorize of the role. Note this path requires two `terraform apply` commands, once for setup and once for auth.
+**WARNING:** The resource `mongodbatlas_cloud_provider_access` is deprecated and will be removed in version v1.14.0, use the Two Resource path instead.
 
 * A Two Resource path: consisting of `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization`. The first resource, `mongodbatlas_cloud_provider_access_setup`, only generates
 the initial configuration (create, delete operations). The second resource, `mongodbatlas_cloud_provider_access_authorization`, helps to perform the authorization using the role_id of the first resource. This path is helpful in a multi-provider Terraform file, and allows for a single and decoupled apply. See example of this Two Resource path option with AWS Cloud [here](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-cloud-provider-access/aws). 
@@ -18,6 +19,8 @@ the initial configuration (create, delete operations). The second resource, `mon
 -> **IMPORTANT** If you want to move from the single resource path to the two resources path see the [migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
 
 ## mongodbatlas_cloud_provider_access
+
+**WARNING:** The resource `mongodbatlas_cloud_provider_access` is deprecated and will be removed in version v1.14.0, use the Two Resource path instead.
 
 `mongodbatlas_cloud_provider_access` Allows you to register and authorize AWS IAM roles in Atlas. This is the resource to use for the single resource path described above.
 


### PR DESCRIPTION
## Description

Ticket: [INTMDB-967](https://jira.mongodb.org/browse/INTMDB-967)

Authorization for a cloud provider role using one resource path is deprecated in favor of two resource path approach.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
