### PR TITLE
fix: INTMDB-1017 - Updated alert configuration schema with required params

### DIFF
--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -166,13 +166,13 @@ func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"field_name": schema.StringAttribute{
-							Optional: true,
+							Required: true,
 						},
 						"operator": schema.StringAttribute{
-							Optional: true,
+							Required: true,
 						},
 						"value": schema.StringAttribute{
-							Optional: true,
+							Required: true,
 						},
 					},
 				},
@@ -184,7 +184,7 @@ func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"metric_name": schema.StringAttribute{
-							Optional: true,
+							Required: true,
 						},
 						"operator": schema.StringAttribute{
 							Optional: true,
@@ -330,7 +330,7 @@ func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 							},
 						},
 						"type_name": schema.StringAttribute{
-							Optional: true,
+							Required: true,
 							Validators: []validator.String{
 								stringvalidator.OneOf("EMAIL", "SMS", pagerDuty, "SLACK",
 									"DATADOG", opsGenie, victorOps,

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -59,8 +58,6 @@ func TestAccConfigRSAlertConfiguration_EmptyMetricThresholdConfig(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasAlertConfigurationConfigEmptyMetricThresholdConfig(orgID, projectName, true),
-				// metric threshold is not created so state is inconsistent with plan
-				ExpectError: regexp.MustCompile("Error: Provider produced inconsistent result after apply"),
 			},
 		},
 	})
@@ -846,9 +843,6 @@ resource "mongodbatlas_alert_configuration" "test" {
     email_enabled = false
 	roles         = ["GROUP_OWNER"]
   }
-
-
-  metric_threshold_config {}
 
   threshold_config {
     operator    = "LESS_THAN"

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -132,7 +132,7 @@ resource "mongodbatlas_alert_configuration" "test" {
 ### Matchers
 Rules to apply when matching an object against this alert configuration. Only entities that match all these rules are checked for an alert condition. You can filter using the matchers array only when the eventTypeName specifies an event for a host, replica set, or sharded cluster.
 
-* `field_name` - Name of the field in the target object to match on.
+* `field_name` - (Required) Name of the field in the target object to match on.
 
 | Host alerts         | Replica set alerts  |  Sharded cluster alerts |
 |:----------           |:-------------       |:------                 |
@@ -144,13 +144,9 @@ Rules to apply when matching an object against this alert configuration. Only en
 
 
 
-  All other types of alerts do not support matchers.
+All other types of alerts do not support matchers.
 
-* `operator` - If omitted, the configuration is disabled.
-* `value` - If omitted, the configuration is disabled.
-
-
-* `operator` - The operator to test the field’s value.
+* `operator` - (Required) The operator to test the field’s value.
   Accepted values are:
     - `EQUALS`
     - `NOT_EQUALS`
@@ -160,7 +156,7 @@ Rules to apply when matching an object against this alert configuration. Only en
     - `ENDS_WITH`
     - `REGEX`
 
-* `value` - Value to test with the specified operator. If `field_name` is set to TYPE_NAME, you can match on the following values:
+* `value` - (Required) Value to test with the specified operator. If `field_name` is set to TYPE_NAME, you can match on the following values:
     - `PRIMARY`
     - `SECONDARY`
     - `STANDALONE`
@@ -170,7 +166,7 @@ Rules to apply when matching an object against this alert configuration. Only en
 ### Metric Threshold Config (`metric_threshold_config`)
 The threshold that causes an alert to be triggered. Required if `event_type_name` : `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`
 
-* `metric_name` - Name of the metric to check. The full list being quite large, please refer to atlas docs [here for general metrics](https://docs.atlas.mongodb.com/reference/alert-host-metrics/#measurement-types) and [here for serverless metrics](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-create-config/#serverless-measurements)
+* `metric_name` - (Required) Name of the metric to check. The full list being quite large, please refer to atlas docs [here for general metrics](https://docs.atlas.mongodb.com/reference/alert-host-metrics/#measurement-types) and [here for serverless metrics](https://www.mongodb.com/docs/atlas/reference/api/alert-configurations-create-config/#serverless-measurements)
 * `operator` - Operator to apply when checking the current metric value against the threshold value.
   Accepted values are:
     - `GREATER_THAN`

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -209,7 +209,7 @@ List of notifications to send when an alert condition is detected.
 * `sms_enabled` - Flag indicating if text message notifications should be sent to this user's mobile phone. This flag is only valid if `type_name` is set to `ORG`, `GROUP`, or `USER`.
 * `team_id` - Unique identifier of a team.
 * `team_name` - Label for the team that receives this notification.
-* `type_name` - Type of alert notification.
+* `type_name` - (Required) Type of alert notification.
   Accepted values are:
     - `DATADOG`
     - `EMAIL`


### PR DESCRIPTION
## Description

This PR updates the alert config fields in MetricThreshold and Matcher to be required
Follow up PR on [CLOUDP-197223: add required param to open api doc for required fields in MetricThreshold and Matcher](https://github.com/10gen/mms/pull/80991)](https://github.com/10gen/mms/pull/80991).

Error:
```bash
╷
│ Error: error creating Alert Configuration information: %s
│
│   with mongodbatlas_alert_configuration.default,
│   on main.tf line 587, in resource "mongodbatlas_alert_configuration" "default":
│  587: resource "mongodbatlas_alert_configuration" "default" {
│
│ POST https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/64ec69f04c5f4423e05af8b3/alertConfigs: 400 (request "MISSING_ATTRIBUTE") The required attribute fieldName was not specified.
```

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
These params are now required in the schema:

```
 Error: Missing Configuration for Required Attribute
│
│   with mongodbatlas_alert_configuration.default,
│   on main.tf line 603, in resource "mongodbatlas_alert_configuration" "default":
│  603:     field_name = null
│
│ Must set a configuration value for the matcher[0].field_name attribute as the provider has marked it as required.
│
│ Refer to the provider documentation or contact the provider developers for additional information about configurable attributes that are required.
╵
╷
│ Error: Missing Configuration for Required Attribute
│
│   with mongodbatlas_alert_configuration.default,
│   on main.tf line 604, in resource "mongodbatlas_alert_configuration" "default":
│  604:     operator   = null
│
│ Must set a configuration value for the matcher[0].operator attribute as the provider has marked it as required.
│
│ Refer to the provider documentation or contact the provider developers for additional information about configurable attributes that are required.
╵
╷
│ Error: Missing Configuration for Required Attribute
│
│   with mongodbatlas_alert_configuration.default,
│   on main.tf line 605, in resource "mongodbatlas_alert_configuration" "default":
│  605:     value      = null
│
│ Must set a configuration value for the matcher[0].value attribute as the provider has marked it as required.
│
│ Refer to the provider documentation or contact the provider developers for additional information about configurable attributes that are required.
╵
╷
│ Error: Missing Configuration for Required Attribute
│
│   with mongodbatlas_alert_configuration.default,
│   on main.tf line 610, in resource "mongodbatlas_alert_configuration" "default":
│  610:     metric_name = null
│
│ Must set a configuration value for the metric_threshold_config[0].metric_name attribute as the provider has marked it as required.
│
│ Refer to the provider documentation or contact the provider developers for additional information about configurable attributes that are required.
```
