### PR TITLE
fix: add prefix to dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    commit-message:
+      prefix: "chore"
     reviewers:
       - "mongodb/apix-integrations"
   - package-ecosystem: github-actions
@@ -12,6 +14,8 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    commit-message:
+      prefix: "chore"
     reviewers:
       - "mongodb/apix-integrations"
 


### PR DESCRIPTION
## Description

This PR adds the `chore` prefix to the dependabot PRs to make the PR linter happy 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
