### PR TITLE
fix: remove validation of empty public_key and private_key attributes in provider config to avoid breaking change

### DIFF
--- a/mongodbatlas/fw_provider.go
+++ b/mongodbatlas/fw_provider.go
@@ -208,7 +208,11 @@ func (p *MongodbtlasProvider) Configure(ctx context.Context, req provider.Config
 		return
 	}
 
-	data = setDefaultValuesWithValidations(&data, resp)
+	var assumeRoles []tfAssumeRoleModel
+	data.AssumeRole.ElementsAs(ctx, &assumeRoles, true)
+	awsRoleDefined := len(assumeRoles) > 0
+
+	data = setDefaultValuesWithValidations(&data, awsRoleDefined, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -220,10 +224,7 @@ func (p *MongodbtlasProvider) Configure(ctx context.Context, req provider.Config
 		RealmBaseURL: data.RealmBaseURL.ValueString(),
 	}
 
-	var assumeRoles []tfAssumeRoleModel
-	data.AssumeRole.ElementsAs(ctx, &assumeRoles, true)
-
-	if len(assumeRoles) > 0 {
+	if awsRoleDefined {
 		config.AssumeRole = parseTfModel(ctx, &assumeRoles[0])
 		secret := data.SecretName.ValueString()
 		region := data.Region.ValueString()
@@ -288,7 +289,7 @@ func parseTfModel(ctx context.Context, tfAssumeRoleModel *tfAssumeRoleModel) *As
 
 const MongodbGovCloudURL = "https://cloud.mongodbgov.com"
 
-func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, resp *provider.ConfigureResponse) tfMongodbAtlasProviderModel {
+func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, awsRoleDefined bool, resp *provider.ConfigureResponse) tfMongodbAtlasProviderModel {
 	if mongodbgovCloud := data.IsMongodbGovCloud.ValueBool(); mongodbgovCloud {
 		data.BaseURL = types.StringValue(MongodbGovCloudURL)
 	}
@@ -304,6 +305,9 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, resp *pr
 			"MONGODB_ATLAS_PUBLIC_KEY",
 			"MCLI_PUBLIC_API_KEY",
 		}, "").(string))
+		if data.PublicKey.ValueString() == "" && !awsRoleDefined {
+			resp.Diagnostics.AddError(ProviderConfigError, MissingAuthAttrError)
+		}
 	}
 
 	if data.PrivateKey.ValueString() == "" {
@@ -311,6 +315,9 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, resp *pr
 			"MONGODB_ATLAS_PRIVATE_KEY",
 			"MCLI_PRIVATE_API_KEY",
 		}, "").(string))
+		if data.PrivateKey.ValueString() == "" && !awsRoleDefined {
+			resp.Diagnostics.AddError(ProviderConfigError, MissingAuthAttrError)
+		}
 	}
 
 	if data.RealmBaseURL.ValueString() == "" {

--- a/mongodbatlas/fw_provider.go
+++ b/mongodbatlas/fw_provider.go
@@ -304,9 +304,6 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, resp *pr
 			"MONGODB_ATLAS_PUBLIC_KEY",
 			"MCLI_PUBLIC_API_KEY",
 		}, "").(string))
-		if data.PublicKey.ValueString() == "" {
-			resp.Diagnostics.AddError(ProviderConfigError, fmt.Sprintf(AttrNotSetError, "public_key"))
-		}
 	}
 
 	if data.PrivateKey.ValueString() == "" {
@@ -314,9 +311,6 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, resp *pr
 			"MONGODB_ATLAS_PRIVATE_KEY",
 			"MCLI_PRIVATE_API_KEY",
 		}, "").(string))
-		if data.PrivateKey.ValueString() == "" {
-			resp.Diagnostics.AddError(ProviderConfigError, fmt.Sprintf(AttrNotSetError, "private_key"))
-		}
 	}
 
 	if data.RealmBaseURL.ValueString() == "" {

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -330,19 +330,12 @@ func setDefaultsAndValidations(d *schema.ResourceData) error {
 	}); err != nil {
 		return err
 	}
-	if d.Get("public_key").(string) == "" {
-		return fmt.Errorf(AttrNotSetError, "public_key")
-	}
 
 	if err := setValueFromConfigOrEnv(d, "private_key", []string{
 		"MONGODB_ATLAS_PRIVATE_KEY",
 		"MCLI_PRIVATE_API_KEY",
 	}); err != nil {
 		return err
-	}
-
-	if d.Get("private_key").(string) == "" {
-		return fmt.Errorf(AttrNotSetError, "private_key")
 	}
 
 	if err := setValueFromConfigOrEnv(d, "realm_base_url", []string{


### PR DESCRIPTION
## Description

Related tickets: [INTMDB-999](https://jira.mongodb.org/browse/INTMDB-999) (manual testing of provider configuration), [INTMDB-971](https://jira.mongodb.org/browse/INTMDB-971) (migration to framework provider, which included changes to the provider configuration)

During manual testing of the provider configuration using [AWS Secrets Manager Authentication method](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#aws-secrets-manager), the following valid case was tested:
```
provider "mongodbatlas" {
  base_url = "https://cloud-dev.mongodb.com/"
  assume_role {
    role_arn = "arn:aws:iam::358363220050:role/agustin-role-for-sts"
  }
  secret_name           = "testing-terraform-provider-with-aws-sm"
  region                = "eu-north-1"
  aws_access_key_id     = "<access key>"
  aws_secret_access_key = "<secret access key>"
  aws_session_token     = "<sts session token>"
  sts_endpoint          = "https://sts.eu-north-1.amazonaws.com/"
}
```
**Note**: no environment variables defined.

- In 1.11.0 this provider configuration correctly retrieves credentials stored in AWS Secret Manager and following resource definitions work as expected.
- In our current migration branch (CLOUDP-189585-plugin-framework-migration) this case results in an error `Error: attribute public_key must be set`

Initially we defined validations for both of these attributes as we can see they are [defined as required](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/mongodbatlas/provider.go#L60). However, since a default function is provided which will always return a value (either value from environment variables or simply empty string) these attributes can be left empty allowing support for cases like the above.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
