### PR TITLE
fix: self document make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,6 +23,10 @@ export SHELL := env PATH=$(PATH) /bin/bash
 
 default: build
 
+.PHONY: help
+help:
+	@grep -h -E '^[a-zA-Z_-]+:.*?$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: build
 build: fmt fmtcheck
 	go build -ldflags "$(LINKER_FLAGS)" -o $(DESTINATION)


### PR DESCRIPTION
## Description

Make targets can be self-documenting which helps with contributing guide. 
Many go libs use it to give developers overview in what actions are possible

## Output

```bash
> make help
default: build                 
help:                          
build: fmt fmtcheck            
install: fmtcheck              
test: fmtcheck                 
testacc: fmtcheck              
testaccgov: fmtcheck           
fmt:                           
fmtcheck: # Currently required by tf-deploy compile 
websitefmtcheck:               
lint-fix:                      
lint:                          
tools                          Install dev tools
check: test lint               
test-compile:                  
website:                       
website-lint:                  
website-test:                  
terratest: fmtcheck            
tflint: fmtcheck               
tf-validate: fmtcheck          
link-git-hooks                 Install git hooks
```

Follow up PR idea: add documentation to targets that are missing. 