### PR TITLE
fix: add debug support for sdk

### DIFF
--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	PrivateKey   string
 	BaseURL      string
 	RealmBaseURL string
+	Debug        bool
 }
 
 // MongoDBClient contains the mongodbatlas clients and configurations
@@ -61,7 +62,7 @@ func (c *Config) NewClient(ctx context.Context) (interface{}, diag.Diagnostics) 
 		return nil, diag.FromErr(err)
 	}
 
-	sdkV2Client, err := c.newSDKV2Client(client)
+	sdkV2Client, err := c.newSDKV2Client(client, c.Debug)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -75,12 +76,12 @@ func (c *Config) NewClient(ctx context.Context) (interface{}, diag.Diagnostics) 
 	return clients, nil
 }
 
-func (c *Config) newSDKV2Client(client *http.Client) (*atlasSDK.APIClient, error) {
+func (c *Config) newSDKV2Client(client *http.Client, debug bool) (*atlasSDK.APIClient, error) {
 	opts := []atlasSDK.ClientModifier{
 		atlasSDK.UseHTTPClient(client),
 		atlasSDK.UseUserAgent(userAgent),
 		atlasSDK.UseBaseURL(c.BaseURL),
-		atlasSDK.UseDebug(false)}
+		atlasSDK.UseDebug(debug)}
 
 	// Initialize the MongoDB Versioned Atlas Client.
 	sdkv2, err := atlasSDK.NewClient(opts...)

--- a/mongodbatlas/provider.go
+++ b/mongodbatlas/provider.go
@@ -139,6 +139,11 @@ func Provider() *schema.Provider {
 				}, ""),
 				Optional: true,
 			},
+			"debug": {
+				Type: schema.TypeBool,
+				Default: false,
+				Optional: true,
+			},
 		},
 		DataSourcesMap:       getDataSourcesMap(),
 		ResourcesMap:         getResourcesMap(),
@@ -323,6 +328,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		PrivateKey:   d.Get("private_key").(string),
 		BaseURL:      baseURL,
 		RealmBaseURL: d.Get("realm_base_url").(string),
+		Debug: d.Get("debug").(bool),
 	}
 
 	if v, ok := d.GetOk("assume_role"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {


### PR DESCRIPTION
## Description

Enable debug support for the terraform provider and the sdk-go.
Just an idea for the team to consider. PR  is missing docs updates.

The debug flag is part of the Atlas CLI/SDK support plan. Having terraform support for the same would make things much easier to handle. 

## Relationship to TF_Logs

TF_Logs are very detailed terraform logs (large volume). For most of the cases when the issue happens in the API we are mostly interested in the Request/Response pair to be able to reproduce the issue locally.