### PR TITLE
doc: add breaking changes strategy for Terraform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,9 +307,7 @@ make update-atlas-sdk
 ### SDK Major Release Update Procedure
 
 1. If the SDK update doesn’t cause any compilation issues create a new SDK update PR
-1.1  Review [API Changelog](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog) for any deprecated fields and breaking changes.
-
-2. If you notice any changes that are breaking compilation and cannot be gracefully fixed
-2.1 Consider using the previous major version of the SDK (including the old client) for the affected resource
-2.2 Create an issue to identify the root cause and mitigation paths based on changelog information
-2.3 If applicable: make required notice/update to the end users based on the plan.
+   1. Review [API Changelog](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog) for any deprecated fields and breaking changes.
+2. If you notice any changes that are breaking compilation and cannot be gracefully fixes Consider using the previous major version of the SDK (including the old client) for the affected resource
+   1. Create an issue to identify the root cause and mitigation paths based on changelog information  
+   2. If applicable: Make required notice/update to the end users based on the plan.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,6 +291,7 @@ Examples:
 Most of the new features of the provider are using [atlas-sdk](https://github.com/mongodb/atlas-sdk-go)
 SDK is updated automatically, tracking all new Atlas features.
 
+
 ### Updating Atlas SDK 
 
 To update Atlas SDK run:
@@ -299,6 +300,16 @@ To update Atlas SDK run:
 make update-atlas-sdk
 ```
 
-> NOTE: Update mechanism is only needed for major releases. Any other releases will be supported by dependabot.
+> NOTE: The update mechanism is only needed for major releases. Any other releases will be supported by dependabot.
 
 > NOTE: Command can make import changes to +500 files. Please make sure that you perform update on main branch without any uncommited changes.
+
+### SDK Major Release Update Procedure
+
+1. If the SDK update doesn’t cause any compilation issues create a new SDK update PR
+1.1  Review [API Changelog](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog) for any deprecated fields and breaking changes.
+
+2. If you notice any changes that are breaking compilation and cannot be gracefully fixed
+2.1 Consider using the previous major version of the SDK (including the old client) for the affected resource
+2.2 Create an issue to identify the root cause and mitigation paths based on changelog information
+2.3 If applicable: make required notice/update to the end users based on the plan.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,6 +308,7 @@ make update-atlas-sdk
 
 1. If the SDK update doesn’t cause any compilation issues create a new SDK update PR
    1. Review [API Changelog](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog) for any deprecated fields and breaking changes.
-2. If you notice any changes that are breaking compilation and cannot be gracefully fixes Consider using the previous major version of the SDK (including the old client) for the affected resource
+2. For SDK updates introducing compilation issues without graceful workaround
+   1. Use the previous major version of the SDK (including the old client) for the affected resource
    1. Create an issue to identify the root cause and mitigation paths based on changelog information  
    2. If applicable: Make required notice/update to the end users based on the plan.


### PR DESCRIPTION
## Description

Proposing breaking changes strategy for Terraform related to SDK updates.
It is focusing on the SDK right now but it can be extended with breaking changes guarantee and notice information to the end users.

## User-facing deprecation policy

We might extend this description with a dedicated ./BREAKING_CHANGES.md file that might contain our policy for breaking changes (like https://github.com/dotnet/docs/blob/main/docs/core/porting/breaking-changes.md)  

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
