### PR TITLE
fix: add instructions for updates of the Atlas SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,18 +288,17 @@ Examples:
 
 ## Discovering New API features
 
-Most of the new features of the SDK using https://github.com/mongodb/atlas-sdk-go
-This SDK updated automatically tracking all Atlas Production releases.
-Developers can 
+Most of the new features of the provider are using [atlas-sdk](https://github.com/mongodb/atlas-sdk-go)
+SDK is updated automatically, tracking all new Atlas features.
 
 ### Updating Atlas SDK 
 
 To update Atlas SDK run:
 
-```
+```bash
 make update-atlas-sdk
 ```
 
-> NOTE: Command can make import changes to +500 files. Please make sure that you perform update on main branch without any uncommited changes.
-
 > NOTE: Update mechanism is only needed for major releases. Any other releases will be supported by dependabot.
+
+> NOTE: Command can make import changes to +500 files. Please make sure that you perform update on main branch without any uncommited changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,7 +266,6 @@ To do this you can:
 
 - In our documentation, when a resource field allows a maximum of only one item, we do not format that field as an array. Instead, we create a subsection specifically for this field. Within this new subsection, we enumerate all the attributes of the field. Let's illustrate this with an example: [cloud_backup_schedule.html.markdown](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/website/docs/r/cloud_backup_schedule.html.markdown?plain=1#L207)
 
-
 ## PR Title Format
 We use [*Conventional Commits*](https://www.conventionalcommits.org/):
 - `fix: description of the PR`: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
@@ -286,3 +285,21 @@ Examples:
   - `fix!: description of the ticket`
   - If the PR has `BREAKING CHANGE`: in its description is a breaking change
 - `remove!: description of the PR`: The commit removes a feature from the product. Typically features are deprecated first for a period of time before being removed. Removing a feature is a breaking change (correlating with MAJOR in Semantic Versioning).
+
+## Discovering New API features
+
+Most of the new features of the SDK using https://github.com/mongodb/atlas-sdk-go
+This SDK updated automatically tracking all Atlas Production releases.
+Developers can 
+
+### Updating Atlas SDK 
+
+To update Atlas SDK run:
+
+```
+make update-atlas-sdk
+```
+
+> NOTE: Command can make import changes to +500 files. Please make sure that you perform update on main branch without any uncommited changes.
+
+> NOTE: Update mechanism is only needed for major releases. Any other releases will be supported by dependabot.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -134,4 +134,5 @@ link-git-hooks: ## Install git hooks
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the atlas-sdk dependency
 	go install github.com/icholy/gomajor@v0.9.5
+	## Fetch the latest major version and update imports.
 	gomajor get go.mongodb.org/atlas-sdk/v20230201001@latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -133,5 +133,5 @@ link-git-hooks: ## Install git hooks
 
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the atlas-sdk dependency
-	go install github.com/icholy/gomajor@latest
+	go install github.com/icholy/gomajor@v0.9.5
 	gomajor get go.mongodb.org/atlas-sdk/v20230201001@latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -130,3 +130,8 @@ link-git-hooks: ## Install git hooks
 	@echo "==> Installing all git hooks..."
 	find .git/hooks -type l -exec rm {} \;
 	find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;
+
+.PHONY: update-atlas-sdk
+update-atlas-sdk: ## Update the atlas-sdk dependency
+	go install github.com/icholy/gomajor@latest
+	gomajor get go.mongodb.org/atlas-sdk/v20230201001@latest


### PR DESCRIPTION
## Description

Adding support for automatic updates of major releases of the sdk. 
In the long run, we can consider having manually triggered github action that will create an update PR.
 
 ## Command in action
 
 All imports have been updated to the latest after running command.
 
<img width="441" alt="Screenshot 2023-08-23 at 10 40 32" src="https://github.com/mongodb/terraform-provider-mongodbatlas/assets/981838/c4c25db2-f2c9-4b50-8d3d-c257aaf3e725">

 