### PR TITLE
PoC: notifierId attribute in alert configuration notifications

### DIFF
--- a/examples/atlas-alert-configurations/README.md
+++ b/examples/atlas-alert-configurations/README.md
@@ -14,6 +14,8 @@ chmod +x ./import-alerts.sh
 terraform apply
 ```
 
+**NOTE**: Third-party notifications will not contain their respective credentials as these are sensitive attributes. If you wish to perform updates on these notifications, make sure to provide the corresponding `notifier_id` attribute so that credentials can be obtained successfuly.
+
 ## Contingency Plans
 If unhappy with the resource file or imports, here are some things that can be done:
 

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
@@ -209,6 +209,9 @@ var alertConfigDSSchemaAttributes = map[string]schema.Attribute{
 				"team_name": schema.StringAttribute{
 					Computed: true,
 				},
+				"notifier_id": schema.StringAttribute{
+					Computed: true,
+				},
 				"type_name": schema.StringAttribute{
 					Computed: true,
 				},
@@ -440,6 +443,10 @@ func convertNotificationToCtyValues(notification *matlas.Notification) map[strin
 
 	if notification.TeamName != "" {
 		values["team_name"] = cty.StringVal(notification.TeamName)
+	}
+
+	if notification.NotifierID != "" {
+		values["notifier_id"] = cty.StringVal(notification.NotifierID)
 	}
 
 	if notification.TypeName != "" {

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -97,6 +97,7 @@ type tfNotificationModel struct {
 	OpsGenieAPIKey           types.String `tfsdk:"ops_genie_api_key"`
 	TeamID                   types.String `tfsdk:"team_id"`
 	TeamName                 types.String `tfsdk:"team_name"`
+	NotifierID               types.String `tfsdk:"notifier_id"`
 	TypeName                 types.String `tfsdk:"type_name"`
 	ChannelName              types.String `tfsdk:"channel_name"`
 	VictorOpsAPIKey          types.String `tfsdk:"victor_ops_api_key"`
@@ -324,6 +325,10 @@ func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
+						},
+						"notifier_id": schema.StringAttribute{
+							Computed: true,
+							Optional: true,
 						},
 						"type_name": schema.StringAttribute{
 							Optional: true,
@@ -583,6 +588,7 @@ func newNotificationList(tfNotificationSlice []tfNotificationModel) ([]matlas.No
 			ServiceKey:               value.ServiceKey.ValueString(),
 			SMSEnabled:               value.SMSEnabled.ValueBoolPointer(),
 			TeamID:                   value.TeamID.ValueString(),
+			NotifierID:               value.NotifierID.ValueString(),
 			TypeName:                 value.TypeName.ValueString(),
 			Username:                 value.Username.ValueString(),
 			VictorOpsAPIKey:          value.VictorOpsAPIKey.ValueString(),
@@ -673,6 +679,7 @@ func newTFNotificationModelList(matlasSlice []matlas.Notification, currStateNoti
 				TeamID:         conversion.StringNullIfEmpty(value.TeamID),
 				TypeName:       conversion.StringNullIfEmpty(value.TypeName),
 				Username:       conversion.StringNullIfEmpty(value.Username),
+				NotifierID:     types.StringValue(value.NotifierID),
 				EmailEnabled:   types.BoolValue(value.EmailEnabled != nil && *value.EmailEnabled),
 				SMSEnabled:     types.BoolValue(value.SMSEnabled != nil && *value.SMSEnabled),
 			}
@@ -728,6 +735,7 @@ func newTFNotificationModelList(matlasSlice []matlas.Notification, currStateNoti
 			newState.Username = conversion.StringNullIfEmpty(value.Username)
 		}
 
+		newState.NotifierID = types.StringValue(value.NotifierID)
 		newState.DelayMin = types.Int64Value(int64(*value.DelayMin))
 		newState.EmailEnabled = types.BoolValue(value.EmailEnabled != nil && *value.EmailEnabled)
 		newState.SMSEnabled = types.BoolValue(value.SMSEnabled != nil && *value.SMSEnabled)

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -230,6 +230,7 @@ List of notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
+* `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials. **NOTE**: If attribute is defined to perform an update, keep in mind that on every successful update the value of the id is also modified and returned in the state. To keep your plan consistent the attribute value must be replaced or removed.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `victor_ops_routing_key` - VictorOps routing key. Optional for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
@@ -266,5 +267,7 @@ Alert Configuration can be imported using the `project_id-alert_configuration_id
 ```
 $ terraform import mongodbatlas_alert_configuration.test 5d0f1f74cf09a29120e123cd-5d0f1f74cf09a29120e1fscg
 ```
+
+**NOTE**: Third-party notifications will not contain their respective credentials as these are sensitive attributes. If you wish to perform updates on these notifications, make sure to provide the corresponding `notifier_id` attribute so that credentials can be obtained successfuly.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/alert-configurations/)


### PR DESCRIPTION
## Description

Related ticket: [INTMDB-981](https://jira.mongodb.org/browse/INTMDB-981)
Related branch in SDK: https://github.com/mongodb/go-client-mongodb-atlas/tree/INTMDB-981

**Summary**: Support for defining and obtaining `notifier_id` attribute can be implemented in terraform, however the use case it is meant to support does face issues due to how Atlas API currently works.

### Example scenario: importing and modifying a third party notification

**Creating an alert with third-party integrated notification**
We can create the following alert configuration with a notification that integrates with Pager Duty using a service key:
```
resource "mongodbatlas_alert_configuration" "test" {
  project_id = var.project_id
  event_type = "NO_PRIMARY"
  enabled    = true

  notification {
    type_name    = "PAGER_DUTY"
    delay_min    = 4
    service_key = var.pager_duty_service_key
  }
}
```

**Importing the existing alert configuration**
Having this resource created, we do want users to be able to import existing notifications and modify them. For this we can run the command:
`terraform import mongodbatlas_alert_configuration.test <project-id>-<alert-config-id>`

Having imported the resource that was created above, from the resulting terraform state the users can define the following resource:
```
resource "mongodbatlas_alert_configuration" "NO_PRIMARY" {  
  project_id = var.project_id 
  event_type = "NO_PRIMARY"  
  enabled    = true  
  notification {    
    delay_min = 30
    notifier_id = "64e87790ef810951d0deb8b1"
    type_name = "PAGER_DUTY"  
  }
}
```
As seen, the `service_key` attribute is no longer present as it is a sensitive attribute that is not returned by the API. However, `notifier_id` attribute is now defined allowing users to update the notification without having to provide the original credentials.

### Existing drawbacks
The Atlas API modifies the `notifierId` value on each successful update. This generates the following undesired behavior to the user:
- After modifying some attribute in the notification (lets say `delay_min`) and running `terraform apply`, the update is successful but the following error is encountered: `Error: Provider produced inconsistent result after apply. produced an unexpected new value: .notification[0].notifier_id: was cty.StringVal("64e87790ef810951d0deb8b1"), but now cty.StringVal("64e727a6ca9dfd073493ff1b"). `
As the attribute is defined in the configuration, and changes during the update request, inconsistency issues are not avoidable. To have a consistent state, the user would have to now manually update to the new value, or remove the field.
- Due to the changes in `notifierId`, for every successful update the user will have to update the `notifier_id` to the most recent value.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
