### PR TITLE
doc: regenerate CHANGELOG.md after v1.11.0 pre-release

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,4 +1,4 @@
-future-release=v1.10.2
-since-tag=v1.10.1
+future-release=v1.11.0
+since-tag=v1.10.2
 date-format=%B %d, %Y
 base=CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-340
 
 **Deprecations and Removals**   
+
 - Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-967	
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Changelog
 
-## [v1.11.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.11.0) (August 02, 2023)
+## [v1.11.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.11.0) (2023-08-04)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.10.2...v1.11.0)
 
 **Enhancements**
 
-- Support for project `limits` in project resource and project/projects data sources [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
-- Add cloud provider access for azure [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Add shared-tier restore job [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Add shared-tier snapshots [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Support for Azure Service Principles in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Add support for Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Support for project `limits` in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Azure Service Principles support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) support in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
+- New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo))
 
 **Bug Fixes**
 
@@ -43,7 +44,6 @@
 - add prefix to dependabot PR [\#1361](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1361) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati))
 - Update README.md with supported OS/Arch [\#1350](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1350) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Create new example for BYOK and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Add PR lint to repo [\#1348](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1348) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Mark `instance_size` in electable specs required in `advanced_cluster` documentation [\#1339](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1339) ([maastha](https://github.com/maastha))
 - Update RELEASE.md Github issue [\#1331](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1331) ([maastha](https://github.com/maastha))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 **Enhancements**
 
-- Support for Azure Service Principles in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Add support for Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Support for project `limits` in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
+- Azure Service Principles support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) support in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-554
 - New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-340
 
-**Deprecations and Removals:**   
+**Deprecations and Removals**   
 - Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-967	
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Enhancements**
 
-- Azure Service Principles support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-545
+- [Azure Service Principles](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals?tabs=browser) support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-545
 - Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) support in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-546
 - Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-554
 - New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-340

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [v1.11.0](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.11.0) (August 02, 2023)
+
+[Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.10.2...v1.11.0)
+
+**Enhancements**
+
+- Support for project `limits` in project resource and project/projects data sources [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
+- Add cloud provider access for azure [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Add shared-tier restore job [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Add shared-tier snapshots [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
+
+**Bug Fixes**
+
+- Update `mongodbatlas_cloud_backup_schedule` to add the ID field to policyItems [\#1357](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1357) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- `project_api_key` data source missing `project_assignment` attribute [\#1356](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1356) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Support update of description for project api key resource [\#1354](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1354) ([AgustinBettati](https://github.com/AgustinBettati))
+- Null pointer in `resource_mongodbatlas_cloud_backup_schedule` [\#1353](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1353) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Plugin did not respond - panic: interface conversion: interface is nil, not map[string]interface [\#1342](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1342) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Error deleting organization information when importing organization [\#1352](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1352) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Mark project api key resource as destroyed if not present [\#1351](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1351) ([AgustinBettati](https://github.com/AgustinBettati))
+- `mongodbatlas_privatelink_endpoint_service` data source doc bug fix [\#1334](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1334) ([Zuhairahmed](https://github.com/Zuhairahmed))
+- Make region atributed optional computed in third-party-integration [\#1332](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1332) ([maastha](https://github.com/maastha))
+
+**Closed Issues**
+
+- json: cannot unmarshal number 4841168896 into Go struct field CloudProviderSnapshot.storageSizeBytes of type int [\#1333](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1333)
+- Labels is not creating tags in the MongoAtlas UI [\#1319](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1319)
+- `mongodbatlas_online_archive` `schedule` parameter update causing crashing in `terraform apply` [\#1318](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1318)
+- Update Pager Duty integration fails with INTEGRATION\_FIELDS\_INVALID [\#1316](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1316)
+- mongodbatlas\_event\_trigger is not updated if config\_match is added [\#1302](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1302)
+- Updating the 'name' field of a 'mongodbatlas\_project' recreates a new Project [\#1296](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1296)
+- mongodbatlas\_org\_invitation is missing ORG\_BILLING\_READ\_ONLY role support [\#1280](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1280)
+- mongodbatlas\_alert\_configuration notification microsoft\_teams\_webhook\_url is always updated [\#1275](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1275)
+- Provider not destroying API keys [\#1261](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1261)
+- Has `project_assignment` of `mongodbatlas_api_key` not been implemented? [\#1249](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1249)
+- Invalid attribute providerBackupEnabled specified. [\#1245](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1245)
+
+**Internal Improvements**
+
+- Fix documentation for `mongodbatlas_api_key` [\#1363](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1363) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Improve self-managed x509 database user docs [\#1336](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1336) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- add prefix to dependabot PR [\#1361](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1361) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati))
+- Update README.md with supported OS/Arch [\#1350](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1350) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Create new example for BYOK and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Add PR lint to repo [\#1348](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1348) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Mark `instance_size` in electable specs required in `advanced_cluster` documentation [\#1339](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1339) ([maastha](https://github.com/maastha))
+- Update RELEASE.md Github issue [\#1331](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1331) ([maastha](https://github.com/maastha))
+- Update privatelink endpoint service resources timeout config [\#1329](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1329) ([maastha](https://github.com/maastha))
+- Use go-version-file in github actions [\#1315](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1315) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Add autogenerated SDK to terraform [\#1309](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1309) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Migrate to terraform-plugin-testing [\#1301](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1301) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Bump github.com/aws/aws-sdk-go from 1.44.308 to 1.44.314 [\#1360](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1360) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.43.10 to 0.43.11 [\#1358](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1358) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/hashicorp/terraform-plugin-testing from 1.3.0 to 1.4.0 [\#1346](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1346) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/gruntwork-io/terratest from 0.43.8 to 0.43.10 [\#1345](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1345) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.44.304 to 1.44.308 [\#1344](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1344) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.44.302 to 1.44.304 [\#1335](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1335) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github.com/aws/aws-sdk-go from 1.44.299 to 1.44.302 [\#1330](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1330) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+
 ## [v1.10.2](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.10.2) (2023-07-19)
 
 [Full Changelog](https://github.com/mongodb/terraform-provider-mongodbatlas/compare/v1.10.1...v1.10.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 **Enhancements**
 
-- Azure Service Principles support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) support in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati))
-- New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo))
+- Azure Service Principles support in `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization` [\#1343](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1343) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-545
+- Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) support in `mongodbatlas_shared_tier_snapshot` and `mongodbatlas_shared_tier_restore_job` [\#1324](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1324) ([andreaangiolillo](https://github.com/andreaangiolillo)) and [\#1323](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1323) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-546
+- Atlas Project `limits` support in `mongodbatlas_project` [\#1347](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1347) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-554
+- New example for Encryption at Rest using Customer Key Management and multi-region cluster [\#1349](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1349) ([andreaangiolillo](https://github.com/andreaangiolillo)) - INTMDB-340
+
+**Deprecations and Removals:**   
+- Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati)) - INTMDB-967	
 
 **Bug Fixes**
 
@@ -42,7 +45,6 @@
 - Fix documentation for `mongodbatlas_api_key` [\#1363](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1363) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Improve self-managed x509 database user docs [\#1336](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1336) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - add prefix to dependabot PR [\#1361](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1361) ([andreaangiolillo](https://github.com/andreaangiolillo))
-- Marking `cloud_provider_access` resource and data source as deprecated [\#1355](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1355) ([AgustinBettati](https://github.com/AgustinBettati))
 - Update README.md with supported OS/Arch [\#1350](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1350) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Add PR lint to repo [\#1348](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1348) ([andreaangiolillo](https://github.com/andreaangiolillo))
 - Mark `instance_size` in electable specs required in `advanced_cluster` documentation [\#1339](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1339) ([maastha](https://github.com/maastha))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,14 +21,21 @@ We pre-release the provider to make for testing purpose. **A Pre-release is not 
 - **There is a bug in the GitHub release page**: after binaries get created, GitHub  flips backthe  status of release as Draft so you have to set it to Pre-Release (or Latest, if publishing the final version) again.
 
 ### Generate the CHANGELOG.md 
+We use a tool called [github changelog generator](https://github.com/github-changelog-generator/github-changelog-generator) to automatically update our changelog. It provides options for downloading a CLI or using a docker image with interactive mode to update the CHANGELOG.md file locally.
+
 - Update `since_tag` and `future-release` in [.github_changelog_generator](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/.github_changelog_generator)
 - **There is a bug with `github_changelog_generator` ([#971](https://github.com/github-changelog-generator/github-changelog-generator/issues/971))**: Make sure to update the `future-tag` with the pre-release tag. Once you generate the changelog, update `future-tag` with the final release tag in [.github_changelog_generator](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/.github_changelog_generator). Then, manually update the generated changelog to remove references to the pre-release tag
-- Run
+- Run the following command: 
 
     ```bash 
-    github_changelog_generator -u mongodb -p terraform-provider-mongodbatlas --enhancement-label "**Enhancements**" --bugs-label "**Bug Fixes**"  --issues-label "**Closed Issues**" --pr-label "**Internal Improvements**"
+    github_changelog_generator -u mongodb -p terraform-provider-mongodbatlas -t <GH_TOKEN> --enhancement-label "**Enhancements**" --bugs-label "**Bug Fixes**"  --issues-label "**Closed Issues**" --pr-label "**Internal Improvements**"
     ```
--  Open a PR against the **master** branch
+    or using docker image
+    ```bash 
+    docker run -it --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator -u mongodb -p terraform-provider-mongodbatlas -t <GH_TOKEN> --enhancement-label "**Enhancements**" --bugs-label "**Bug Fixes**"  --issues-label "**Closed Issues**" --pr-label "**Internal Improvements**"
+    ```
+    To obtain your github personal access token you can use the following guide: [Authorizing a personal access token for use with SAML single sign-on](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on)
+-  Make any manual adjustments if needed, and open a PR against the **master** branch
 -  Example: [#1308](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1308)
 
 ### Release the provider

--- a/website/docs/guides/1.11.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.11.0-upgrade-guide.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "mongodbatlas"
+page_title: "MongoDB Atlas Provider 1.11.0: Upgrade and Information Guide"
+sidebar_current: "docs-mongodbatlas-guides-1110-upgrade-guide"
+description: |-
+MongoDB Atlas Provider 1.11.0: Upgrade and Information Guide
+---
+
+# MongoDB Atlas Provider 1.11.0: Upgrade and Information Guide
+
+The Terraform MongoDB Atlas Provider version 1.11.0 has a number of new and exciting features.
+
+**New Resources, Data Sources, and Features:**
+- You can now manage [Azure Service Principles](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals?tabs=browser) in [`mongodbatlas_cloud_provider_access_setup`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access) and [`mongodbatlas_cloud_provider_access_authorization`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access). To learn more see [Set Up and Manage Azure Service Principal Access](https://www.mongodb.com/docs/atlas/security/set-up-azure-access/).
+- You can now manage Atlas [Shared Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/shared-cluster-backup/) in [`mongodbatlas_shared_tier_snapshot`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/shared_tier_snapshot) and [`mongodbatlas_shared_tier_restore_job`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/mongodbatlas_shared_tier_restore_job). See M2 and M5 [shared-tier cluster limitations](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/). 
+
+
+**Deprecations and Removals:**   
+- [`cloud_provider_access`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access) Single Resource Path has been deprecated. We will proceed with code removal in future release targeting v1.14.0. Two Resource Path is now recondmended approach for this resource. 
+
+
+1.11.0 also includes other general improvements, bug fixes, and several key documentation updates. See the [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for more specific information.
+
+
+### Helpful Links
+
+* [Report bugs](https://github.com/mongodb/terraform-provider-mongodbatlas/issues)
+
+* [Request Features](https://feedback.mongodb.com/forums/924145-atlas?category_id=370723)
+
+* [Contact Support](https://docs.atlas.mongodb.com/support/) covered by MongoDB Atlas support plans, Developer and above.


### PR DESCRIPTION
## Description

Ticket: [INTMDB-983](https://jira.mongodb.org/browse/INTMDB-983)

This PR regenerates the CHANGELOG.md after the pre-release of 1.11.0. Also adds some additional documentation in release documentation for setting up github changelog generator tool.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
