### PR TITLE
fix: docs and example fix for project_api_key resource after removing role_names deprecated field

### DIFF
--- a/examples/atlas-api-key/create-and-assign-pak-together/main.tf
+++ b/examples/atlas-api-key/create-and-assign-pak-together/main.tf
@@ -3,7 +3,10 @@
 resource "mongodbatlas_project_api_key" "test" {
   description = "test create and assign"
   project_id  = var.project_id
-  role_names  = ["GROUP_OWNER"]
+  project_assignment {
+    project_id = var.project_id
+    role_names = ["GROUP_OWNER"]
+  }
 }
 
 # Add IP Access List Entry to Programmatic API Key 

--- a/website/docs/r/project_api_key.html.markdown
+++ b/website/docs/r/project_api_key.html.markdown
@@ -18,7 +18,10 @@ description: |-
 resource "mongodbatlas_project_api_key" "test" {
   description   = "Description of your API key"
   project_id    = "64259ee860c43338194b0f8e"
-  role_names    = ["GROUP_OWNER"]
+  project_assignment {
+    project_id = "64259ee860c43338194b0f8e"
+    role_names = ["GROUP_OWNER"]
+  }
 }
 ```
 


### PR DESCRIPTION
## Description

Follow up from https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1418 adjusting example and docs for project_api_key resource.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
