### PR TITLE
refactor: extract Configure and Metadata framework functions into single implementation

### DIFF
--- a/mongodbatlas/fw_common.go
+++ b/mongodbatlas/fw_common.go
@@ -1,0 +1,68 @@
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// common struct for all framework resources. Implements the following plugin-framework defined functions:
+// - Metadata
+// - Configure
+// client is left empty and populated by the framework when envoking Configure method.
+// resourceName must be defined when creating an instance of a resource.
+type RSCommon struct {
+	client       *MongoDBClient
+	resourceName string
+}
+
+func (r *RSCommon) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, r.resourceName)
+}
+
+func (r *RSCommon) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, err := ConfigureClient(req.ProviderData)
+	if err != nil {
+		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
+		return
+	}
+	r.client = client
+}
+
+// common struct for all framework data sources. Implements the following plugin-framework defined functions:
+// - Metadata
+// - Configure
+// client is left empty and populated by the framework when envoking Configure method.
+// dataSourceName must be defined when creating an instance of a data source.
+type DSCommon struct {
+	client         *MongoDBClient
+	dataSourceName string
+}
+
+func (d *DSCommon) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.dataSourceName)
+}
+
+func (d *DSCommon) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, err := ConfigureClient(req.ProviderData)
+	if err != nil {
+		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
+		return
+	}
+	d.client = client
+}
+
+func ConfigureClient(providerData any) (*MongoDBClient, error) {
+	if providerData == nil {
+		return nil, nil
+	}
+
+	client, ok := providerData.(*MongoDBClient)
+	if !ok {
+		return nil, fmt.Errorf(errorConfigure, providerData)
+	}
+
+	return client, nil
+}

--- a/mongodbatlas/fw_common.go
+++ b/mongodbatlas/fw_common.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// common struct for all framework resources. Implements the following plugin-framework defined functions:
+// RSCommon is used as an embedded struct for all framework resources. Implements the following plugin-framework defined functions:
 // - Metadata
 // - Configure
 // client is left empty and populated by the framework when envoking Configure method.
@@ -23,7 +23,7 @@ func (r *RSCommon) Metadata(ctx context.Context, req resource.MetadataRequest, r
 }
 
 func (r *RSCommon) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
+	client, err := configureClient(req.ProviderData)
 	if err != nil {
 		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
 		return
@@ -31,7 +31,7 @@ func (r *RSCommon) Configure(ctx context.Context, req resource.ConfigureRequest,
 	r.client = client
 }
 
-// common struct for all framework data sources. Implements the following plugin-framework defined functions:
+// DSCommon is used as an embedded struct for all framework data sources. Implements the following plugin-framework defined functions:
 // - Metadata
 // - Configure
 // client is left empty and populated by the framework when envoking Configure method.
@@ -46,7 +46,7 @@ func (d *DSCommon) Metadata(ctx context.Context, req datasource.MetadataRequest,
 }
 
 func (d *DSCommon) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
+	client, err := configureClient(req.ProviderData)
 	if err != nil {
 		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
 		return
@@ -54,15 +54,14 @@ func (d *DSCommon) Configure(ctx context.Context, req datasource.ConfigureReques
 	d.client = client
 }
 
-func ConfigureClient(providerData any) (*MongoDBClient, error) {
+func configureClient(providerData any) (*MongoDBClient, error) {
 	if providerData == nil {
 		return nil, nil
 	}
 
-	client, ok := providerData.(*MongoDBClient)
-	if !ok {
-		return nil, fmt.Errorf(errorConfigure, providerData)
+	if client, ok := providerData.(*MongoDBClient); ok {
+		return client, nil
 	}
 
-	return client, nil
+	return nil, fmt.Errorf(errorConfigure, providerData)
 }

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
@@ -39,24 +39,15 @@ type tfAlertConfigurationOutputModel struct {
 }
 
 func NewAlertConfigurationDS() datasource.DataSource {
-	return &AlertConfigurationDS{}
+	return &AlertConfigurationDS{
+		DSCommon: DSCommon{
+			dataSourceName: alertConfigurationResourceName,
+		},
+	}
 }
 
 type AlertConfigurationDS struct {
-	client *MongoDBClient
-}
-
-func (d *AlertConfigurationDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, alertConfigurationResourceName)
-}
-
-func (d *AlertConfigurationDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	d.client = client
+	DSCommon
 }
 
 var alertConfigDSSchemaBlocks = map[string]schema.Block{

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
@@ -34,24 +34,15 @@ type tfListOptionsModel struct {
 }
 
 func NewAlertConfigurationsDS() datasource.DataSource {
-	return &AlertConfigurationsDS{}
+	return &AlertConfigurationsDS{
+		DSCommon: DSCommon{
+			dataSourceName: alertConfigurationsDataSourceName,
+		},
+	}
 }
 
 type AlertConfigurationsDS struct {
-	client *MongoDBClient
-}
-
-func (d *AlertConfigurationsDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, alertConfigurationsDataSourceName)
-}
-
-func (d *AlertConfigurationsDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	d.client = client
+	DSCommon
 }
 
 func (d *AlertConfigurationsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
@@ -12,11 +12,15 @@ import (
 )
 
 type DatabaseUserDS struct {
-	client *MongoDBClient
+	DSCommon
 }
 
 func NewDatabaseUserDS() datasource.DataSource {
-	return &DatabaseUserDS{}
+	return &DatabaseUserDS{
+		DSCommon: DSCommon{
+			dataSourceName: databaseUserResourceName,
+		},
+	}
 }
 
 type tfDatabaseUserDSModel struct {
@@ -36,19 +40,6 @@ type tfDatabaseUserDSModel struct {
 
 var _ datasource.DataSource = &DatabaseUserDS{}
 var _ datasource.DataSourceWithConfigure = &DatabaseUserDS{}
-
-func (d *DatabaseUserDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, databaseUserResourceName)
-}
-
-func (d *DatabaseUserDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	d.client = client
-}
 
 func (d *DatabaseUserDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
@@ -2,7 +2,6 @@ package mongodbatlas
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -17,28 +16,19 @@ const (
 )
 
 type DatabaseUsersDS struct {
-	client *MongoDBClient
+	DSCommon
 }
 
 func NewDatabaseUsersDS() datasource.DataSource {
-	return &DatabaseUsersDS{}
+	return &DatabaseUsersDS{
+		DSCommon: DSCommon{
+			dataSourceName: databaseUsersDSName,
+		},
+	}
 }
 
 var _ datasource.DataSource = &DatabaseUsersDS{}
 var _ datasource.DataSourceWithConfigure = &DatabaseUsersDS{}
-
-func (d *DatabaseUsersDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, databaseUsersDSName)
-}
-
-func (d *DatabaseUsersDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	d.client = client
-}
 
 type tfDatabaseUsersDSModel struct {
 	ID        types.String             `tfsdk:"id"`

--- a/mongodbatlas/fw_data_source_mongodbatlas_project.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project.go
@@ -19,11 +19,15 @@ var _ datasource.DataSource = &ProjectDS{}
 var _ datasource.DataSourceWithConfigure = &ProjectDS{}
 
 func NewProjectDS() datasource.DataSource {
-	return &ProjectDS{}
+	return &ProjectDS{
+		DSCommon: DSCommon{
+			dataSourceName: projectResourceName,
+		},
+	}
 }
 
 type ProjectDS struct {
-	client *MongoDBClient
+	DSCommon
 }
 
 type tfProjectDSModel struct {
@@ -47,23 +51,6 @@ type tfProjectDSModel struct {
 type tfTeamDSModel struct {
 	TeamID    types.String `tfsdk:"team_id"`
 	RoleNames types.List   `tfsdk:"role_names"`
-}
-
-func (d *ProjectDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, projectResourceName)
-}
-
-func (d *ProjectDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	client, ok := req.ProviderData.(*MongoDBClient)
-
-	if !ok {
-		resp.Diagnostics.AddError(errorConfigureSummary, fmt.Sprintf(errorConfigure, req.ProviderData))
-		return
-	}
-	d.client = client
 }
 
 func (d *ProjectDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
@@ -3,7 +3,6 @@ package mongodbatlas
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -21,29 +20,19 @@ const (
 )
 
 type ProjectIPAccessListDS struct {
-	client *MongoDBClient
+	DSCommon
 }
 
 func NewProjectIPAccessListDS() datasource.DataSource {
-	return &ProjectIPAccessListDS{}
+	return &ProjectIPAccessListDS{
+		DSCommon: DSCommon{
+			dataSourceName: projectIPAccessList,
+		},
+	}
 }
 
 var _ datasource.DataSource = &ProjectIPAccessListDS{}
 var _ datasource.DataSourceWithConfigure = &ProjectIPAccessListDS{}
-
-func (d *ProjectIPAccessListDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, projectIPAccessList)
-}
-
-func (d *ProjectIPAccessListDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-
-	d.client = client
-}
 
 type tfProjectIPAccessListDSModel struct {
 	ID               types.String `tfsdk:"id"`

--- a/mongodbatlas/fw_data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_projects.go
@@ -18,11 +18,15 @@ var _ datasource.DataSource = &ProjectsDS{}
 var _ datasource.DataSourceWithConfigure = &ProjectsDS{}
 
 func NewProjectsDS() datasource.DataSource {
-	return &ProjectsDS{}
+	return &ProjectsDS{
+		DSCommon: DSCommon{
+			dataSourceName: projectsDataSourceName,
+		},
+	}
 }
 
 type ProjectsDS struct {
-	client *MongoDBClient
+	DSCommon
 }
 
 type tfProjectsDSModel struct {
@@ -31,24 +35,6 @@ type tfProjectsDSModel struct {
 	PageNum      types.Int64         `tfsdk:"page_num"`
 	ItemsPerPage types.Int64         `tfsdk:"items_per_page"`
 	TotalCount   types.Int64         `tfsdk:"total_count"`
-}
-
-func (d *ProjectsDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_projects"
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, projectsDataSourceName)
-}
-
-func (d *ProjectsDS) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-	client, ok := req.ProviderData.(*MongoDBClient)
-
-	if !ok {
-		resp.Diagnostics.AddError(errorConfigureSummary, fmt.Sprintf(errorConfigure, req.ProviderData))
-		return
-	}
-	d.client = client
 }
 
 func (d *ProjectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_provider.go
+++ b/mongodbatlas/fw_provider.go
@@ -2,7 +2,6 @@ package mongodbatlas
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"regexp"
 	"time"
@@ -418,17 +417,4 @@ func muxedProviderFactory(sdkV2Provider *sdkv2schema.Provider) func() tfprotov6.
 		log.Fatal(err)
 	}
 	return muxServer.ProviderServer
-}
-
-func ConfigureClient(providerData any) (*MongoDBClient, error) {
-	if providerData == nil {
-		return nil, nil
-	}
-
-	client, ok := providerData.(*MongoDBClient)
-	if !ok {
-		return nil, fmt.Errorf(errorConfigure, providerData)
-	}
-
-	return client, nil
 }

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -36,15 +36,19 @@ const (
 	encodedIDKeyProjectID          = "project_id"
 )
 
-var _ resource.Resource = &AlertConfigurationRS{}
+var _ resource.ResourceWithConfigure = &AlertConfigurationRS{}
 var _ resource.ResourceWithImportState = &AlertConfigurationRS{}
 
 func NewAlertConfigurationRS() resource.Resource {
-	return &AlertConfigurationRS{}
+	return &AlertConfigurationRS{
+		RSCommon: RSCommon{
+			resourceName: alertConfigurationResourceName,
+		},
+	}
 }
 
 type AlertConfigurationRS struct {
-	client *MongoDBClient
+	RSCommon
 }
 
 type tfAlertConfigurationRSModel struct {
@@ -105,19 +109,6 @@ type tfNotificationModel struct {
 	DelayMin                 types.Int64  `tfsdk:"delay_min"`
 	SMSEnabled               types.Bool   `tfsdk:"sms_enabled"`
 	EmailEnabled             types.Bool   `tfsdk:"email_enabled"`
-}
-
-func (r *AlertConfigurationRS) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, alertConfigurationResourceName)
-}
-
-func (r *AlertConfigurationRS) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	r.client = client
 }
 
 func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user.go
@@ -26,8 +26,20 @@ const (
 	databaseUserResourceName = "database_user"
 )
 
-var _ resource.Resource = &DatabaseUserRS{}
+var _ resource.ResourceWithConfigure = &DatabaseUserRS{}
 var _ resource.ResourceWithImportState = &DatabaseUserRS{}
+
+type DatabaseUserRS struct {
+	RSCommon
+}
+
+func NewDatabaseUserRS() resource.Resource {
+	return &DatabaseUserRS{
+		RSCommon: RSCommon{
+			resourceName: databaseUserResourceName,
+		},
+	}
+}
 
 type tfDatabaseUserModel struct {
 	ID               types.String `tfsdk:"id"`
@@ -58,10 +70,6 @@ type tfLabelModel struct {
 type tfScopeModel struct {
 	Name types.String `tfsdk:"name"`
 	Type types.String `tfsdk:"type"`
-}
-
-type DatabaseUserRS struct {
-	client *MongoDBClient
 }
 
 var RoleObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -196,23 +204,6 @@ func (r *DatabaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 			},
 		},
 	}
-}
-
-func NewDatabaseUserRS() resource.Resource {
-	return &DatabaseUserRS{}
-}
-
-func (r *DatabaseUserRS) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, databaseUserResourceName)
-}
-
-func (r *DatabaseUserRS) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	r.client = client
 }
 
 func (r *DatabaseUserRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -33,15 +33,19 @@ const (
 	errorUpdateEncryptionAtRest  = "error updating Encryption At Rest: %s"
 )
 
-var _ resource.Resource = &EncryptionAtRestRS{}
+var _ resource.ResourceWithConfigure = &EncryptionAtRestRS{}
 var _ resource.ResourceWithImportState = &EncryptionAtRestRS{}
 
 func NewEncryptionAtRestRS() resource.Resource {
-	return &EncryptionAtRestRS{}
+	return &EncryptionAtRestRS{
+		RSCommon: RSCommon{
+			resourceName: encryptionAtRestResourceName,
+		},
+	}
 }
 
 type EncryptionAtRestRS struct {
-	client *MongoDBClient
+	RSCommon
 }
 
 type tfEncryptionAtRestRSModel struct {
@@ -75,19 +79,6 @@ type tfGcpKmsConfigModel struct {
 	ServiceAccountKey    types.String `tfsdk:"service_account_key"`
 	KeyVersionResourceID types.String `tfsdk:"key_version_resource_id"`
 	Enabled              types.Bool   `tfsdk:"enabled"`
-}
-
-func (r *EncryptionAtRestRS) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, encryptionAtRestResourceName)
-}
-
-func (r *EncryptionAtRestRS) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	r.client = client
 }
 
 func (r *EncryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/mongodbatlas/fw_resource_mongodbatlas_project.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project.go
@@ -42,15 +42,19 @@ const (
 	projectDependentsStateRetry    = "RETRY"
 )
 
-var _ resource.Resource = &ProjectRS{}
+var _ resource.ResourceWithConfigure = &ProjectRS{}
 var _ resource.ResourceWithImportState = &ProjectRS{}
 
 func NewProjectRS() resource.Resource {
-	return &ProjectRS{}
+	return &ProjectRS{
+		RSCommon: RSCommon{
+			resourceName: projectResourceName,
+		},
+	}
 }
 
 type ProjectRS struct {
-	client *MongoDBClient
+	RSCommon
 }
 
 type tfProjectRSModel struct {
@@ -100,19 +104,6 @@ var tfLimitObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 // Resources that need to be cleaned up before a project can be deleted
 type AtlastProjectDependents struct {
 	AdvancedClusters *matlas.AdvancedClustersResponse
-}
-
-func (r *ProjectRS) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, projectResourceName)
-}
-
-func (r *ProjectRS) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
-	}
-	r.client = client
 }
 
 func (r *ProjectRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
@@ -43,29 +43,19 @@ type tfProjectIPAccessListModel struct {
 }
 
 type ProjectIPAccessListRS struct {
-	client *MongoDBClient
+	RSCommon
 }
 
 func NewProjectIPAccessListRS() resource.Resource {
-	return &ProjectIPAccessListRS{}
-}
-
-var _ resource.Resource = &ProjectIPAccessListRS{}
-var _ resource.ResourceWithImportState = &ProjectIPAccessListRS{}
-
-func (r *ProjectIPAccessListRS) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, projectIPAccessList)
-}
-
-func (r *ProjectIPAccessListRS) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := ConfigureClient(req.ProviderData)
-	if err != nil {
-		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
-		return
+	return &ProjectIPAccessListRS{
+		RSCommon: RSCommon{
+			resourceName: projectIPAccessList,
+		},
 	}
-
-	r.client = client
 }
+
+var _ resource.ResourceWithConfigure = &ProjectIPAccessListRS{}
+var _ resource.ResourceWithImportState = &ProjectIPAccessListRS{}
 
 func (r *ProjectIPAccessListRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{


### PR DESCRIPTION
## Description

Small refactor that removes boilerplate definition of `Metadata` and `Configure` functions in all our plugin-framework resources and data sources into common structs.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
