### PR TITLE
fix: Fix documentation for mongodbatlas_api_key

### DIFF
--- a/website/docs/r/api_key.html.markdown
+++ b/website/docs/r/api_key.html.markdown
@@ -35,22 +35,6 @@ The following are valid roles:
   * `ORG_READ_ONLY`
   * `ORG_MEMBER`
 
-~> **NOTE:** Project created by API Keys must belong to an existing organization.
-
-### Programmatic API Keys
-api_keys allows one to assign an existing organization programmatic API key to a Project. The api_keys attribute is optional.
-
-* `api_key_id` - (Required) The unique identifier of the Programmatic API key you want to associate with the Project.  The Programmatic API key and Project must share the same parent organization.  Note: this is not the `publicKey` of the Programmatic API key but the `id` of the key. See [Programmatic API Keys](https://docs.atlas.mongodb.com/reference/api/apiKeys/) for more.
-
-* `role_names` - (Required) List of Project roles that the Programmatic API key needs to have. Ensure you provide: at least one role and ensure all roles are valid for the Project.  You must specify an array even if you are only associating a single role with the Programmatic API key.
- The following are valid roles:
-  * `GROUP_OWNER`
-  * `GROUP_READ_ONLY`
-  * `GROUP_DATA_ACCESS_ADMIN`
-  * `GROUP_DATA_ACCESS_READ_WRITE`
-  * `GROUP_DATA_ACCESS_READ_ONLY`
-  * `GROUP_CLUSTER_MANAGER`
- 
  ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
## Description

Jira Ticket: [INTMDB-984](https://jira.mongodb.org/browse/INTMDB-984)


[mongodbatlas_api_key](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/api_key#programmatic-api-keys) currently have a section about project api keys which are not supported by the resource. Indeed the [`api_keys` field is not avalable](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/be6c131c04d7fb09bdcf534a85593072fc546c35/mongodbatlas/resource_mongodbatlas_api_key.go#L25)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
