### PR TITLE
fix: fix cluster outage tests

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
-	SkipTestExtCred(t)
 	var (
 		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -39,7 +38,6 @@ func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
 }
 
 func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
-	SkipTestExtCred(t)
 	var (
 		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
-	SkipTestExtCred(t)
 	var (
 		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -41,7 +40,6 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 }
 
 func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
-	SkipTestExtCred(t)
 	var (
 		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")


### PR DESCRIPTION
## Description

Cluster outage tests were not running. This PR enables the tests to run against cloud-dev

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
