### PR TITLE
fix: Trigger resource force replacement when app id changes

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -43,6 +43,7 @@ func resourceMongoDBAtlasEventTriggers() *schema.Resource {
 			"app_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/website/docs/r/event_trigger.html.markdown
+++ b/website/docs/r/event_trigger.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 `mongodbatlas_event_trigger` provides a Event Trigger resource. 
 
+Note: If the `app_id` changes in the mongodbatlas_event_trigger resource, it will force a replacement and delete itself from the old Atlas App Services app if it still exists then create itself in the new  Atlas App Services app. See [Atlas Triggers](https://www.mongodb.com/docs/atlas/app-services/triggers/) to learn more.   
+
 ## Example Usages
 
 ### Example Usage: Database Trigger with Function


### PR DESCRIPTION
## Description

This PR addresses issue in https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1310 and will enable deletion of trigger from existing app followed by creation of a new trigger in the new app on change of app_id attribute.

Link to any related issue(s): [INTMDB-925](https://jira.mongodb.org/browse/INTMDB-925)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
![Screenshot 2023-08-15 at 09 43 40](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/122359335/8fe40185-1450-40e2-bdd5-57038ba01397)


<img width="1031" alt="Screenshot 2023-08-15 at 10 01 17" src="https://github.com/mongodb/terraform-provider-mongodbatlas/assets/122359335/33d5c7f6-97da-4c4c-a5f2-66f6b7207aa8">
