### PR TITLE
fix: HELP: Error: The terraform-provider-mongodbatlas_v1.11.0 plugin crashed

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -515,8 +514,11 @@ func expandAlertConfigurationMatchers(d *schema.ResourceData) []matlas.Matcher {
 
 	if m, ok := d.GetOk("matcher"); ok {
 		for _, value := range m.([]interface{}) {
-			v := value.(map[string]interface{})
+			if value == nil {
+				break
+			}
 
+			v := value.(map[string]interface{})
 			matchers = append(matchers, matlas.Matcher{
 				FieldName: v["field_name"].(string),
 				Operator:  v["operator"].(string),
@@ -610,6 +612,10 @@ func expandAlertConfigurationThresholdConfig(d *schema.ResourceData) *matlas.Thr
 		vL := value.([]interface{})
 
 		if len(vL) > 0 {
+			if vL[0] == nil {
+				return nil
+			}
+
 			v := vL[0].(map[string]interface{})
 
 			return &matlas.Threshold{

--- a/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_alert_configuration_test.go
@@ -72,6 +72,31 @@ func TestAccConfigRSAlertConfiguration_EmptyMetricThresholdConfig(t *testing.T) 
 	})
 }
 
+func TestAccConfigRSAlertConfiguration_EmptyMatcherMetricThresholdConfig(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckBasic(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigEmptyMatcherMetricThresholdConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 func TestAccConfigRSAlertConfiguration_Notifications(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
@@ -805,6 +830,50 @@ resource "mongodbatlas_alert_configuration" "test" {
     units       = "HOURS"
   }
 
+}
+	`, orgID, projectName, enabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigEmptyMatcherMetricThresholdConfig(orgID, projectName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = mongodbatlas_project.test.id
+  event_type = "CLUSTER_MONGOS_IS_MISSING"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name     = "GROUP"
+    interval_min  = 60
+    delay_min     = 0
+    sms_enabled   = true
+    email_enabled = false
+	roles         = ["GROUP_OWNER"]
+  }
+
+  matcher {
+    field_name = ""
+    operator   = null
+    value      = ""
+  }
+
+  metric_threshold_config {
+    metric_name = ""
+    operator    = null
+    threshold   = null
+    units       = null
+    mode        = ""
+  }
+
+  threshold_config {
+    operator  = null
+    threshold = null
+    units     = null
+  }
 }
 	`, orgID, projectName, enabled)
 }


### PR DESCRIPTION
## Description

This PR fixes an NPE when the matcher & metrics threshold are provided with null fields

Link to any related issue(s): #1396

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments

Next Steps:

- Reproduce the issue with the resource migrated to the new framework
- Backport the fix in 1.12.0 if needed