### PR TITLE
poc: reuse acceptance tests framework for unit tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/mongodb-forks/digest"
+	"github.com/mongodb/terraform-provider-mongodbatlas/version"
+	"github.com/spf13/cast"
+	atlasSDK "go.mongodb.org/atlas-sdk/v20230201002/admin"
+	matlasClient "go.mongodb.org/atlas/mongodbatlas"
+	realmAuth "go.mongodb.org/realm/auth"
+	"go.mongodb.org/realm/realm"
+)
+
+const ToolName = "terraform-provider-mongodbatlas"
+
+var userAgent = fmt.Sprintf("%s/%s", ToolName, version.ProviderVersion)
+
+// Config contains the configurations needed to use SDKs
+type Config struct {
+	AssumeRole   *AssumeRole
+	PublicKey    string
+	PrivateKey   string
+	BaseURL      string
+	RealmBaseURL string
+}
+
+type AssumeRole struct {
+	Tags              map[string]string
+	RoleARN           string
+	ExternalID        string
+	Policy            string
+	SessionName       string
+	SourceIdentity    string
+	PolicyARNs        []string
+	TransitiveTagKeys []string
+	Duration          time.Duration
+}
+
+// MongoDBClient contains the mongodbatlas clients and configurations
+type MongoDBClient struct {
+	Atlas   *matlasClient.Client
+	AtlasV2 *atlasSDK.APIClient
+	Config  *Config
+}
+
+// NewClient func...
+func (c *Config) NewClient(ctx context.Context) (interface{}, error) {
+	// setup a transport to handle digest
+	transport := digest.NewTransport(cast.ToString(c.PublicKey), cast.ToString(c.PrivateKey))
+
+	// initialize the client
+	client, err := transport.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	client.Transport = logging.NewTransport("MongoDB Atlas", transport)
+
+	optsAtlas := []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent)}
+	if c.BaseURL != "" {
+		optsAtlas = append(optsAtlas, matlasClient.SetBaseURL(c.BaseURL))
+	}
+
+	// Initialize the MongoDB Atlas API Client.
+	atlasClient, err := matlasClient.New(client, optsAtlas...)
+	if err != nil {
+		return nil, err
+	}
+
+	sdkV2Client, err := c.newSDKV2Client(client)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := &MongoDBClient{
+		Atlas:   atlasClient,
+		AtlasV2: sdkV2Client,
+		Config:  c,
+	}
+
+	return clients, nil
+}
+
+func (c *Config) newSDKV2Client(client *http.Client) (*atlasSDK.APIClient, error) {
+	opts := []atlasSDK.ClientModifier{
+		atlasSDK.UseHTTPClient(client),
+		atlasSDK.UseUserAgent(userAgent),
+		atlasSDK.UseBaseURL(c.BaseURL),
+		atlasSDK.UseDebug(false)}
+
+	// Initialize the MongoDB Versioned Atlas Client.
+	sdkv2, err := atlasSDK.NewClient(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return sdkv2, nil
+}
+
+func (c *MongoDBClient) GetRealmClient(ctx context.Context) (*realm.Client, error) {
+	// Realm
+	if c.Config.PublicKey == "" && c.Config.PrivateKey == "" {
+		return nil, errors.New("please set `public_key` and `private_key` in order to use the realm client")
+	}
+
+	optsRealm := []realm.ClientOpt{realm.SetUserAgent(userAgent)}
+	if c.Config.BaseURL != "" && c.Config.RealmBaseURL != "" {
+		optsRealm = append(optsRealm, realm.SetBaseURL(c.Config.RealmBaseURL))
+	}
+	authConfig := realmAuth.NewConfig(nil)
+	token, err := authConfig.NewTokenFromCredentials(ctx, c.Config.PublicKey, c.Config.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	clientRealm := realmAuth.NewClient(realmAuth.BasicTokenSource(token))
+	clientRealm.Transport = logging.NewTransport("MongoDB Realm", clientRealm.Transport)
+
+	// Initialize the MongoDB Realm API Client.
+	realmClient, err := realm.New(clientRealm, optsRealm...)
+	if err != nil {
+		return nil, err
+	}
+
+	return realmClient, nil
+}

--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/mongodb-forks/digest"
@@ -29,6 +30,17 @@ type Config struct {
 	RealmBaseURL string
 }
 
+type AssumeRole struct {
+	Tags              map[string]string
+	RoleARN           string
+	ExternalID        string
+	Policy            string
+	SessionName       string
+	SourceIdentity    string
+	PolicyARNs        []string
+	TransitiveTagKeys []string
+	Duration          time.Duration
+}
 // MongoDBClient contains the mongodbatlas clients and configurations
 type MongoDBClient struct {
 	Atlas   *matlasClient.Client

--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -41,6 +41,7 @@ type AssumeRole struct {
 	TransitiveTagKeys []string
 	Duration          time.Duration
 }
+
 // MongoDBClient contains the mongodbatlas clients and configurations
 type MongoDBClient struct {
 	Atlas   *matlasClient.Client

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	"github.com/zclconf/go-cty/cty"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -43,7 +44,7 @@ func NewAlertConfigurationDS() datasource.DataSource {
 }
 
 type AlertConfigurationDS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func (d *AlertConfigurationDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -38,7 +39,7 @@ func NewAlertConfigurationsDS() datasource.DataSource {
 }
 
 type AlertConfigurationsDS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func (d *AlertConfigurationsDS) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
@@ -8,11 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 type DatabaseUserDS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func NewDatabaseUserDS() datasource.DataSource {

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -17,7 +18,7 @@ const (
 )
 
 type DatabaseUsersDS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func NewDatabaseUsersDS() datasource.DataSource {

--- a/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -21,7 +22,7 @@ const (
 )
 
 type ProjectIPAccessListDS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func NewProjectIPAccessListDS() datasource.DataSource {

--- a/mongodbatlas/fw_provider_test.go
+++ b/mongodbatlas/fw_provider_test.go
@@ -1,0 +1,84 @@
+package mongodbatlas
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
+	"github.com/mongodb/terraform-provider-mongodbatlas/test/mock"
+	"github.com/mongodb/terraform-provider-mongodbatlas/version"
+)
+
+const (
+	ProviderNameMongoDBAtlas = "mongodbatlas"
+)
+
+// frameworkTestProvider is a test version of the plugin-framework version of the provider
+// that uses mock clients
+type frameworkTestProvider struct {
+	MongodbtlasProvider
+	MockClient *config.MongoDBClient
+}
+
+var fwProviders map[string]*frameworkTestProvider
+
+// MuxedProviderFactoryWithProvider creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
+// Used in testing where existing sdk v2 provider has to be used.
+func MuxedProviderFactoryWithProvider() func() tfprotov6.ProviderServer {
+	ctx := context.Background()
+
+	// Unit Tests
+	providers := []func() tfprotov6.ProviderServer{
+		providerserver.NewProtocol6(NewFrameworkTestProvider()),
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return muxServer.ProviderServer
+}
+
+// Configure is here to overwrite the FrameworkProvider configure function for unit testing
+func (p *frameworkTestProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	resp.DataSourceData = p.MockClient
+	resp.ResourceData = p.MockClient
+	return
+}
+
+func (p *frameworkTestProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return p.MongodbtlasProvider.DataSources(ctx)
+}
+
+func (p *frameworkTestProvider) Resources(ctx context.Context) []func() resource.Resource {
+	return p.MongodbtlasProvider.Resources(ctx)
+}
+
+func (p *frameworkTestProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "mongodbatlas"
+	resp.Version = version.ProviderVersion
+}
+func (p *frameworkTestProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+	p.MongodbtlasProvider.Schema(ctx, req, resp)
+}
+
+func NewFrameworkTestProvider() provider.Provider {
+	return &frameworkTestProvider{
+		MongodbtlasProvider: MongodbtlasProvider{},
+		MockClient:          mock.NewMockMongoDBClient(),
+	}
+}
+
+func NewUnitTestProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
+			return MuxedProviderFactoryWithProvider()(), nil
+		},
+	}
+}

--- a/mongodbatlas/fw_provider_test.go
+++ b/mongodbatlas/fw_provider_test.go
@@ -26,11 +26,9 @@ type frameworkTestProvider struct {
 	MockClient *config.MongoDBClient
 }
 
-var fwProviders map[string]*frameworkTestProvider
-
-// MuxedProviderFactoryWithProvider creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
+// UnitTestMuxedProviderFactoryWithProvider creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
 // Used in testing where existing sdk v2 provider has to be used.
-func MuxedProviderFactoryWithProvider() func() tfprotov6.ProviderServer {
+func UnitTestMuxedProviderFactoryWithProvider() func() tfprotov6.ProviderServer {
 	ctx := context.Background()
 
 	// Unit Tests
@@ -49,7 +47,6 @@ func MuxedProviderFactoryWithProvider() func() tfprotov6.ProviderServer {
 func (p *frameworkTestProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	resp.DataSourceData = p.MockClient
 	resp.ResourceData = p.MockClient
-	return
 }
 
 func (p *frameworkTestProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
@@ -78,7 +75,7 @@ func NewFrameworkTestProvider() provider.Provider {
 func NewUnitTestProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
-			return MuxedProviderFactoryWithProvider()(), nil
+			return UnitTestMuxedProviderFactoryWithProvider()(), nil
 		},
 	}
 }

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	conversion "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -44,7 +45,7 @@ func NewAlertConfigurationRS() resource.Resource {
 }
 
 type AlertConfigurationRS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 type tfAlertConfigurationRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -61,7 +62,7 @@ type tfScopeModel struct {
 }
 
 type DatabaseUserRS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 var RoleObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
@@ -1,0 +1,38 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestConfigRSDatabaseUser_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: NewUnitTestProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_database_user.basic_ds", "project_id"),
+					resource.TestCheckResourceAttr("mongodbatlas_database_user.basic_ds", "username", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDatabaseUserConfig() string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "basic_ds" {
+			username           = "test"
+			project_id         = "test"
+			auth_database_name = "test"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`)
+}

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
@@ -1,7 +1,6 @@
 package mongodbatlas
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -23,7 +22,7 @@ func TestConfigRSDatabaseUser_basic(t *testing.T) {
 }
 
 func testAccMongoDBAtlasDatabaseUserConfig() string {
-	return fmt.Sprintf(`
+	return `
 		resource "mongodbatlas_database_user" "basic_ds" {
 			username           = "test"
 			project_id         = "test"
@@ -34,5 +33,5 @@ func testAccMongoDBAtlasDatabaseUserConfig() string {
 				database_name = "admin"
 			}
 		}
-	`)
+	`
 }

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestConfigRSDatabaseUser_basic(t *testing.T) {
+func TestDatabaseUser_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: NewUnitTestProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 )
 
@@ -41,7 +42,7 @@ func NewEncryptionAtRestRS() resource.Resource {
 }
 
 type EncryptionAtRestRS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 type tfEncryptionAtRestRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/config"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 )
 

--- a/mongodbatlas/fw_resource_mongodbatlas_project.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 
 	conversion "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 )
@@ -50,7 +51,7 @@ func NewProjectRS() resource.Resource {
 }
 
 type ProjectRS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 type tfProjectRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -43,7 +44,7 @@ type tfProjectIPAccessListModel struct {
 }
 
 type ProjectIPAccessListRS struct {
-	client *MongoDBClient
+	client *config.MongoDBClient
 }
 
 func NewProjectIPAccessListRS() resource.Resource {

--- a/test/acceptance-test/data_source_mongodbatlas_accesslist_api_key_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_accesslist_api_key_test.go
@@ -1,0 +1,63 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSAccesslistAPIKey_basic(t *testing.T) {
+	resourceName := "mongodbatlas_access_list_api_key.test"
+	dataSourceName := "data.mongodbatlas_access_list_api_key.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	description := fmt.Sprintf("test-acc-accesslist-api_key-%s", acctest.RandString(5))
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAccessListAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAccesslistAPIKeyConfig(orgID, description, ipAddress),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ip_address"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_address", ipAddress),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAccesslistAPIKeyConfig(orgID, description, ipAddress string) string {
+	return fmt.Sprintf(`
+	data "mongodbatlas_access_list_api_key" "test" {
+		org_id     = %[1]q
+		api_key_id = mongodbatlas_access_list_api_key.test.api_key_id
+		ip_address = %[3]q
+	  }
+	  
+	  resource "mongodbatlas_api_key" "test" {
+		org_id = %[1]q
+		description = %[2]q
+		role_names  = ["ORG_MEMBER","ORG_BILLING_ADMIN"]
+	  }
+	  
+	  resource "mongodbatlas_access_list_api_key" "test" {
+		org_id     = %[1]q
+		ip_address = %[3]q
+	    api_key_id = mongodbatlas_api_key.test.api_key_id
+	  }
+	`, orgID, description, ipAddress)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_accesslist_api_keys_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_accesslist_api_keys_test.go
@@ -1,0 +1,61 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSAccesslistAPIKeys_basic(t *testing.T) {
+	resourceName := "mongodbatlas_access_list_api_key.test"
+	dataSourceName := "data.mongodbatlas_access_list_api_keys.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	description := fmt.Sprintf("test-acc-accesslist-api_keys-%s", acctest.RandString(5))
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAccessListAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAccesslistAPIKeysConfig(orgID, description, ipAddress),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAccesslistAPIKeysConfig(orgID, description, ipAddress string) string {
+	return fmt.Sprintf(`
+	data "mongodbatlas_access_list_api_keys" "test" {
+		org_id     = %[1]q
+		api_key_id = mongodbatlas_access_list_api_key.test.api_key_id
+	  }
+	  
+	  resource "mongodbatlas_api_key" "test" {
+		org_id = %[1]q
+		description = %[2]q
+		role_names  = ["ORG_MEMBER","ORG_BILLING_ADMIN"]
+	  }
+	  
+	  resource "mongodbatlas_access_list_api_key" "test" {
+		org_id     = %[1]q
+		ip_address = %[3]q
+	    api_key_id = mongodbatlas_api_key.test.api_key_id
+	  }
+	`, orgID, description, ipAddress)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_api_key_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_api_key_test.go
@@ -1,0 +1,55 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSAPIKey_basic(t *testing.T) {
+	resourceName := "mongodbatlas_api_key.test"
+	dataSourceName := "data.mongodbatlas_api_key.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	description := fmt.Sprintf("test-acc-api_key-%s", acctest.RandString(5))
+	roleName := "ORG_MEMBER"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAPIKeyConfig(orgID, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAPIKeyConfig(orgID, apiKeyID, roleNames string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_api_key" "test" {
+		  org_id = "%s"
+		  description  = "%s"
+		  role_names  = ["%s"]	
+		}
+
+		data "mongodbatlas_api_key" "test" {
+		  org_id      = "${mongodbatlas_api_key.test.org_id}"
+		  api_key_id  = "${mongodbatlas_api_key.test.api_key_id}"
+		}
+	`, orgID, apiKeyID, roleNames)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_api_keys_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_api_keys_test.go
@@ -1,0 +1,56 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSAPIKeys_basic(t *testing.T) {
+	resourceName := "mongodbatlas_api_key.test"
+	dataSourceName := "data.mongodbatlas_api_keys.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	description := fmt.Sprintf("test-acc-api_key-%s", acctest.RandString(5))
+	roleName := "ORG_MEMBER"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAPIKeysConfig(orgID, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAPIKeysConfig(orgID, description, roleNames string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_api_key" "test" {
+		  org_id = "%s"
+		  description  = "%s"
+		  role_names  = ["%s"]
+		}
+
+		data "mongodbatlas_api_keys" "test" {
+		  org_id = "${mongodbatlas_api_key.test.org_id}"
+		}
+	`, orgID, description, roleNames)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_auditing_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_auditing_test.go
@@ -1,0 +1,69 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvDSAuditing_basic(t *testing.T) {
+	var (
+		auditing       matlas.Auditing
+		dataSourceName = "data.mongodbatlas_auditing.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		auditAuth      = true
+		auditFilter    = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"
+		enabled        = true
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceAuditingConfig(projectID, auditFilter, auditAuth, enabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAuditingExists("mongodbatlas_auditing.test", &auditing),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(dataSourceName, "audit_filter", auditFilter),
+					resource.TestCheckResourceAttr(dataSourceName, "audit_authorization_success", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "configuration_type", "FILTER_JSON"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDataSourceAuditingConfig(projectID, "{}", false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAuditingExists("mongodbatlas_auditing.test", &auditing),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(dataSourceName, "audit_filter", "{}"),
+					resource.TestCheckResourceAttr(dataSourceName, "audit_authorization_success", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "configuration_type", "FILTER_JSON"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceAuditingConfig(projectID, auditFilter string, auditAuth, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_auditing" "test" {
+			project_id                  = "%s"
+			audit_filter                = "%s"
+			audit_authorization_success = %t
+			enabled                     = %t
+		}
+
+		data "mongodbatlas_auditing" "test" {
+			project_id = "${mongodbatlas_auditing.test.id}"
+		}
+	`, projectID, auditFilter, auditAuth, enabled)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_backup_compliance_policy_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_backup_compliance_policy_test.go
@@ -1,0 +1,93 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGenericBackupDSBackupCompliancePolicy_basic(t *testing.T) {
+	projectName := fmt.Sprintf("testacc-project-%s", acctest.RandString(10))
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectOwnerID := os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists("data.mongodbatlas_backup_compliance_policy.backup_policy"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "copy_protection_enabled", "false"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "encryption_at_rest_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name                                             = "%s"
+			org_id                                           = "%s"
+			project_owner_id                                 = "%s"
+			with_default_alerts_settings                     = false
+			is_collect_database_specifics_statistics_enabled = false
+			is_data_explorer_enabled                         = false
+			is_performance_advisor_enabled                   = false
+			is_realtime_performance_panel_enabled            = false
+			is_schema_advisor_enabled                        = false
+		  }
+		  
+		  data "mongodbatlas_backup_compliance_policy" "backup_policy" {
+			project_id = mongodbatlas_backup_compliance_policy.backup_policy_res.project_id
+		  }
+		  
+		  resource "mongodbatlas_backup_compliance_policy" "backup_policy_res" {
+			project_id                 = mongodbatlas_project.test.id
+			authorized_email           = "test@example.com"
+			copy_protection_enabled    = false
+			pit_enabled                = false
+			encryption_at_rest_enabled = false
+		  
+			restore_window_days = 7
+		  
+			on_demand_policy_item {
+		  
+			  frequency_interval = 0
+			  retention_unit     = "days"
+			  retention_value    = 3
+			}
+			
+			policy_item_hourly {
+				frequency_interval = 6
+				retention_unit     = "days"
+				retention_value    = 7
+			  }
+		  
+			policy_item_daily {
+				frequency_interval = 0
+				retention_unit     = "days"
+				retention_value    = 7
+			  }
+		  
+			  policy_item_weekly {
+				frequency_interval = 0
+				retention_unit     = "weeks"
+				retention_value    = 4
+			  }
+		  
+			  policy_item_monthly {
+				frequency_interval = 0
+				retention_unit     = "months"
+				retention_value    = 12
+			  }
+		  
+		  }
+`, projectName, orgID, projectOwnerID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
@@ -1,0 +1,53 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupDSCloudBackupSnapshotExportBucket_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		snapshotExportBackup matlas.CloudProviderSnapshotExportBucket
+		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName           = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID            = os.Getenv("IAM_ROLE_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportBucketConfig(projectID, iamRoleID, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists("mongodbatlas_cloud_backup_snapshot_export_bucket.test", &snapshotExportBackup),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_bucket.test", "iam_role_id"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_bucket.test", "bucket_name"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_bucket.test", "cloud_provider"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportBucketConfig(projectID, iamRoleID, bucketName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+			project_id   = "%[1]s"
+			
+    	  	iam_role_id = "%[2]s"
+       		bucket_name = "%[3]s"
+       		cloud_provider = "AWS"
+		}
+
+data "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id
+  id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.id
+}
+`, projectID, iamRoleID, bucketName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_buckets_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_buckets_test.go
@@ -1,0 +1,50 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBackupDSCloudBackupSnapshotExportBuckets_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName     = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID      = os.Getenv("IAM_ROLE_ID")
+		datasourceName = "mongodbatlas_cloud_backup_snapshot_export_buckets"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportBucketsConfig(projectID, bucketName, iamRoleID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "iam_role_id"),
+					resource.TestCheckResourceAttr(datasourceName, "results.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "bucket_name", "example-bucket"),
+					resource.TestCheckResourceAttr(datasourceName, "cloud_provider", "AWS"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportBucketsConfig(projectID, iamRoleID, bucketName string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id   = "%[1]s"
+  iam_role_id = "%[2]s"
+  bucket_name = "%[3]s"
+  cloud_provider = "AWS"
+}
+
+data "mongodbatlas_cloud_backup_snapshot_export_buckets" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id
+}`, projectID, iamRoleID, bucketName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_job_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_job_test.go
@@ -1,0 +1,87 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupDSCloudBackupSnapshotExportJob_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		snapshotExportJob matlas.CloudProviderSnapshotExportJob
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName        = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID         = os.Getenv("IAM_ROLE_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportJobConfig(projectID, iamRoleID, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupSnapshotExportJobExists("mongodbatlas_cloud_backup_snapshot_export_job.test", &snapshotExportJob),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_job.test", "iam_role_id"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_job.test", "bucket_name"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_backup_snapshot_export_job.test", "cloud_provider"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportJobConfig(projectID, iamRoleID, bucketName string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id   = "%[1]s"
+  iam_role_id = "%[2]s"
+  bucket_name = "%[3]s"
+  cloud_provider = "AWS"
+}
+
+data "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id
+  id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.id
+}
+
+
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = "%[1]s"
+  name         = "MyCluster"
+  disk_size_gb = 1
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true 
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = "%[1]s"
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = "myDescription"
+  retention_in_days = 1
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_export_job" "myjob" {
+  project_id   = "%[1]s"
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+  snapshot_id = mongodbatlas_cloud_backup_snapshot.test.snapshot_id
+  export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
+
+  custom_data {
+    key   = "exported by"
+    value = "myName"
+  }
+}
+
+data "mongodbatlas_cloud_backup_snapshot_export_job" "test" {
+  project_id = "%[1]s"
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+  export_job_id = mongodbatlas_cloud_backup_snapshot_export_job.myjob.export_job_id
+}`, projectID, iamRoleID, bucketName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_jobs_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cloud_backup_snapshot_export_jobs_test.go
@@ -1,0 +1,85 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBackupDSCloudBackupSnapshotExportJobs_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName     = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID      = os.Getenv("IAM_ROLE_ID")
+		datasourceName = "mongodbatlas_cloud_backup_snapshot_export_jobs"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportJobsConfig(projectID, bucketName, iamRoleID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "iam_role_id"),
+					resource.TestCheckResourceAttr(datasourceName, "results.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "bucket_name", "example-bucket"),
+					resource.TestCheckResourceAttr(datasourceName, "cloud_provider", "AWS"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceCloudBackupSnapshotExportJobsConfig(projectID, iamRoleID, bucketName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+			project_id   = "%[1]s"
+			
+    	  	iam_role_id = "%[2]s"
+       		bucket_name = "%[3]s"
+       		cloud_provider = "AWS"
+		}
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = "%[1]s"
+  name         = "MyCluster"
+  disk_size_gb = 1
+
+  //Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true // enable cloud backup snapshots
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = "%[1]s"
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = "myDescription"
+  retention_in_days = 1
+}
+
+
+resource "mongodbatlas_cloud_backup_snapshot_export_job" "myjob" {
+  project_id   = "%[1]s"
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+  snapshot_id = mongodbatlas_cloud_backup_snapshot.test.snapshot_id
+  export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
+
+
+  custom_data {
+    key   = "exported by"
+    value = "myName"
+  }
+}
+
+data "mongodbatlas_cloud_backup_snapshot_export_jobs" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+}
+	`, projectID, iamRoleID, bucketName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cloud_provider_access_setup_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cloud_provider_access_setup_test.go
@@ -1,0 +1,62 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// covers both resource creation and datasource creation for setup
+
+const (
+	dataSourceCPASProviderConfig = `
+	resource "mongodbatlas_project" "test" {
+		name   = %[3]q
+		org_id = %[2]q
+	}
+	resource "mongodbatlas_cloud_provider_access_setup" "%[1]s" {
+		project_id = mongodbatlas_project.test.id
+		provider_name = %[4]q
+	 }
+	 
+	 data "mongodbatlas_cloud_provider_access_setup" "%[5]s" {
+		project_id = mongodbatlas_cloud_provider_access_setup.%[1]s.project_id
+		provider_name = %[4]q
+		role_id =  mongodbatlas_cloud_provider_access_setup.%[1]s.role_id
+	 }
+	 `
+)
+
+func TestAccConfigDSCloudProviderAccessSetup_aws_basic(t *testing.T) {
+	var (
+		suffix      = acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+		name        = "cpas" + suffix
+		dataSCName  = "ds_cpas" + suffix
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+
+		// resources fqdn name
+		resourceName = "mongodbatlas_cloud_provider_access_setup." + name
+		dsName       = "data.mongodbatlas_cloud_provider_access_setup." + dataSCName
+	)
+
+	config := fmt.Sprintf(dataSourceCPASProviderConfig, name, orgID, projectName, "AWS", dataSCName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
+					resource.TestCheckResourceAttrSet(dsName, "aws.atlas_assumed_role_external_id"),
+				),
+			},
+		},
+	})
+}

--- a/test/acceptance-test/data_source_mongodbatlas_cluster_outage_simulation_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_cluster_outage_simulation_test.go
@@ -1,0 +1,162 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id                  = mongodbatlas_project.outage_project.id
+   		provider_name               = "AWS"
+   		name                        = "%s"
+   		backing_provider_name       = "AWS"
+   		provider_region_name        = "US_EAST_1"
+   		provider_instance_size_name = "M10"
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+	}
+
+	data "mongodbatlas_cluster_outage_simulation" "test" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		depends_on = [
+    		mongodbatlas_cluster_outage_simulation.test_outage,
+  		]
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id   = mongodbatlas_project.outage_project.id
+		name         = "%s"
+		cluster_type = "REPLICASET"
+	  
+		provider_name               = "AWS"
+		provider_instance_size_name = "M10"
+	  
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_EAST_2"
+			electable_nodes = 2
+			priority        = 6
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_WEST_1"
+			electable_nodes = 2
+			priority        = 5
+			read_only_nodes = 2
+		  }
+		}
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+		outage_filters {
+			   cloud_provider = "AWS"
+			   region_name    = "US_EAST_2"
+		}
+	}
+
+	data "mongodbatlas_cluster_outage_simulation" "test" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		depends_on = [
+    		mongodbatlas_cluster_outage_simulation.test_outage,
+  		]
+	}
+	`, projectName, orgID, clusterName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_custom_db_role_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_custom_db_role_test.go
@@ -1,0 +1,70 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSCustomDBRole_basic(t *testing.T) {
+	resourceName := "mongodbatlas_custom_db_role.test"
+	dataSourceName := "data.mongodbatlas_custom_db_role.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	roleName := fmt.Sprintf("test-acc-custom_role-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasCustomDBRoleConfig(orgID, projectName, roleName, "INSERT", fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "INSERT"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.resources.#", "1"),
+
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "role_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasCustomDBRoleConfig(orgID, projectName, roleName, action, databaseName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_db_role" "test" {
+			project_id = mongodbatlas_project.test.id
+			role_name  = %[3]q
+
+			actions {
+				action = %[4]q
+				resources {
+					collection_name = ""
+					database_name   = %[5]q
+				}
+			}
+		}
+
+		data "mongodbatlas_custom_db_role" "test" {
+			project_id = "${mongodbatlas_custom_db_role.test.project_id}"
+			role_name  = "${mongodbatlas_custom_db_role.test.role_name}"
+		}
+	`, orgID, projectName, roleName, action, databaseName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_custom_db_roles_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_custom_db_roles_test.go
@@ -1,0 +1,68 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSCustomDBRoles_basic(t *testing.T) {
+	resourceName := "mongodbatlas_custom_db_role.test"
+	dataSourceName := "data.mongodbatlas_custom_db_roles.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	roleName := fmt.Sprintf("test-acc-custom_role-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasCustomDBRolesConfig(orgID, projectName, roleName, "INSERT", fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+				Check: resource.ComposeTestCheckFunc(
+					// Test for Resource
+					testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "INSERT"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.resources.#", "1"),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasCustomDBRolesConfig(orgID, projectName, roleName, action, databaseName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_db_role" "test" {
+			project_id = mongodbatlas_project.test.id
+			role_name  = %[3]q
+
+			actions {
+				action = %[4]q
+				resources {
+					collection_name = ""
+					database_name   = %[5]q
+				}
+			}
+		}
+
+		data "mongodbatlas_custom_db_roles" "test" {
+			project_id = "${mongodbatlas_custom_db_role.test.project_id}"
+		}
+	`, orgID, projectName, roleName, action, databaseName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
@@ -1,0 +1,48 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSCustomDNSConfigurationAWS_basic(t *testing.T) {
+	resourceName := "data.mongodbatlas_custom_dns_configuration_cluster_aws.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(orgID, projectName string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id     = mongodbatlas_project.test.id
+			enabled       = %[3]t
+		}
+
+		data "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id      = mongodbatlas_custom_dns_configuration_cluster_aws.test.id
+		}
+	`, orgID, projectName, enabled)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_run_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_run_test.go
@@ -1,0 +1,49 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBackupDSDataLakePipelineRun_basic(t *testing.T) {
+	testCheckDataLakePipelineRun(t)
+	var (
+		dataSourceName = "data.mongodbatlas_data_lake_pipeline_run.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		pipelineName   = os.Getenv("MONGODB_ATLAS_DATA_LAKE_PIPELINE_NAME")
+		runID          = os.Getenv("MONGODB_ATLAS_DATA_LAKE_PIPELINE_RUN_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakeDataSourcePipelineRunConfig(projectID, pipelineName, runID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "pipeline_name", pipelineName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "phase"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "pipeline_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "dataset_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataLakeDataSourcePipelineRunConfig(projectID, pipelineName, runID string) string {
+	return fmt.Sprintf(`
+
+data "mongodbatlas_data_lake_pipeline_run" "test" {
+  project_id           = %[1]q
+  pipeline_name        = %[2]q
+  pipeline_run_id      = %[3]q
+}
+	`, projectID, pipelineName, runID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_runs_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_runs_test.go
@@ -1,0 +1,43 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBackupDSDataLakePipelineRuns_basic(t *testing.T) {
+	testCheckDataLakePipelineRuns(t)
+	var (
+		dataSourceName = "data.mongodbatlas_data_lake_pipeline_runs.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		pipelineName   = os.Getenv("MONGODB_ATLAS_DATA_LAKE_PIPELINE_NAME")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakeDataSourcePipelineRunsConfig(projectID, pipelineName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "pipeline_name", pipelineName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataLakeDataSourcePipelineRunsConfig(projectID, pipelineName string) string {
+	return fmt.Sprintf(`
+
+data "mongodbatlas_data_lake_pipeline_runs" "test" {
+  project_id           = %[1]q
+  pipeline_name        = %[2]q
+}
+	`, projectID, pipelineName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lake_pipeline_test.go
@@ -1,0 +1,89 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccDataSourceClusterRSDataLakePipeline_basic(t *testing.T) {
+	var (
+		pipeline     matlas.DataLakePipeline
+		resourceName = "mongodbatlas_data_lake_pipeline.test"
+		clusterName  = acctest.RandomWithPrefix("test-acc-index")
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = acctest.RandomWithPrefix("test-acc-index")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDataLakeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasDataLakePipelineConfig(projectID, clusterName, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasDataLakePipelineConfig(projectID, clusterName, pipelineName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "aws_conf" {
+			project_id   = %[1]q
+			name         = %[2]q
+			cluster_type = "REPLICASET"
+		
+			replication_specs {
+			region_configs {
+				electable_specs {
+				instance_size = "M10"
+				node_count    = 3
+				}
+				provider_name = "AWS"
+				priority      = 7
+				region_name   = "US_EAST_1"
+			}
+			}
+			backup_enabled               = true
+		}
+
+		resource "mongodbatlas_data_lake_pipeline" "test" {
+			project_id       = "%[1]s"
+			name			 = "%[3]s"
+			sink {
+				type = "DLS"
+				partition_fields {
+						field_name = "access"
+						order = 0
+				}
+			}	
+	
+			source {
+				type = "ON_DEMAND_CPS"
+				cluster_name = mongodbatlas_advanced_cluster.aws_conf.name
+				database_name = "sample_airbnb"
+				collection_name = "listingsAndReviews"
+			}
+
+			transformations {
+				field = "test"
+				type =  "EXCLUDE"
+			}
+		}
+
+		data "mongodbatlas_data_lake_pipeline" "testDataSource" {
+			project_id       = mongodbatlas_data_lake_pipeline.test.project_id
+			name			 = mongodbatlas_data_lake_pipeline.test.name	
+		}
+	`, projectID, clusterName, pipelineName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lake_pipelines_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lake_pipelines_test.go
@@ -1,0 +1,138 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccDataSourceClusterRSDataLakePipelines_basic(t *testing.T) {
+	var (
+		pipeline           matlas.DataLakePipeline
+		resourceName       = "mongodbatlas_data_lake_pipeline.test"
+		dataSourceName     = "data.mongodbatlas_data_lake_pipelines.testDataSource"
+		firstClusterName   = acctest.RandomWithPrefix("test-acc-index")
+		secondClusterName  = acctest.RandomWithPrefix("test-acc-index")
+		projectID          = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		firstPipelineName  = acctest.RandomWithPrefix("test-acc-index")
+		secondPipelineName = acctest.RandomWithPrefix("test-acc-index")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDataLakeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasDataLakePipelinesConfig(projectID, firstClusterName, secondClusterName, firstPipelineName, secondPipelineName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.state"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.1.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.1.state"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.1.project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasDataLakePipelinesConfig(projectID, firstClusterName, secondClusterName, firstPipelineName, secondPipelineName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "aws_conf" {
+			project_id   = %[1]q
+			name         = %[2]q
+			cluster_type = "REPLICASET"
+		
+			replication_specs {
+			region_configs {
+				electable_specs {
+				instance_size = "M10"
+				node_count    = 3
+				}
+				provider_name = "AWS"
+				priority      = 7
+				region_name   = "US_EAST_1"
+			}
+			}
+			backup_enabled               = true
+		}
+
+		resource "mongodbatlas_advanced_cluster" "aws_conf2" {
+			project_id   = %[1]q
+			name         = %[3]q
+			cluster_type = "REPLICASET"
+		
+			replication_specs {
+			region_configs {
+				electable_specs {
+				instance_size = "M10"
+				node_count    = 3
+				}
+				provider_name = "AWS"
+				priority      = 7
+				region_name   = "US_EAST_1"
+			}
+			}
+			backup_enabled               = true
+		}
+
+		resource "mongodbatlas_data_lake_pipeline" "test" {
+			project_id       =  "%[1]s"
+			name = "%[4]s"
+			sink {
+				type = "DLS"
+				partition_fields {
+						field_name = "access"
+						order = 0
+				}
+			}	
+	
+			source {
+				type = "ON_DEMAND_CPS"
+				cluster_name = mongodbatlas_advanced_cluster.aws_conf.name
+				database_name = "sample_airbnb"
+				collection_name = "listingsAndReviews"
+			}
+
+			transformations {
+				field = "test"
+				type =  "EXCLUDE"
+			}
+		}
+
+		resource "mongodbatlas_data_lake_pipeline" "test2" {
+			project_id       =  "%[1]s"
+			name			 = 	"%[5]s"
+			sink {
+				type = "DLS"
+				partition_fields {
+						field_name = "access"
+						order = 0
+				}
+			}	
+	
+			source {
+				type = "ON_DEMAND_CPS"
+				cluster_name = mongodbatlas_advanced_cluster.aws_conf2.name
+				database_name = "sample_airbnb"
+				collection_name = "listingsAndReviews"
+			}
+
+			transformations {
+				field = "test"
+				type =  "EXCLUDE"
+			}
+		}
+
+		data "mongodbatlas_data_lake_pipelines" "testDataSource" {
+			project_id       = mongodbatlas_data_lake_pipeline.test.project_id
+		}
+	`, projectID, firstClusterName, secondClusterName, firstPipelineName, secondPipelineName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lake_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lake_test.go
@@ -1,0 +1,122 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupDSDataLake_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_data_lake.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		dataLake     = matlas.DataLake{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakeDataSourceConfig(policyName, roleName, projectName, orgID, name, testS3Bucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDataLakeExists(resourceName, &dataLake),
+					testAccCheckMongoDBAtlasDataLakeAttributes(&dataLake, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataLakeDataSourceConfig(policyName, roleName, projectName, orgID, name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+		resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}
+
+resource "mongodbatlas_project" "test" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+resource "mongodbatlas_data_lake" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[5]q
+   aws {
+     role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+     test_s3_bucket = %[6]q
+   }
+}
+
+data "mongodbatlas_data_lake" "test" {
+  project_id           = mongodbatlas_data_lake.test.project_id
+  name = mongodbatlas_data_lake.test.name
+}
+	`, policyName, roleName, projectName, orgID, name, testS3Bucket)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_data_lakes_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_data_lakes_test.go
@@ -1,0 +1,42 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGenericBackupDSDataLakes_basic(t *testing.T) {
+	resourceName := "data.mongodbatlas_data_lakes.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakesDataSourceConfig(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataLakesDataSourceConfig(orgID, projectName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		data "mongodbatlas_data_lakes" "test" {
+			project_id = mongodbatlas_project.backup_project.id
+		}
+	`, orgID, projectName)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_event_trigger_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_event_trigger_test.go
@@ -1,0 +1,77 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mwielbut/pointy"
+	"go.mongodb.org/realm/realm"
+)
+
+func TestAccConfigDSEventTrigger_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE"},
+			Database:       "sample_airbnb",
+			Collection:     "listingsAndReviews",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+			FullDocument:   pointy.Bool(false),
+			Unordered:      pointy.Bool(true),
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceEventTriggerConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceEventTriggerConfig(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			function_id = %[5]q
+			disabled = %[6]t
+			unordered = %[7]t
+			config_operation_types = [%s]
+			config_database = %[8]q
+			config_collection = %[9]q
+			config_service_id = %[10]q
+			config_match = "{\"updateDescription.updatedFields\":{\"status\":\"blocked\"}}"
+		}
+
+		data "mongodbatlas_event_trigger" "test" {
+			project_id = mongodbatlas_event_trigger.test.project_id
+			app_id = mongodbatlas_event_trigger.test.app_id
+			trigger_id = mongodbatlas_event_trigger.test.id
+		}
+`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled, *eventTrigger.Config.Unordered, operationTypes,
+		eventTrigger.Config.Database, eventTrigger.Config.Collection,
+		eventTrigger.Config.ServiceID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_event_triggers_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_event_triggers_test.go
@@ -1,0 +1,78 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mwielbut/pointy"
+	"go.mongodb.org/realm/realm"
+)
+
+func TestAccConfigDSEventTriggers_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE"},
+			OperationType:  "LOGIN",
+			Providers:      []string{"anon-user", "local-userpass"},
+			Database:       "database",
+			Collection:     "collection",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+			FullDocument:   pointy.Bool(false),
+			Schedule:       "*",
+			Unordered:      pointy.Bool(true),
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			function_id = %[5]q
+			disabled = %[6]t
+			unordered = %[7]t
+			config_operation_types = [%s]
+			config_database = %[8]q
+			config_collection = %[9]q
+			config_service_id = %[10]q
+			config_match = "{\"updateDescription.updatedFields\":{\"status\":\"blocked\"}}"
+		}
+
+		data "mongodbatlas_event_triggers" "test" {
+			project_id = mongodbatlas_event_trigger.test.project_id
+			app_id = mongodbatlas_event_trigger.test.app_id
+		}
+`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled, *eventTrigger.Config.Unordered, operationTypes,
+		eventTrigger.Config.Database, eventTrigger.Config.Collection,
+		eventTrigger.Config.ServiceID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_database_instance_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_database_instance_test.go
@@ -1,0 +1,314 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccDataSourceFederatedDatabaseInstance_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName      = "data.mongodbatlas_federated_database_instance.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		name              = acctest.RandomWithPrefix("test-acc")
+		federatedInstance = matlas.DataFederationInstance{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstanceConfigDataSourceFirstSteps(name, projectName, orgID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedDatabaseDataSourceInstanceExists(resourceName, &federatedInstance),
+					testAccCheckMongoDBAtlasFederatedDabaseInstanceAttributes(&federatedInstance, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceFederatedDatabaseInstance_S3Bucket(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName      = "data.mongodbatlas_federated_database_instance.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		name              = acctest.RandomWithPrefix("test-acc")
+		policyName        = acctest.RandomWithPrefix("test-acc")
+		roleName          = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket      = os.Getenv("AWS_S3_BUCKET")
+		region            = "VIRGINIA_USA"
+		federatedInstance = matlas.DataFederationInstance{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstanceDataSourceConfigS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedDatabaseDataSourceInstanceExists(resourceName, &federatedInstance),
+					testAccCheckMongoDBAtlasFederatedDabaseInstanceAttributes(&federatedInstance, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseDataSourceInstanceExists(resourceName string, dataFederatedInstance *matlas.DataFederationInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if dataLakeResp, _, err := conn.DataFederation.Get(context.Background(), ids["project_id"], ids["name"]); err == nil {
+			*dataFederatedInstance = *dataLakeResp
+			return nil
+		}
+
+		return fmt.Errorf("federated database instance (%s) does not exist", ids["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedDabaseInstanceAttributes(dataFederatedInstance *matlas.DataFederationInstance, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Printf("[DEBUG] difference dataFederatedInstance.Name: %s , username : %s", dataFederatedInstance.Name, name)
+		if dataFederatedInstance.Name != name {
+			return fmt.Errorf("bad data federated instance name: %s", dataFederatedInstance.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstanceDataSourceConfigS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseInstanceConfigDataSourceFirstStepS3Bucket(name, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+func testAccMongoDBAtlasFederatedDatabaseInstanceConfigDataSourceFirstStepS3Bucket(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+
+   cloud_provider_config {
+	aws {
+		role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+		test_s3_bucket = %[2]q
+	  }
+   }
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[2]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[2]q
+	delimiter = "/"
+	name = %[2]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+data "mongodbatlas_federated_database_instance" "test" {
+	project_id           = mongodbatlas_federated_database_instance.test.project_id
+	name = mongodbatlas_federated_database_instance.test.name
+
+	cloud_provider_config {
+		aws {
+			test_s3_bucket = %[2]q
+		  }
+	}
+}
+	`, name, testS3Bucket)
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstanceConfigDataSourceFirstSteps(federatedInstanceName, projectName, orgID string) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[3]q
+	}
+
+resource "mongodbatlas_federated_database_instance" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+data "mongodbatlas_federated_database_instance" "test" {
+	project_id           = mongodbatlas_federated_database_instance.test.project_id
+	name = mongodbatlas_federated_database_instance.test.name
+}
+	`, federatedInstanceName, projectName, orgID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_database_instances_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_database_instances_test.go
@@ -1,0 +1,215 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceFederatedDatabaseInstances_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "data.mongodbatlas_federated_database_instances.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		firstName    = acctest.RandomWithPrefix("test-acc")
+		secondName   = acctest.RandomWithPrefix("test-acc")
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		region       = "VIRGINIA_USA"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstancesDataSourceConfig(policyName, roleName, projectName, orgID, firstName, secondName, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstancesDataSourceConfig(policyName, roleName, projectName, orgID, firstName, secondName, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseInstancesConfigDataSourceFirstStep(firstName, secondName, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+func testAccMongoDBAtlasFederatedDatabaseInstancesConfigDataSourceFirstStep(firstName, secondName, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+   cloud_provider_config {
+	aws {
+		role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+		test_s3_bucket = %[3]q
+	  }
+   }
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[3]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[3]q
+	delimiter = "/"
+	name = %[3]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+resource "mongodbatlas_federated_database_instance" "test2" {
+	project_id         = mongodbatlas_project.test.id
+	name = %[2]q
+ 
+	storage_databases {
+	 name = "VirtualDatabase0"
+	 collections {
+			 name = "VirtualCollection0"
+			 data_sources {
+					 collection = "listingsAndReviews"
+					 database = "sample_airbnb"
+					 store_name =  "ClusterTest2"
+			 }
+	 }
+	}
+ 
+	storage_stores {
+	 name = "ClusterTest2"
+	 cluster_name = "ClusterTest2"
+	 project_id = mongodbatlas_project.test.id
+	 provider = "atlas"
+	 read_preference {
+		 mode = "secondary"
+	 }
+	}
+ 
+	storage_stores {
+	 name = "dataStore0"
+	 cluster_name = "ClusterTest2"
+	 project_id = mongodbatlas_project.test.id
+	 provider = "atlas"
+	 read_preference {
+		 mode = "secondary"
+	 }
+	}
+ }
+
+data "mongodbatlas_federated_database_instances" "test" {
+	project_id           = mongodbatlas_federated_database_instance.test.project_id
+}
+	`, firstName, secondName, testS3Bucket)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_query_limit_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_query_limit_test.go
@@ -1,0 +1,235 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccDataSourceFederatedDatabaseQueryLimit_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "data.mongodbatlas_federated_query_limit.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-project")
+		tenantName   = acctest.RandomWithPrefix("test-acc-tenant")
+		limitName    = "bytesProcessed.monthly"
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		region       = "VIRGINIA_USA"
+
+		queryLimit = matlas.DataFederationQueryLimit{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseQueryLimitDataSourceConfig(policyName, roleName, projectName, orgID, tenantName, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedDatabaseDataSourceQueryLimitExists(resourceName, &queryLimit),
+					testAccCheckMongoDBAtlasFederatedDabaseQueryLimitAttributes(&queryLimit, limitName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "tenant_name"),
+					resource.TestCheckResourceAttr(resourceName, "limit_name", limitName),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitDataSourceConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseQueryLimitConfigDataSourceFirstStep(name, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test_project" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test_project.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test_project.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitConfigDataSourceFirstStep(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "db_instance" {
+   project_id         = mongodbatlas_project.test_project.id
+   name = %[1]q
+   cloud_provider_config {
+    aws {
+		role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+		test_s3_bucket = %[2]q
+    }
+   }
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[2]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[2]q
+	delimiter = "/"
+	name = %[2]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+resource "mongodbatlas_federated_query_limit" "test" {
+	project_id = mongodbatlas_project.test_project.id
+	tenant_name = mongodbatlas_federated_database_instance.db_instance.name
+	limit_name = "bytesProcessed.monthly"
+	overrun_policy = "BLOCK"
+	value = 5147483648
+  }
+
+  data "mongodbatlas_federated_query_limit" "test" {
+	project_id = mongodbatlas_project.test_project.id
+	tenant_name = mongodbatlas_federated_database_instance.db_instance.name
+	limit_name = "bytesProcessed.monthly"
+  }
+
+	`, name, testS3Bucket)
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseDataSourceQueryLimitExists(resourceName string, queryLimit *matlas.DataFederationQueryLimit) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if queryLimitResp, _, err := conn.DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"]); err == nil {
+			*queryLimit = *queryLimitResp
+			return nil
+		}
+
+		return fmt.Errorf("federated database query limit for project (%s), tenant (%s) and limit (%s) does not exist", ids["project_id"], ids["tenant_name"], ids["limit_name"])
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedDabaseQueryLimitAttributes(queryLimit *matlas.DataFederationQueryLimit, limitName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Printf("[DEBUG] difference queryLimit.Name: %s , limitName : %s", queryLimit.Name, limitName)
+		if queryLimit.Name != limitName {
+			return fmt.Errorf("bad data federated query limit name: %s", queryLimit.Name)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_query_limits_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_query_limits_test.go
@@ -1,0 +1,190 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceFederatedDatabaseQueryLimits_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "data.mongodbatlas_federated_query_limits.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-project")
+		tenantName   = acctest.RandomWithPrefix("test-acc-tenant")
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		region       = "VIRGINIA_USA"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseQueryLimitsDataSourceConfig(policyName, roleName, projectName, orgID, tenantName, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "tenant_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitsDataSourceConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseQueryLimitsConfigDataSourceFirstStep(name, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test_project" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test_project.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test_project.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitsConfigDataSourceFirstStep(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "db_instance" {
+   project_id         = mongodbatlas_project.test_project.id
+   name = %[1]q
+
+   cloud_provider_config {
+		aws {
+			role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+			test_s3_bucket = %[2]q
+		}
+	}
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[2]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[2]q
+	delimiter = "/"
+	name = %[2]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+resource "mongodbatlas_federated_query_limit" "test" {
+	project_id = mongodbatlas_project.test_project.id
+	tenant_name = mongodbatlas_federated_database_instance.db_instance.name
+	limit_name = "bytesProcessed.monthly"
+	overrun_policy = "BLOCK"
+	value = 5147483648
+  }
+
+  data "mongodbatlas_federated_query_limits" "test" {
+	project_id = mongodbatlas_project.test_project.id
+	tenant_name = mongodbatlas_federated_database_instance.db_instance.name
+  }
+
+	`, name, testS3Bucket)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_connected_organization_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_connected_organization_test.go
@@ -1,0 +1,71 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettingsOrganizationConfig_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "data.mongodbatlas_federated_settings_org_config.test"
+		federatedSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID               = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigConfig(federatedSettingsID, orgID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_provider_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_id", "0oad4fas87jL5Xnk1297"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigConfig(federatedSettingsID, orgID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_org_config" "test" {
+			federation_settings_id = "%[1]s"
+			org_id = "%[2]s"
+
+		}
+`, federatedSettingsID, orgID)
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
+		if err != nil {
+			return fmt.Errorf("FederatedSettingsConnectedOrganization (%s) does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_connected_organizations_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_connected_organizations_test.go
@@ -1,0 +1,70 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettingsOrganizationConfigs_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "data.mongodbatlas_federated_settings_org_configs.test"
+		federatedSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigsConfig(federatedSettingsID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigsExists(resourceName),
+
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.identity_provider_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.org_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigsConfig(federatedSettingsID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_org_configs" "test" {
+			federation_settings_id = "%[1]s"
+			page_num = 1
+			items_per_page = 100
+		}
+`, federatedSettingsID)
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigsExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
+		if err != nil {
+			return fmt.Errorf("FederatedSettingsConnectedOrganization (%s) does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_identity_provider_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_identity_provider_test.go
@@ -1,0 +1,45 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccFedDSFederatedSettingsIdentityProvider_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "data.mongodbatlas_federated_settings_identity_provider.test"
+		federatedSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		idpID               = os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID")
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProviderConfig(federatedSettingsID, idpID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsIdentityProvidersExists(resourceName),
+
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "associated_orgs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "acs_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "mongodb_federation_test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProviderConfig(federatedSettingsID, idpID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_identity_provider" "test" {
+			federation_settings_id = "%[1]s"
+            identity_provider_id   = "%[2]s"
+		}
+`, federatedSettingsID, idpID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_identity_providers_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_identity_providers_test.go
@@ -1,0 +1,70 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettingsIdentityProviders_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "data.mongodbatlas_federated_settings_identity_providers.test"
+		federatedSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProvidersConfig(federatedSettingsID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsIdentityProvidersExists(resourceName),
+
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.acs_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.display_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProvidersConfig(federatedSettingsID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_identity_providers" "test" {
+			federation_settings_id = "%[1]s"
+			page_num = 1
+			items_per_page = 100
+		}
+`, federatedSettingsID)
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsIdentityProvidersExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.FederatedSettings.ListIdentityProviders(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
+		if err != nil {
+			return fmt.Errorf("FederatedSettingsIdentityProviders (%s) does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_organization_role_mapping_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_organization_role_mapping_test.go
@@ -1,0 +1,49 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettingsOrganizationRoleMapping_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		federatedSettingsOrganizationRoleMapping matlas.FederatedSettingsOrganizationRoleMapping
+		resourceName                             = "data.mongodbatlas_federated_settings_org_role_mapping.test"
+		federatedSettingsID                      = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                                    = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		roleMappingID                            = os.Getenv("MONGODB_ATLAS_FEDERATED_ROLE_MAPPING_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingConfig(federatedSettingsID, orgID, roleMappingID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingExists(resourceName, &federatedSettingsOrganizationRoleMapping),
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "external_group_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_assignments.#"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "external_group_name", "group2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingConfig(federatedSettingsID, orgID, roleMappingID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_org_role_mapping" "test" {
+			federation_settings_id = "%[1]s"
+			org_id                 = "%[2]s"
+			role_mapping_id        = "%[3]s"
+		}
+`, federatedSettingsID, orgID, roleMappingID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_organization_role_mappings_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_organization_role_mappings_test.go
@@ -1,0 +1,71 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettingsOrganizationRoleMappings_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "data.mongodbatlas_federated_settings_org_role_mappings.test"
+		federatedSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID               = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingsConfig(federatedSettingsID, orgID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingsExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.external_group_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.role_assignments.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingsConfig(federatedSettingsID, orgID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings_org_role_mappings" "test" {
+			federation_settings_id = "%[1]s"
+			org_id                 = "%[2]s"
+			page_num = 1
+			items_per_page = 100
+		}
+`, federatedSettingsID, orgID)
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingsExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.FederatedSettings.ListRoleMappings(context.Background(), rs.Primary.Attributes["federation_settings_id"], rs.Primary.Attributes["org_id"], nil)
+		if err != nil {
+			return fmt.Errorf("FederatedSettingsOrganizationRoleMappings (%s) does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_federated_settings_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_federated_settings_test.go
@@ -1,0 +1,72 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccFedDSFederatedSettings_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		federatedSettings matlas.FederatedSettings
+		resourceName      = "data.mongodbatlas_federated_settings.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceFederatedSettingsConfig(orgID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsExists(resourceName, &federatedSettings),
+
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_provider_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "identity_provider_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "has_role_mappings"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceFederatedSettingsConfig(orgID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_federated_settings" "test" {
+			org_id = "%[1]s"
+		}
+`, orgID)
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsExists(resourceName string, federatedSettings *matlas.FederatedSettings) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		federatedSettingsRes, _, err := conn.FederatedSettings.Get(context.Background(), rs.Primary.Attributes["org_id"])
+		if err != nil {
+			return fmt.Errorf("FederatedSettings (%s) does not exist", rs.Primary.ID)
+		}
+
+		federatedSettings = federatedSettingsRes
+
+		return nil
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_global_cluster_config_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_global_cluster_config_test.go
@@ -1,0 +1,92 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccClusterDSGlobalCluster_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_global_cluster_config.config"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name           = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasGlobalClusterConfig(projectID, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasGlobalClusterConfig(projectID, name string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cluster" "test" {
+		project_id              = "%s"
+		name                    = "%s"
+		disk_size_gb            = 80
+		provider_backup_enabled = false
+		cluster_type            = "GEOSHARDED"
+
+		// Provider Settings "block"
+		provider_name               = "AWS"
+		provider_instance_size_name = "M30"
+
+		replication_specs {
+			zone_name  = "Zone 1"
+			num_shards = 2
+			regions_config {
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+			}
+		}
+
+		replication_specs {
+			zone_name  = "Zone 2"
+			num_shards = 2
+			regions_config {
+			region_name     = "US_EAST_2"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+			}
+		}
+	}
+
+	resource "mongodbatlas_global_cluster_config" "config" {
+		project_id = mongodbatlas_cluster.test.project_id
+		cluster_name = mongodbatlas_cluster.test.name
+
+		managed_namespaces {
+			db 				 = "mydata"
+			collection 		 = "publishers"
+			custom_shard_key = "city"
+		}
+
+		custom_zone_mappings {
+			location ="CA"
+			zone =  "Zone 1"
+		}
+	}
+
+	data "mongodbatlas_global_cluster_config" "config" {
+		project_id = mongodbatlas_global_cluster_config.config.project_id
+		cluster_name = mongodbatlas_global_cluster_config.config.cluster_name
+	}
+	`, projectID, name)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_ldap_configuration_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_ldap_configuration_test.go
@@ -1,0 +1,69 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvDSLDAPConfiguration_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapConfiguration matlas.LDAPConfiguration
+		resourceName      = "mongodbatlas_ldap_configuration.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		hostname          = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username          = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password          = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		authEnabled       = true
+		port              = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceLDAPConfigurationConfig(projectName, orgID, hostname, username, password, authEnabled, cast.ToInt(port)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName, &ldapConfiguration),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "authentication_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceLDAPConfigurationConfig(projectName, orgID, hostname, username, password string, authEnabled bool, port int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_ldap_configuration" "test" {
+			project_id                  =  mongodbatlas_project.test.id
+			authentication_enabled      =  %[6]t
+			hostname 					= "%[3]s"
+			port                        =  %[7]d
+			bind_username               = "%[4]s"
+			bind_password               = "%[5]s"
+		}
+		
+		data "mongodbatlas_ldap_configuration" "test" {
+			project_id = mongodbatlas_ldap_configuration.test.id
+		}
+`, projectName, orgID, hostname, username, password, authEnabled, port)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_ldap_verify_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_ldap_verify_test.go
@@ -1,0 +1,81 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvDSLDAPVerify_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapVerify   matlas.LDAPConfiguration
+		resourceName = "mongodbatlas_ldap_verify.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+		hostname     = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username     = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password     = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		port         = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceLDAPVerifyConfig(projectName, orgID, clusterName, hostname, username, password, cast.ToInt(port)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName, &ldapVerify),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceLDAPVerifyConfig(projectName, orgID, clusterName, hostname, username, password string, port int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = mongodbatlas_project.test.id
+			name         = "%[3]s"
+			
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			provider_backup_enabled     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_ldap_verify" "test" {
+			project_id               =  mongodbatlas_project.test.id
+			hostname 				 = "%[4]s"
+			port                     =  %[7]d
+			bind_username            = "%[5]s"
+			bind_password            = "%[6]s"
+			depends_on = ["mongodbatlas_cluster.test"]
+		}
+		
+		data "mongodbatlas_ldap_verify" "test" {
+			project_id = mongodbatlas_ldap_verify.test.project_id
+			request_id = mongodbatlas_ldap_verify.test.request_id
+		}
+`, projectName, orgID, clusterName, hostname, username, password, port)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_maintenance_window_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_maintenance_window_test.go
@@ -1,0 +1,56 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
+	var maintenance matlas.MaintenanceWindow
+
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	dayOfWeek := 7
+	hourOfDay := 3
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists("mongodbatlas_maintenance_window.test", &maintenance),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "project_id"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "day_of_week"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "hour_of_day"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "auto_defer_once_enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+			resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = mongodbatlas_project.test.id
+			day_of_week = %[3]d
+			hour_of_day = %[4]d
+			auto_defer_once_enabled = true
+		}
+
+		data "mongodbatlas_maintenance_window" "test" {
+			project_id = "${mongodbatlas_maintenance_window.test.id}"
+		}
+	`, orgID, projectName, dayOfWeek, hourOfDay)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_network_peering_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_network_peering_test.go
@@ -1,0 +1,73 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccNetworkDSNetworkPeering_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var peer matlas.Peer
+
+	resourceName := "mongodbatlas_network_peering.basic"
+	dataSourceName := "data.mongodbatlas_network_peering.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	vpcID := os.Getenv("AWS_VPC_ID")
+	vpcCIDRBlock := os.Getenv("AWS_VPC_CIDR_BLOCK")
+	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
+	awsRegion := os.Getenv("AWS_REGION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvAWS(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasNetworkPeeringConfig(projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName, &peer),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(resourceName, "aws_account_id", awsAccountID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(dataSourceName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(dataSourceName, "aws_account_id", awsAccountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasNetworkPeeringConfig(projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		= "%[1]s"
+			atlas_cidr_block    = "192.168.208.0/21"
+			provider_name		= "AWS"
+			region_name			= "%[5]s"
+		}
+
+		resource "mongodbatlas_network_peering" "basic" {
+			accepter_region_name	= lower(replace("%[5]s", "_", "-"))
+			project_id    			= "%[1]s"
+			container_id            = mongodbatlas_network_container.test.id
+			provider_name           = "AWS"
+			route_table_cidr_block  = "%[4]s"
+			vpc_id					= "%[2]s"
+			aws_account_id			= "%[3]s"
+		}
+
+		data "mongodbatlas_network_peering" "test" {
+			project_id = "%[1]s"
+			peering_id = mongodbatlas_network_peering.basic.peer_id
+		}
+	`, projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_network_peerings_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_network_peerings_test.go
@@ -1,0 +1,71 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccNetworkDSNetworkPeerings_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var peer matlas.Peer
+
+	resourceName := "mongodbatlas_network_peering.test"
+	dataSourceName := "data.mongodbatlas_network_peerings.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	vpcID := os.Getenv("AWS_VPC_ID")
+	vpcCIDRBlock := os.Getenv("AWS_VPC_CIDR_BLOCK")
+	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
+	awsRegion := os.Getenv("AWS_REGION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvAWS(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasNetworkPeeringsConfig(projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName, &peer),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(resourceName, "aws_account_id", awsAccountID),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "results.0.aws_account_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasNetworkPeeringsConfig(projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_network_container" "test" {
+	project_id   		= "%[1]s"
+	atlas_cidr_block    = "192.168.208.0/21"
+	provider_name		= "AWS"
+	region_name			= "%[5]s"
+}
+
+resource "mongodbatlas_network_peering" "test" {
+	accepter_region_name	= "us-east-1"
+	project_id    			= "%[1]s"
+	container_id            = mongodbatlas_network_container.test.id
+	provider_name           = "AWS"
+	route_table_cidr_block  = "%[4]s"
+	vpc_id					= "%[2]s"
+	aws_account_id			= "%[3]s"
+}
+
+data "mongodbatlas_network_peerings" "test" {
+	project_id = mongodbatlas_network_peering.test.project_id
+}
+`, projectID, vpcID, awsAccountID, vpcCIDRBlock, awsRegion)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_org_id_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_org_id_test.go
@@ -1,0 +1,43 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSOrgID_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_roles_org_id.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole    = []string{"ORG_OWNER"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrgInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasOrgIDConfig(orgID, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasOrgIDConfig(orgID, username string, roles []string) string {
+	return (`
+	data "mongodbatlas_roles_org_id" "test" {
+	}
+	
+	output "org_id" {
+	 value = data.mongodbatlas_roles_org_id.test.org_id
+	}`)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_org_invitation_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_org_invitation_test.go
@@ -1,0 +1,55 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSOrgInvitation_basic(t *testing.T) {
+	var (
+		dataSourceName = "mongodbatlas_org_invitation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole    = []string{"ORG_OWNER"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrgInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasOrgInvitationConfig(orgID, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "username"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "invitation_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "username", name),
+					resource.TestCheckResourceAttr(dataSourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasOrgInvitationConfig(orgID, username string, roles []string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_org_invitation" "test" {
+			org_id   = %[1]q
+			username = %[2]q
+			roles  	 = ["%[3]s"]
+		}
+
+		data "mongodbatlas_org_invitation" "test" {
+			org_id        = mongodbatlas_org_invitation.test.org_id
+			username      = mongodbatlas_org_invitation.test.username
+			invitation_id = mongodbatlas_org_invitation.test.invitation_id
+		}`, orgID, username,
+		strings.Join(roles, `", "`),
+	)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_organization_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_organization_test.go
@@ -1,0 +1,36 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSOrganization_basic(t *testing.T) {
+	var (
+		orgID = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationConfigWithDS(orgID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_organization.test", "name"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_organization.test", "id"),
+				),
+			},
+		},
+	})
+}
+func testAccMongoDBAtlasOrganizationConfigWithDS(orgID string) string {
+	config := fmt.Sprintf(`
+		
+		data "mongodbatlas_organization" "test" {
+			org_id = %[1]q
+		}
+	`, orgID)
+	return config
+}

--- a/test/acceptance-test/data_source_mongodbatlas_organizations_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_organizations_test.go
@@ -1,0 +1,63 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSOrganizations_basic(t *testing.T) {
+	var (
+		datasourceName = "data.mongodbatlas_organizations.test"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationsConfigWithDS(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSOrganizations_withPagination(t *testing.T) {
+	var (
+		datasourceName = "data.mongodbatlas_organizations.test"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationsConfigWithPagination(2, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasOrganizationsConfigWithDS(includedeletedorgs bool) string {
+	config := fmt.Sprintf(`
+		
+		data "mongodbatlas_organizations" "test" {
+			include_deleted_orgs = %t
+		}
+	`, includedeletedorgs)
+	return config
+}
+
+func testAccMongoDBAtlasOrganizationsConfigWithPagination(pageNum, itemPage int) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_organizations" "test" {
+			page_num = %d
+			items_per_page = %d
+		}
+	`, pageNum, itemPage)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -1,0 +1,58 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccNetworkDSPrivateEndpointRegionalMode_basic(t *testing.T) {
+	resourceName := "mongodbatlas_private_endpoint_regional_mode.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointRegionalModeDataSourceConfig(projectID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName),
+					testAccMongoDBAtlasPrivateEndpointRegionalModeUnmanagedResource(resourceName, projectID),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeUnmanagedResource(resourceName, projectID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
+
+		if err != nil || setting == nil {
+			return fmt.Errorf("Could not get regionalized private endpoint setting for project_id (%s)", projectID)
+		}
+
+		return resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(setting.Enabled))(s)
+	}
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeDataSourceConfig(projectID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_private_endpoint_regional_mode" "test" {
+			project_id = data.mongodbatlas_private_endpoint_regional_mode.test.project_id
+		}
+
+		data "mongodbatlas_private_endpoint_regional_mode" "test" {
+			project_id  = %q
+		}
+	`, projectID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -1,0 +1,49 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccNetworkDSPrivateLinkEndpointServiceADL_basic(t *testing.T) {
+	datasourceName := "data.mongodbatlas_privatelink_endpoint_service_adl.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	endpointID := "vpce-jjg5e24qp93513h03"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointADLDataSourceConfig(projectID, endpointID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLExists(datasourceName),
+					resource.TestCheckResourceAttr(datasourceName, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttr(datasourceName, "type", "DATA_LAKE"),
+					resource.TestCheckResourceAttr(datasourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(datasourceName, "comment", "private link adl comment"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointADLDataSourceConfig(projectID, endpointID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_privatelink_endpoint_service_adl" "test" {
+			project_id   = "%[1]s"
+			endpoint_id  = "%[2]s"
+			comment      = "private link adl comment"
+			type		 = "DATA_LAKE"
+			provider_name	 = "AWS"
+		}
+
+		data "mongodbatlas_privatelink_endpoint_service_adl" "test" {
+			project_id      = mongodbatlas_privatelink_endpoint_service_adl.test.project_id
+			endpoint_id = mongodbatlas_privatelink_endpoint_service_adl.test.endpoint_id
+		}
+	`, projectID, endpointID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -1,0 +1,50 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var (
+	dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive = "data.mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test"
+)
+
+func TestAccDataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t *testing.T) {
+	testCheckPrivateEndpointServiceDataFederationOnlineArchiveRun(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveConfig(projectID, endpointID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive),
+					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "project_id", projectID),
+					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttrSet(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "comment"),
+					resource.TestCheckResourceAttrSet(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "type"),
+					resource.TestCheckResourceAttrSet(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "provider_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveConfig(projectID, endpointID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
+	  project_id				= %[1]q
+	  endpoint_id				= %[2]q
+	  provider_name				= "AWS"
+	  comment					= "Terraform Acceptance Test"
+	}
+
+	data "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
+		project_id				= mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test.project_id
+		endpoint_id				= mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test.endpoint_id
+	}
+	`, projectID, endpointID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archives_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archives_test.go
@@ -1,0 +1,46 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+var (
+	dataSourcePrivatelinkEndpointServiceDataFederetionDataArchives = "data.mongodbatlas_privatelink_endpoint_service_data_federation_online_archives.test"
+)
+
+func TestAccDataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchives_basic(t *testing.T) {
+	testCheckPrivateEndpointServiceDataFederationOnlineArchiveRun(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchivesConfig(projectID, endpointID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive),
+					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchives, "project_id", projectID),
+					resource.TestCheckResourceAttrSet(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchives, "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchivesConfig(projectID, endpointID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
+	  project_id				= %[1]q
+	  endpoint_id				= %[2]q
+	  provider_name				= "AWS"
+	  comment					= "Terraform Acceptance Test"
+	}
+
+	data "mongodbatlas_privatelink_endpoint_service_data_federation_online_archives" "test" {
+		project_id				= mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test.project_id
+	}
+	`, projectID, endpointID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_service_test.go
@@ -1,0 +1,81 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccNetworkDSPrivateLinkEndpointServiceAWS_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	resourceName := "data.mongodbatlas_privatelink_endpoint_service.test"
+
+	awsAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	awsSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	region := os.Getenv("AWS_REGION")
+	providerName := "AWS"
+
+	vpcID := os.Getenv("AWS_VPC_ID")
+	subnetID := os.Getenv("AWS_SUBNET_ID")
+	securityGroupID := os.Getenv("AWS_SECURITY_GROUP_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceDataSourceConfig(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServiceDataSourceConfig(awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID string) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+			region     = "us-east-1"
+			access_key = "%s"
+			secret_key = "%s"
+		}
+
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = "%s"
+			provider_name = "%s"
+			region        = "%s"
+		}
+
+		resource "aws_vpc_endpoint" "ptfe_service" {
+			vpc_id             = "%s"
+			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
+			vpc_endpoint_type  = "Interface"
+			subnet_ids         = ["%s"]
+			security_group_ids = ["%s"]
+		}
+
+		resource "mongodbatlas_privatelink_endpoint_service" "test" {
+			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
+			endpoint_service_id       =  aws_vpc_endpoint.ptfe_service.id
+			private_link_id = mongodbatlas_privatelink_endpoint.test.private_link_id
+			provider_name = "%[4]s"
+		}
+
+		data "mongodbatlas_privatelink_endpoint_service" "test" {
+			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
+			private_link_id       =  mongodbatlas_privatelink_endpoint_service.test.private_link_id
+			endpoint_service_id = mongodbatlas_privatelink_endpoint_service.test.endpoint_service_id
+			provider_name = "%[4]s"
+		}
+	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoint_test.go
@@ -1,0 +1,48 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccNetworkDSPrivateLinkEndpoint_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	resourceName := "data.mongodbatlas_privatelink_endpoint.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	region := os.Getenv("AWS_REGION")
+	providerName := "AWS"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointDataSourceConfig(projectID, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointDataSourceConfig(projectID, providerName, region string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = "%s"
+			provider_name = "%s"
+			region        = "%s"
+		}
+
+		data "mongodbatlas_privatelink_endpoint" "test" {
+			project_id      = mongodbatlas_privatelink_endpoint.test.project_id
+			private_link_id = mongodbatlas_privatelink_endpoint.test.id
+			provider_name = "%[2]s"
+		}
+	`, projectID, providerName, region)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoints_service_adl_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_privatelink_endpoints_service_adl_test.go
@@ -1,0 +1,51 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccNetworkDSPrivateLinkEndpointsServiceADL_basic(t *testing.T) {
+	datasourceName := "data.mongodbatlas_privatelink_endpoints_service_adl.test"
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	endpointID := "vpce-jjg5e24qp93513h03"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointsADLDataSourceConfig(projectID, endpointID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "links.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.endpoint_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.type"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.provider_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.comment"),
+					resource.TestCheckResourceAttr(datasourceName, "total_count", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointsADLDataSourceConfig(projectID, endpointID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_privatelink_endpoint_service_adl" "test" {
+			project_id   = "%[1]s"
+			endpoint_id  = "%[2]s"
+			comment      = "private link adl comment"
+			type		 = "DATA_LAKE"
+			provider_name	 = "AWS"
+		}
+
+		data "mongodbatlas_privatelink_endpoints_service_adl" "test" {
+			project_id      = mongodbatlas_privatelink_endpoint_service_adl.test.project_id
+		}
+	`, projectID, endpointID)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_project_invitation_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_project_invitation_test.go
@@ -1,0 +1,61 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectDSProjectInvitation_basic(t *testing.T) {
+	var (
+		dataSourceName = "mongodbatlas_project_invitation.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		name           = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole    = []string{"GROUP_OWNER"}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasProjectInvitationConfig(orgID, projectName, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "username"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "invitation_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "username", name),
+					resource.TestCheckResourceAttr(dataSourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasProjectInvitationConfig(orgID, projectName, username string, roles []string) string {
+	return fmt.Sprintf(`
+
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_invitation" "test" {
+			project_id = mongodbatlas_project.test.id
+			username   = %[3]q
+			roles  	 = ["%[4]s"]
+		}
+
+		data "mongodbatlas_project_invitation" "test" {
+			project_id    = mongodbatlas_project_invitation.test.project_id
+			username 	  = mongodbatlas_project_invitation.test.username
+			invitation_id = mongodbatlas_project_invitation.test.invitation_id
+		}`, orgID, projectName, username,
+		strings.Join(roles, `", "`),
+	)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_team_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_team_test.go
@@ -1,0 +1,93 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSTeam_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_teams.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		username       = os.Getenv("MONGODB_ATLAS_USERNAME_CLOUD_DEV")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasTeamConfig(orgID, name, username),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSTeamByName_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_teams.test2"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		username       = os.Getenv("MONGODB_ATLAS_USERNAME_CLOUD_DEV")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasTeamConfigByName(orgID, name, username),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasTeamConfig(orgID, name, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_teams" "test" {
+			org_id     = "%s"
+			name       = "%s"
+			usernames  = ["%s"]
+		}
+
+		data "mongodbatlas_teams" "test" {
+			org_id     = mongodbatlas_teams.test.org_id
+			team_id    = mongodbatlas_teams.test.team_id
+		}
+
+	`, orgID, name, username)
+}
+
+func testAccDataSourceMongoDBAtlasTeamConfigByName(orgID, name, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_teams" "test" {
+			org_id     = "%s"
+			name       = "%s"
+			usernames  = ["%s"]
+		}
+
+		data "mongodbatlas_teams" "test2" {
+			org_id     = mongodbatlas_teams.test.org_id
+			name    = mongodbatlas_teams.test.name
+		}
+	`, orgID, name, username)
+}

--- a/test/acceptance-test/data_source_mongodbatlas_third_party_integration_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_third_party_integration_test.go
@@ -1,0 +1,308 @@
+package acceptancetests
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	Unknown3rdParty = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+	}
+	`
+
+	PAGERDUTY = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		service_key = "%[4]s"
+	}
+	`
+
+	DATADOG = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		api_key = "%[4]s"
+		region  ="%[5]s"
+	}
+	`
+
+	NEWRELIC = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		license_key = "%[4]s"
+		account_id  = "%[5]s"
+		write_token = "%[6]s"
+		read_token  = "%[7]s"
+	}
+	`
+
+	OPSGENIE = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		api_key = "%[4]s"
+		region  = "%[5]s"
+	}
+	`
+	VICTOROPS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		api_key = "%[4]s"
+		routing_key = "%[5]s"
+	}
+	`
+
+	FLOWDOCK = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		flow_name = "%[4]s"
+		api_token = "%[5]s"
+		org_name =  "%[6]s"
+	}
+	`
+
+	MICROSOFTTEAMS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		microsoft_teams_webhook_url = "%[4]s"	
+	}
+	`
+
+	PROMETHEUS = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		user_name = "%[4]s"	
+		password  = "%[5]s"
+		service_discovery = "%[6]s" 
+		scheme = "%[7]s"
+		enabled = true
+	}
+	`
+
+	WEBHOOK = `
+	resource "mongodbatlas_third_party_integration" "%[1]s" {
+		project_id = "%[2]s"
+		type = "%[3]s"
+		url = "%[4]s"	
+	}
+`
+	alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	numeric  = "0123456789"
+	alphaNum = alphabet + numeric
+)
+
+type thirdPartyConfig struct {
+	Name        string
+	ProjectID   string
+	Integration matlas.ThirdPartyIntegration
+}
+
+func TestAccConfigDSThirdPartyIntegration_basic(t *testing.T) {
+	SkipTestForCI(t) // TODO: Address failures in v1.4.6
+
+	var (
+		targetIntegration = matlas.ThirdPartyIntegration{}
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
+		config            = testAccCreateThirdPartyIntegrationConfig()
+
+		testExecutionName = "test_" + config.AccountID
+		resourceName      = "data.mongodbatlas_third_party_integration." + testExecutionName
+
+		seedConfig = thirdPartyConfig{
+			Name:        testExecutionName,
+			ProjectID:   projectID,
+			Integration: *config,
+		}
+	)
+	seedConfig.Integration.APIKey = apiKey
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasThirdPartyIntegrationDataSourceConfig(&seedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
+					resource.TestCheckResourceAttr(resourceName, "type", config.Type),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasThirdPartyIntegrationDataSourceConfig(config *thirdPartyConfig) string {
+	// create the resource config first
+	resourceConfig := testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config)
+
+	return fmt.Sprintf(`
+	%[1]s
+
+	data "mongodbatlas_third_party_integration" "%[2]s" {
+		project_id = mongodbatlas_third_party_integration.%[2]s.project_id
+		type = mongodbatlas_third_party_integration.%[2]s.type
+	}
+	`, resourceConfig, config.Name)
+}
+
+func testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(config *thirdPartyConfig) string {
+	switch config.Integration.Type {
+	case "PAGER_DUTY":
+		return fmt.Sprintf(PAGERDUTY,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.LicenseKey,
+		)
+	case "DATADOG":
+		return fmt.Sprintf(DATADOG,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.APIKey,
+			config.Integration.Region,
+		)
+	case "NEW_RELIC":
+		return fmt.Sprintf(NEWRELIC,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.LicenseKey,
+			config.Integration.AccountID,
+			config.Integration.WriteToken,
+			config.Integration.ReadToken,
+		)
+	case "OPS_GENIE":
+		return fmt.Sprintf(OPSGENIE,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.APIKey,
+			config.Integration.Region,
+		)
+	case "VICTOR_OPS":
+		return fmt.Sprintf(VICTOROPS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.APIKey,
+			config.Integration.RoutingKey,
+		)
+	case "WEBHOOK":
+		return fmt.Sprintf(WEBHOOK,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.URL,
+		)
+	case "MICROSOFT_TEAMS":
+		return fmt.Sprintf(MICROSOFTTEAMS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.MicrosoftTeamsWebhookURL,
+		)
+	case "PROMETHEUS":
+		return fmt.Sprintf(PROMETHEUS,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+			config.Integration.UserName,
+			config.Integration.Password,
+			config.Integration.ServiceDiscovery,
+			config.Integration.Scheme,
+		)
+	default:
+		return fmt.Sprintf(Unknown3rdParty,
+			config.Name,
+			config.ProjectID,
+			config.Integration.Type,
+		)
+	}
+}
+
+func testAccCreateThirdPartyIntegrationConfig() *matlas.ThirdPartyIntegration {
+	account := testGenString(6, numeric)
+	return &matlas.ThirdPartyIntegration{
+		Type: "OPS_GENIE",
+		// Pager dutty 20-character strings
+		LicenseKey:  testGenString(20, alphabet),
+		APIToken:    fmt.Sprintf("xoxb-%s-%s-%s", testGenString(12, numeric), testGenString(12, numeric), testGenString(24, alphaNum)),
+		TeamName:    "MongoSlackTestTeam " + account,
+		ChannelName: "MongoSlackTestChannel " + account,
+		// DataDog 40
+		APIKey: testGenString(40, alphaNum),
+		Region: "EU",
+
+		AccountID:        account,
+		WriteToken:       "write-test-" + testGenString(20, alphaNum),
+		ReadToken:        "read-test-" + testGenString(20, alphaNum),
+		RoutingKey:       testGenString(40, alphaNum),
+		FlowName:         "MongoFlow test" + account,
+		OrgName:          "MongoOrgTest " + account,
+		URL:              "https://www.mongodb.com/webhook",
+		Secret:           account,
+		UserName:         "PROM_USER",
+		Password:         "PROM_PASSWORD",
+		ServiceDiscovery: "http",
+		Scheme:           "https",
+		Enabled:          false,
+		MicrosoftTeamsWebhookURL: "https://apps.webhook.office.com/webhookb2/" +
+			"c9c5fafc-d9fe-4ffb-9773-77d804ea4372@c9656" +
+			"3a8-841b-4ef9-af16-33548fffc958/IncomingWebhook" +
+			"/484cccf0a678fffff86388b63203110a/42a0070b-5f35-ffff-be83-ac7e7f55d7d3",
+	}
+}
+
+func testGenString(length int, charSet string) string {
+	sequence := make([]byte, length)
+	upperBound := big.NewInt(int64(len(charSet)))
+	for i := range sequence {
+		n, _ := rand.Int(rand.Reader, upperBound)
+		sequence[i] = charSet[int(n.Int64())]
+	}
+	return string(sequence)
+}
+
+func testAccCheckThirdPartyIntegrationExists(resourceName string, integration *matlas.ThirdPartyIntegration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if integrationResponse, _, err := conn.Integrations.Get(context.Background(), ids["project_id"], ids["type"]); err == nil {
+			*integration = *integrationResponse
+			return nil
+		}
+
+		return fmt.Errorf("third party integration (%s) does not exist", ids["project_id"])
+	}
+}

--- a/test/acceptance-test/data_source_mongodbatlas_third_party_integrations_test.go
+++ b/test/acceptance-test/data_source_mongodbatlas_third_party_integrations_test.go
@@ -1,0 +1,96 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSThirdPartyIntegrations_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		intgTypes       = []string{"NEW_RELIC", "OPS_GENIE", "DATADOG", "VICTOR_OPS", "WEBHOOK", "PROMETHEUS"}
+		hclConfig       = make([]*thirdPartyConfig, 0, len(intgTypes))
+		dsName          = "data.mongodbatlas_third_party_integrations.test"
+		integrationType = ""
+	)
+
+	for _, intg := range intgTypes {
+		hclConfig = append(
+			hclConfig,
+			&thirdPartyConfig{
+				Name:      "test_" + intg,
+				ProjectID: projectID,
+				Integration: func() mongodbatlas.ThirdPartyIntegration {
+					out := testAccCreateThirdPartyIntegrationConfig()
+					out.Type = intg
+					integrationType = "test_" + intg
+					out.APIKey = testOpsGenieOrDatadog(intg)
+					return *out
+				}(),
+			},
+		)
+	}
+
+	intgResourcesHCL := testAccMongoDBAtlasThirdPartyIntegrationsDataSourceConfig(hclConfig, projectID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: intgResourcesHCL,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(fmt.Sprintf("mongodbatlas_third_party_integration.%s", integrationType), "id"),
+				),
+			}, {
+
+				Config: testAccMongoDBAtlasThirdPartyIntegrationsDataSourceConfigWithDS(intgResourcesHCL, projectID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsName, "project_id", projectID),
+					resource.TestCheckResourceAttrSet(dsName, "project_id"),
+					resource.TestCheckResourceAttrSet(dsName, "results.#"),
+					resource.TestCheckResourceAttrSet(dsName, "results.0.type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasThirdPartyIntegrationsDataSourceConfig(configs []*thirdPartyConfig, projectID string) string {
+	var factory strings.Builder
+
+	for _, cfg := range configs {
+		hclEntry := testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(cfg)
+		factory.WriteString(hclEntry + "\n")
+	}
+
+	return factory.String()
+}
+
+func testAccMongoDBAtlasThirdPartyIntegrationsDataSourceConfigWithDS(resources, projectID string) string {
+	return fmt.Sprintf(`
+	%s
+	data "mongodbatlas_third_party_integrations" "test" {
+		project_id = "%s"
+	}
+`, resources, projectID)
+}
+
+func testOpsGenieOrDatadog(intTtype string) string {
+	if intTtype == "DATADOG" {
+		return os.Getenv("DD_API_KEY")
+	}
+	if intTtype == "OPS_GENIE" {
+		return os.Getenv("OPS_GENIE_API_KEY")
+	}
+	if intTtype == "VICTOR_OPS" {
+		return os.Getenv("VICTOR_OPS_API_KEY")
+	}
+	return ""
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_alert_configuration_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_alert_configuration_test.go
@@ -1,0 +1,267 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSAlertConfiguration_basic(t *testing.T) {
+	var (
+		alert          = &matlas.AlertConfiguration{}
+		dataSourceName = "data.mongodbatlas_alert_configuration.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfiguration(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(dataSourceName, alert),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "matcher.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "metric_threshold_config.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "threshold_config.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSAlertConfiguration_withThreshold(t *testing.T) {
+	var (
+		alert          = &matlas.AlertConfiguration{}
+		dataSourceName = "data.mongodbatlas_alert_configuration.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfigurationConfigWithThreshold(orgID, projectName, true, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(dataSourceName, alert),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "matcher.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "metric_threshold_config.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "threshold_config.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSAlertConfiguration_withOutput(t *testing.T) {
+	var (
+		alert          = &matlas.AlertConfiguration{}
+		dataSourceName = "data.mongodbatlas_alert_configuration.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		outputLabel    = "resource_import"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfigurationWithOutputs(orgID, projectName, outputLabel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(dataSourceName, alert),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "output.0.label", outputLabel),
+					resource.TestCheckResourceAttr(dataSourceName, "output.0.type", "resource_import"),
+					resource.TestCheckResourceAttrWith(dataSourceName, "output.0.value", testutils.MatchesExpression("terraform import mongodbatlas_alert_configuration.*")),
+					resource.TestCheckResourceAttr(dataSourceName, "output.1.label", outputLabel),
+					resource.TestCheckResourceAttr(dataSourceName, "output.1.type", "resource_hcl"),
+					resource.TestCheckResourceAttrWith(dataSourceName, "output.1.value", testutils.MatchesExpression("resource \"mongodbatlas_alert_configuration\".*")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSAlertConfiguration_withPagerDuty(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	var (
+		alert          = &matlas.AlertConfiguration{}
+		dataSourceName = "data.mongodbatlas_alert_configuration.test"
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		serviceKey     = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(projectID, serviceKey, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(dataSourceName, alert),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAlertConfiguration(orgID, projectName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "OUTSIDE_METRIC_THRESHOLD"
+			enabled    = true
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = true
+			}
+
+			matcher {
+				field_name = "HOSTNAME_AND_PORT"
+				operator   = "EQUALS"
+				value      = "SECONDARY"
+			}
+
+			metric_threshold_config {
+				metric_name = "ASSERT_REGULAR"
+				operator    = "LESS_THAN"
+				threshold   = 99.0
+				units       = "RAW"
+				mode        = "AVERAGE"
+			}
+		}
+
+		data "mongodbatlas_alert_configuration" "test" {
+			project_id             = "${mongodbatlas_alert_configuration.test.project_id}"
+			alert_configuration_id = "${mongodbatlas_alert_configuration.test.id}"
+		}
+	`, orgID, projectName)
+}
+
+func testAccDSMongoDBAtlasAlertConfigurationConfigWithThreshold(orgID, projectName string, enabled bool, threshold float64) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = true
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY", "GROUP_CLUSTER_MANAGER"]
+			}
+
+			matcher {
+				field_name = "REPLICA_SET_NAME"
+				operator   = "EQUALS"
+				value      = "SECONDARY"
+			}
+
+			threshold_config {
+				operator    = "LESS_THAN"
+				units       = "HOURS"
+				threshold   = %[4]f
+			}
+		}
+
+		data "mongodbatlas_alert_configuration" "test" {
+			project_id             = "${mongodbatlas_alert_configuration.test.project_id}"
+			alert_configuration_id = "${mongodbatlas_alert_configuration.test.id}"
+		}
+	`, orgID, projectName, enabled, threshold)
+}
+
+func testAccDSMongoDBAtlasAlertConfigurationWithOutputs(orgID, projectName, outputLabel string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			
+			event_type = "NO_PRIMARY"
+			enabled    = true
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = true
+				email_enabled = false
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY"]
+			}
+		}
+
+		data "mongodbatlas_alert_configuration" "test" {
+			project_id             = "${mongodbatlas_alert_configuration.test.project_id}"
+			alert_configuration_id = "${mongodbatlas_alert_configuration.test.id}"
+
+			output {
+				type = "resource_import"
+				label = %[3]q
+			}
+			output {
+				type = "resource_hcl"
+				label = %[3]q
+			}
+		}
+	`, orgID, projectName, outputLabel)
+}
+
+func testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(projectID, serviceKey string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = %[1]q
+  event_type = "NO_PRIMARY"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name    = "PAGER_DUTY"
+    service_key  = %[2]q
+    delay_min    = 0
+  }
+}
+
+data "mongodbatlas_alert_configuration" "test" {
+  project_id             = "${mongodbatlas_alert_configuration.test.project_id}"
+  alert_configuration_id = "${mongodbatlas_alert_configuration.test.id}"
+}
+	`, projectID, serviceKey, enabled)
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_alert_configurations_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_alert_configurations_test.go
@@ -1,0 +1,151 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSAlertConfigurations_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_alert_configurations.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfigurations(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationsCount(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSAlertConfigurations_withOutputTypes(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_alert_configurations.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDSMongoDBAtlasAlertConfigurationsOutputType(orgID, projectName, []string{"resource_hcl", "resource_import"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationsCount(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "results.0.output.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSAlertConfigurations_invalidOutputTypeValue(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDSMongoDBAtlasAlertConfigurationsOutputType(orgID, projectName, []string{"resource_hcl", "invalid_type"}),
+				ExpectError: regexp.MustCompile("value must be one of:"),
+			},
+		},
+	})
+}
+
+func testAccDSMongoDBAtlasAlertConfigurations(orgID, projectName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		data "mongodbatlas_alert_configurations" "test" {
+			project_id = mongodbatlas_project.test.id
+
+			list_options {
+				page_num = 0
+			}
+		}
+	`, orgID, projectName)
+}
+
+func testAccDSMongoDBAtlasAlertConfigurationsOutputType(orgID, projectName string, outputTypes []string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		data "mongodbatlas_alert_configurations" "test" {
+			project_id = mongodbatlas_project.test.id
+			output_type = %[3]s
+		}
+	`, orgID, projectName, strings.ReplaceAll(fmt.Sprintf("%+q", outputTypes), " ", ","))
+}
+
+func testAccCheckMongoDBAtlasAlertConfigurationsCount(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+
+		alertResp, _, err := conn.AlertConfigurations.List(context.Background(), projectID, &matlas.ListOptions{
+			PageNum:      0,
+			ItemsPerPage: 100,
+			IncludeCount: true,
+		})
+
+		if err != nil {
+			return fmt.Errorf("the Alert Configurations List for project (%s) could not be read", projectID)
+		}
+
+		resultsNumber := rs.Primary.Attributes["results.#"]
+		var dataSourceResultsCount int
+
+		if dataSourceResultsCount, err = strconv.Atoi(resultsNumber); err != nil {
+			return fmt.Errorf("%s results count is somehow not a number %s", resourceName, resultsNumber)
+		}
+
+		apiResultsCount := len(alertResp)
+		if dataSourceResultsCount != len(alertResp) {
+			return fmt.Errorf("%s results count (%v) did not match that of current Alert Configurations (%d)", resourceName, dataSourceResultsCount, apiResultsCount)
+		}
+
+		return nil
+	}
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_database_user_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_database_user_test.go
@@ -1,0 +1,77 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigDSDatabaseUser_basic(t *testing.T) {
+	var dbUser matlas.DatabaseUser
+
+	resourceName := "data.mongodbatlas_database_user.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	roleName := "atlasAdmin"
+	username := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserDataSourceConfig(orgID, projectName, roleName, username),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "roles.0.role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "roles.0.database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDatabaseUserDataSourceConfig(orgID, projectName, roleName, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_database_user" "test" {
+			username           = %[4]q
+			password           = "test-acc-password"
+			project_id         = mongodbatlas_project.test.id
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = %[3]q
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "key 1"
+				value = "value 1"
+			}
+			labels {
+				key   = "key 2"
+				value = "value 2"
+			}
+		}
+
+		data "mongodbatlas_database_user" "test" {
+			username           = mongodbatlas_database_user.test.username
+			project_id         = mongodbatlas_database_user.test.project_id
+			auth_database_name = "admin"
+		}
+	`, orgID, projectName, roleName, username)
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_database_users_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_database_users_test.go
@@ -1,0 +1,101 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigDSDatabaseUsers_basic(t *testing.T) {
+	resourceName := "data.mongodbatlas_database_users.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+
+	username := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	roleName := "atlasAdmin"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUsersDataSourceConfig(orgID, projectName, roleName, username),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_database_user.db_user", "id"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_database_user.db_user_1", "id"),
+					resource.TestCheckResourceAttr("mongodbatlas_database_user.db_user_1", "labels.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUsersDataSourceConfigWithDS(orgID, projectName, roleName, username),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.username"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.0.roles.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "results.1.labels.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasDatabaseUsersDataSourceConfig(orgID, projectName, roleName, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_database_user" "db_user" {
+			username           = %[4]q
+			password           = "test-acc-password"
+			project_id         = mongodbatlas_project.test.id
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = %[3]q
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "key 1"
+				value = "value 1"
+			}
+		}
+
+		resource "mongodbatlas_database_user" "db_user_1" {
+			username           = "%[4]s-1"
+			password           = "test-acc-password-1"
+			project_id         = mongodbatlas_project.test.id
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = %[3]q
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "key 1"
+				value = "value 1"
+			}
+
+			labels {
+				key   = "key 2"
+				value = "value 2"
+			}
+		}
+	`, orgID, projectName, roleName, username)
+}
+
+func testAccMongoDBAtlasDatabaseUsersDataSourceConfigWithDS(orgID, projectName, roleName, username string) string {
+	return fmt.Sprintf(`
+		%s
+
+		data "mongodbatlas_database_users" "test" {
+			project_id = mongodbatlas_project.test.id
+		}
+	`, testAccMongoDBAtlasDatabaseUsersDataSourceConfig(orgID, projectName, roleName, username))
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_project_ip_access_list_migration_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_project_ip_access_list_migration_test.go
@@ -1,0 +1,140 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccProjectDSProjectIPAccessList_Migration_SettingIPAddress(t *testing.T) {
+	dataSourceName := "data.mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "comment"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_address", ipAddress),
+					resource.TestCheckResourceAttr(dataSourceName, "comment", comment),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProjectIPAccessList_Migration_SettingCIDRBlock(t *testing.T) {
+	dataSourceName := "data.mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	cidrBlock := fmt.Sprintf("179.154.226.%d/32", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "comment"),
+					resource.TestCheckResourceAttr(dataSourceName, "cidr_block", cidrBlock),
+					resource.TestCheckResourceAttr(dataSourceName, "comment", comment),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProjectIPAccessList_Migration_SettingAWSSecurityGroup(t *testing.T) {
+	SkipTestExtCred(t)
+	dataSourceName := "data.mongodbatlas_project_ip_access_list.test"
+	vpcID := os.Getenv("AWS_VPC_ID")
+	vpcCIDRBlock := os.Getenv("AWS_VPC_CIDR_BLOCK")
+	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
+	awsRegion := os.Getenv("AWS_REGION")
+	providerName := "AWS"
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	awsSGroup := os.Getenv("AWS_SECURITY_GROUP_ID")
+	comment := fmt.Sprintf("TestAcc for awsSecurityGroup (%s)", awsSGroup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_security_group"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "comment"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(dataSourceName, "aws_security_group", awsSGroup),
+					resource.TestCheckResourceAttr(dataSourceName, "comment", comment),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_project_ip_access_list_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_project_ip_access_list_test.go
@@ -1,0 +1,166 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccProjectDSProjectIPAccessList_SettingIPAddress(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProjectIPAccessList_SettingCIDRBlock(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	cidrBlock := fmt.Sprintf("179.154.226.%d/32", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProjectIPAccessList_SettingAWSSecurityGroup(t *testing.T) {
+	SkipTestExtCred(t)
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	vpcID := os.Getenv("AWS_VPC_ID")
+	vpcCIDRBlock := os.Getenv("AWS_VPC_CIDR_BLOCK")
+	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
+	awsRegion := os.Getenv("AWS_REGION")
+	providerName := "AWS"
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	awsSGroup := os.Getenv("AWS_SECURITY_GROUP_ID")
+	comment := fmt.Sprintf("TestAcc for awsSecurityGroup (%s)", awsSGroup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_security_group"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_security_group", awsSGroup),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project.test.id
+			ip_address = %[3]q
+			comment    = %[4]q
+		}
+
+		data "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project_ip_access_list.test.project_id
+			ip_address = mongodbatlas_project_ip_access_list.test.ip_address
+		}
+	`, orgID, projectName, ipAddress, comment)
+}
+
+func testAccDataMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project.test.id
+			cidr_block = %[3]q
+			comment    = %[4]q
+		}
+		data "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project_ip_access_list.test.project_id
+			cidr_block = mongodbatlas_project_ip_access_list.test.cidr_block
+		}
+	`, orgID, projectName, cidrBlock, comment)
+}
+
+func testAccDataMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.208.0/21"
+			provider_name		  = "%[2]s"
+			region_name			  = "%[6]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			accepter_region_name    = lower(replace("%[6]s", "_", "-"))
+			project_id    		    = "%[1]s"
+			container_id            = mongodbatlas_network_container.test.container_id
+			provider_name           = "%[2]s"
+			route_table_cidr_block  = "%[5]s"
+			vpc_id					        = "%[3]s"
+			aws_account_id	        = "%[4]s"
+		}
+
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id         = "%[1]s"
+			aws_security_group = "%[7]s"
+			comment            = "%[8]s"
+
+			depends_on = ["mongodbatlas_network_peering.test"]
+		}
+
+		data "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project_ip_access_list.test.project_id
+			aws_security_group = mongodbatlas_project_ip_access_list.test.aws_security_group
+		}
+	`, projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment)
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_project_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_project_test.go
@@ -1,0 +1,166 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"go.mongodb.org/atlas-sdk/v20230201002/admin"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccProjectDSProject_byID(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("test-acc")
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectDSByIDUsingRS(testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttr("mongodbatlas_project.test", "teams.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProject_byName(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("test-acc")
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectDSByNameUsingRS(testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttr("mongodbatlas_project.test", "teams.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProject_defaultFlags(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("test-acc")
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectDSByNameUsingRS(testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_collect_database_specifics_statistics_enabled"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_data_explorer_enabled"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_extended_storage_sizes_enabled"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_performance_advisor_enabled"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_realtime_performance_panel_enabled"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "is_schema_advisor_enabled"),
+					resource.TestCheckResourceAttr("mongodbatlas_project.test", "teams.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProject_limits(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("test-acc")
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectDSByNameUsingRS(testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{})),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_project.test", "limits.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasProjectDSByNameUsingRS(rs string) string {
+	return fmt.Sprintf(`
+		%s
+
+		data "mongodbatlas_project" "test" {
+			name = "${mongodbatlas_project.test.name}"
+		}
+	`, rs)
+}
+
+func testAccMongoDBAtlasProjectDSByIDUsingRS(rs string) string {
+	return fmt.Sprintf(`
+		%s
+
+		data "mongodbatlas_project" "test" {
+			project_id = "${mongodbatlas_project.test.id}"
+		}
+	`, rs)
+}

--- a/test/acceptance-test/fw_data_source_mongodbatlas_projects_test.go
+++ b/test/acceptance-test/fw_data_source_mongodbatlas_projects_test.go
@@ -1,0 +1,107 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccProjectDSProjects_basic(t *testing.T) {
+	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectsConfigWithDS(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttr("mongodbatlas_project.test", "teams.#", "2"),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_projects.test", "total_count"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_projects.test", "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectDSProjects_withPagination(t *testing.T) {
+	projectName := fmt.Sprintf("test-datasource-project-%s", acctest.RandString(10))
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	teamsIds := strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectsConfigWithPagination(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+					2, 5,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "name"),
+					resource.TestCheckResourceAttrSet("mongodbatlas_project.test", "org_id"),
+					resource.TestCheckResourceAttr("mongodbatlas_project.test", "teams.#", "2"),
+					// Test for Data source
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_projects.test", "total_count"),
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_projects.test", "results.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasProjectsConfigWithDS(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+	config := fmt.Sprintf(`
+		%s
+		data "mongodbatlas_projects" "test" {}
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams))
+	return config
+}
+
+func testAccMongoDBAtlasProjectsConfigWithPagination(projectName, orgID string, teams []*matlas.ProjectTeam, pageNum, itemPage int) string {
+	return fmt.Sprintf(`
+		%s
+		data "mongodbatlas_projects" "test" {
+			page_num = %d
+			items_per_page = %d
+		}
+	`, testAccMongoDBAtlasProjectConfig(projectName, orgID, teams), pageNum, itemPage)
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_alert_configuration_migration_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_alert_configuration_migration_test.go
@@ -1,0 +1,282 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSAlertConfiguration_Migration_NotificationsWithMetricThreshold(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+		config       = testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName, true)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_Migration_WithThreshold(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+		config       = testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(orgID, projectName, true, 1)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "matcher.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_config.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_Migration_EmptyOptionalBlocks(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+		config       = testAccMongoDBAtlasAlertConfigurationConfigEmptyOptionalBlocks(orgID, projectName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "matcher.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metric_threshold_config.#", "0"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_Migration_MultipleMatchers(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+		config       = testAccMongoDBAtlasAlertConfigurationConfigWithMatchers(orgID, projectName, true, false, true,
+			matlas.Matcher{
+				FieldName: "TYPE_NAME",
+				Operator:  "EQUALS",
+				Value:     "SECONDARY",
+			},
+			matlas.Matcher{
+				FieldName: "TYPE_NAME",
+				Operator:  "CONTAINS",
+				Value:     "MONGOS",
+			})
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "matcher.#", "2"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_Migration_EmptyOptionalAttributes(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+		config       = testAccMongoDBAtlasAlertConfigurationConfigWithEmptyOptionalAttributes(orgID, projectName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// does not define notification.delay_min, notification.sms_enabled, and metric_threshold_config.threshold
+func testAccMongoDBAtlasAlertConfigurationConfigWithEmptyOptionalAttributes(orgID, projectName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "OUTSIDE_METRIC_THRESHOLD"
+		  
+			notification {
+			  type_name     = "ORG"
+			  interval_min  = 5
+			  email_enabled   = true
+			}
+		  
+			metric_threshold_config {
+			  metric_name = "ASSERT_REGULAR"
+			  operator    = "LESS_THAN"
+			  units       = "RAW"
+			  mode        = "AVERAGE"
+			} 
+		  }
+	`, orgID, projectName)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigEmptyOptionalBlocks(orgID, projectName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "NO_PRIMARY"
+			enabled    = true
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = true
+				email_enabled = false
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY"]
+			}
+		}
+	`, orgID, projectName)
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -1,0 +1,861 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	encodedIDKeyProjectID = "project_id"
+	encodedIDKeyAlertID   = "id"
+)
+
+func TestAccConfigRSAlertConfiguration_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_EmptyMetricThresholdConfig(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigEmptyMetricThresholdConfig(orgID, projectName, true),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_Notifications(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigNotifications(orgID, projectName, true, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigNotifications(orgID, projectName, false, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_WithMatchers(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithMatchers(orgID, projectName, true, false, true,
+					matlas.Matcher{
+						FieldName: "TYPE_NAME",
+						Operator:  "EQUALS",
+						Value:     "SECONDARY",
+					},
+					matlas.Matcher{
+						FieldName: "TYPE_NAME",
+						Operator:  "CONTAINS",
+						Value:     "MONGOS",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithMatchers(orgID, projectName, false, true, false,
+					matlas.Matcher{
+						FieldName: "TYPE_NAME",
+						Operator:  "NOT_EQUALS",
+						Value:     "SECONDARY",
+					},
+					matlas.Matcher{
+						FieldName: "HOSTNAME",
+						Operator:  "EQUALS",
+						Value:     "PRIMARY",
+					}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_withMetricUpdated(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithMetrictUpdated(orgID, projectName, true, 99.0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithMetrictUpdated(orgID, projectName, false, 89.7),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_whitThresholdUpdated(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(orgID, projectName, true, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(orgID, projectName, false, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "matcher.0.field_name"},
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_whitoutRoles(t *testing.T) {
+	var (
+		alert        = &matlas.AlertConfiguration{}
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithoutRoles(orgID, projectName, true, 99.0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_withoutOptionalAttributes(t *testing.T) {
+	var (
+		alert        = &matlas.AlertConfiguration{}
+		resourceName = "mongodbatlas_alert_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithEmptyOptionalAttributes(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_importBasic(t *testing.T) {
+	var (
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		resourceName = "mongodbatlas_alert_configuration.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName, true),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id"},
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_importConfigNotifications(t *testing.T) {
+	var (
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		resourceName = "mongodbatlas_alert_configuration.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigNotifications(orgID, projectName, true, true, false),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id"},
+			},
+		},
+	})
+}
+
+// used for testing notification that does not define interval_min attribute
+func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		serviceKey   = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"notification.0.service_key"}, // service key is not returned by api in import operation
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	SkipTest(t)        // Will force skip if enabled
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		ddAPIKey     = os.Getenv("DD_API_KEY")
+		ddRegion     = "US"
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(projectID, ddAPIKey, ddRegion, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		serviceKey   = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey       = os.Getenv("OPS_GENIE_API_KEY")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(projectID, apiKey, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
+	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
+	var (
+		resourceName = "mongodbatlas_alert_configuration.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey       = os.Getenv("VICTOR_OPS_API_KEY")
+		alert        = &matlas.AlertConfiguration{}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(projectID, apiKey, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName string, alert *matlas.AlertConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		alertResp, _, err := conn.AlertConfigurations.GetAnAlertConfig(context.Background(), ids[encodedIDKeyProjectID], ids[encodedIDKeyAlertID])
+		if err != nil {
+			return fmt.Errorf("the Alert Configuration(%s) does not exist", ids[encodedIDKeyAlertID])
+		}
+
+		alert = alertResp
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAlertConfigurationDestroy(s *terraform.State) error {
+	conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_alert_configuration" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		alert, _, err := conn.AlertConfigurations.GetAnAlertConfig(context.Background(), ids[encodedIDKeyProjectID], ids[encodedIDKeyAlertID])
+		if alert != nil {
+			return fmt.Errorf("the Project Alert Configuration(%s) still exists %s", ids[encodedIDKeyAlertID], err)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["alert_configuration_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = mongodbatlas_project.test.id
+  event_type = "OUTSIDE_METRIC_THRESHOLD"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name     = "GROUP"
+    interval_min  = 5
+    delay_min     = 0
+    sms_enabled   = false
+    email_enabled = true
+    roles = ["GROUP_DATA_ACCESS_READ_ONLY", "GROUP_CLUSTER_MANAGER", "GROUP_DATA_ACCESS_ADMIN"]
+  }
+
+  notification {
+    type_name     = "ORG"
+    interval_min  = 5
+    delay_min     = 0
+    sms_enabled   = true
+    email_enabled = false
+  }
+
+  matcher {
+    field_name = "HOSTNAME_AND_PORT"
+    operator   = "EQUALS"
+    value      = "SECONDARY"
+  }
+
+  metric_threshold_config {
+    metric_name = "ASSERT_REGULAR"
+    operator    = "LESS_THAN"
+    threshold   = 99.0
+    units       = "RAW"
+    mode        = "AVERAGE"
+  } 
+}
+	`, orgID, projectName, enabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigNotifications(orgID, projectName string, enabled, smsEnabled, emailEnabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "NO_PRIMARY"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = %[4]t
+				email_enabled = %[5]t
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY"]
+			}
+
+			notification {
+				type_name     = "ORG"
+				interval_min  = 5
+				delay_min     = 1
+				sms_enabled   = %[4]t
+				email_enabled = %[5]t
+			}
+		}
+	`, orgID, projectName, enabled, smsEnabled, emailEnabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigWithMatchers(orgID, projectName string, enabled, smsEnabled, emailEnabled bool, m1, m2 matlas.Matcher) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "HOST_DOWN"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = %[4]t
+				email_enabled = %[5]t
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY", "GROUP_CLUSTER_MANAGER"]
+			}
+
+			matcher {
+				field_name = %[6]q
+				operator   = %[7]q
+				value      = %[8]q
+			}
+			matcher {
+				field_name = %[9]q
+				operator   = %[10]q
+				value      = %[11]q
+			}
+		}
+	`, orgID, projectName, enabled, smsEnabled, emailEnabled,
+		m1.FieldName, m1.Operator, m1.Value,
+		m2.FieldName, m2.Operator, m2.Value)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigWithMetrictUpdated(orgID, projectName string, enabled bool, threshold float64) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "OUTSIDE_METRIC_THRESHOLD"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = true
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY"]
+			}
+
+			matcher {
+				field_name = "HOSTNAME_AND_PORT"
+				operator   = "EQUALS"
+				value      = "SECONDARY"
+			}
+
+			metric_threshold_config {
+				metric_name = "ASSERT_REGULAR"
+				operator    = "LESS_THAN"
+				threshold   = %[4]f
+				units       = "RAW"
+				mode        = "AVERAGE"
+			}
+		}
+	`, orgID, projectName, enabled, threshold)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigWithoutRoles(orgID, projectName string, enabled bool, threshold float64) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "OUTSIDE_METRIC_THRESHOLD"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "EMAIL"
+				email_address = "mongodbatlas.testing@gmail.com"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = false
+			}
+
+			matcher {
+				field_name = "HOSTNAME_AND_PORT"
+				operator   = "EQUALS"
+				value      = "SECONDARY"
+			}
+
+			metric_threshold_config {
+				metric_name = "ASSERT_REGULAR"
+				operator    = "LESS_THAN"
+				threshold   = %[4]f
+				units       = "RAW"
+				mode        = "AVERAGE"
+			}
+		}
+	`, orgID, projectName, enabled, threshold)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(orgID, projectName string, enabled bool, threshold float64) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = mongodbatlas_project.test.id
+			event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"
+			enabled    = "%[3]t"
+
+			notification {
+				type_name     = "GROUP"
+				interval_min  = 5
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = true
+				roles = ["GROUP_DATA_ACCESS_READ_ONLY", "GROUP_CLUSTER_MANAGER"]
+			}
+
+			matcher {
+				field_name = "REPLICA_SET_NAME"
+				operator   = "EQUALS"
+				value      = "SECONDARY"
+			}
+
+			threshold_config {
+				operator    = "LESS_THAN"
+				units       = "HOURS"
+				threshold   = %[4]f
+			}
+		}
+	`, orgID, projectName, enabled, threshold)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(projectID, dataDogAPIKey, dataDogRegion string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_third_party_integration" "atlas_datadog" {
+  project_id = "%[1]s"
+  type = "DATADOG"
+  api_key = "%[3]s"
+  region = "%[4]s"
+}
+
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = "%[1]s"
+  event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"
+  enabled    = %t
+
+  notification {
+    type_name     = "GROUP"
+    interval_min  = 5
+    delay_min     = 0
+    sms_enabled   = false
+    email_enabled = true
+    roles         = ["GROUP_OWNER"]
+  }
+
+  notification {
+    type_name = "DATADOG"
+    datadog_api_key = mongodbatlas_third_party_integration.atlas_datadog.api_key
+    datadog_region = mongodbatlas_third_party_integration.atlas_datadog.region
+    interval_min  = 5
+    delay_min     = 0
+  }
+
+  matcher {
+    field_name = "REPLICA_SET_NAME"
+    operator   = "EQUALS"
+    value      = "SECONDARY"
+  }
+
+  threshold_config {
+    operator    = "LESS_THAN"
+    threshold   = 72
+    units       = "HOURS"
+  }
+}
+	`, projectID, enabled, dataDogAPIKey, dataDogRegion)
+}
+
+func testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = %[1]q
+  event_type = "NO_PRIMARY"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name    = "PAGER_DUTY"
+    service_key  = %[2]q
+    delay_min    = 0
+  }
+}
+	`, projectID, serviceKey, enabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(projectID, apiKey string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = %[1]q
+  event_type = "NO_PRIMARY"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name          = "OPS_GENIE"
+    ops_genie_api_key  = %[2]q
+    ops_genie_region   = "US"
+    delay_min          = 0
+  }
+}
+	`, projectID, apiKey, enabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(projectID, apiKey string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = %[1]q
+  event_type = "NO_PRIMARY"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name              = "VICTOR_OPS"
+    victor_ops_api_key     = %[2]q
+    victor_ops_routing_key = "testing"
+    delay_min              = 0
+  }
+}
+	`, projectID, apiKey, enabled)
+}
+
+func testAccMongoDBAtlasAlertConfigurationConfigEmptyMetricThresholdConfig(orgID, projectName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = mongodbatlas_project.test.id
+  event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"
+  enabled    = "%[3]t"
+
+  notification {
+    type_name     = "GROUP"
+    interval_min  = 60
+    delay_min     = 0
+    sms_enabled   = true
+    email_enabled = false
+	roles         = ["GROUP_OWNER"]
+  }
+
+  threshold_config {
+    operator    = "LESS_THAN"
+    threshold   = 72
+    units       = "HOURS"
+  }
+
+}
+	`, orgID, projectName, enabled)
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_database_user_migration_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_database_user_migration_test.go
@@ -1,0 +1,455 @@
+package acceptancetests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSDatabaseUser_Migration_Basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.basic_ds"
+		username     = acctest.RandomWithPrefix("dbUser")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithX509TypeCustomer(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=ellen@example.com,OU=users,DC=example,DC=com"
+		x509Type     = "CUSTOMER"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+func TestAccConfigRSDatabaseUser_Migration_WithAWSIAMType(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithLabels(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username,
+					[]matlas.Label{
+						{
+							Key:   "key 1",
+							Value: "value 1",
+						},
+						{
+							Key:   "key 2",
+							Value: "value 2",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username,
+					[]matlas.Label{
+						{
+							Key:   "key 1",
+							Value: "value 1",
+						},
+						{
+							Key:   "key 2",
+							Value: "value 2",
+						},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+func TestAccConfigRSDatabaseUser_Migration_WithEmptyLabels(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username, []matlas.Label{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username, []matlas.Label{}),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithRoles(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectName, orgID,
+					[]*matlas.Role{
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "stir",
+						},
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "unpledged",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config: testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectName, orgID,
+					[]*matlas.Role{
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "stir",
+						},
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "unpledged",
+						},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithScopes(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "CLUSTER",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "CLUSTER",
+						},
+					},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithScopesAndEmpty(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "0"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{},
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_Migration_WithLDAPAuthType(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=david@example.com,OU=users,DC=example,DC=com"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "ldap_auth_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_database_user_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_database_user_test.go
@@ -1,0 +1,934 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSDatabaseUser_basic(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.basic_ds"
+		username     = acctest.RandomWithPrefix("dbUser")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "read", username, "Second Key", "Second value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withX509TypeCustomer(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=ellen@example.com,OU=users,DC=example,DC=com"
+		x509Type     = "CUSTOMER"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withX509TypeManaged(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc")
+		x509Type     = "MANAGED"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withAWSIAMType(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withAWSIAMType_import(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = os.Getenv("TEST_DB_USER_IAM_ARN")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	if username == "" {
+		username = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_WithLabels(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username, []matlas.Label{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username,
+					[]matlas.Label{
+						{
+							Key:   "key 1",
+							Value: "value 1",
+						},
+						{
+							Key:   "key 2",
+							Value: "value 2",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "read", username,
+					[]matlas.Label{
+						{
+							Key:   "key 4",
+							Value: "value 4",
+						},
+						{
+							Key:   "key 3",
+							Value: "value 3",
+						},
+						{
+							Key:   "key 2",
+							Value: "value 2",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withRoles(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectName, orgID,
+					[]*matlas.Role{
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "stir",
+						},
+						{
+							RoleName:       "read",
+							DatabaseName:   "admin",
+							CollectionName: "unpledged",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectName, orgID,
+					[]*matlas.Role{
+						{
+							RoleName:     "read",
+							DatabaseName: "admin",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withScopes(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "CLUSTER",
+						},
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "DATA_LAKE",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "CLUSTER",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withScopesAndEmpty(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc-user-")
+		password     = acctest.RandomWithPrefix("test-acc-pass-")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "CLUSTER",
+						},
+						{
+							Name: "test-acc-nurk4llu2z",
+							Type: "DATA_LAKE",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, "atlasAdmin", clusterName,
+					[]*matlas.Scope{},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "scopes.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=david@example.com,OU=users,DC=example,DC=com"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "ldap_auth_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_importBasic(t *testing.T) {
+	var (
+		username     = fmt.Sprintf("test-username-%s", acctest.RandString(5))
+		resourceName = "mongodbatlas_database_user.basic_ds"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "read", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_importX509TypeCustomer(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=ellen@example.com,OU=users,DC=example,DC=com"
+		x509Type     = "CUSTOMER"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccConfigRSDatabaseUser_importLDAPAuthType(t *testing.T) {
+	var (
+		dbUser       matlas.DatabaseUser
+		resourceName = "mongodbatlas_database_user.test"
+		username     = "CN=david@example.com,OU=users,DC=example,DC=com"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDatabaseUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDatabaseUserExists(resourceName, &dbUser),
+					testAccCheckMongoDBAtlasDatabaseUserAttributes(&dbUser, username),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "ldap_auth_type", "USER"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		projectID, username, authDatabaseName, err := mongodbatlas.SplitDatabaseUserImportID(rs.Primary.ID)
+		if err != nil {
+			return "", fmt.Errorf("error splitting database User info from ID: %s", rs.Primary.ID)
+		}
+
+		return fmt.Sprintf("%s-%s-%s", projectID, username, authDatabaseName), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasDatabaseUserExists(resourceName string, dbUser *matlas.DatabaseUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no project_id is set")
+		}
+
+		if rs.Primary.Attributes["auth_database_name"] == "" {
+			return fmt.Errorf("no auth_database_name is set")
+		}
+
+		if rs.Primary.Attributes["username"] == "" {
+			return fmt.Errorf("no username is set")
+		}
+
+		authDB := rs.Primary.Attributes["auth_database_name"]
+		projectID := rs.Primary.Attributes["project_id"]
+		username := rs.Primary.Attributes["username"]
+
+		if dbUserResp, _, err := conn.DatabaseUsers.Get(context.Background(), authDB, projectID, username); err == nil {
+			*dbUser = *dbUserResp
+			return nil
+		}
+
+		return fmt.Errorf("database user(%s-%s-%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["username"], rs.Primary.Attributes["auth_database_name"])
+	}
+}
+
+func testAccCheckMongoDBAtlasDatabaseUserAttributes(dbUser *matlas.DatabaseUser, username string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Printf("[DEBUG] difference dbUser.Username: %s , username : %s", dbUser.Username, username)
+		if dbUser.Username != username {
+			return fmt.Errorf("bad username: %s", dbUser.Username)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasDatabaseUserDestroy(s *terraform.State) error {
+	conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_database_user" {
+			continue
+		}
+
+		projectID, username, authDatabaseName, err := mongodbatlas.SplitDatabaseUserImportID(rs.Primary.ID)
+		if err != nil {
+			continue
+		}
+		// Try to find the database user
+		_, _, err = conn.DatabaseUsers.Get(context.Background(), authDatabaseName, projectID, username)
+		if err == nil {
+			return fmt.Errorf("database user (%s) still exists", projectID)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, roleName, username, keyLabel, valueLabel string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "basic_ds" {
+			username           = "%[4]s"
+			password           = "test-acc-password"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = "%[3]s"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		}
+	`, projectName, orgID, roleName, username, keyLabel, valueLabel)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, roleName, username, keyLabel, valueLabel, x509Type string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%[4]s"
+			x509_type          = "%[7]s"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "$external"
+
+			roles {
+				role_name     = "%[3]s"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		}
+	`, projectName, orgID, roleName, username, keyLabel, valueLabel, x509Type)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, roleName, username string, labels []matlas.Label) string {
+	var labelsConf string
+	for _, label := range labels {
+		labelsConf += fmt.Sprintf(`
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		`, label.Key, label.Value)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%[4]s"
+			password           = "test-acc-password"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = "%[3]s"
+				database_name = "admin"
+			}
+
+			%[5]s
+
+		}
+	`, projectName, orgID, roleName, username, labelsConf)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithRoles(username, password, projectName, orgID string, rolesArr []*matlas.Role) string {
+	var roles string
+
+	for _, role := range rolesArr {
+		var roleName, databaseName, collection string
+
+		if role.RoleName != "" {
+			roleName = fmt.Sprintf(`role_name = %q`, role.RoleName)
+		}
+
+		if role.DatabaseName != "" {
+			databaseName = fmt.Sprintf(`database_name = %q`, role.DatabaseName)
+		}
+
+		if role.CollectionName != "" {
+			collection = fmt.Sprintf(`collection_name = %q`, role.CollectionName)
+		}
+
+		roles += fmt.Sprintf(`
+			roles {
+				%s
+				%s
+				%s
+			}
+		`, roleName, databaseName, collection)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%s"
+			password           = "%s"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "admin"
+
+			%s
+
+		}
+	`, projectName, orgID, username, password, roles)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, roleName, username, keyLabel, valueLabel string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%[4]s"
+			aws_iam_type       = "USER"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "$external"
+
+			roles {
+				role_name     = "%[3]s"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		}
+	`, projectName, orgID, roleName, username, keyLabel, valueLabel)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithScopes(username, password, projectName, orgID, roleName, clusterName string, scopesArr []*matlas.Scope) string {
+	var scopes string
+
+	for _, scope := range scopesArr {
+		var scopeType string
+
+		if scope.Type != "" {
+			scopeType = fmt.Sprintf(`type = %q`, scope.Type)
+		}
+
+		scopes += fmt.Sprintf(`
+			scopes {
+				name = "${mongodbatlas_cluster.my_cluster.name}"
+				%s
+			}
+		`, scopeType)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = "${mongodbatlas_project.test.id}"
+			name         = "%s"
+			
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			provider_backup_enabled     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%s"
+			password           = "%s"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "admin"
+
+			roles {
+				role_name     = "%s"
+				database_name = "admin"
+			}
+
+			%s
+
+		}
+	`, projectName, orgID, clusterName, username, password, roleName, scopes)
+}
+
+func testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, roleName, username, keyLabel, valueLabel string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "test" {
+			username           = "%[4]s"
+			ldap_auth_type     = "USER"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "$external"
+
+			roles {
+				role_name     = "%[3]s"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		}
+	`, projectName, orgID, roleName, username, keyLabel, valueLabel)
+}
+
+func TestMongoDBAtlasDatabaseUserResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	schemaRequest := fwresource.SchemaRequest{}
+	schemaResponse := &fwresource.SchemaResponse{}
+
+	// Instantiate the resource.Resource and call its Schema method
+	mongodbatlas.NewDatabaseUserRS().Schema(ctx, schemaRequest, schemaResponse)
+
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("Schema method diagnostics: %+v", schemaResponse.Diagnostics)
+	}
+
+	// Validate the schema
+	diagnostics := schemaResponse.Schema.ValidateImplementation(ctx)
+
+	if diagnostics.HasError() {
+		t.Fatalf("Schema validation diagnostics: %+v", diagnostics)
+	}
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_encryption_at_rest_migration_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_encryption_at_rest_migration_test.go
@@ -1,0 +1,222 @@
+package acceptancetests
+
+import (
+	"os"
+	"testing"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mwielbut/pointy"
+)
+
+func TestAccAdvRS_Migration_EncryptionAtRest_basicAWS(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		awsKms = matlas.AwsKms{
+			Enabled:             pointy.Bool(true),
+			CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID"),
+			Region:              os.Getenv("AWS_REGION"),
+			RoleID:              os.Getenv("AWS_ROLE_ID"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.Region),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.RoleID),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccAdvRS_Migration_EncryptionAtRest_WithRole_basicAWS(t *testing.T) {
+	SkipTest(t)
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		accessKeyID  = os.Getenv("AWS_ACCESS_KEY_ID")
+		secretKey    = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		policyName   = acctest.RandomWithPrefix("test-aws-policy")
+		roleName     = acctest.RandomWithPrefix("test-aws-role")
+
+		awsKms = matlas.AwsKms{
+			Enabled:             pointy.Bool(true),
+			CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID"),
+			Region:              os.Getenv("AWS_REGION"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.Region, accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.Region, accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.Region),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.RoleID),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccAdvRS_Migration_EncryptionAtRest_basicAzure(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		azureKeyVault = matlas.AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			ClientID:          os.Getenv("AZURE_CLIENT_ID"),
+			AzureEnvironment:  "AZURE",
+			SubscriptionID:    os.Getenv("AZURE_SUBSCRIPTION_ID"),
+			ResourceGroupName: os.Getenv("AZURE_RESOURCE_GROUP_NAME"),
+			KeyVaultName:      os.Getenv("AZURE_KEY_VAULT_NAME"),
+			KeyIdentifier:     os.Getenv("AZURE_KEY_IDENTIFIER"),
+			Secret:            os.Getenv("AZURE_SECRET"),
+			TenantID:          os.Getenv("AZURE_TENANT_ID"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testCheckEncryptionAtRestEnvAzure(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVault.AzureEnvironment),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVault.ResourceGroupName),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVault.KeyVaultName),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccAdvRS_Migration_EncryptionAtRest_basicGCP(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		googleCloudKms = matlas.GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			ServiceAccountKey:    os.Getenv("GCP_SERVICE_ACCOUNT_KEY"),
+			KeyVersionResourceID: os.Getenv("GCP_KEY_VERSION_RESOURCE_ID"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckGPCEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_encryption_at_rest_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_encryption_at_rest_test.go
@@ -1,0 +1,445 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+)
+
+const (
+	initialConfigEncryptionRestRoleAWS = `
+provider "aws" {
+	region     = lower(replace("%[1]s", "_", "-"))
+	access_key = "%[2]s"
+	secret_key = "%[3]s"
+}
+
+%[7]s
+
+resource "mongodbatlas_cloud_provider_access" "test" {
+	project_id = "%[4]s"
+	provider_name = "AWS"
+	%[8]s
+		
+}
+
+resource "aws_iam_role_policy" "test_policy" {
+  name = "%[5]s"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+ name = "%[6]s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access.test.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access.test.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}
+
+%[9]s
+
+`
+	configEncryptionRest = `
+resource "mongodbatlas_encryption_at_rest" "test" {
+	project_id = "%s"
+
+	aws_kms_config {
+		enabled                = %t
+		customer_master_key_id = "%s"
+		region                 = "%s"
+		role_id = mongodbatlas_cloud_provider_access.test.role_id
+	}
+}`
+	dataAWSARNConfig = `
+data "aws_iam_role" "test" {
+  name = "%s"
+}
+
+`
+)
+
+func TestAccAdvRSEncryptionAtRest_basicAWS(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		awsKms = matlas.AwsKms{
+			Enabled:             pointy.Bool(true),
+			AccessKeyID:         os.Getenv("AWS_ACCESS_KEY_ID"),
+			SecretAccessKey:     os.Getenv("AWS_SECRET_ACCESS_KEY"),
+			CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID"),
+			Region:              os.Getenv("AWS_REGION"),
+			RoleID:              os.Getenv("AWS_ROLE_ID"),
+		}
+
+		awsKmsUpdated = matlas.AwsKms{
+			Enabled:             pointy.Bool(true),
+			AccessKeyID:         os.Getenv("AWS_ACCESS_KEY_ID_UPDATED"),
+			SecretAccessKey:     os.Getenv("AWS_SECRET_ACCESS_KEY_UPDATED"),
+			CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID_UPDATED"),
+			Region:              os.Getenv("AWS_REGION_UPDATED"),
+			RoleID:              os.Getenv("AWS_ROLE_ID"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.Region),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.RoleID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKmsUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKmsUpdated.Region),
+					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKmsUpdated.RoleID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"google_cloud_kms_config", "azure_key_vault_config"},
+			},
+		},
+	})
+}
+
+func TestAccAdvRSEncryptionAtRest_basicAzure(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		azureKeyVault = matlas.AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			ClientID:          os.Getenv("AZURE_CLIENT_ID"),
+			AzureEnvironment:  "AZURE",
+			SubscriptionID:    os.Getenv("AZURE_SUBSCRIPTION_ID"),
+			ResourceGroupName: os.Getenv("AZURE_RESOURCE_GROUP_NAME"),
+			KeyVaultName:      os.Getenv("AZURE_KEY_VAULT_NAME"),
+			KeyIdentifier:     os.Getenv("AZURE_KEY_IDENTIFIER"),
+			Secret:            os.Getenv("AZURE_SECRET"),
+			TenantID:          os.Getenv("AZURE_TENANT_ID"),
+		}
+
+		azureKeyVaultUpdated = matlas.AzureKeyVault{
+			Enabled:           pointy.Bool(true),
+			ClientID:          os.Getenv("AZURE_CLIENT_ID_UPDATED"),
+			AzureEnvironment:  "AZURE",
+			SubscriptionID:    os.Getenv("AZURE_SUBSCRIPTION_ID"),
+			ResourceGroupName: os.Getenv("AZURE_RESOURCE_GROUP_NAME_UPDATED"),
+			KeyVaultName:      os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED"),
+			KeyIdentifier:     os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED"),
+			Secret:            os.Getenv("AZURE_SECRET_UPDATED"),
+			TenantID:          os.Getenv("AZURE_TENANT_ID"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckEncryptionAtRestEnvAzure(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVault.AzureEnvironment),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVault.ResourceGroupName),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVault.KeyVaultName),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVaultUpdated.AzureEnvironment),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVaultUpdated.ResourceGroupName),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVaultUpdated.KeyVaultName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// "azure_key_vault_config.0.secret" is a sensitive value not returned by the API
+				ImportStateVerifyIgnore: []string{"google_cloud_kms_config", "aws_kms_config", "azure_key_vault_config.0.secret"},
+			},
+		},
+	})
+}
+
+func TestAccAdvRSEncryptionAtRest_basicGCP(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		googleCloudKms = matlas.GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			ServiceAccountKey:    os.Getenv("GCP_SERVICE_ACCOUNT_KEY"),
+			KeyVersionResourceID: os.Getenv("GCP_KEY_VERSION_RESOURCE_ID"),
+		}
+
+		googleCloudKmsUpdated = matlas.GoogleCloudKms{
+			Enabled:              pointy.Bool(true),
+			ServiceAccountKey:    os.Getenv("GCP_SERVICE_ACCOUNT_KEY_UPDATED"),
+			KeyVersionResourceID: os.Getenv("GCP_KEY_VERSION_RESOURCE_ID_UPDATED"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testAccPreCheckGPCEnv(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKmsUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// "google_cloud_kms_config.0.service_account_key" is a sensitive value not returned by the API
+				ImportStateVerifyIgnore: []string{"aws_kms_config", "azure_key_vault_config", "google_cloud_kms_config.0.service_account_key"},
+			},
+		},
+	})
+}
+
+func TestAccAdvRSEncryptionAtRestWithRole_basicAWS(t *testing.T) {
+	SkipTest(t) // For now it will skipped because of aws errors reasons, already made another test using terratest.
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		accessKeyID  = os.Getenv("AWS_ACCESS_KEY_ID")
+		secretKey    = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		policyName   = acctest.RandomWithPrefix("test-aws-policy")
+		roleName     = acctest.RandomWithPrefix("test-aws-role")
+
+		awsKms = matlas.AwsKms{
+			Enabled:             pointy.Bool(true),
+			CustomerMasterKeyID: os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID"),
+			Region:              os.Getenv("AWS_REGION"),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"aws": {
+				VersionConstraint: "5.1.0",
+				Source:            "hashicorp/aws",
+			},
+		},
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.Region, accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
+			},
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.Region, accessKeyID, secretKey, projectID, policyName, roleName, true, &awsKms),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"google_cloud_kms_config", "azure_key_vault_config"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		if _, _, err := conn.EncryptionsAtRest.Get(context.Background(), rs.Primary.ID); err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("encryptionAtRest (%s) does not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCheckMongoDBAtlasEncryptionAtRestDestroy(s *terraform.State) error {
+	conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_encryption_at_rest" {
+			continue
+		}
+
+		res, _, err := conn.EncryptionsAtRest.Get(context.Background(), rs.Primary.ID)
+
+		if err != nil ||
+			(*res.AwsKms.Enabled != false &&
+				*res.AzureKeyVault.Enabled != false &&
+				*res.GoogleCloudKms.Enabled != false) {
+			return fmt.Errorf("encryptionAtRest (%s) still exists: err: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID string, aws *matlas.AwsKms) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  aws_kms_config {
+				enabled                = %t
+				customer_master_key_id = "%s"
+				region                 = "%s"
+				role_id              = "%s"
+			}
+		}
+	`, projectID, *aws.Enabled, aws.CustomerMasterKeyID, aws.Region, aws.RoleID)
+}
+
+func testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID string, azure *matlas.AzureKeyVault) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  azure_key_vault_config {
+				enabled             = %t
+				client_id           = "%s"
+				azure_environment   = "%s"
+				subscription_id     = "%s"
+				resource_group_name = "%s"
+				key_vault_name  	  = "%s"
+				key_identifier  	  = "%s"
+				secret  						= "%s"
+				tenant_id  					= "%s"
+			}
+		}
+	`, projectID, *azure.Enabled, azure.ClientID, azure.AzureEnvironment, azure.SubscriptionID, azure.ResourceGroupName,
+		azure.KeyVaultName, azure.KeyIdentifier, azure.Secret, azure.TenantID)
+}
+
+func testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID string, google *matlas.GoogleCloudKms) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  google_cloud_kms_config {
+				enabled                 = %t
+				service_account_key     = "%s"
+				key_version_resource_id = "%s"
+			}
+		}
+	`, projectID, *google.Enabled, google.ServiceAccountKey, google.KeyVersionResourceID)
+}
+
+func testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName string, isUpdate bool, aws *matlas.AwsKms) string {
+	config := fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, "", "", "")
+	if isUpdate {
+		configEncrypt := fmt.Sprintf(configEncryptionRest, projectID, *aws.Enabled, aws.CustomerMasterKeyID, aws.Region)
+		dataAWSARN := fmt.Sprintf(dataAWSARNConfig, awsRoleName)
+		dataARN := `iam_assumed_role_arn = data.aws_iam_role.test.arn`
+		config = fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, dataAWSARN, dataARN, configEncrypt)
+	}
+	return config
+}
+
+func testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_project_ip_access_list_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_project_ip_access_list_test.go
@@ -1,0 +1,371 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccProjectRSProjectIPAccesslist_SettingIPAddress(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
+
+	updatedIPAddress := fmt.Sprintf("179.154.228.%d", acctest.RandIntRange(0, 255))
+	updatedComment := fmt.Sprintf("TestAcc for ipAddress updated (%s)", updatedIPAddress)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, updatedIPAddress, updatedComment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", updatedIPAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", updatedComment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_SettingCIDRBlock(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	cidrBlock := fmt.Sprintf("179.154.226.%d/32", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
+
+	updatedCIDRBlock := fmt.Sprintf("179.154.228.%d/32", acctest.RandIntRange(0, 255))
+	updatedComment := fmt.Sprintf("TestAcc for cidrBlock updated (%s)", updatedCIDRBlock)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, updatedCIDRBlock, updatedComment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),
+					resource.TestCheckResourceAttr(resourceName, "comment", updatedComment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_SettingAWSSecurityGroup(t *testing.T) {
+	SkipTestExtCred(t)
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	vpcID := os.Getenv("AWS_VPC_ID")
+	vpcCIDRBlock := os.Getenv("AWS_VPC_CIDR_BLOCK")
+	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
+	awsRegion := os.Getenv("AWS_REGION")
+	providerName := "AWS"
+
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	awsSGroup := "sg-0026348ec11780bd1"
+	comment := fmt.Sprintf("TestAcc for awsSecurityGroup (%s)", awsSGroup)
+
+	updatedAWSSgroup := "sg-0026348ec11780bd2"
+	updatedComment := fmt.Sprintf("TestAcc for awsSecurityGroup updated (%s)", updatedAWSSgroup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_security_group"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_security_group", awsSGroup),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, updatedAWSSgroup, updatedComment),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_security_group"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "aws_security_group", updatedAWSSgroup),
+					resource.TestCheckResourceAttr(resourceName, "comment", updatedComment),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_SettingMultiple(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test_%d"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	const ipWhiteListCount = 20
+	accessList := make([]map[string]string, 0)
+
+	for i := 0; i < ipWhiteListCount; i++ {
+		entry := make(map[string]string)
+		entryName := ""
+		ipAddr := ""
+
+		if i%2 == 0 {
+			entryName = "cidr_block"
+			entry["cidr_block"] = fmt.Sprintf("%d.2.3.%d/32", i, acctest.RandIntRange(0, 255))
+			ipAddr = entry["cidr_block"]
+		} else {
+			entryName = "ip_address"
+			entry["ip_address"] = fmt.Sprintf("%d.2.3.%d", i, acctest.RandIntRange(0, 255))
+			ipAddr = entry["ip_address"]
+		}
+		entry["comment"] = fmt.Sprintf("TestAcc for %s (%s)", entryName, ipAddr)
+
+		accessList = append(accessList, entry)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID, accessList, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 0)),
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 1)),
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 2)),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID, accessList, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 0)),
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 1)),
+					testAccCheckMongoDBAtlasProjectIPAccessListExists(fmt.Sprintf(resourceName, 2)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_importBasic(t *testing.T) {
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for ipaddres (%s)", ipAddress)
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectIPAccessListImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.ProjectIPAccessList.Get(context.Background(), ids["project_id"], ids["entry"])
+		if err != nil {
+			return fmt.Errorf("project ip access list entry (%s) does not exist", ids["entry"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectIPAccessListDestroy(s *terraform.State) error {
+	conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_project_ip_access_list" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.ProjectIPAccessList.Get(context.Background(), ids["project_id"], ids["entry"])
+		if err == nil {
+			return fmt.Errorf("project ip access list entry (%s) still exists", ids["entry"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProjectIPAccessListImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["entry"]), nil
+	}
+}
+
+func testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project.test.id
+			ip_address = %[3]q
+			comment    = %[4]q
+		}
+	`, orgID, projectName, ipAddress, comment)
+}
+
+func testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id = mongodbatlas_project.test.id
+			cidr_block = %[3]q
+			comment    = %[4]q
+		}
+	`, orgID, projectName, cidrBlock, comment)
+}
+
+func testAccMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.208.0/21"
+			provider_name		  = "%[2]s"
+			region_name			  = "%[6]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			accepter_region_name	  = "us-east-1"
+			project_id    			    = "%[1]s"
+			container_id            = mongodbatlas_network_container.test.container_id
+			provider_name           = "%[2]s"
+			route_table_cidr_block  = "%[5]s"
+			vpc_id					        = "%[3]s"
+			aws_account_id	        = "%[4]s"
+		}
+
+		resource "mongodbatlas_project_ip_access_list" "test" {
+			project_id         = "%[1]s"
+			aws_security_group = "%[7]s"
+			comment            = "%[8]s"
+
+			depends_on = ["mongodbatlas_network_peering.test"]
+		}
+	`, projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment)
+}
+
+func testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID string, accessList []map[string]string, isUpdate bool) string {
+	config := fmt.Sprintf(`
+			resource "mongodbatlas_project" "test" {
+				name   = %[1]q
+				org_id = %[2]q
+			}`, projectName, orgID)
+
+	for i, entry := range accessList {
+		comment := entry["comment"]
+
+		if isUpdate {
+			comment = entry["comment"] + " update"
+		}
+
+		if cidr, ok := entry["cidr_block"]; ok {
+			config += fmt.Sprintf(`
+			resource "mongodbatlas_project_ip_access_list" "test_%[1]d" {
+				project_id   = mongodbatlas_project.test.id
+				cidr_block = %[2]q
+				comment    = %[3]q
+			}
+		`, i, cidr, comment)
+		} else {
+			config += fmt.Sprintf(`
+			resource "mongodbatlas_project_ip_access_list" "test_%[1]d" {
+				project_id   = mongodbatlas_project.test.id
+				ip_address = %[2]q
+				comment    = %[3]q
+			}
+		`, i, entry["ip_address"], comment)
+		}
+	}
+	return config
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_project_migration_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_project_migration_test.go
@@ -1,0 +1,367 @@
+package acceptancetests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"go.mongodb.org/atlas-sdk/v20230201002/admin"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+var _ plancheck.PlanCheck = debugPlan{}
+
+type debugPlan struct{}
+
+func (e debugPlan) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	rd, err := json.Marshal(req.Plan)
+	if err != nil {
+		tflog.Debug(ctx, fmt.Sprintf("error marshaling machine-readable plan output: %s", err))
+	}
+	tflog.Info(ctx, fmt.Sprintf("req.Plan - %s\n", string(rd)))
+}
+
+func DebugPlan() plancheck.PlanCheck {
+	return debugPlan{}
+}
+
+func TestAccRSProject_Migration_NoProps(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project.test"
+		projectName  = acctest.RandomWithPrefix("test-acc-migration")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: fmt.Sprintf(`resource "mongodbatlas_project" "test" {
+					name   = "%s"
+					org_id = "%s"
+				  }`, projectName, orgID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config: fmt.Sprintf(`resource "mongodbatlas_project" "test" {
+					name   = "%s"
+					org_id = "%s"
+				  }`, projectName, orgID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccRSProject_Migration_Teams(t *testing.T) {
+	var teamsIds = strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	if len(teamsIds) < 2 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 2 team ids for this acceptance testing")
+	}
+
+	var (
+		project         matlas.Project
+		resourceName    = "mongodbatlas_project.test"
+		projectName     = acctest.RandomWithPrefix("test-acc-teams")
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		clusterCount    = "0"
+		configWithTeams = testAccMongoDBAtlasProjectConfig(projectName, orgID,
+			[]*matlas.ProjectTeam{
+				{
+					TeamID:    teamsIds[0],
+					RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+				},
+				{
+					TeamID:    teamsIds[1],
+					RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+				},
+			})
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: configWithTeams,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   configWithTeams,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccRSProject_Migration_WithFalseDefaultSettings(t *testing.T) {
+	var (
+		project         matlas.Project
+		resourceName    = "mongodbatlas_project.test"
+		projectName     = acctest.RandomWithPrefix("tf-acc-project")
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID  = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+		configWithTeams = testAccMongoDBAtlasProjectConfigWithFalseDefaultSettings(projectName, orgID, projectOwnerID)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasicOwnerID(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: configWithTeams,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   configWithTeams,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccRSProject_Migration_WithLimits(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project.test"
+		projectName  = acctest.RandomWithPrefix("tf-acc-project")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		config       = testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+			{
+				Name:  "atlas.project.deployment.clusters",
+				Value: 1,
+			},
+			{
+				Name:  "atlas.project.deployment.nodesPerPrivateLinkRegion",
+				Value: 2,
+			},
+		})
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.clusters"),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "limits.1.name", "atlas.project.deployment.nodesPerPrivateLinkRegion"),
+					resource.TestCheckResourceAttr(resourceName, "limits.1.value", "2"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccesslist_Migration_SettingIPAddress(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for ipAddress (%s)", ipAddress)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_Migration_SettingCIDRBlock(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	cidrBlock := fmt.Sprintf("179.154.226.%d/32", acctest.RandIntRange(0, 255))
+	comment := fmt.Sprintf("TestAcc for cidrBlock (%s)", cidrBlock)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "comment"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectIPAccessList_Multiple_SettingMultiple(t *testing.T) {
+	resourceName := "mongodbatlas_project_ip_access_list.test_1"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	const ipWhiteListCount = 20
+	accessList := make([]map[string]string, 0)
+
+	for i := 0; i < ipWhiteListCount; i++ {
+		entry := make(map[string]string)
+		entryName := ""
+		ipAddr := ""
+
+		if i%2 == 0 {
+			entryName = "cidr_block"
+			entry["cidr_block"] = fmt.Sprintf("%d.2.3.%d/32", i, acctest.RandIntRange(0, 255))
+			ipAddr = entry["cidr_block"]
+		} else {
+			entryName = "ip_address"
+			entry["ip_address"] = fmt.Sprintf("%d.2.3.%d", i, acctest.RandIntRange(0, 255))
+			ipAddr = entry["ip_address"]
+		}
+		entry["comment"] = fmt.Sprintf("TestAcc for %s (%s)", entryName, ipAddr)
+
+		accessList = append(accessList, entry)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasProjectIPAccessListDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID, accessList, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID, accessList, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/test/acceptance-test/fw_resource_mongodbatlas_project_test.go
+++ b/test/acceptance-test/fw_resource_mongodbatlas_project_test.go
@@ -1,0 +1,612 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20230201002/admin"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccProjectRSProject_basic(t *testing.T) {
+	var (
+		project      matlas.Project
+		resourceName = "mongodbatlas_project.test"
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		clusterCount = "0"
+		teamsIds     = strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	)
+	if len(teamsIds) < 3 {
+		t.Skip("`MONGODB_ATLAS_TEAMS_IDS` must have 3 team ids for this acceptance testing")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_OWNER"},
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+					resource.TestCheckResourceAttr(resourceName, "teams.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_OWNER"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_DATA_ACCESS_READ_WRITE"},
+						},
+						{
+							TeamID:    teamsIds[2],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+					resource.TestCheckResourceAttr(resourceName, "teams.#", "3"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
+
+					[]*matlas.ProjectTeam{
+						{
+							TeamID:    teamsIds[0],
+							RoleNames: []string{"GROUP_READ_ONLY", "GROUP_READ_ONLY"},
+						},
+						{
+							TeamID:    teamsIds[1],
+							RoleNames: []string{"GROUP_OWNER", "GROUP_DATA_ACCESS_ADMIN"},
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+					resource.TestCheckResourceAttr(resourceName, "teams.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID, []*matlas.ProjectTeam{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+					resource.TestCheckNoResourceAttr(resourceName, "teams.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_CreateWithProjectOwner(t *testing.T) {
+	var (
+		project        matlas.Project
+		resourceName   = "mongodbatlas_project.test"
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasicOwnerID(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSGovProject_CreateWithProjectOwner(t *testing.T) {
+	var (
+		project        matlas.Project
+		resourceName   = "mongodbatlas_project.test"
+		projectName    = acctest.RandomWithPrefix("tf-acc-project")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID_GOV")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID_GOV")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckGov(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasGovProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+		},
+	})
+}
+func TestAccProjectRSProject_CreateWithFalseDefaultSettings(t *testing.T) {
+	var (
+		project        matlas.Project
+		resourceName   = "mongodbatlas_project.test"
+		projectName    = acctest.RandomWithPrefix("tf-acc-project")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasicOwnerID(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithFalseDefaultSettings(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_CreateWithFalseDefaultAdvSettings(t *testing.T) {
+	var (
+		project        matlas.Project
+		resourceName   = "mongodbatlas_project.test"
+		projectName    = acctest.RandomWithPrefix("tf-acc-project")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasicOwnerID(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithFalseDefaultAdvSettings(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectExists(resourceName, &project),
+					testAccCheckMongoDBAtlasProjectAttributes(&project, projectName),
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_withUpdatedRole(t *testing.T) {
+	var (
+		resourceName    = "mongodbatlas_project.test"
+		projectName     = acctest.RandomWithPrefix("tf-acc-project")
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		roleName        = "GROUP_DATA_ACCESS_ADMIN"
+		roleNameUpdated = "GROUP_READ_ONLY"
+		clusterCount    = "0"
+		teamsIds        = strings.Split(os.Getenv("MONGODB_ATLAS_TEAMS_IDS"), ",")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t); testCheckTeamsIds(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithUpdatedRole(projectName, orgID, teamsIds[0], roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithUpdatedRole(projectName, orgID, teamsIds[0], roleNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_importBasic(t *testing.T) {
+	var (
+		projectName  = acctest.RandomWithPrefix("tf-acc-project")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		resourceName = "mongodbatlas_project.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfig(projectName, orgID,
+					[]*matlas.ProjectTeam{},
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasProjectImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"with_default_alerts_settings"},
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_withUpdatedLimits(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project.test"
+		projectName  = acctest.RandomWithPrefix("tf-acc-project")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+					{
+						Name:  "atlas.project.deployment.clusters",
+						Value: 1,
+					},
+					{
+						Name:  "atlas.project.deployment.nodesPerPrivateLinkRegion",
+						Value: 1,
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.clusters"),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "limits.1.name", "atlas.project.deployment.nodesPerPrivateLinkRegion"),
+					resource.TestCheckResourceAttr(resourceName, "limits.1.value", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+					{
+						Name:  "atlas.project.deployment.nodesPerPrivateLinkRegion",
+						Value: 2,
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.nodesPerPrivateLinkRegion"),
+					resource.TestCheckResourceAttr(resourceName, "limits.0.value", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+					{
+						Name:  "atlas.project.deployment.nodesPerPrivateLinkRegion",
+						Value: 3,
+					},
+					{
+						Name:  "atlas.project.security.databaseAccess.customRoles",
+						Value: 110,
+					},
+					{
+						Name:  "atlas.project.security.databaseAccess.users",
+						Value: 30,
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						"limits.*",
+						map[string]string{
+							"name":  "atlas.project.deployment.nodesPerPrivateLinkRegion",
+							"value": "3",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						"limits.*",
+						map[string]string{
+							"name":  "atlas.project.security.databaseAccess.customRoles",
+							"value": "110",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						resourceName,
+						"limits.*",
+						map[string]string{
+							"name":  "atlas.project.security.databaseAccess.users",
+							"value": "30",
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_withInvalidLimitName(t *testing.T) {
+	var (
+		projectName = acctest.RandomWithPrefix("tf-acc-project")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+					{
+						Name:  "incorrect.name",
+						Value: 1,
+					},
+				}),
+				ExpectError: regexp.MustCompile("Limit not found"),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProject_withInvalidLimitNameOnUpdate(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project.test"
+		projectName  = acctest.RandomWithPrefix("tf-acc-project")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", projectName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID, []*admin.DataFederationLimit{
+					{
+						Name:  "incorrect.name",
+						Value: 1,
+					},
+				}),
+				ExpectError: regexp.MustCompile("Limit not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasProjectExists(resourceName string, project *matlas.Project) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] projectID: %s", rs.Primary.ID)
+
+		if projectResp, _, err := conn.Projects.GetOneProjectByName(context.Background(), rs.Primary.Attributes["name"]); err == nil {
+			*project = *projectResp
+			return nil
+		}
+
+		return fmt.Errorf("project (%s) does not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectAttributes(project *matlas.Project, projectName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if project.Name != projectName {
+			return fmt.Errorf("bad project name: %s", project.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectDestroy(s *terraform.State) error {
+	conn := testMongoDBClient.(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_project" {
+			continue
+		}
+
+		projectRes, _, _ := conn.Projects.GetOneProjectByName(context.Background(), rs.Primary.ID)
+		if projectRes != nil {
+			return fmt.Errorf("project (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProjectImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasProjectConfig(projectName, orgID string, teams []*matlas.ProjectTeam) string {
+	var ts string
+
+	for _, t := range teams {
+		ts += fmt.Sprintf(`
+		teams {
+			team_id = "%s"
+			role_names = %s
+		}
+		`, t.TeamID, strings.ReplaceAll(fmt.Sprintf("%+q", t.RoleNames), " ", ","))
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name  			 = "%s"
+			org_id 			 = "%s"
+
+			%s
+		}
+	`, projectName, orgID, ts)
+}
+
+func testAccMongoDBAtlasProjectConfigWithUpdatedRole(projectName, orgID, teamID, roleName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+
+			teams {
+				team_id = "%s"
+				role_names = ["%s"]
+			}
+		}
+	`, projectName, orgID, teamID, roleName)
+}
+
+func testAccMongoDBAtlasProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   			 = "%[1]s"
+			org_id 			 = "%[2]s"
+		    project_owner_id = "%[3]s"
+		}
+	`, projectName, orgID, projectOwnerID)
+}
+
+func testAccMongoDBAtlasGovProjectConfigWithProjectOwner(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   			 = "%[1]s"
+			org_id 			 = "%[2]s"
+		    project_owner_id = "%[3]s"
+			region_usage_restrictions = "GOV_REGIONS_ONLY"
+		}
+	`, projectName, orgID, projectOwnerID)
+}
+
+func testAccMongoDBAtlasProjectConfigWithFalseDefaultSettings(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   			 = "%[1]s"
+			org_id 			 = "%[2]s"
+			project_owner_id = "%[3]s"
+			with_default_alerts_settings = false
+		}
+	`, projectName, orgID, projectOwnerID)
+}
+
+func testAccMongoDBAtlasProjectConfigWithFalseDefaultAdvSettings(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   			 = "%[1]s"
+			org_id 			 = "%[2]s"
+			project_owner_id = "%[3]s"
+			with_default_alerts_settings = false
+			is_collect_database_specifics_statistics_enabled = false
+			is_data_explorer_enabled = false
+			is_extended_storage_sizes_enabled = false
+			is_performance_advisor_enabled = false
+			is_realtime_performance_panel_enabled = false
+			is_schema_advisor_enabled = false
+		}
+	`, projectName, orgID, projectOwnerID)
+}
+
+func testAccMongoDBAtlasProjectConfigWithLimits(projectName, orgID string, limits []*admin.DataFederationLimit) string {
+	var limitsString string
+
+	for _, limit := range limits {
+		limitsString += fmt.Sprintf(`
+		limits {
+			name = "%s"
+			value = %d
+		}
+		`, limit.Name, limit.Value)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   			 = "%s"
+			org_id 			 = "%s"
+
+			%s
+		}
+	`, projectName, orgID, limitsString)
+}

--- a/test/acceptance-test/helper.go
+++ b/test/acceptance-test/helper.go
@@ -1,0 +1,359 @@
+package acceptancetests
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	sdkv2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	// Provider name for single configuration testing
+	ProviderNameMongoDBAtlas = "mongodbatlas"
+)
+
+var TestAccProviderV6Factories map[string]func() (tfprotov6.ProviderServer, error)
+
+// only being used in tests obtaining client: .Meta().(*MongoDBClient)
+// this provider instance has to be passed into mux server factory for its configure method to be invoked
+var testAccProviderSdkV2 *sdkv2schema.Provider
+
+// testMongoDBClient is used to configure client required for Framework-based acceptance tests
+var testMongoDBClient interface{}
+
+func init() {
+	testAccProviderSdkV2 = mongodbatlas.NewSdkV2Provider()
+	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
+		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
+			return MuxedProviderFactoryWithProvider(testAccProviderSdkV2)(), nil
+		},
+	}
+
+	config := mongodbatlas.Config{
+		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
+		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
+		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
+	}
+	testMongoDBClient, _ = config.NewClient(context.Background())
+}
+
+func MuxedProviderFactory() func() tfprotov6.ProviderServer {
+	return MuxedProviderFactoryWithProvider(mongodbatlas.NewSdkV2Provider())
+}
+
+// MuxedProviderFactoryWithProvider creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
+// Used in testing where existing sdk v2 provider has to be used.
+func MuxedProviderFactoryWithProvider(sdkV2Provider *sdkv2schema.Provider) func() tfprotov6.ProviderServer {
+	fwProvider := mongodbatlas.NewFrameworkProvider()
+
+	ctx := context.Background()
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(ctx, sdkV2Provider.GRPCProvider)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkProvider
+		},
+		providerserver.NewProtocol6(fwProvider),
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return muxServer.ProviderServer
+}
+
+func TestSdkV2Provider(t *testing.T) {
+	if err := mongodbatlas.NewSdkV2Provider().InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func testAccPreCheck(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_ID` and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	}
+}
+
+func testAccPreCheckBasic(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	}
+}
+
+func testAccPreCheckCloudProviderAccessAzure(tb testing.TB) {
+	testAccPreCheckBasic(tb)
+	if os.Getenv("AZURE_ATLAS_APP_ID") == "" ||
+		os.Getenv("AZURE_SERVICE_PRINCIPAL_ID") == "" ||
+		os.Getenv("AZURE_TENANT_ID") == "" {
+		tb.Fatal("`AZURE_ATLAS_APP_ID`, `AZURE_SERVICE_PRINCIPAL_ID`, and `AZURE_TENANT_ID` must be set for acceptance testing")
+	}
+}
+
+func testAccPreCheckBasicOwnerID(tb testing.TB) {
+	testAccPreCheckBasic(tb)
+	if os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_OWNER_ID` must be set ")
+	}
+}
+
+func testAccPreCheckGov(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PROJECT_ID_GOV") == "" ||
+		os.Getenv("MONGODB_ATLAS_ORG_ID_GOV") == "" {
+		tb.Skip()
+	}
+}
+
+func testAccPreCheckGPCEnv(tb testing.TB) {
+	if os.Getenv("GCP_SERVICE_ACCOUNT_KEY") == "" || os.Getenv("GCP_KEY_VERSION_RESOURCE_ID") == "" {
+		tb.Fatal("`GCP_SERVICE_ACCOUNT_KEY` and `GCP_KEY_VERSION_RESOURCE_ID` must be set for acceptance testing")
+	}
+}
+
+func testCheckPeeringEnvAWS(tb testing.TB) {
+	if os.Getenv("AWS_ACCOUNT_ID") == "" ||
+		os.Getenv("AWS_VPC_ID") == "" ||
+		os.Getenv("AWS_VPC_CIDR_BLOCK") == "" ||
+		os.Getenv("AWS_REGION") == "" {
+		tb.Fatal("`AWS_ACCOUNT_ID`, `AWS_VPC_ID`, `AWS_VPC_CIDR_BLOCK` and `AWS_VPC_ID` must be set for  network peering acceptance testing")
+	}
+}
+
+func testCheckPeeringEnvAzure(tb testing.TB) {
+	if os.Getenv("AZURE_DIRECTORY_ID") == "" ||
+		os.Getenv("AZURE_SUBSCRIPTION_ID") == "" ||
+		os.Getenv("AZURE_VNET_NAME") == "" ||
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME") == "" {
+		tb.Fatal("`AZURE_DIRECTORY_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_VNET_NAME` and `AZURE_RESOURCE_GROUP_NAME` must be set for  network peering acceptance testing")
+	}
+}
+
+func testCheckEncryptionAtRestEnvAzure(tb testing.TB) {
+	if os.Getenv("AZURE_CLIENT_ID") == "" ||
+		os.Getenv("AZURE_CLIENT_ID_UPDATED") == "" ||
+		os.Getenv("AZURE_SUBSCRIPTION_ID") == "" ||
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME") == "" ||
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME_UPDATED") == "" ||
+		os.Getenv("AZURE_SECRET") == "" ||
+		os.Getenv("AZURE_KEY_VAULT_NAME") == "" ||
+		os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED") == "" ||
+		os.Getenv("AZURE_KEY_IDENTIFIER") == "" ||
+		os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED") == "" ||
+		os.Getenv("AZURE_TENANT_ID") == "" {
+		tb.Fatal(`'AZURE_CLIENT_ID','AZURE_CLIENT_ID_UPDATED', 'AZURE_SUBSCRIPTION_ID',
+		'AZURE_RESOURCE_GROUP_NAME','AZURE_RESOURCE_GROUP_NAME_UPDATED', 'AZURE_SECRET',
+		'AZURE_SECRET_UPDATED', 'AZURE_KEY_VAULT_NAME', 'AZURE_KEY_IDENTIFIER', 'AZURE_KEY_VAULT_NAME_UPDATED',
+		'AZURE_KEY_IDENTIFIER_UPDATED', and 'AZURE_TENANT_ID' must be set for Encryption At Rest acceptance testing`)
+	}
+}
+
+func testCheckPeeringEnvGCP(tb testing.TB) {
+	if os.Getenv("GCP_PROJECT_ID") == "" ||
+		os.Getenv("GCP_CLUSTER_REGION_NAME") == "" ||
+		os.Getenv("GCP_REGION_NAME") == "" ||
+		os.Getenv("GOOGLE_CLOUD_KEYFILE_JSON") == "" {
+		tb.Fatal("`GCP_PROJECT_ID`,`GOOGLE_CLOUD_KEYFILE_JSON`, `GCP_CLUSTER_REGION_NAME`, `and GCP_REGION_NAME` must be set for network peering acceptance testing")
+	}
+}
+
+func testCheckAwsEnv(tb testing.TB) {
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
+		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" ||
+		os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID") == "" {
+		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_CUSTOMER_MASTER_KEY_ID` must be set for acceptance testing")
+	}
+}
+
+func TestEncodeDecodeID(t *testing.T) {
+	expected := map[string]string{
+		"project_id":   "5cf5a45a9ccf6400e60981b6",
+		"cluster_name": "test-acc-q4y272zo9y",
+		"snapshot_id":  "5e42e646553855a5aee40138",
+	}
+
+	got := decodeStateID(encodeStateID(expected))
+
+	if diff := deep.Equal(expected, got); diff != nil {
+		t.Fatalf("Bad testEncodeDecodeID return \n got = %#v\nwant = %#v \ndiff = %#v", got, expected, diff)
+	}
+}
+
+func TestDecodeID(t *testing.T) {
+	expected := "Y2x1c3Rlcl9uYW1l:dGVzdC1hY2MtcTR5Mjcyem85eQ==-c25hcHNob3RfaWQ=:NWU0MmU2NDY1NTM4NTVhNWFlZTQwMTM4-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2"
+	expected2 := "c25hcHNob3RfaWQ=:NWU0MmU2NDY1NTM4NTVhNWFlZTQwMTM4-cHJvamVjdF9pZA==:NWNmNWE0NWE5Y2NmNjQwMGU2MDk4MWI2-Y2x1c3Rlcl9uYW1l:dGVzdC1hY2MtcTR5Mjcyem85eQ=="
+
+	got := decodeStateID(expected)
+	got2 := decodeStateID(expected2)
+
+	if diff := deep.Equal(got, got2); diff != nil {
+		t.Fatalf("Bad TestDecodeID return \n got = %#v\nwant = %#v \ndiff = %#v", got, got2, diff)
+	}
+}
+
+func TestRemoveLabel(t *testing.T) {
+	toRemove := matlas.Label{Key: "To Remove", Value: "To remove value"}
+
+	expected := []matlas.Label{
+		{Key: "Name", Value: "Test"},
+		{Key: "Version", Value: "1.0"},
+		{Key: "Type", Value: "testing"},
+	}
+
+	labels := []matlas.Label{
+		{Key: "Name", Value: "Test"},
+		{Key: "Version", Value: "1.0"},
+		{Key: "To Remove", Value: "To remove value"},
+		{Key: "Type", Value: "testing"},
+	}
+
+	got := removeLabel(labels, toRemove)
+
+	if diff := deep.Equal(expected, got); diff != nil {
+		t.Fatalf("Bad removeLabel return \n got = %#v\nwant = %#v \ndiff = %#v", got, expected, diff)
+	}
+}
+
+func SkipTestExtCred(tb testing.TB) {
+	if strings.EqualFold(os.Getenv("SKIP_TEST_EXTERNAL_CREDENTIALS"), "true") {
+		tb.Skip()
+	}
+}
+
+func testCheckDataLakePipelineRun(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_DATA_LAKE_PIPELINE_RUN_ID") == "" {
+		tb.Skip("`MONGODB_ATLAS_DATA_LAKE_PIPELINE_RUN_ID` must be set for Projects acceptance testing")
+	}
+	testCheckDataLakePipelineRuns(tb)
+}
+
+func testCheckDataLakePipelineRuns(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_DATA_LAKE_PIPELINE_NAME") == "" {
+		tb.Skip("`MONGODB_ATLAS_DATA_LAKE_PIPELINE_NAME` must be set for Projects acceptance testing")
+	}
+}
+
+func testCheckTeamsIds(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_TEAMS_IDS") == "" {
+		tb.Skip("`MONGODB_ATLAS_TEAMS_IDS` must be set for Projects acceptance testing")
+	}
+}
+
+func SkipTest(tb testing.TB) {
+	if strings.EqualFold(os.Getenv("SKIP_TEST"), "true") {
+		tb.Skip()
+	}
+}
+
+// SkipTestForCI is added to tests that cannot run as part of a CI
+func SkipTestForCI(tb testing.TB) {
+	if strings.EqualFold(os.Getenv("CI"), "true") {
+		tb.Skip()
+	}
+}
+
+func testCheckLDAP(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME") == "" ||
+		os.Getenv("MONGODB_ATLAS_LDAP_USERNAME") == "" ||
+		os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD") == "" ||
+		os.Getenv("MONGODB_ATLAS_LDAP_PORT") == "" {
+		tb.Fatal("`MONGODB_ATLAS_LDAP_HOSTNAME`, `MONGODB_ATLAS_LDAP_USERNAME`, `MONGODB_ATLAS_LDAP_PASSWORD` and `MONGODB_ATLAS_LDAP_PORT` must be set for ldap configuration/verify acceptance testing")
+	}
+}
+
+func testCheckFederatedSettings(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_FEDERATED_PROJECT_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_FEDERATED_PROJECT_ID`, `MONGODB_ATLAS_FEDERATED_ORG_ID` and `MONGODB_ATLAS_FEDERATION_SETTINGS_ID` must be set for federated settings/verify acceptance testing")
+	}
+}
+
+func testCheckPrivateEndpointServiceDataFederationOnlineArchiveRun(tb testing.TB) {
+	if os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID") == "" {
+		tb.Skip("`MONGODB_ATLAS_PRIVATE_ENDPOINT_ID` must be set for Private Endpoint Service Data Federation and Online Archive acceptance testing")
+	}
+}
+func decodeStateID(stateID string) map[string]string {
+	decode := func(d string) string {
+		decodedString, err := base64.StdEncoding.DecodeString(d)
+		if err != nil {
+			log.Printf("[WARN] error decoding state ID: %s", err)
+		}
+
+		return string(decodedString)
+	}
+	decodedValues := make(map[string]string)
+	encodedValues := strings.Split(stateID, "-")
+
+	for _, value := range encodedValues {
+		keyValue := strings.Split(value, ":")
+		if len(keyValue) > 1 {
+			decodedValues[decode(keyValue[0])] = decode(keyValue[1])
+		}
+	}
+
+	return decodedValues
+}
+
+func encodeStateID(values map[string]string) string {
+	encode := func(e string) string { return base64.StdEncoding.EncodeToString([]byte(e)) }
+	encodedValues := make([]string, 0)
+
+	// sort to make sure the same encoding is returned in case of same input
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		encodedValues = append(encodedValues, fmt.Sprintf("%s:%s", encode(key), encode(values[key])))
+	}
+
+	return strings.Join(encodedValues, "-")
+}
+
+func removeLabel(list []matlas.Label, item matlas.Label) []matlas.Label {
+	var pos int
+
+	for _, v := range list {
+		if reflect.DeepEqual(v, item) {
+			list = append(list[:pos], list[pos+1:]...)
+
+			if pos > 0 {
+				pos--
+			}
+
+			continue
+		}
+		pos++
+	}
+
+	return list
+}

--- a/test/acceptance-test/resource_mongodbatlas_access_list_api_key_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_access_list_api_key_test.go
@@ -1,0 +1,202 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
+	resourceName := "mongodbatlas_access_list_api_key.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	description := fmt.Sprintf("test-acc-access_list-api_key-%s", acctest.RandString(5))
+	updatedIPAddress := fmt.Sprintf("179.154.228.%d", acctest.RandIntRange(0, 255))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAccessListAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAccessListAPIKeyConfigSettingIPAddress(orgID, description, ipAddress),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAccessListAPIKeyConfigSettingIPAddress(orgID, description, updatedIPAddress),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "ip_address", updatedIPAddress),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
+	resourceName := "mongodbatlas_access_list_api_key.test"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	cidrBlock := fmt.Sprintf("179.154.226.%d/32", acctest.RandIntRange(0, 255))
+	description := fmt.Sprintf("test-acc-access_list-api_key-%s", acctest.RandString(5))
+	updatedCIDRBlock := fmt.Sprintf("179.154.228.%d/32", acctest.RandIntRange(0, 255))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAccessListAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAccessListAPIKeyConfigSettingCIDRBlock(orgID, description, cidrBlock),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAccessListAPIKeyConfigSettingCIDRBlock(orgID, description, updatedCIDRBlock),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cidr_block"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSAccessListAPIKey_importBasic(t *testing.T) {
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	ipAddress := fmt.Sprintf("179.154.226.%d", acctest.RandIntRange(0, 255))
+	resourceName := "mongodbatlas_access_list_api_key.test"
+	description := fmt.Sprintf("test-acc-access_list-api_key-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAccessListAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAccessListAPIKeyConfigSettingIPAddress(orgID, description, ipAddress),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasAccessListAPIKeyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.AccessListAPIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"], ids["entry"])
+		if err != nil {
+			return fmt.Errorf("access list API Key (%s) does not exist", ids["api_key_id"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAccessListAPIKeyDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_access_list_api_key" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.AccessListAPIKeys.Get(context.Background(), ids["project_id"], ids["api_key_id"], ids["entry"])
+		if err == nil {
+			return fmt.Errorf("access list API Key (%s) still exists", ids["api_key_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasAccessListAPIKeyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s", ids["org_id"], ids["api_key_id"], ids["entry"]), nil
+	}
+}
+
+func testAccMongoDBAtlasAccessListAPIKeyConfigSettingIPAddress(orgID, description, ipAddress string) string {
+	return fmt.Sprintf(`
+
+	   resource "mongodbatlas_api_key" "test" {
+		  org_id = %[1]q
+		  description = %[2]q
+		  role_names  = ["ORG_MEMBER","ORG_BILLING_ADMIN"]
+	    }
+
+		resource "mongodbatlas_access_list_api_key" "test" {
+			org_id = %[1]q
+			ip_address = %[3]q
+			api_key_id = mongodbatlas_api_key.test.api_key_id
+		}
+	`, orgID, description, ipAddress)
+}
+func testAccMongoDBAtlasAccessListAPIKeyConfigSettingCIDRBlock(orgID, description, cidrBlock string) string {
+	return fmt.Sprintf(`
+
+	resource "mongodbatlas_api_key" "test" {
+		org_id = %[1]q
+		description = %[2]q
+		role_names  = ["ORG_MEMBER","ORG_BILLING_ADMIN"]
+	  }
+
+		resource "mongodbatlas_access_list_api_key" "test" {
+		  org_id = %[1]q
+		  api_key_id = mongodbatlas_api_key.test.api_key_id
+		  cidr_block = %[3]q
+		}
+	`, orgID, description, cidrBlock)
+}

--- a/test/acceptance-test/resource_mongodbatlas_advanced_cluster_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_advanced_cluster_test.go
@@ -1,0 +1,1020 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
+	var (
+		cluster                matlas.AdvancedCluster
+		resourceName           = "mongodbatlas_advanced_cluster.test"
+		dataSourceName         = "data.mongodbatlas_advanced_cluster.test"
+		dataSourceClustersName = "data.mongodbatlas_advanced_clusters.test"
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acctest.RandomWithPrefix("test-acc")
+		rName                  = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated           = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigTenant(orgID, projectName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "termination_protection_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "termination_protection_enabled", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.termination_protection_enabled"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigTenant(orgID, projectName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(dataSourceName, "termination_protection_enabled", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.termination_protection_enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_singleProvider(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProvider(orgID, projectName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(orgID, projectName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs", "retain_backups_enabled"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
+	var (
+		cluster                matlas.AdvancedCluster
+		resourceName           = "mongodbatlas_advanced_cluster.test"
+		dataSourceName         = "data.mongodbatlas_advanced_cluster.test"
+		dataSourceClustersName = "data.mongodbatlas_advanced_clusters.test"
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acctest.RandomWithPrefix("test-acc")
+		rName                  = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated           = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(orgID, projectName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(orgID, projectName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rNameUpdated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs", "retain_backups_enabled"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_multicloudSharded(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigMultiCloudSharded(orgID, projectName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigMultiCloudSharded(orgID, projectName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_UnpausedToPaused(t *testing.T) {
+	SkipTest(t)
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_PausedToUnpaused(t *testing.T) {
+	SkipTest(t)
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_specs"},
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_advancedConf(t *testing.T) {
+	var (
+		cluster                matlas.AdvancedCluster
+		resourceName           = "mongodbatlas_advanced_cluster.test"
+		dataSourceName         = "data.mongodbatlas_advanced_cluster.test"
+		dataSourceNameClusters = "data.mongodbatlas_advanced_clusters.test"
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acctest.RandomWithPrefix("test-acc")
+		rName                  = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated           = acctest.RandomWithPrefix("test-acc")
+		processArgs            = &matlas.ProcessArgs{
+			DefaultReadConcern:               "available",
+			DefaultWriteConcern:              "1",
+			FailIndexKeyTooLong:              pointy.Bool(false),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_1",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+			TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+		}
+		processArgsUpdated = &matlas.ProcessArgs{
+			DefaultReadConcern:               "available",
+			DefaultWriteConcern:              "0",
+			FailIndexKeyTooLong:              pointy.Bool(false),
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_2",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+			TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(orgID, projectName, rName, processArgs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.0.name"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(orgID, projectName, rNameUpdated, processArgsUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceNameClusters, "results.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedCluster_DefaultWrite(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated = acctest.RandomWithPrefix("test-acc")
+		processArgs  = &matlas.ProcessArgs{
+			DefaultReadConcern:               "available",
+			DefaultWriteConcern:              "1",
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_1",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+		}
+		processArgsUpdated = &matlas.ProcessArgs{
+			DefaultReadConcern:               "available",
+			DefaultWriteConcern:              "majority",
+			JavascriptEnabled:                pointy.Bool(true),
+			MinimumEnabledTLSProtocol:        "TLS1_2",
+			NoTableScan:                      pointy.Bool(false),
+			OplogSizeMB:                      pointy.Int64(1000),
+			SampleRefreshIntervalBIConnector: pointy.Int64(310),
+			SampleSizeBIConnector:            pointy.Int64(110),
+			TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConfDefaultWrite(orgID, projectName, rName, processArgs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigAdvancedConfDefaultWrite(orgID, projectName, rNameUpdated, processArgsUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "majority"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedClusterConfig_ReplicationSpecsAutoScaling(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated = acctest.RandomWithPrefix("test-acc")
+		autoScaling  = &matlas.AutoScaling{
+			Compute:       &matlas.Compute{Enabled: pointy.Bool(false), MaxInstanceSize: ""},
+			DiskGBEnabled: pointy.Bool(true),
+		}
+		autoScalingUpdated = &matlas.AutoScaling{
+			Compute:       &matlas.Compute{Enabled: pointy.Bool(true), MaxInstanceSize: "M20"},
+			DiskGBEnabled: pointy.Bool(true),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAutoScaling(orgID, projectName, rName, autoScaling),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					testAccCheckMongoDBAtlasAdvancedClusterScaling(&cluster, *autoScaling.Compute.Enabled),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAutoScaling(orgID, projectName, rNameUpdated, autoScalingUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					testAccCheckMongoDBAtlasAdvancedClusterScaling(&cluster, *autoScalingUpdated.Compute.Enabled),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterAdvancedClusterConfig_ReplicationSpecsAnalyticsAutoScaling(t *testing.T) {
+	var (
+		cluster      matlas.AdvancedCluster
+		resourceName = "mongodbatlas_advanced_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		rName        = acctest.RandomWithPrefix("test-acc")
+		rNameUpdated = acctest.RandomWithPrefix("test-acc")
+		autoScaling  = &matlas.AutoScaling{
+			Compute:       &matlas.Compute{Enabled: pointy.Bool(false), MaxInstanceSize: ""},
+			DiskGBEnabled: pointy.Bool(true),
+		}
+		autoScalingUpdated = &matlas.AutoScaling{
+			Compute:       &matlas.Compute{Enabled: pointy.Bool(true), MaxInstanceSize: "M20"},
+			DiskGBEnabled: pointy.Bool(true),
+		}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAdvancedClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAnalyticsAutoScaling(orgID, projectName, rName, autoScaling),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					testAccCheckMongoDBAtlasAdvancedClusterAnalyticsScaling(&cluster, *autoScaling.Compute.Enabled),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAnalyticsAutoScaling(orgID, projectName, rNameUpdated, autoScalingUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasAdvancedClusterAttributes(&cluster, rNameUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
+					testAccCheckMongoDBAtlasAdvancedClusterAnalyticsScaling(&cluster, *autoScalingUpdated.Compute.Enabled),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName string, cluster *matlas.AdvancedCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
+
+		if clusterResp, _, err := conn.AdvancedClusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
+			*cluster = *clusterResp
+			return nil
+		}
+
+		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
+	}
+}
+
+func testAccCheckMongoDBAtlasAdvancedClusterAttributes(cluster *matlas.AdvancedCluster, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cluster.Name != name {
+			return fmt.Errorf("bad name: %s", cluster.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAdvancedClusterScaling(cluster *matlas.AdvancedCluster, computeEnabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *cluster.ReplicationSpecs[0].RegionConfigs[0].AutoScaling.Compute.Enabled != computeEnabled {
+			return fmt.Errorf("compute_enabled: %d", cluster.ReplicationSpecs[0].RegionConfigs[0].AutoScaling.Compute.Enabled)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAdvancedClusterAnalyticsScaling(cluster *matlas.AdvancedCluster, computeEnabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *cluster.ReplicationSpecs[0].RegionConfigs[0].AnalyticsAutoScaling.Compute.Enabled != computeEnabled {
+			return fmt.Errorf("compute_enabled: %d", cluster.ReplicationSpecs[0].RegionConfigs[0].AnalyticsAutoScaling.Compute.Enabled)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAdvancedClusterDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_advanced_cluster" {
+			continue
+		}
+
+		// Try to find the cluster
+		_, _, err := conn.AdvancedClusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
+
+		if err == nil {
+			return fmt.Errorf("cluster (%s:%s) still exists", rs.Primary.Attributes["cluster_name"], rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigTenant(orgID, projectName, name string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  cluster_type = "REPLICASET"
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M5"
+      }
+      provider_name         = "TENANT"
+      backing_provider_name = "AWS"
+      region_name           = "US_EAST_1"
+      priority              = 7
+    }
+  }
+}
+
+data "mongodbatlas_advanced_cluster" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+	name 	     = mongodbatlas_advanced_cluster.test.name
+}
+
+data "mongodbatlas_advanced_clusters" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+}
+	`, orgID, projectName, name)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigSingleProvider(orgID, projectName, name string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  cluster_type = "REPLICASET"
+  retain_backups_enabled = "true"
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+}
+data "mongodbatlas_advanced_cluster" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+	name 	     = mongodbatlas_advanced_cluster.test.name
+}
+
+	`, orgID, projectName, name)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(orgID, projectName, name string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  cluster_type = "REPLICASET"
+  retain_backups_enabled = false
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 2
+      }
+      provider_name = "GCP"
+      priority      = 6
+      region_name   = "NORTH_AMERICA_NORTHEAST_1"
+    }
+  }
+}
+
+data "mongodbatlas_advanced_cluster" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+	name 	     = mongodbatlas_advanced_cluster.test.name
+}
+
+data "mongodbatlas_advanced_clusters" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+}
+	`, orgID, projectName, name)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigMultiCloudSharded(orgID, projectName, name string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}	
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  cluster_type = "SHARDED"
+
+  replication_specs {
+    num_shards = 1
+    region_configs {
+      electable_specs {
+        instance_size = "M30"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M30"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+    region_configs {
+      electable_specs {
+        instance_size = "M30"
+        node_count    = 2
+      }
+      provider_name = "AZURE"
+      priority      = 6
+      region_name   = "US_EAST_2"
+    }
+  }
+}
+	`, orgID, projectName, name)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigSingleProviderPaused(orgID, projectName, name string, paused bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  cluster_type = "REPLICASET"
+  paused       = %[4]t
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+}
+	`, orgID, projectName, name, paused)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigAdvancedConf(orgID, projectName, name string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}	
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id             = mongodbatlas_project.cluster_project.id
+  name                   = %[3]q
+  cluster_type           = "REPLICASET"
+
+   replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+
+  advanced_configuration  {
+    fail_index_key_too_long              = %[4]t
+    javascript_enabled                   = %[5]t
+    minimum_enabled_tls_protocol         = %[6]q
+    no_table_scan                        = %[7]t
+    oplog_size_mb                        = %[8]d
+    sample_size_bi_connector			 = %[9]d
+    sample_refresh_interval_bi_connector = %[10]d
+	transaction_lifetime_limit_seconds   = %[11]d
+  }
+}
+data "mongodbatlas_advanced_cluster" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+	name 	     = mongodbatlas_advanced_cluster.test.name
+}
+
+data "mongodbatlas_advanced_clusters" "test" {
+	project_id = mongodbatlas_advanced_cluster.test.project_id
+}
+
+	`, orgID, projectName, name,
+		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
+		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, *p.TransactionLifetimeLimitSeconds)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigAdvancedConfDefaultWrite(orgID, projectName, name string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}	
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id             = mongodbatlas_project.cluster_project.id
+  name                   = %[3]q
+  cluster_type           = "REPLICASET"
+
+   replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+
+  advanced_configuration  {
+    javascript_enabled                   = %[4]t
+    minimum_enabled_tls_protocol         = %[5]q
+    no_table_scan                        = %[6]t
+    oplog_size_mb                        = %[7]d
+    sample_size_bi_connector			 = %[8]d
+    sample_refresh_interval_bi_connector = %[9]d
+    default_read_concern                 = %[10]q
+    default_write_concern                = %[11]q
+  }
+}
+
+	`, orgID, projectName, name, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
+		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, p.DefaultReadConcern, p.DefaultWriteConcern)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAutoScaling(orgID, projectName, name string, p *matlas.AutoScaling) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}	
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id             = mongodbatlas_project.cluster_project.id
+  name                   = %[3]q
+  cluster_type           = "REPLICASET"
+
+   replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+	  auto_scaling {
+        compute_enabled = %[4]t
+        disk_gb_enabled = %[5]t
+		compute_max_instance_size = %[6]q
+	  }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+
+
+}
+
+	`, orgID, projectName, name, *p.Compute.Enabled, *p.DiskGBEnabled, p.Compute.MaxInstanceSize)
+}
+
+func testAccMongoDBAtlasAdvancedClusterConfigReplicationSpecsAnalyticsAutoScaling(orgID, projectName, name string, p *matlas.AutoScaling) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id             = mongodbatlas_project.cluster_project.id
+  name                   = %[3]q
+  cluster_type           = "REPLICASET"
+
+   replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+	  analytics_auto_scaling {
+        compute_enabled = %[4]t
+        disk_gb_enabled = %[5]t
+		compute_max_instance_size = %[6]q
+	  }
+      provider_name = "AWS"
+      priority      = 7
+      region_name   = "US_EAST_1"
+    }
+  }
+
+
+}
+
+	`, orgID, projectName, name, *p.Compute.Enabled, *p.DiskGBEnabled, p.Compute.MaxInstanceSize)
+}

--- a/test/acceptance-test/resource_mongodbatlas_api_key_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_api_key_test.go
@@ -1,0 +1,143 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccConfigRSAPIKey_Basic(t *testing.T) {
+	var (
+		resourceName      = "mongodbatlas_api_key.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		description       = fmt.Sprintf("test-acc-api_key-%s", acctest.RandString(5))
+		descriptionUpdate = fmt.Sprintf("test-acc-api_key-%s", acctest.RandString(5))
+		roleName          = "ORG_MEMBER"
+		roleNameUpdated   = "ORG_BILLING_ADMIN"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAPIKeyConfigBasic(orgID, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAPIKeyConfigBasic(orgID, descriptionUpdate, roleNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAPIKeyExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSAPIKey_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		description  = fmt.Sprintf("test-acc-import-api_key-%s", acctest.RandString(5))
+		roleName     = "ORG_MEMBER"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAPIKeyConfigBasic(orgID, description, roleName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasAPIKeyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasAPIKeyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.APIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"])
+		if err != nil {
+			return fmt.Errorf("API Key (%s) does not exist", ids["api_key_id"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAPIKeyDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_api_key" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.APIKeys.Get(context.Background(), ids["org_id"], ids["role_name"])
+		if err == nil {
+			return fmt.Errorf("API Key (%s) still exists", ids["role_name"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasAPIKeyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["org_id"], rs.Primary.Attributes["api_key_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasAPIKeyConfigBasic(orgID, description, roleNames string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_api_key" "test" {
+			org_id     = "%s"
+			description  = "%s"
+
+			role_names  = ["%s"]
+		}
+	`, orgID, description, roleNames)
+}

--- a/test/acceptance-test/resource_mongodbatlas_auditing_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_auditing_test.go
@@ -1,0 +1,170 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvRSAuditing_basic(t *testing.T) {
+	var (
+		auditing     matlas.Auditing
+		resourceName = "mongodbatlas_auditing.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		auditAuth    = true
+		auditFilter  = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"
+		enabled      = true
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAuditingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAuditingConfig(orgID, projectName, auditFilter, auditAuth, enabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAuditingExists(resourceName, &auditing),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_filter"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_authorization_success"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "audit_filter", auditFilter),
+					resource.TestCheckResourceAttr(resourceName, "audit_authorization_success", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_type", "FILTER_JSON"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasAuditingConfig(orgID, projectName, "{}", false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAuditingExists(resourceName, &auditing),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_filter"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_authorization_success"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "audit_filter", "{}"),
+					resource.TestCheckResourceAttr(resourceName, "audit_authorization_success", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_type", "FILTER_JSON"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvRSAuditing_importBasic(t *testing.T) {
+	var (
+		auditing     = &matlas.Auditing{}
+		resourceName = "mongodbatlas_auditing.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		auditAuth    = true
+		auditFilter  = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"
+		enabled      = true
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasAuditingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasAuditingConfig(orgID, projectName, auditFilter, auditAuth, enabled),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasAuditingExists(resourceName, auditing),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_filter"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_authorization_success"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "audit_filter", auditFilter),
+					resource.TestCheckResourceAttr(resourceName, "audit_authorization_success", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_type", "FILTER_JSON"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasAuditingImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasAuditingExists(resourceName string, auditing *matlas.Auditing) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		auditingRes, _, err := conn.Auditing.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("auditing (%s) does not exist", rs.Primary.ID)
+		}
+
+		auditing = auditingRes
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasAuditingDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_auditing" {
+			continue
+		}
+
+		_, _, err := conn.Auditing.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("auditing (%s) does not exist", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasAuditingImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasAuditingConfig(orgID, projectName, auditFilter string, auditAuth, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_auditing" "test" {
+			project_id                  = mongodbatlas_project.test.id
+			audit_filter                = %[3]q
+			audit_authorization_success = %[4]t
+			enabled                     = %[5]t
+		}`, orgID, projectName, auditFilter, auditAuth, enabled)
+}

--- a/test/acceptance-test/resource_mongodbatlas_backup_compliance_policy_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_backup_compliance_policy_test.go
@@ -1,0 +1,293 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccGenericBackupRSBackupCompliancePolicy_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_backup_compliance_policy.backup_policy_res"
+		projectName    = fmt.Sprintf("testacc-project-%s", acctest.RandString(10))
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName),
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists("data.mongodbatlas_backup_compliance_policy.backup_policy"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "copy_protection_enabled", "false"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "encryption_at_rest_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGenericBackupRSBackupCompliancePolicy_withoutRestoreWindowDays(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_backup_compliance_policy.backup_policy_res"
+		projectName    = fmt.Sprintf("testacc-project-%s", acctest.RandString(10))
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupCompliancePolicyConfigWithoutRestoreDays(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName),
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists("data.mongodbatlas_backup_compliance_policy.backup_policy"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "copy_protection_enabled", "false"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "encryption_at_rest_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasBackupCompliancePolicyConfigWithoutRestoreDays(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName),
+					testAccCheckMongoDBAtlasBackupCompliancePolicyExists("data.mongodbatlas_backup_compliance_policy.backup_policy"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "copy_protection_enabled", "false"),
+					resource.TestCheckResourceAttr("mongodbatlas_backup_compliance_policy.backup_policy_res", "encryption_at_rest_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGenericBackupRSBackupCompliancePolicy_importBasic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_backup_compliance_policy.backup_policy_res"
+		projectName    = fmt.Sprintf("testacc-project-%s", acctest.RandString(10))
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasBackupCompliancePolicyImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{""},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+
+		schedule, _, err := conn.BackupCompliancePolicy.Get(context.Background(), projectID)
+		if err != nil || schedule == nil {
+			return fmt.Errorf("backup compliance policy (%s) does not exist: %s", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_backup_compliance_policy" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+
+		compliancePolicy, _, err := conn.BackupCompliancePolicy.Get(context.Background(), projectID)
+		if compliancePolicy != nil || err == nil {
+			return fmt.Errorf("Backup Compliance Policy (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasBackupCompliancePolicyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return ids["project_id"], nil
+	}
+}
+
+func testAccMongoDBAtlasBackupCompliancePolicyConfig(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name                                             = "%s"
+		org_id                                           = "%s"
+		project_owner_id                                 = "%s"
+		with_default_alerts_settings                     = false
+		is_collect_database_specifics_statistics_enabled = false
+		is_data_explorer_enabled                         = false
+		is_performance_advisor_enabled                   = false
+		is_realtime_performance_panel_enabled            = false
+		is_schema_advisor_enabled                        = false
+	  }
+	  
+	  data "mongodbatlas_backup_compliance_policy" "backup_policy" {
+		project_id = mongodbatlas_backup_compliance_policy.backup_policy_res.project_id
+	  }
+	  
+	  resource "mongodbatlas_backup_compliance_policy" "backup_policy_res" {
+		project_id                 = mongodbatlas_project.test.id
+		authorized_email           = "test@example.com"
+		copy_protection_enabled    = false
+		pit_enabled                = false
+		encryption_at_rest_enabled = false
+	  
+		restore_window_days = 7
+	  
+		on_demand_policy_item {
+		  frequency_interval = 0
+		  retention_unit     = "days"
+		  retention_value    = 3
+		}
+		
+		policy_item_hourly {
+			frequency_interval = 6
+			retention_unit     = "days"
+			retention_value    = 7
+		  }
+	  
+		policy_item_daily {
+			frequency_interval = 0
+			retention_unit     = "days"
+			retention_value    = 7
+		  }
+	  
+		  policy_item_weekly {
+			frequency_interval = 0
+			retention_unit     = "weeks"
+			retention_value    = 4
+		  }
+	  
+		  policy_item_monthly {
+			frequency_interval = 0
+			retention_unit     = "months"
+			retention_value    = 12
+		  }
+	  
+	  }
+	`, projectName, orgID, projectOwnerID)
+}
+
+func testAccMongoDBAtlasBackupCompliancePolicyConfigWithoutRestoreDays(projectName, orgID, projectOwnerID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name                                             = "%s"
+		org_id                                           = "%s"
+		project_owner_id                                 = "%s"
+		with_default_alerts_settings                     = false
+		is_collect_database_specifics_statistics_enabled = false
+		is_data_explorer_enabled                         = false
+		is_performance_advisor_enabled                   = false
+		is_realtime_performance_panel_enabled            = false
+		is_schema_advisor_enabled                        = false
+	  }
+	  
+	  data "mongodbatlas_backup_compliance_policy" "backup_policy" {
+		project_id = mongodbatlas_backup_compliance_policy.backup_policy_res.project_id
+	  }
+	  
+	  resource "mongodbatlas_backup_compliance_policy" "backup_policy_res" {
+		project_id                 = mongodbatlas_project.test.id
+		authorized_email           = "test@example.com"
+		copy_protection_enabled    = false
+		pit_enabled                = false
+		encryption_at_rest_enabled = false
+	  
+		//restore_window_days = 7
+	  
+		on_demand_policy_item {
+		  frequency_interval = 0
+		  retention_unit     = "days"
+		  retention_value    = 3
+		}
+		
+		policy_item_hourly {
+			frequency_interval = 6
+			retention_unit     = "days"
+			retention_value    = 7
+		  }
+	  
+		policy_item_daily {
+			frequency_interval = 0
+			retention_unit     = "days"
+			retention_value    = 7
+		  }
+	  
+		  policy_item_weekly {
+			frequency_interval = 0
+			retention_unit     = "weeks"
+			retention_value    = 4
+		  }
+	  
+		  policy_item_monthly {
+			frequency_interval = 0
+			retention_unit     = "months"
+			retention_value    = 12
+		  }
+	  
+	  }
+	`, projectName, orgID, projectOwnerID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -1,0 +1,920 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		dataSourceName = "data.mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		clusterName    = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleConfigNoPolicies(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(3),
+					ReferenceMinuteOfHour: pointy.Int64(45),
+					RestoreWindowDays:     pointy.Int64(4),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "reference_hour_of_day"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "reference_minute_of_hour"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "restore_window_days"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_hourly.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_daily.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_weekly.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_monthly.#")),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleNewPoliciesConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(0),
+					ReferenceMinuteOfHour: pointy.Int64(0),
+					RestoreWindowDays:     pointy.Int64(7),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "0"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_hourly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_daily.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "4"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_weekly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_monthly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "3"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "reference_hour_of_day"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "reference_minute_of_hour"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "restore_window_days"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleAdvancedPoliciesConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(0),
+					ReferenceMinuteOfHour: pointy.Int64(0),
+					RestoreWindowDays:     pointy.Int64(7),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "0"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_hourly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_daily.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "4"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_weekly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_monthly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.1.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.1.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.1.retention_value", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.frequency_interval", "6"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.retention_value", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		region       = os.Getenv("AWS_REGION")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleExportPoliciesConfig(orgID, projectName, clusterName, policyName, roleName, awsAccessKey, awsSecretKey, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "20"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "5"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "4"),
+				),
+			},
+		},
+	})
+}
+func TestAccBackupRSCloudBackupSchedule_onepolicy(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleDefaultConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(3),
+					ReferenceMinuteOfHour: pointy.Int64(45),
+					RestoreWindowDays:     pointy.Int64(4),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleOnePolicyConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(0),
+					ReferenceMinuteOfHour: pointy.Int64(0),
+					RestoreWindowDays:     pointy.Int64(7),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "0"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleCopySettingsConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(3),
+					ReferenceMinuteOfHour: pointy.Int64(45),
+					RestoreWindowDays:     pointy.Int64(1),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.cloud_provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.region_name", "US_EAST_1"),
+					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.should_copy_oplogs", "true"),
+				),
+			},
+		},
+	})
+}
+func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleDefaultConfig(orgID, projectName, clusterName, &matlas.CloudProviderSnapshotBackupPolicy{
+					ReferenceHourOfDay:    pointy.Int64(3),
+					ReferenceMinuteOfHour: pointy.Int64(45),
+					RestoreWindowDays:     pointy.Int64(4),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
+					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
+					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "3"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_backup_schedule.schedule_test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(orgID, projectName, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 1,
+					RetentionUnit:     "days",
+					RetentionValue:    1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1")),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudBackupScheduleBasicConfig(orgID, projectName, clusterName, &matlas.PolicyItem{
+					FrequencyInterval: 2,
+					RetentionUnit:     "days",
+					RetentionValue:    3,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+		clusterName := ids["cluster_name"]
+
+		schedule, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
+		if err != nil || schedule == nil {
+			return fmt.Errorf("cloud Provider Snapshot Schedule (%s) does not exist: %s", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudBackupScheduleDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_backup_schedule" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		projectID := ids["project_id"]
+		clusterName := ids["cluster_name"]
+
+		schedule, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
+		if schedule != nil || err == nil {
+			return fmt.Errorf("cloud Provider Snapshot Schedule (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleConfigNoPolicies(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "EU_CENTRAL_1"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+		}
+
+		data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+		 }	
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleDefaultConfig(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "EU_CENTRAL_1"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+
+			policy_item_hourly {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 1
+			}
+			policy_item_daily {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 2
+			}
+			policy_item_weekly {
+				frequency_interval = 4
+				retention_unit     = "weeks"
+				retention_value    = 3
+			}
+			policy_item_monthly {
+				frequency_interval = 5
+				retention_unit     = "months"
+				retention_value    = 4
+			}
+		}
+
+		data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+		 }	
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleCopySettingsConfig(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+			
+			cluster_type = "REPLICASET"
+            replication_specs {
+            num_shards = 1
+            regions_config {
+              region_name     = "US_EAST_2"
+              electable_nodes = 3
+              priority        = 7
+              read_only_nodes = 0
+              }
+            }
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+			pit_enabled = true // enable point in time restore. you cannot copy oplogs when pit is not enabled.
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+
+			policy_item_hourly {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 1
+			}
+			policy_item_daily {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 2
+			}
+			policy_item_weekly {
+				frequency_interval = 4
+				retention_unit     = "weeks"
+				retention_value    = 3
+			}
+			policy_item_monthly {
+				frequency_interval = 5
+				retention_unit     = "months"
+				retention_value    = 4
+			}
+			copy_settings {
+				cloud_provider = "AWS"
+				frequencies = ["HOURLY",
+							"DAILY",
+							"WEEKLY",
+							"MONTHLY",
+							"ON_DEMAND"]
+				region_name = "US_EAST_1"
+				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
+				should_copy_oplogs = true
+			  }
+		}
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleOnePolicyConfig(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "EU_CENTRAL_1"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+
+			policy_item_hourly {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 1
+			}
+		}
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleNewPoliciesConfig(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "EU_CENTRAL_1"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+
+			policy_item_hourly {
+				frequency_interval = 2
+				retention_unit     = "days"
+				retention_value    = 1
+			}
+			policy_item_daily {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 4
+			}
+			policy_item_weekly {
+				frequency_interval = 4
+				retention_unit     = "weeks"
+				retention_value    = 2
+			}
+			policy_item_monthly {
+				frequency_interval = 5
+				retention_unit     = "months"
+				retention_value    = 3
+			}
+		}
+
+		data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+		 }	
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleBasicConfig(orgID, projectName, clusterName string, policy *matlas.PolicyItem) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+
+  // Provider Settings "block"
+  provider_name               = "AZURE"
+  provider_region_name        = "US_EAST_2"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true //enable cloud provider snapshots
+}
+
+resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+  project_id   = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+
+  policy_item_hourly {
+    frequency_interval = %[4]d
+    retention_unit     = %[5]q
+    retention_value    = %[6]d
+  }
+}
+
+data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+	project_id   = mongodbatlas_cluster.my_cluster.project_id
+	cluster_name = mongodbatlas_cluster.my_cluster.name
+}	
+	`, orgID, projectName, clusterName, policy.FrequencyInterval, policy.RetentionUnit, policy.RetentionValue)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleAdvancedPoliciesConfig(orgID, projectName, clusterName string, p *matlas.CloudProviderSnapshotBackupPolicy) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name         = %[3]q
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "EU_CENTRAL_1"
+			provider_instance_size_name = "M10"
+			cloud_backup     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+			project_id   = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name = mongodbatlas_cluster.my_cluster.name
+			auto_export_enabled = false
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
+
+			policy_item_hourly {
+				frequency_interval = 2
+				retention_unit     = "days"
+				retention_value    = 1
+			}
+			policy_item_daily {
+				frequency_interval = 1
+				retention_unit     = "days"
+				retention_value    = 4
+			}
+			policy_item_weekly {
+				frequency_interval = 4
+				retention_unit     = "weeks"
+				retention_value    = 2
+			}
+			policy_item_weekly {
+				frequency_interval = 5
+				retention_unit     = "weeks"
+				retention_value    = 5
+			}
+			policy_item_monthly {
+				frequency_interval = 5
+				retention_unit     = "months"
+				retention_value    = 3
+			}
+			policy_item_monthly {
+				frequency_interval = 6
+				retention_unit     = "months"
+				retention_value    = 4
+			}
+		}
+	`, orgID, projectName, clusterName, *p.ReferenceHourOfDay, *p.ReferenceMinuteOfHour, *p.RestoreWindowDays)
+}
+
+func testAccMongoDBAtlasCloudBackupScheduleExportPoliciesConfig(orgID, projectName, clusterName, policyName, roleName, awsAccessKey, awsSecretKey, region string) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+locals {
+	mongodbatlas_project_id = mongodbatlas_project.backup_project.id
+}
+
+provider "aws" {
+	region     = %[8]q
+	access_key = %[6]q
+	secret_key = %[7]q
+}
+
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "US_WEST_2"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true //enable cloud provider snapshots
+  depends_on = ["mongodbatlas_cloud_backup_snapshot_export_bucket.test"]
+}
+
+resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
+  project_id               = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name             = mongodbatlas_cluster.my_cluster.name
+  auto_export_enabled      = true
+  reference_hour_of_day    = 20
+  reference_minute_of_hour = "05"
+  restore_window_days      = 4
+
+  policy_item_daily {
+	frequency_interval = 1
+	retention_unit     = "days"
+	retention_value    = 4
+  }
+  export {
+		export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
+		frequency_type   = "daily"
+  }
+}
+
+resource "aws_s3_bucket" "backup" {
+	bucket = "${local.mongodbatlas_project_id}-s3-mongodb-backups"
+	force_destroy = true
+    object_lock_configuration {
+      object_lock_enabled = "Enabled"
+    }
+}
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+  project_id    = mongodbatlas_project.backup_project.id
+  provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+  project_id = mongodbatlas_project.backup_project.id
+  role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+	aws {
+	  iam_assumed_role_arn = aws_iam_role.test_role.arn
+	}
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id = mongodbatlas_project.backup_project.id
+
+  iam_role_id    = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+  bucket_name    = aws_s3_bucket.backup.bucket
+  cloud_provider = "AWS"
+}
+
+resource "aws_iam_role_policy" "test_policy" {
+	name = mongodbatlas_project.backup_project.id
+	role = aws_iam_role.test_role.id
+
+	policy = <<-EOF
+	{
+	  "Version": "2012-10-17",
+	  "Statement": [
+		{
+		  "Effect": "Allow",
+		  "Action": "*",
+		  "Resource": "*"
+		}
+	  ]
+	}
+	EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[5]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}
+	`, orgID, projectName, clusterName, policyName, roleName, awsAccessKey, awsSecretKey, region)
+}
+
+func testAccCheckMongoDBAtlasCloudProviderSnapshotBackupPolicyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["cluster_name"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
@@ -1,0 +1,135 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSBackupSnapshotExportBucket_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		snapshotExportBucket matlas.CloudProviderSnapshotExportBucket
+		resourceName         = "mongodbatlas_cloud_backup_snapshot_export_bucket.test"
+		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName           = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID            = os.Getenv("IAM_ROLE_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupSnapshotExportBucketConfig(projectID, bucketName, iamRoleID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName, &snapshotExportBucket),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "example-bucket"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSBackupSnapshotExportBucket_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_cloud_backup_snapshot_export_bucket.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName   = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID    = os.Getenv("IAM_ROLE_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupSnapshotExportBucketConfig(projectID, bucketName, iamRoleID),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasBackupSnapshotExportBucketImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName string, snapshotExportBucket *matlas.CloudProviderSnapshotExportBucket) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		response, _, err := conn.CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
+		if err == nil {
+			*snapshotExportBucket = *response
+			return nil
+		}
+
+		return fmt.Errorf("snapshot export bucket (%s) does not exist", ids["id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_bucket" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		snapshotExportBucket, _, err := conn.CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
+		if err == nil && snapshotExportBucket != nil {
+			return fmt.Errorf("snapshot export bucket (%s) still exists", ids["id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportBucketImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasBackupSnapshotExportBucketConfig(projectID, bucketName, iamRoleID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+			project_id     = "%[1]s"
+    	  	iam_role_id    = "%[3]s"
+       		bucket_name    = "%[2]s"
+       		cloud_provider = "AWS"
+    }
+	`, projectID, bucketName, iamRoleID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_export_job_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_export_job_test.go
@@ -1,0 +1,163 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSBackupSnapshotExportJob_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		snapshotExportJob matlas.CloudProviderSnapshotExportJob
+		resourceName      = "mongodbatlas_cloud_backup_snapshot_export_job.test"
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName        = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID         = os.Getenv("IAM_ROLE_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupSnapshotExportJobConfig(projectID, bucketName, iamRoleID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasBackupSnapshotExportJobExists(resourceName, &snapshotExportJob),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "example-bucket"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSBackupSnapshotExportJob_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_cloud_backup_snapshot_export_job.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		bucketName   = os.Getenv("AWS_S3_BUCKET")
+		iamRoleID    = os.Getenv("IAM_ROLE_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasBackupSnapshotExportJobConfig(projectID, bucketName, iamRoleID),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasBackupSnapshotExportJobImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportJobExists(resourceName string, snapshotExportJob *matlas.CloudProviderSnapshotExportJob) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		response, _, err := conn.CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
+		if err == nil {
+			*snapshotExportJob = *response
+			return nil
+		}
+
+		return fmt.Errorf("snapshot export job (%s) does not exist", ids["export_job_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_job" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		snapshotExportBucket, _, err := conn.CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
+		if err == nil && snapshotExportBucket != nil {
+			return fmt.Errorf("snapshot export job (%s) still exists", ids["export_job_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasBackupSnapshotExportJobImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["cluster_name"], ids["export_job_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasBackupSnapshotExportJobConfig(projectID, bucketName, iamRoleID string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = var.project_id
+  name         = "MyCluster"
+  disk_size_gb = 1
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true // enable cloud backup snapshots
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = var.project_id
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = "myDescription"
+  retention_in_days = 1
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+  project_id     = "%[1]s"
+  iam_role_id    = "%[3]s"
+  bucket_name    = "%[2]s"
+  cloud_provider = "AWS"
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_export_job" "test" {
+  project_id   = var.project_id
+  cluster_name = mongodbatlas_cluster.my_cluster.name
+  snapshot_id = mongodbatlas_cloud_backup_snapshot.test.snapshot_id
+  export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
+
+  custom_data {
+    key   = "exported by"
+    value = "myName"
+  }
+}`, projectID, bucketName, iamRoleID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
@@ -1,0 +1,356 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSCloudBackupSnapshotRestoreJob_basic(t *testing.T) {
+	var (
+		cloudBackupSnapshotRestoreJob     = matlas.CloudProviderSnapshotRestoreJob{}
+		resourceName                      = "mongodbatlas_cloud_backup_snapshot_restore_job.test"
+		snapshotsDataSourceName           = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.test"
+		snapshotsDataSourcePaginationName = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.pagination"
+		dataSourceName                    = "data.mongodbatlas_cloud_backup_snapshot_restore_job.test"
+		orgID                             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName                       = acctest.RandomWithPrefix("test-snapshot-acc")
+		targetProjectName                 = acctest.RandomWithPrefix("test-acc")
+		clusterName                       = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		description                       = fmt.Sprintf("My description in %s", clusterName)
+		retentionInDays                   = "1"
+		targetClusterName                 = fmt.Sprintf("test-acc-target-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigAutomated(orgID, projectName, clusterName, description, retentionInDays, targetProjectName, targetClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobExists(resourceName, &cloudBackupSnapshotRestoreJob),
+					testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobAttributes(&cloudBackupSnapshotRestoreJob, "automated"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.target_cluster_name", targetClusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "snapshot_id"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourcePaginationName, "results.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days", "snapshot_id"},
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSnapshotRestoreJob_basicDownload(t *testing.T) {
+	var (
+		cloudBackupSnapshotRestoreJob = matlas.CloudProviderSnapshotRestoreJob{}
+		resourceName                  = "mongodbatlas_cloud_backup_snapshot_restore_job.test"
+		orgID                         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName                   = acctest.RandomWithPrefix("test-acc")
+		clusterName                   = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		description                   = fmt.Sprintf("My description in %s", clusterName)
+		retentionInDays               = "1"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigDownload(orgID, projectName, clusterName, description, retentionInDays),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobExists(resourceName, &cloudBackupSnapshotRestoreJob),
+					testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobAttributes(&cloudBackupSnapshotRestoreJob, "download"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.download", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSnapshotRestoreJobWithPointTime_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		targetProjectName = acctest.RandomWithPrefix("test-acc-target")
+		clusterName       = acctest.RandomWithPrefix("test-acc")
+		description       = fmt.Sprintf("My description in %s", clusterName)
+		retentionInDays   = "1"
+		timeUtc           = int64(1)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigPointInTime(orgID, projectName, clusterName, description, retentionInDays, targetProjectName, timeUtc),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobExists(resourceName string, cloudBackupSnapshotRestoreJob *matlas.CloudProviderSnapshotRestoreJob) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if ids["snapshot_restore_job_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] cloudBackupSnapshotRestoreJob ID: %s", rs.Primary.Attributes["snapshot_restore_job_id"])
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			GroupID:     ids["project_id"],
+			ClusterName: ids["cluster_name"],
+			JobID:       ids["snapshot_restore_job_id"],
+		}
+
+		if snapshotRes, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters); err == nil {
+			*cloudBackupSnapshotRestoreJob = *snapshotRes
+			return nil
+		}
+
+		return fmt.Errorf("cloudBackupSnapshotRestoreJob (%s) does not exist", rs.Primary.Attributes["snapshot_restore_job_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobAttributes(cloudBackupSnapshotRestoreJob *matlas.CloudProviderSnapshotRestoreJob, deliveryType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cloudBackupSnapshotRestoreJob.DeliveryType != deliveryType {
+			return fmt.Errorf("bad cloudBackupSnapshotRestoreJob deliveryType: %s", cloudBackupSnapshotRestoreJob.DeliveryType)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_backup_snapshot_restore_job" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			GroupID:     ids["project_id"],
+			ClusterName: ids["cluster_name"],
+			JobID:       ids["snapshot_restore_job_id"],
+		}
+
+		res, _, _ := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+		if res != nil {
+			return fmt.Errorf("cloudBackupSnapshotRestoreJob (%s) still exists", rs.Primary.Attributes["snapshot_restore_job_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found:: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"], rs.Primary.Attributes["snapshot_restore_job_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigAutomated(orgID, projectName, clusterName, description, retentionInDays, targetProjectName, targetClusterName string) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+  
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true
+}
+
+resource "mongodbatlas_cluster" "targer_cluster" {
+	project_id   = mongodbatlas_project.backup_project.id
+	name         = %[7]q
+	
+	// Provider Settings "block"
+	provider_name               = "AWS"
+	provider_region_name        = "US_EAST_1"
+	provider_instance_size_name = "M10"
+	cloud_backup                = true
+  }
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = %[4]q
+  retention_in_days = %[5]q
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
+  project_id      = mongodbatlas_cloud_backup_snapshot.test.project_id
+  cluster_name    = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+  snapshot_id     = mongodbatlas_cloud_backup_snapshot.test.id
+
+  delivery_type_config   {
+    automated           = true
+    target_cluster_name = mongodbatlas_cluster.targer_cluster.name
+    target_project_id   = mongodbatlas_cluster.targer_cluster.project_id
+  }
+}
+
+data "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
+	project_id      = mongodbatlas_cloud_backup_snapshot.test.project_id
+	cluster_name    = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+	job_id       = mongodbatlas_cloud_backup_snapshot_restore_job.test.id  
+}
+
+data "mongodbatlas_cloud_backup_snapshot_restore_jobs" "test" {
+	project_id      = mongodbatlas_cloud_backup_snapshot.test.project_id
+	cluster_name    = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+}
+
+data "mongodbatlas_cloud_backup_snapshot_restore_jobs" "pagination" {
+	project_id      = mongodbatlas_cloud_backup_snapshot.test.project_id
+	cluster_name    = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+	page_num = 1
+	items_per_page = 5
+}
+
+	`, orgID, projectName, clusterName, description, retentionInDays, targetProjectName, targetClusterName)
+}
+
+func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigDownload(orgID, projectName, clusterName, description, retentionInDays string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+  
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true   // enable cloud provider snapshots
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = %[4]q
+  retention_in_days = %[5]q
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot.test.project_id
+  cluster_name = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+  snapshot_id  = mongodbatlas_cloud_backup_snapshot.test.id
+
+  delivery_type_config {
+    download = true
+  }
+}
+	`, orgID, projectName, clusterName, description, retentionInDays)
+}
+
+func testAccMongoDBAtlasCloudBackupSnapshotRestoreJobConfigPointInTime(orgID, projectName, clusterName, description, retentionInDays, targetProjectName string, pointTimeUTC int64) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_project" "target_project" {
+	name   = %[6]q
+	org_id = %[1]q
+}
+
+resource "mongodbatlas_cluster" "target_cluster" {
+  project_id   = mongodbatlas_project.target_project.id
+  name         = "cluster-target"
+  disk_size_gb = 10
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true
+}
+
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+  disk_size_gb = 10
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "US_EAST_1"
+  provider_instance_size_name = "M10"
+  provider_backup_enabled     = true   // enable cloud provider snapshots
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = %[4]q
+  retention_in_days = %[5]q
+}
+
+resource "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
+  project_id   = mongodbatlas_cloud_backup_snapshot.test.project_id
+  cluster_name = mongodbatlas_cloud_backup_snapshot.test.cluster_name
+  snapshot_id  = mongodbatlas_cloud_backup_snapshot.test.id
+
+  delivery_type_config {
+    point_in_time       = true
+    target_cluster_name = mongodbatlas_cluster.target_cluster.name
+    target_project_id   = mongodbatlas_cluster.target_cluster.project_id
+    oplog_ts            = %[7]d
+    oplog_inc           = 300
+  }
+}
+	`, orgID, projectName, clusterName, description, retentionInDays, targetProjectName, pointTimeUTC)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_backup_snapshot_test.go
@@ -1,0 +1,210 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
+	var (
+		cloudBackupSnapshot               = matlas.CloudProviderSnapshot{}
+		resourceName                      = "mongodbatlas_cloud_backup_snapshot.test"
+		snapshotsDataSourceName           = "data.mongodbatlas_cloud_backup_snapshots.test"
+		snapshotsDataSourcePaginationName = "data.mongodbatlas_cloud_backup_snapshots.pagination"
+		dataSourceName                    = "data.mongodbatlas_cloud_backup_snapshot.test"
+		orgID                             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName                       = acctest.RandomWithPrefix("test-acc")
+		clusterName                       = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		description                       = "My description in my cluster"
+		retentionInDays                   = "4"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCloudBackupSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudBackupSnapshotConfig(orgID, projectName, clusterName, description, retentionInDays),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCloudBackupSnapshotExists(resourceName, &cloudBackupSnapshot),
+					testAccCheckMongoDBAtlasCloudBackupSnapshotAttributes(&cloudBackupSnapshot, description),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourcePaginationName, "results.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasCloudBackupSnapshotImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotExists(resourceName string, cloudBackupSnapshot *matlas.CloudProviderSnapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if ids["snapshot_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] cloudBackupSnapshot ID: %s", ids["snapshot_id"])
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			SnapshotID:  ids["snapshot_id"],
+			GroupID:     ids["project_id"],
+			ClusterName: ids["cluster_name"],
+		}
+
+		res, _, err := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
+		if err == nil {
+			*cloudBackupSnapshot = *res
+			return nil
+		}
+
+		return fmt.Errorf("cloudBackupSnapshot (%s) does not exist", rs.Primary.Attributes["snapshot_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotAttributes(cloudBackupSnapshot *matlas.CloudProviderSnapshot, description string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cloudBackupSnapshot.Description != description {
+			return fmt.Errorf("bad cloudBackupSnapshot description: %s", cloudBackupSnapshot.Description)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_backup_snapshot" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		requestParameters := &matlas.SnapshotReqPathParameters{
+			SnapshotID:  ids["snapshot_id"],
+			GroupID:     ids["project_id"],
+			ClusterName: ids["cluster_name"],
+		}
+
+		res, _, _ := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
+
+		if res != nil {
+			return fmt.Errorf("cloudBackupSnapshot (%s) still exists", rs.Primary.Attributes["snapshot_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCloudBackupSnapshotImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"], rs.Primary.Attributes["snapshot_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasCloudBackupSnapshotConfig(orgID, projectName, clusterName, description, retentionInDays string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "backup_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "my_cluster" {
+  project_id   = mongodbatlas_project.backup_project.id
+  name         = %[3]q
+  disk_size_gb = 10
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_region_name        = "EU_CENTRAL_1"
+  provider_instance_size_name = "M10"
+  cloud_backup                = true //enable cloud backup snapshots
+}
+
+resource "mongodbatlas_cloud_backup_snapshot" "test" {
+  project_id        = mongodbatlas_cluster.my_cluster.project_id
+  cluster_name      = mongodbatlas_cluster.my_cluster.name
+  description       = %[4]q
+  retention_in_days = %[5]q
+}
+
+data "mongodbatlas_cloud_backup_snapshot" "test" {
+	snapshot_id  = mongodbatlas_cloud_backup_snapshot.test.snapshot_id
+	project_id        = mongodbatlas_cluster.my_cluster.project_id
+	cluster_name      = mongodbatlas_cluster.my_cluster.name
+}
+
+data "mongodbatlas_cloud_backup_snapshots" "test" {
+	project_id        = mongodbatlas_cluster.my_cluster.project_id
+	cluster_name      = mongodbatlas_cluster.my_cluster.name
+}
+
+data "mongodbatlas_cloud_backup_snapshots" "pagination" {
+	project_id        = mongodbatlas_cluster.my_cluster.project_id
+	cluster_name      = mongodbatlas_cluster.my_cluster.name
+	page_num = 1
+	items_per_page = 5
+}
+
+
+
+	`, orgID, projectName, clusterName, description, retentionInDays)
+}
+
+func TestResourceMongoDBAtlasCloudBackupSnapshot_snapshotID(t *testing.T) {
+	got, err := mongodbatlas.SplitSnapshotImportID("5cf5a45a9ccf6400e60981b6-projectname-environment-mongo-global-cluster-5cf5a45a9ccf6400e60981b7")
+	if err != nil {
+		t.Errorf("splitSnapshotImportID returned error(%s), expected error=nil", err)
+	}
+
+	expected := &matlas.SnapshotReqPathParameters{
+		GroupID:     "5cf5a45a9ccf6400e60981b6",
+		ClusterName: "projectname-environment-mongo-global-cluster",
+		SnapshotID:  "5cf5a45a9ccf6400e60981b7",
+	}
+
+	if diff := deep.Equal(expected, got); diff != nil {
+		t.Errorf("Bad splitSnapshotImportID return \n got = %#v\nwant = %#v \ndiff = %#v", expected, *got, diff)
+	}
+
+	if _, err := mongodbatlas.SplitSnapshotImportID("5cf5a45a9ccf6400e60981b6projectname-environment-mongo-global-cluster5cf5a45a9ccf6400e60981b7"); err == nil {
+		t.Error("splitSnapshotImportID expected to have error")
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_authorization_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_authorization_test.go
@@ -1,0 +1,153 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccConfigRSCloudProviderAccessAuthorizationAWS_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		policyName      = acctest.RandomWithPrefix("tf-acc")
+		roleName        = acctest.RandomWithPrefix("tf-acc")
+		roleNameUpdated = acctest.RandomWithPrefix("tf-acc")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"aws": {
+				VersionConstraint: "5.1.0",
+				Source:            "hashicorp/aws",
+			},
+		},
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		// same as regular cloud provider access resource
+		CheckDestroy: testAccCheckMongoDBAtlasProviderAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, policyName, roleName),
+			},
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, policyName, roleNameUpdated),
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSCloudProviderAccessAuthorizationAzure_basic(t *testing.T) {
+	var (
+		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName        = acctest.RandomWithPrefix("tf-acc")
+		atlasAzureAppID    = os.Getenv("AZURE_ATLAS_APP_ID")
+		servicePrincipalID = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
+		tenantID           = os.Getenv("AZURE_TENANT_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudProviderAccessAzure(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProviderAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAuthorizationAzure(orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID),
+			},
+		},
+	},
+	)
+}
+
+func testAccMongoDBAtlasCloudProviderAccessAuthorizationConfig(projectID, roleName, policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[2]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[3]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+  project_id    = %[1]q
+  provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+  project_id = %[1]q
+  role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+  aws {
+    iam_assumed_role_arn = aws_iam_role.test_role.arn
+  }
+}
+	`, projectID, policyName, roleName)
+}
+
+func testAccMongoDBAtlasCloudProviderAccessAuthorizationAzure(orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_project.test.id
+		provider_name = "AZURE"
+		azure_config {
+			atlas_azure_app_id = %[3]q
+			service_principal_id = %[4]q
+			tenant_id = %[5]q
+		}
+	 }
+
+   resource "mongodbatlas_cloud_provider_access_authorization" "test" {
+		project_id = mongodbatlas_project.test.id
+    role_id = mongodbatlas_cloud_provider_access_setup.test.role_id
+		azure {
+			atlas_azure_app_id = %[3]q
+			service_principal_id = %[4]q
+			tenant_id = %[5]q
+		}
+	 }
+	`, orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_setup_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_setup_test.go
@@ -1,0 +1,159 @@
+package acceptancetests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSCloudProviderAccessSetupAWS_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_cloud_provider_access_setup.test"
+		dataSourceName = "data.mongodbatlas_cloud_provider_access_setup.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		targetRole     = matlas.CloudProviderAccessRole{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProviderAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessSetupAWS(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					// same as regular cloud resource
+					testAccCheckMongoDBAtlasProviderAccessExists(resourceName, &targetRole),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.atlas_aws_account_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_config.0.atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_config.0.atlas_aws_account_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "created_date"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSCloudProviderAccessSetupAWS_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_provider_access_setup.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		targetRole   = matlas.CloudProviderAccessRole{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProviderAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessSetupAWS(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					// same as regular cloud provider because we are just checking in the api
+					testAccCheckMongoDBAtlasProviderAccessExists(resourceName, &targetRole),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.atlas_aws_account_arn"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				// ID remains the same project-id, provider-name and id for consistency
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderAccessImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSCloudProviderAccessSetupAzure_basic(t *testing.T) {
+	var (
+		resourceName       = "mongodbatlas_cloud_provider_access_setup.test"
+		dataSourceName     = "data.mongodbatlas_cloud_provider_access_setup.test"
+		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		atlasAzureAppID    = os.Getenv("AZURE_ATLAS_APP_ID")
+		servicePrincipalID = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
+		tenantID           = os.Getenv("AZURE_TENANT_ID")
+		projectName        = acctest.RandomWithPrefix("test-acc")
+		targetRole         = matlas.CloudProviderAccessRole{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckCloudProviderAccessAzure(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessSetupAzure(orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProviderAccessExists(resourceName, &targetRole),
+					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_config.0.atlas_azure_app_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_config.0.service_principal_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_config.0.tenant_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "last_updated_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "role_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "azure_config.0.atlas_azure_app_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "azure_config.0.service_principal_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "azure_config.0.tenant_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_updated_date"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testAccMongoDBAtlasCloudProviderAccessSetupAWS(orgID, projectName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_project.test.id
+		provider_name = "AWS"
+	 }
+
+	 data "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
+		provider_name = "AWS"
+		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
+	 }
+
+	`, orgID, projectName)
+}
+
+func testAccMongoDBAtlasCloudProviderAccessSetupAzure(orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_project.test.id
+		provider_name = "AZURE"
+		azure_config {
+			atlas_azure_app_id = %[3]q
+			service_principal_id = %[4]q
+			tenant_id = %[5]q
+		}
+	 }
+
+	 data "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
+		provider_name = "AWS"
+		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
+	 }
+	`, orgID, projectName, atlasAzureAppID, servicePrincipalID, tenantID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cloud_provider_access_test.go
@@ -1,0 +1,191 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	errorGetRead = "error reading cloud provider access %s"
+)
+
+func TestAccConfigRSCloudProviderAccessAWS_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_cloud_provider_access.test"
+		dataSourceName = "data.mongodbatlas_cloud_provider_access.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		targetRole     = matlas.CloudProviderAccessRole{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAWS(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProviderAccessExists(resourceName, &targetRole),
+					resource.TestCheckResourceAttrSet(resourceName, "atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "atlas_aws_account_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.atlas_aws_account_arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.created_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.role_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "aws_iam_roles.0.created_date"),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSCloudProviderAccess_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cloud_provider_access.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		targetRole   = matlas.CloudProviderAccessRole{}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCloudProviderAccessAWS(orgID, projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProviderAccessExists(resourceName, &targetRole),
+					resource.TestCheckResourceAttrSet(resourceName, "atlas_assumed_role_external_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "atlas_aws_account_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCloudProviderAccessImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	},
+	)
+}
+
+func testAccCheckMongoDBAtlasCloudProviderAccessImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["provider_name"], ids["id"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasProviderAccessDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cloud_provider_access" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		roles, _, err := conn.CloudProviderAccess.ListRoles(context.Background(), ids["project_id"])
+
+		if err != nil {
+			return fmt.Errorf(errorGetRead, err)
+		}
+
+		var targetRole matlas.CloudProviderAccessRole
+
+		// searching in roles
+		for i := range roles.AWSIAMRoles {
+			role := &(roles.AWSIAMRoles[i])
+
+			if role.RoleID == ids["id"] && role.ProviderName == ids["provider_name"] {
+				targetRole = *role
+			}
+		}
+
+		//  Found !!
+		if targetRole.RoleID != "" {
+			return fmt.Errorf("error cloud Provider Access Role (%s) still exists", ids["id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProviderAccessExists(resourceName string, targetRole *matlas.CloudProviderAccessRole) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		providerName := ids["provider_name"]
+		id := ids["id"]
+
+		roles, _, err := conn.CloudProviderAccess.ListRoles(context.Background(), ids["project_id"])
+
+		if err != nil {
+			return fmt.Errorf(errorGetRead, err)
+		}
+
+		if providerName == "AWS" {
+			for i := range roles.AWSIAMRoles {
+				if roles.AWSIAMRoles[i].RoleID == id && roles.AWSIAMRoles[i].ProviderName == providerName {
+					*targetRole = roles.AWSIAMRoles[i]
+					return nil
+				}
+			}
+		}
+
+		if providerName == "AZURE" {
+			for i := range roles.AzureServicePrincipals {
+				if *roles.AzureServicePrincipals[i].AzureID == id && roles.AzureServicePrincipals[i].ProviderName == providerName {
+					*targetRole = roles.AzureServicePrincipals[i]
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("error cloud Provider Access (%s) does not exist", ids["project_id"])
+	}
+}
+
+func testAccMongoDBAtlasCloudProviderAccessAWS(orgID, projectName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cloud_provider_access" "test" {
+		project_id = mongodbatlas_project.test.id
+		provider_name = "AWS"
+	 }
+
+	 data "mongodbatlas_cloud_provider_access" "test" {
+		project_id = mongodbatlas_cloud_provider_access.test.project_id
+	 }	 
+	`, orgID, projectName)
+}

--- a/test/acceptance-test/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -1,0 +1,167 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
+	var (
+		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
+	var (
+		dataSourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-project")
+		clusterName    = acctest.RandomWithPrefix("test-acc-cluster")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id                  = mongodbatlas_project.outage_project.id
+   		provider_name               = "AWS"
+   		name                        = "%s"
+   		backing_provider_name       = "AWS"
+   		provider_region_name        = "US_EAST_1"
+   		provider_instance_size_name = "M10"
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "outage_project" {
+		name   = "%s"
+		org_id = "%s"
+	}
+
+	resource "mongodbatlas_cluster" "atlas_cluster" {
+		project_id   = mongodbatlas_project.outage_project.id
+		name         = "%s"
+		cluster_type = "REPLICASET"
+	  
+		provider_name               = "AWS"
+		provider_instance_size_name = "M10"
+	  
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_EAST_2"
+			electable_nodes = 2
+			priority        = 6
+			read_only_nodes = 0
+		  }
+		  regions_config {
+			region_name     = "US_WEST_1"
+			electable_nodes = 2
+			priority        = 5
+			read_only_nodes = 2
+		  }
+		}
+	  }
+
+	  resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
+		project_id = mongodbatlas_project.outage_project.id
+		cluster_name = mongodbatlas_cluster.atlas_cluster.name
+		 outage_filters {
+		  cloud_provider = "AWS"
+		  region_name    = "US_EAST_1"
+		}
+		outage_filters {
+			   cloud_provider = "AWS"
+			   region_name    = "US_EAST_2"
+		}
+	}
+	`, projectName, orgID, clusterName)
+}
+
+func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cluster_outage_simulation" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
+		if err == nil {
+			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["cluster_name"])
+		}
+	}
+
+	return nil
+}

--- a/test/acceptance-test/resource_mongodbatlas_cluster_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_cluster_test.go
@@ -1,0 +1,2257 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, name, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "pit_enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "pit_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "version_release_system", "LTS"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, name, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "pit_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "version_release_system", "LTS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, name, "M40_NVME"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M40_NVME"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, name, "M50_NVME"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M50_NVME"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
+	var (
+		cluster                matlas.Cluster
+		resourceName           = "mongodbatlas_cluster.advance_conf"
+		dataSourceName         = "data.mongodbatlas_cluster.test"
+		dataSourceClustersName = "data.mongodbatlas_clusters.test"
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acctest.RandomWithPrefix("test-acc")
+		name                   = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					FailIndexKeyTooLong:              pointy.Bool(false),
+					JavascriptEnabled:                pointy.Bool(true),
+					MinimumEnabledTLSProtocol:        "TLS1_1",
+					NoTableScan:                      pointy.Bool(false),
+					OplogSizeMB:                      pointy.Int64(1000),
+					SampleRefreshIntervalBIConnector: pointy.Int64(310),
+					SampleSizeBIConnector:            pointy.Int64(110),
+					TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "version_release_system", "LTS"),
+					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.version_release_system", "LTS"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					MinimumEnabledTLSProtocol: "TLS1_2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.advance_conf"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					DefaultReadConcern:               "available",
+					DefaultWriteConcern:              "1",
+					FailIndexKeyTooLong:              pointy.Bool(false),
+					JavascriptEnabled:                pointy.Bool(true),
+					MinimumEnabledTLSProtocol:        "TLS1_1",
+					NoTableScan:                      pointy.Bool(false),
+					OplogSizeMB:                      pointy.Int64(1000),
+					SampleRefreshIntervalBIConnector: pointy.Int64(310),
+					SampleSizeBIConnector:            pointy.Int64(110),
+					TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					MinimumEnabledTLSProtocol: "TLS1_2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster.advance_conf"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					MinimumEnabledTLSProtocol: "TLS1_2",
+				}),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					FailIndexKeyTooLong:              pointy.Bool(false),
+					JavascriptEnabled:                pointy.Bool(true),
+					MinimumEnabledTLSProtocol:        "TLS1_1",
+					NoTableScan:                      pointy.Bool(false),
+					OplogSizeMB:                      pointy.Int64(1000),
+					SampleRefreshIntervalBIConnector: pointy.Int64(310),
+					SampleSizeBIConnector:            pointy.Int64(110),
+					TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.advance_conf"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					FailIndexKeyTooLong:              pointy.Bool(false),
+					JavascriptEnabled:                pointy.Bool(true),
+					MinimumEnabledTLSProtocol:        "TLS1_2",
+					NoTableScan:                      pointy.Bool(true),
+					OplogSizeMB:                      pointy.Int64(1000),
+					SampleRefreshIntervalBIConnector: pointy.Int64(310),
+					SampleSizeBIConnector:            pointy.Int64(110),
+					TransactionLifetimeLimitSeconds:  pointy.Int64(300),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "true"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, "false", &matlas.ProcessArgs{
+					FailIndexKeyTooLong:              pointy.Bool(false),
+					JavascriptEnabled:                pointy.Bool(false),
+					MinimumEnabledTLSProtocol:        "TLS1_1",
+					NoTableScan:                      pointy.Bool(false),
+					OplogSizeMB:                      pointy.Int64(990),
+					SampleRefreshIntervalBIConnector: pointy.Int64(0),
+					SampleSizeBIConnector:            pointy.Int64(0),
+					TransactionLifetimeLimitSeconds:  pointy.Int64(60),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "990"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "0"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "0"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "60"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicAzure(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.basic_azure"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicGCP(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.basic_gcp"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.basic_gcp"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, "true", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "bi_connector_config.0.enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, "false", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "bi_connector_config.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.multi_region"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-multi-%s", acctest.RandString(10))
+	)
+
+	createRegionsConfig := `regions_config {
+					region_name     = "US_EAST_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}`
+
+	updatedRegionsConfig := `regions_config {
+					region_name     = "US_WEST_2"
+					electable_nodes = 3
+					priority        = 6
+					read_only_nodes = 0
+				}
+				regions_config {
+					region_name     = "US_WEST_1"
+					electable_nodes = 1
+					priority        = 5
+					read_only_nodes = 0
+				}
+				regions_config {
+					region_name     = "US_EAST_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, "true", createRegionsConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "REPLICASET"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.regions_config.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, "false", updatedRegionsConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "REPLICASET"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.regions_config.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_Global(t *testing.T) {
+	var (
+		cluster        matlas.Cluster
+		resourceSuffix = "global_cluster"
+		resourceName   = fmt.Sprintf("mongodbatlas_cluster.%s", resourceSuffix)
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		name           = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGlobal(resourceSuffix, orgID, projectName, name, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.1.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "80"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "GEOSHARDED"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.regions_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.1.regions_config.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.aws_with_labels"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("testAcc-%s-%s-%s", "AWS", "M10", acctest.RandString(1))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, "false", "M10", "EU_CENTRAL_1", []matlas.Label{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, "false", "M10", "EU_CENTRAL_1",
+					[]matlas.Label{
+						{
+							Key:   "key 4",
+							Value: "value 4",
+						},
+						{
+							Key:   "key 3",
+							Value: "value 3",
+						},
+						{
+							Key:   "key 2",
+							Value: "value 2",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "3"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, "false", "M10", "EU_CENTRAL_1",
+					[]matlas.Label{
+						{
+							Key:   "key 1",
+							Value: "value 1",
+						},
+						{
+							Key:   "key 5",
+							Value: "value 5",
+						},
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.with_endpoint_link"
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		region       = os.Getenv("AWS_REGION")
+		providerName = "AWS"
+
+		vpcID           = os.Getenv("AWS_VPC_ID")
+		subnetID        = os.Getenv("AWS_SUBNET_ID")
+		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
+		clusterName     = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t); testCheckPeeringEnvAWS(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.with_azure_peering"
+
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
+		subcrptionID      = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+		vNetName          = os.Getenv("AZURE_VNET_NAME")
+		providerName      = "AZURE"
+		region            = os.Getenv("AZURE_REGION")
+
+		atlasCidrBlock = "192.168.208.0/21"
+		clusterName    = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		cluster          matlas.Cluster
+		resourceName     = "mongodbatlas_cluster.test"
+		projectID        = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		gcpRegion        = os.Getenv("GCP_REGION_NAME")
+		gcpProjectID     = os.Getenv("GCP_PROJECT_ID")
+		providerName     = "GCP"
+		gcpPeeringName   = fmt.Sprintf("test-acc-%s", acctest.RandString(3))
+		clusterName      = fmt.Sprintf("test-acc-%s", acctest.RandString(3))
+		gcpClusterRegion = os.Getenv("GCP_CLUSTER_REGION_NAME")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvGCP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName      = "mongodbatlas_cluster.test"
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName       = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		providerName      = "AZURE"
+		region            = os.Getenv("AZURE_REGION")
+		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
+		subcrptionID      = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+		vNetName          = os.Getenv("AZURE_VNET_NAME")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvAzure(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_cluster.test"
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		providerName = "AWS"
+		awsRegion    = os.Getenv("AWS_REGION")
+		vpcCIDRBlock = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, awsRegion, vpcCIDRBlock, awsAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName     = "mongodbatlas_cluster.test"
+		gcpProjectID     = os.Getenv("GCP_PROJECT_ID")
+		gcpRegion        = os.Getenv("GCP_REGION_NAME")
+		projectID        = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		clusterName      = fmt.Sprintf("test-acc-%s", acctest.RandString(3))
+		providerName     = "GCP"
+		gcpClusterRegion = os.Getenv("GCP_CLUSTER_REGION_NAME")
+		gcpPeeringName   = fmt.Sprintf("test-acc-%s", acctest.RandString(3))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvGCP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
+	var (
+		cluster                matlas.Cluster
+		resourceName           = "mongodbatlas_cluster.test"
+		dataSourceName         = "data.mongodbatlas_cluster.test"
+		dataSourceClustersName = "data.mongodbatlas_clusters.test"
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acctest.RandomWithPrefix("test-acc")
+		name                   = acctest.RandomWithPrefix("test-acc")
+
+		instanceSize = "M30"
+		minSize      = ""
+		maxSize      = "M60"
+
+		instanceSizeUpdated = "M60"
+		minSizeUpdated      = "M20"
+		maxSizeUpdated      = "M80"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(orgID, projectName, name, "true", "false", "true", "false", minSize, maxSize, instanceSize),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_compute_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "provider_auto_scaling_compute_max_instance_size", maxSize),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "auto_scaling_compute_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "provider_auto_scaling_compute_max_instance_size", maxSize),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttr(dataSourceName, "version_release_system", "LTS"),
+					resource.TestCheckResourceAttr(dataSourceName, "termination_protection_enabled", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
+					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.version_release_system", "LTS"),
+					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.termination_protection_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(orgID, projectName, name, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_compute_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_compute_scale_down_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "provider_auto_scaling_compute_min_instance_size", minSizeUpdated),
+					resource.TestCheckResourceAttr(resourceName, "provider_auto_scaling_compute_max_instance_size", maxSizeUpdated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, clusterName, true, false),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cloud_backup", "provider_backup_enabled", "retain_backups_enabled"},
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_tenant(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.tenant"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+	)
+
+	dbMajorVersion := testAccGetMongoDBAtlasMajorVersion()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, "M2", "2", dbMajorVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
+	var cluster matlas.Cluster
+
+	resourceName := "mongodbatlas_cluster.tenant"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+	name := fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	dbMajorVersion := testAccGetMongoDBAtlasMajorVersion()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, "M5", "5", dbMajorVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+		regionName   = "WESTERN_US"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+		regionName   = "US_WEST_2"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
+	SkipTest(t)
+	var (
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	replications := `replication_specs {
+		num_shards = 1
+		zone_name = "us2"
+		regions_config{
+			region_name     = "US_WEST_2"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	  }
+	 replication_specs {
+		num_shards = 1
+		zone_name = "us3"
+		regions_config{
+			region_name     = "US_EAST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	 }
+	 replication_specs {
+		num_shards = 1
+		zone_name = "us1"
+		regions_config{
+			region_name     = "US_WEST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	}`
+
+	replicationsUpdate := `replication_specs {
+		num_shards = 1
+		zone_name = "us2"
+		regions_config{
+			region_name     = "US_WEST_2"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	  }
+
+	 replication_specs {
+		num_shards = 1
+		zone_name = "us1"
+		regions_config{
+			region_name     = "US_WEST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replications),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "3"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cloud_backup", "provider_backup_enabled"},
+			},
+		},
+	})
+}
+
+func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
+	var (
+		cluster      matlas.Cluster
+		resourceName = "mongodbatlas_cluster.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					testAccCheckMongoDBAtlasClusterAttributes(&cluster, name),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.regions_config.#"),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasClusterImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["name"]), nil
+	}
+}
+
+func testAccGetMongoDBAtlasMajorVersion() string {
+	conn, _ := matlas.New(http.DefaultClient, matlas.SetBaseURL(matlas.CloudURL))
+	majorVersion, _, _ := conn.DefaultMongoDBMajorVersion.Get(context.Background())
+
+	return majorVersion
+}
+
+func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
+
+		if clusterResp, _, err := conn.Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
+			*cluster = *clusterResp
+			return nil
+		}
+
+		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
+	}
+}
+
+func testAccCheckMongoDBAtlasClusterAttributes(cluster *matlas.Cluster, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if cluster.Name != name {
+			return fmt.Errorf("bad name: %s", cluster.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasClusterDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_cluster" {
+			continue
+		}
+
+		// Try to find the cluster
+		_, _, err := conn.Clusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
+
+		if err == nil {
+			return fmt.Errorf("cluster (%s:%s) still exists", rs.Primary.Attributes["cluster_name"], rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, name string, backupEnabled, autoDiskGBEnabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "test" {
+			project_id                   = mongodbatlas_project.cluster_project.id
+			name                         = %[3]q
+			disk_size_gb                 = 100
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "EU_CENTRAL_1"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+			cloud_backup                 = %[4]t
+			pit_enabled                  = %[4]t
+			retain_backups_enabled       = true
+			auto_scaling_disk_gb_enabled = %[5]t
+			// Provider Settings "block"
+
+			provider_name               = "AWS"
+			provider_instance_size_name = "M30"
+		}
+	`, orgID, projectName, name, backupEnabled, autoDiskGBEnabled)
+}
+
+func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, name, instanceName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+
+			cloud_backup                 = true
+			// Provider Settings "block"
+			provider_region_name     = "US_EAST_1"
+			provider_name               = "AWS"
+			provider_instance_size_name = %[4]q
+			provider_volume_type        = "PROVISIONED"
+		}
+	`, orgID, projectName, name, instanceName)
+}
+
+func testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "advance_conf" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+			disk_size_gb = 10
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "EU_CENTRAL_1"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled =  %[4]s
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+
+			advanced_configuration  {
+				fail_index_key_too_long              = %[5]t
+				javascript_enabled                   = %[6]t
+				minimum_enabled_tls_protocol         = %[7]q
+				no_table_scan                        = %[8]t
+				oplog_size_mb                        = %[9]d
+				sample_size_bi_connector			 = %[10]d
+				sample_refresh_interval_bi_connector = %[11]d
+				transaction_lifetime_limit_seconds   = %[12]d
+			}
+		}
+
+		data "mongodbatlas_cluster" "test" {
+			project_id = mongodbatlas_cluster.advance_conf.project_id
+			name 	     = mongodbatlas_cluster.advance_conf.name
+		}
+
+		data "mongodbatlas_clusters" "test" {
+			project_id = mongodbatlas_cluster.advance_conf.project_id
+		}
+
+	`, orgID, projectName, name, autoscalingEnabled,
+		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
+		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, *p.TransactionLifetimeLimitSeconds)
+}
+
+func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "advance_conf" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  disk_size_gb = 10
+  cluster_type = "REPLICASET"
+  replication_specs {
+    num_shards = 1
+    regions_config {
+      region_name     = "EU_CENTRAL_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+
+  backup_enabled               = false
+  auto_scaling_disk_gb_enabled =  %[4]s
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_instance_size_name = "M10"
+
+  advanced_configuration {
+  default_read_concern                 = %[11]q
+  default_write_concern                = %[12]q
+  javascript_enabled                   = %[5]t
+  minimum_enabled_tls_protocol         = %[6]q
+  no_table_scan                        = %[7]t
+  oplog_size_mb                        = %[8]d
+  sample_size_bi_connector             = %[9]d
+  sample_refresh_interval_bi_connector = %[10]d
+  }
+}
+	`, orgID, projectName, name, autoscalingEnabled,
+		*p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
+		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, p.DefaultReadConcern, p.DefaultWriteConcern)
+}
+
+func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "advance_conf" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+			disk_size_gb = 10
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "EU_CENTRAL_1"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled =  %[4]s
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+			provider_region_name        = "EU_CENTRAL_1"
+
+			advanced_configuration {
+				minimum_enabled_tls_protocol         = %[5]q
+			}
+		}
+	`, orgID, projectName, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
+}
+
+func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "advance_conf" {
+  project_id   = mongodbatlas_project.cluster_project.id
+  name         = %[3]q
+  disk_size_gb = 10
+
+  cluster_type = "REPLICASET"
+  replication_specs {
+    num_shards = 1
+    regions_config {
+      region_name     = "EU_CENTRAL_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+
+  backup_enabled               = false
+  auto_scaling_disk_gb_enabled =  %[4]s
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_instance_size_name = "M10"
+  provider_region_name        = "EU_CENTRAL_1"
+
+  advanced_configuration {
+    minimum_enabled_tls_protocol = %[5]q
+  }
+}
+	`, orgID, projectName, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
+}
+
+func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabled string) string {
+	return fmt.Sprintf(`
+
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "basic_azure" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "US_EAST_2"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			cloud_backup                 = %[4]q
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "AZURE"
+			provider_disk_type_name     = "P6"
+			provider_instance_size_name = "M30"
+			provider_region_name        = "US_EAST_2"
+		}
+	`, orgID, projectName, name, backupEnabled)
+}
+
+func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "basic_gcp" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+			disk_size_gb = 40
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "US_EAST_4"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			cloud_backup                 = %[4]q
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "GCP"
+			provider_instance_size_name = "M30"
+		}
+	`, orgID, projectName, name, backupEnabled)
+}
+
+func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, backupEnabled string, biConnectorEnabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "basic_gcp" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+			disk_size_gb = 40
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "US_EAST_4"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			cloud_backup                 = %[4]q
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "GCP"
+			provider_instance_size_name = "M30"
+			bi_connector_config {
+				enabled = %[5]t
+			}
+		}
+	`, orgID, projectName, name, backupEnabled, biConnectorEnabled)
+}
+
+func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "multi_region" {
+			project_id              = mongodbatlas_project.cluster_project.id
+			name                    = %[3]q
+			disk_size_gb            = 100
+			num_shards              = 1
+			provider_backup_enabled = %[4]s
+			cluster_type            = "REPLICASET"
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+
+			replication_specs {
+				num_shards = 1
+
+				%[5]s
+			}
+		}
+	`, orgID, projectName, name, backupEnabled, regionsConfig)
+}
+
+func testAccMongoDBAtlasClusterConfigGlobal(resourceName, orgID, projectName, name, backupEnabled string) string {
+	return fmt.Sprintf(`
+
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[3]q
+			org_id = %[2]q
+		}
+		resource "mongodbatlas_cluster" %[1]q {
+			project_id              = mongodbatlas_project.cluster_project.id
+			name                    = %[4]q
+			disk_size_gb            = 80
+			num_shards              = 1
+			backup_enabled          = %[5]s
+			provider_backup_enabled = true
+			cluster_type            = "GEOSHARDED"
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M30"
+
+			replication_specs {
+				zone_name  = "Zone 1"
+				num_shards = 2
+				regions_config {
+				region_name     = "US_EAST_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+				}
+			}
+
+			replication_specs {
+				zone_name  = "Zone 2"
+				num_shards = 2
+				regions_config {
+				region_name     = "US_EAST_2"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+				}
+			}
+		}
+	`, resourceName, orgID, projectName, name, backupEnabled)
+}
+
+func testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, instanceSize, diskSize, majorDBVersion string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "tenant" {
+		project_id = mongodbatlas_project.cluster_project.id
+		name       = %[3]q
+
+		provider_name         = "TENANT"
+		backing_provider_name = "AWS"
+		provider_region_name  = "US_EAST_1"
+	  	//M2 must be 2, M5 must be 5
+	  	disk_size_gb            = %[4]q
+
+		provider_instance_size_name  = %[5]q
+		//These must be the following values
+ 	 	mongo_db_major_version = %[6]q
+	  }
+	`, orgID, projectName, name, diskSize, instanceSize, majorDBVersion)
+}
+
+func testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, name string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "tenant" {
+		project_id = mongodbatlas_project.cluster_project.id
+		name       = %[3]q
+
+		provider_name        = "AWS"
+		provider_region_name = "EU_CENTRAL_1"
+
+		provider_instance_size_name  = "M10"
+		disk_size_gb                 = 10
+		auto_scaling_disk_gb_enabled = true
+	  }
+	`, orgID, projectName, name)
+}
+
+func testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, backupEnabled, tier, region string, labels []matlas.Label) string {
+	var labelsConf string
+	for _, label := range labels {
+		labelsConf += fmt.Sprintf(`
+			labels {
+				key   = "%s"
+				value = "%s"
+			}
+		`, label.Key, label.Value)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "aws_with_labels" {
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
+			disk_size_gb = 10
+  
+			backup_enabled               = %[4]s
+			auto_scaling_disk_gb_enabled = false
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = %[5]q
+			cluster_type = "REPLICASET"
+			  replication_specs {
+				num_shards = 1
+				regions_config {
+				  region_name     = %[6]q
+				  electable_nodes = 3
+				  priority        = 7
+				  read_only_nodes = 0
+				}
+		  	}
+			%[7]s
+		}
+	`, orgID, projectName, name, backupEnabled, tier, region, labelsConf)
+}
+
+func testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName string) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+			region     = "${lower(replace("%[5]s", "_", "-"))}"
+			access_key = "%[1]s"
+			secret_key = "%[2]s"
+		}
+
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = "%[3]s"
+			provider_name = "%[4]s"
+			region        = "%[5]s"
+		}
+
+		resource "aws_vpc_endpoint" "ptfe_service" {
+			vpc_id             = "%[6]s"
+			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
+			vpc_endpoint_type  = "Interface"
+			subnet_ids         = ["%[7]s"]
+			security_group_ids = ["%[8]s"]
+		}
+
+		resource "mongodbatlas_privatelink_endpoint_service" "test" {
+			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
+			private_link_id       = mongodbatlas_privatelink_endpoint.test.private_link_id
+			endpoint_service_id = aws_vpc_endpoint.ptfe_service.id
+			provider_name = "%[4]s"
+		}
+
+		resource "mongodbatlas_cluster" "with_endpoint_link" {
+		  project_id             = "%[3]s"
+		  name                   = "%[9]s"
+		  disk_size_gb           = 5
+
+		  // Provider Settings "block"
+		  provider_name               = "AWS"
+		  provider_region_name        = "${upper(replace("%[5]s", "-", "_"))}"
+		  provider_instance_size_name = "M10"
+		  provider_backup_enabled     = true // enable cloud provider snapshots
+		  depends_on = ["mongodbatlas_privatelink_endpoint_service.test"]
+		}
+	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName)
+}
+
+func testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id       = "%[1]s"
+			atlas_cidr_block = "%[8]s"
+			provider_name    = "%[2]s"
+			region           = "%[9]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id            = "%[1]s"
+			atlas_cidr_block      = "192.168.0.0/21"
+			container_id          = mongodbatlas_network_container.test.container_id
+			provider_name         = "%[2]s"
+			azure_directory_id    = "%[3]s"
+			azure_subscription_id = "%[4]s"
+			resource_group_name   = "%[5]s"
+			vnet_name             = "%[6]s"
+		}
+
+		resource "mongodbatlas_cluster" "with_azure_peering" {
+			project_id   = "%[1]s"
+			name         = "%[7]s"
+
+			cluster_type = "REPLICASET"
+			  replication_specs {
+				num_shards = 1
+				regions_config {
+				  region_name     = "%[9]s"
+				  electable_nodes = 3
+				  priority        = 7
+				  read_only_nodes = 0
+				}
+		  	}
+
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "%[2]s"
+			provider_disk_type_name     = "P6"
+			provider_instance_size_name = "M10"
+
+			depends_on = ["mongodbatlas_network_peering.test"]
+		}
+	`, projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region)
+}
+
+func testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion string) string {
+	return fmt.Sprintf(`
+		provider "google" {
+			project     = "%[1]s"
+			region      = "%[2]s"
+		}
+
+		resource "mongodbatlas_network_container" "test" {
+			project_id       = "%[3]s"
+			atlas_cidr_block = "192.168.192.0/18"
+			provider_name    = "%[4]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id     = "%[3]s"
+			container_id   = "${mongodbatlas_network_container.test.container_id}"
+			provider_name  = "%[4]s"
+			gcp_project_id = "%[1]s"
+			network_name   = "default"
+		}
+
+		data "google_compute_network" "default" {
+			name = "default"
+		}
+
+		resource "google_compute_network_peering" "gcp_peering" {
+			name         = "%[5]s"
+			network      = "${data.google_compute_network.default.self_link}"
+			peer_network = "https://www.googleapis.com/compute/v1/projects/${mongodbatlas_network_peering.test.atlas_gcp_project_id}/global/networks/${mongodbatlas_network_peering.test.atlas_vpc_name}"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = "%[3]s"
+			name         = "%[6]s"
+			
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "%[7]s"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "%[4]s"
+			provider_instance_size_name = "M10"
+
+			depends_on = ["google_compute_network_peering.gcp_peering"]
+		}
+	`, gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion)
+}
+
+func testAccMongoDBAtlasClusterConfigAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = "%[1]s"
+			name         = "%[2]s"
+
+            cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "%[4]s"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			auto_scaling_disk_gb_enabled = false
+
+			// Provider Settings "block"
+			provider_name               = "%[3]s"
+			provider_instance_size_name = "M10"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id            = "%[1]s"
+			atlas_cidr_block      = "192.168.0.0/21"
+			container_id          = "${mongodbatlas_cluster.test.container_id}"
+			provider_name         = "%[3]s"
+			azure_directory_id    = "%[5]s"
+			azure_subscription_id = "%[6]s"
+			resource_group_name   = "%[7]s"
+			vnet_name             = "%[8]s"
+		}
+	`, projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName)
+}
+
+func testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, region, vpcCIDRBlock, awsAccountID string) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+			region     = lower(replace("%[6]s", "_", "-"))
+			access_key = "%[1]s"
+			secret_key = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = "%[3]s"
+			name         = "%[4]s"
+			
+			cluster_type = "REPLICASET"
+		    replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "%[6]s"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			auto_scaling_disk_gb_enabled = false
+
+			// Provider Settings "block"
+			provider_name               = "%[5]s"
+			provider_instance_size_name = "M10"
+		}
+
+		resource "aws_default_vpc" "default" {
+			tags = {
+				Name = "Default VPC"
+			}
+		}
+
+		resource "mongodbatlas_network_peering" "mongo_peer" {
+			accepter_region_name   = lower(replace("%[6]s", "_", "-"))
+			project_id             = "%[3]s"
+			container_id           = mongodbatlas_cluster.test.container_id
+			provider_name          = "%[5]s"
+			route_table_cidr_block = "%[7]s"
+			vpc_id                 = aws_default_vpc.default.id
+			aws_account_id         = "%[8]s"
+		}
+
+		resource "aws_vpc_peering_connection_accepter" "aws_peer" {
+			vpc_peering_connection_id = mongodbatlas_network_peering.mongo_peer.connection_id
+			auto_accept               = true
+
+			tags = {
+				Side = "Accepter"
+			}
+		}
+	`, awsAccessKey, awsSecretKey, projectID, clusterName, providerName, region, vpcCIDRBlock, awsAccountID)
+}
+
+func testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName string) string {
+	return fmt.Sprintf(`
+		provider "google" {
+			project     = "%[1]s"
+			region      = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = "%[3]s"
+			name         = "%[4]s"
+			
+            cluster_type = "REPLICASET"
+			replication_specs {
+			  num_shards = 1
+			  regions_config {
+			     region_name     = "%[6]s"
+			     electable_nodes = 3
+			     priority        = 7
+                 read_only_nodes = 0
+		       }
+		    }
+
+			auto_scaling_disk_gb_enabled = true
+
+			// Provider Settings "block"
+			provider_name               = "%[5]s"
+			provider_instance_size_name = "M10"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id     = "%[3]s"
+			container_id   = mongodbatlas_cluster.test.container_id
+			provider_name  = "%[5]s"
+			gcp_project_id = "%[1]s"
+			network_name   = "default"
+		}
+
+		data "google_compute_network" "default" {
+			name = "default"
+		}
+
+		resource "google_compute_network_peering" "gcp_peering" {
+			name         = "%[7]s"
+			network      = data.google_compute_network.default.self_link
+			peer_network = "https://www.googleapis.com/compute/v1/projects/${mongodbatlas_network_peering.test.atlas_gcp_project_id}/global/networks/${mongodbatlas_network_peering.test.atlas_vpc_name}"
+		}
+	`, gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName)
+}
+
+func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(
+	orgID, projectName, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "test" {
+		project_id                              = mongodbatlas_project.cluster_project.id
+		name                                    = %[3]q
+		disk_size_gb                            = 100
+
+		cluster_type = "REPLICASET"
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			 region_name     = "EU_CENTRAL_1"
+			 electable_nodes = 3
+			 priority        = 7
+			 read_only_nodes = 0
+		   }
+		}
+		cloud_backup                            = %[4]s
+		auto_scaling_disk_gb_enabled            = %[5]s
+		auto_scaling_compute_enabled            = %[6]s
+		auto_scaling_compute_scale_down_enabled = %[7]s
+
+		//Provider Settings "block"
+		provider_name                                   = "AWS"
+		provider_instance_size_name                     = %[9]q
+		provider_auto_scaling_compute_min_instance_size = %[8]q
+		provider_auto_scaling_compute_max_instance_size = %[9]q
+
+		lifecycle { // To simulate if there a new instance size name to avoid scale cluster down to original value
+			ignore_changes = [provider_instance_size_name]
+		}
+	}
+
+	data "mongodbatlas_cluster" "test" {
+		project_id = mongodbatlas_cluster.test.project_id
+		name 	     = mongodbatlas_cluster.test.name
+	}
+
+	data "mongodbatlas_clusters" "test" {
+		project_id = mongodbatlas_cluster.test.project_id
+	}
+	`, orgID, projectName, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
+}
+
+func testAccMongoDBAtlasClusterConfigGCPRegionName(
+	orgID, projectName, name, regionName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "test" {
+  project_id                   = mongodbatlas_project.cluster_project.id
+  name                         = %[3]q
+  auto_scaling_disk_gb_enabled = true
+  provider_name                = "GCP"
+  disk_size_gb                 = 10
+  provider_instance_size_name  = "M10"
+  num_shards                   = 1
+  provider_region_name         = %[4]q
+}
+	`, orgID, projectName, name, regionName)
+}
+
+func testAccMongoDBAtlasClusterConfigRegions(
+	orgID, projectName, name, replications string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "test" {
+		project_id                              = mongodbatlas_project.cluster_project.id
+		name                                    = "%[3]s"
+		disk_size_gb            = 400
+	  num_shards              = 3
+	  provider_backup_enabled = true
+	  cluster_type            = "GEOSHARDED"
+	  // Provider Settings "block"
+	  provider_name               = "AWS"
+	  provider_disk_iops          = 1200
+	  provider_instance_size_name = "M30"
+	  %[4]s
+
+		lifecycle {
+		# avoid cluster has been auto-scaled to different instance size
+		ignore_changes = [provider_instance_size_name, disk_size_gb]
+	  }
+	}
+	`, orgID, projectName, name, replications)
+}
+
+func testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name string, backupEnabled, paused bool) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_project" "cluster_project" {
+	name   = %[2]q
+	org_id = %[1]q
+}
+resource "mongodbatlas_cluster" "test" {
+  project_id                   = mongodbatlas_project.cluster_project.id
+  name                         = %[3]q
+  disk_size_gb                 = 100
+  cluster_type = "REPLICASET"
+  replication_specs {
+    num_shards = 1
+    regions_config {
+      region_name     = "EU_CENTRAL_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+  cloud_backup                 = %[4]t
+  paused                       = %[5]t
+  // Provider Settings "block"
+
+  provider_name               = "AWS"
+  provider_instance_size_name = "M30"
+}
+	`, orgID, projectName, name, backupEnabled, paused)
+}

--- a/test/acceptance-test/resource_mongodbatlas_custom_db_role_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_custom_db_role_test.go
@@ -1,0 +1,793 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSCustomDBRoles_Basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_db_role.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		roleName     = fmt.Sprintf("test-acc-custom_role-%s", acctest.RandString(5))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "INSERT", fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "INSERT"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.resources.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "UPDATE", fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "UPDATE"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.resources.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSCustomDBRoles_WithInheritedRoles(t *testing.T) {
+	testRoleResourceName := "mongodbatlas_custom_db_role.test_role"
+	InheritedRoleResourceNameOne := "mongodbatlas_custom_db_role.inherited_role_one"
+	InheritedRoleResourceNameTwo := "mongodbatlas_custom_db_role.inherited_role_two"
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	projectName := acctest.RandomWithPrefix("test-acc")
+
+	inheritRole := []matlas.CustomDBRole{
+		{
+			RoleName: fmt.Sprintf("test-acc-INHERITED_ROLE-%s", acctest.RandString(5)),
+			Actions: []matlas.Action{{
+				Action: "INSERT",
+				Resources: []matlas.Resource{{
+					DB: pointy.String(fmt.Sprintf("b_test-acc-ddb_name-%s", acctest.RandString(5))),
+				}},
+			}},
+		},
+		{
+			RoleName: fmt.Sprintf("test-acc-INHERITED_ROLE-%s", acctest.RandString(5)),
+			Actions: []matlas.Action{{
+				Action: "SERVER_STATUS",
+				Resources: []matlas.Resource{{
+					Cluster: pointy.Bool(true),
+				}},
+			}},
+		},
+	}
+
+	testRole := &matlas.CustomDBRole{
+		RoleName: fmt.Sprintf("test-acc-TEST_ROLE-%s", acctest.RandString(5)),
+		Actions: []matlas.Action{{
+			Action: "UPDATE",
+			Resources: []matlas.Resource{{
+				DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+			}},
+		}},
+	}
+
+	inheritRoleUpdated := []matlas.CustomDBRole{
+		{
+			RoleName: inheritRole[0].RoleName,
+			Actions: []matlas.Action{{
+				Action: "FIND",
+				Resources: []matlas.Resource{{
+					DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+				}},
+			}},
+		},
+		{
+			RoleName: inheritRole[1].RoleName,
+			Actions: []matlas.Action{{
+				Action: "CONN_POOL_STATS",
+				Resources: []matlas.Resource{{
+					Cluster: pointy.Bool(true),
+				}},
+			}},
+		},
+	}
+
+	testRoleUpdated := &matlas.CustomDBRole{
+		RoleName: testRole.RoleName,
+		Actions: []matlas.Action{{
+			Action: "REMOVE",
+			Resources: []matlas.Resource{{
+				DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+			}},
+		}},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigWithInheritedRoles(orgID, projectName, inheritRole, testRole),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Roles
+					// inherited Role [0]
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceNameOne),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "role_name", inheritRole[0].RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.#", cast.ToString(len(inheritRole[0].Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.0.action", inheritRole[0].Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.0.resources.#", cast.ToString(len(inheritRole[0].Actions[0].Resources))),
+
+					// inherited Role [1]
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceNameTwo),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "role_name", inheritRole[1].RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.#", cast.ToString(len(inheritRole[1].Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.0.action", inheritRole[1].Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.0.resources.#", cast.ToString(len(inheritRole[1].Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRole.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.#", cast.ToString(len(testRole.Actions))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.action", testRole.Actions[0].Action),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.resources.#", cast.ToString(len(testRole.Actions[0].Resources))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "inherited_roles.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigWithInheritedRoles(orgID, projectName, inheritRoleUpdated, testRoleUpdated),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Role
+					// inherited Role [0]
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceNameOne),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameOne, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "role_name", inheritRoleUpdated[0].RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.#", cast.ToString(len(inheritRoleUpdated[0].Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.0.action", inheritRoleUpdated[0].Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameOne, "actions.0.resources.#", cast.ToString(len(inheritRoleUpdated[0].Actions[0].Resources))),
+
+					// inherited Role [1]
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceNameTwo),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceNameTwo, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "role_name", inheritRoleUpdated[1].RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.#", cast.ToString(len(inheritRoleUpdated[1].Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.0.action", inheritRoleUpdated[1].Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceNameTwo, "actions.0.resources.#", cast.ToString(len(inheritRoleUpdated[1].Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRoleUpdated.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.#", cast.ToString(len(testRoleUpdated.Actions))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.action", testRoleUpdated.Actions[0].Action),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.resources.#", cast.ToString(len(testRoleUpdated.Actions[0].Resources))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "inherited_roles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSCustomDBRoles_MultipleCustomRoles(t *testing.T) {
+	var (
+		testRoleResourceName      = "mongodbatlas_custom_db_role.test_role"
+		InheritedRoleResourceName = "mongodbatlas_custom_db_role.inherited_role"
+		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName               = acctest.RandomWithPrefix("test-acc")
+	)
+
+	inheritRole := &matlas.CustomDBRole{
+		RoleName: fmt.Sprintf("test-acc-INHERITED_ROLE-%s", acctest.RandString(5)),
+		Actions: []matlas.Action{
+			{
+				Action: "REMOVE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "FIND",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+	}
+
+	testRole := &matlas.CustomDBRole{
+		RoleName: fmt.Sprintf("test-acc-TEST_ROLE-%s", acctest.RandString(5)),
+		Actions: []matlas.Action{
+			{
+				Action: "UPDATE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "INSERT",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+		InheritedRoles: []matlas.InheritedRole{
+			{
+				Role: inheritRole.RoleName,
+				Db:   "admin",
+			},
+		},
+	}
+
+	inheritRoleUpdated := &matlas.CustomDBRole{
+		RoleName: inheritRole.RoleName,
+		Actions: []matlas.Action{
+			{
+				Action: "UPDATE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "FIND",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "INSERT",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+	}
+
+	testRoleUpdated := &matlas.CustomDBRole{
+		RoleName: testRole.RoleName,
+		Actions: []matlas.Action{
+			{
+				Action: "REMOVE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+		InheritedRoles: []matlas.InheritedRole{
+			{
+				Role: inheritRole.RoleName,
+				Db:   "admin",
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigMultiple(orgID, projectName, inheritRole, testRole),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceName),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "role_name", inheritRole.RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.#", cast.ToString(len(inheritRole.Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.action", inheritRole.Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.resources.#", cast.ToString(len(inheritRole.Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRole.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.#", cast.ToString(len(testRole.Actions))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.action", testRole.Actions[0].Action),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.resources.#", cast.ToString(len(testRole.Actions[0].Resources))),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigMultiple(orgID, projectName, inheritRoleUpdated, testRoleUpdated),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceName),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "role_name", inheritRoleUpdated.RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.#", cast.ToString(len(inheritRoleUpdated.Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.action", inheritRoleUpdated.Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.resources.#", cast.ToString(len(inheritRoleUpdated.Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRoleUpdated.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.#", cast.ToString(len(testRoleUpdated.Actions))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.action", testRoleUpdated.Actions[0].Action),
+					resource.TestCheckResourceAttr(testRoleResourceName, "actions.0.resources.#", cast.ToString(len(testRoleUpdated.Actions[0].Resources))),
+					resource.TestCheckResourceAttr(testRoleResourceName, "inherited_roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSCustomDBRoles_MultipleResources(t *testing.T) {
+	t.Skip()
+	var (
+		resourceName = "mongodbatlas_custom_db_role.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		roleName     string
+	)
+
+	for i := 0; i < 100; i++ {
+		roleName = fmt.Sprintf("test-acc-custom_role-%d", i)
+
+		t.Run(roleName, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				PreCheck:                 func() { testAccPreCheckBasic(t) },
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "INSERT", fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+						Check: resource.ComposeTestCheckFunc(
+							testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName),
+							resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+							resource.TestCheckResourceAttrSet(resourceName, "role_name"),
+							resource.TestCheckResourceAttrSet(resourceName, "actions.0.action"),
+							resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
+							resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
+							resource.TestCheckResourceAttr(resourceName, "actions.0.action", "INSERT"),
+							resource.TestCheckResourceAttr(resourceName, "actions.0.resources.#", "1"),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccConfigRSCustomDBRoles_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_db_role.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		roleName     = fmt.Sprintf("test-acc-custom_role-%s", acctest.RandString(5))
+		databaseName = fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "INSERT", databaseName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCustomDBRolesImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSCustomDBRoles_UpdatedInheritRoles(t *testing.T) {
+	var (
+		testRoleResourceName      = "mongodbatlas_custom_db_role.test_role"
+		InheritedRoleResourceName = "mongodbatlas_custom_db_role.inherited_role"
+		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName               = acctest.RandomWithPrefix("test-acc")
+	)
+
+	inheritRole := &matlas.CustomDBRole{
+		RoleName: fmt.Sprintf("test-acc-INHERITED_ROLE-%s", acctest.RandString(5)),
+		Actions: []matlas.Action{
+			{
+				Action: "REMOVE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "FIND",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+	}
+
+	inheritRoleUpdated := &matlas.CustomDBRole{
+		RoleName: inheritRole.RoleName,
+		Actions: []matlas.Action{
+			{
+				Action: "UPDATE",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "FIND",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+			{
+				Action: "INSERT",
+				Resources: []matlas.Resource{
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+					{
+						DB: pointy.String(fmt.Sprintf("test-acc-db_name-%s", acctest.RandString(5))),
+					},
+				},
+			},
+		},
+	}
+
+	testRole := &matlas.CustomDBRole{
+		RoleName: fmt.Sprintf("test-acc-TEST_ROLE-%s", acctest.RandString(5)),
+		InheritedRoles: []matlas.InheritedRole{
+			{
+				Role: inheritRole.RoleName,
+				Db:   "admin",
+			},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDBRolesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigMultiple(orgID, projectName, inheritRole, testRole),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceName),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "role_name", inheritRole.RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.#", cast.ToString(len(inheritRole.Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.action", inheritRole.Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.resources.#", cast.ToString(len(inheritRole.Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRole.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "inherited_roles.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigMultiple(orgID, projectName, inheritRoleUpdated, testRole),
+				Check: resource.ComposeTestCheckFunc(
+
+					// For Inherited Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(InheritedRoleResourceName),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttrSet(InheritedRoleResourceName, "actions.0.action"),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "role_name", inheritRoleUpdated.RoleName),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.#", cast.ToString(len(inheritRoleUpdated.Actions))),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.action", inheritRoleUpdated.Actions[0].Action),
+					resource.TestCheckResourceAttr(InheritedRoleResourceName, "actions.0.resources.#", cast.ToString(len(inheritRoleUpdated.Actions[0].Resources))),
+
+					// For Test Role
+					testAccCheckMongoDBAtlasCustomDBRolesExists(testRoleResourceName),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(testRoleResourceName, "role_name"),
+					resource.TestCheckResourceAttr(testRoleResourceName, "role_name", testRole.RoleName),
+					resource.TestCheckResourceAttr(testRoleResourceName, "inherited_roles.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
+		if err != nil {
+			return fmt.Errorf("custom DB Role (%s) does not exist", ids["role_name"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasCustomDBRolesDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_custom_db_role" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
+		if err == nil {
+			return fmt.Errorf("custom DB Role (%s) still exists", ids["role_name"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCustomDBRolesImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["role_name"]), nil
+	}
+}
+
+func testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, action, databaseName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_db_role" "test" {
+			project_id = mongodbatlas_project.test.id
+			role_name  = %[3]q
+
+			actions {
+				action = %[4]q
+				resources {
+					collection_name = ""
+					database_name   = %[5]q
+				}
+			}
+		}
+	`, orgID, projectName, roleName, action, databaseName)
+}
+
+func testAccMongoDBAtlasCustomDBRolesConfigWithInheritedRoles(orgID, projectName string, inheritedRole []matlas.CustomDBRole, testRole *matlas.CustomDBRole) string {
+	return fmt.Sprintf(`
+
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_db_role" "inherited_role_one" {
+		 	project_id = mongodbatlas_project.test.id
+		 	role_name  = %[3]q
+
+			actions {
+				action = %[4]q
+				resources {
+					collection_name = ""
+					database_name   = %[5]q
+				}
+			}
+		}
+
+		resource "mongodbatlas_custom_db_role" "inherited_role_two" {
+			project_id = "${mongodbatlas_custom_db_role.inherited_role_one.project_id}"
+		 	role_name  = %[6]q
+
+			actions {
+				action = %[7]q
+				resources {
+					cluster = %[8]t
+				}
+			}
+		}
+
+		resource "mongodbatlas_custom_db_role" "test_role" {
+			project_id = "${mongodbatlas_custom_db_role.inherited_role_one.project_id}"
+			role_name  = %[9]q
+
+			actions {
+				action = %[10]q
+				resources {
+					collection_name = ""
+					database_name   = %[11]q
+				}
+			}
+
+			inherited_roles {
+				role_name     = "${mongodbatlas_custom_db_role.inherited_role_one.role_name}"
+				database_name = "admin"
+			}
+
+			inherited_roles {
+				role_name     = "${mongodbatlas_custom_db_role.inherited_role_two.role_name}"
+				database_name = "admin"
+			}
+		}
+	`, orgID, projectName,
+		inheritedRole[0].RoleName, inheritedRole[0].Actions[0].Action, *inheritedRole[0].Actions[0].Resources[0].DB,
+		inheritedRole[1].RoleName, inheritedRole[1].Actions[0].Action, *inheritedRole[1].Actions[0].Resources[0].Cluster,
+		testRole.RoleName, testRole.Actions[0].Action, *testRole.Actions[0].Resources[0].DB,
+	)
+}
+
+func testAccMongoDBAtlasCustomDBRolesConfigMultiple(orgID, projectName string, inheritedRole, testRole *matlas.CustomDBRole) string {
+	getCustomRoleFields := func(customRole *matlas.CustomDBRole) map[string]string {
+		var (
+			actions        string
+			inheritedRoles string
+		)
+
+		for _, a := range customRole.Actions {
+			var resources string
+
+			// get the resources
+			for _, r := range a.Resources {
+				resources += fmt.Sprintf(`
+					resources {
+						collection_name = ""
+						database_name   = "%s"
+					}
+			`, *r.DB)
+			}
+
+			// get the actions and set the resources
+			actions += fmt.Sprintf(`
+				actions {
+					action = "%s"
+					%s
+				}
+			`, a.Action, resources)
+		}
+
+		for _, in := range customRole.InheritedRoles {
+			inheritedRoles += fmt.Sprintf(`
+				inherited_roles {
+					role_name     = "%s"
+					database_name = "%s"
+				}
+			`, in.Role, in.Db)
+		}
+
+		return map[string]string{
+			"actions":         actions,
+			"inherited_roles": inheritedRoles,
+		}
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_db_role" "inherited_role" {
+		 	project_id = mongodbatlas_project.test.id
+		 	role_name  = %[3]q
+
+			 %[4]s
+		}
+
+		resource "mongodbatlas_custom_db_role" "test_role" {
+			project_id = "${mongodbatlas_custom_db_role.inherited_role.project_id}"
+			role_name  = %[5]q
+
+			%[6]s
+
+			%[7]s
+		}
+	`, orgID, projectName,
+		inheritedRole.RoleName, getCustomRoleFields(inheritedRole)["actions"],
+		testRole.RoleName, getCustomRoleFields(testRole)["actions"], getCustomRoleFields(testRole)["inherited_roles"],
+	)
+}

--- a/test/acceptance-test/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
@@ -1,0 +1,144 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		_, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("custom dns configuration cluster(%s) does not exist", rs.Primary.ID)
+	}
+}
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_custom_dns_configuration_cluster_aws" {
+			continue
+		}
+
+		// Try to find the Custom DNS Configuration for Atlas Clusters on AWS
+		resp, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		if err != nil && resp != nil && resp.Enabled {
+			return fmt.Errorf("custom dns configuration cluster aws (%s) still enabled", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_custom_dns_configuration_cluster_aws" "test" {
+			project_id     = mongodbatlas_project.test.id
+			enabled       = %[3]t
+		}`, orgID, projectName, enabled)
+}

--- a/test/acceptance-test/resource_mongodbatlas_data_lake_pipeline_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_data_lake_pipeline_test.go
@@ -1,0 +1,132 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccClusterRSDataLakePipeline_basic(t *testing.T) {
+	var (
+		pipeline     matlas.DataLakePipeline
+		resourceName = "mongodbatlas_data_lake_pipeline.test"
+		clusterName  = acctest.RandomWithPrefix("test-acc-index")
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = acctest.RandomWithPrefix("test-acc-index")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakePipelineConfig(projectID, clusterName, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName, &pipeline),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasDataLakePipelineImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasDataLakePipelineImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s", ids["project_id"], ids["name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName string, pipeline *matlas.DataLakePipeline) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		response, _, err := conn.DataLakePipeline.Get(context.Background(), ids["project_id"], ids["name"])
+		if err == nil {
+			*pipeline = *response
+			return nil
+		}
+
+		return fmt.Errorf("DataLake pipeline (%s) does not exist", ids["name"])
+	}
+}
+
+func testAccMongoDBAtlasDataLakePipelineConfig(projectID, clusterName, pipelineName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "aws_conf" {
+			project_id   = %[1]q
+			name         = %[2]q
+			cluster_type = "REPLICASET"
+		  
+			replication_specs {
+			  region_configs {
+				electable_specs {
+				  instance_size = "M10"
+				  node_count    = 3
+				}
+				provider_name = "AWS"
+				priority      = 7
+				region_name   = "US_EAST_1"
+			  }
+			}
+			backup_enabled               = true
+		  }
+
+		resource "mongodbatlas_data_lake_pipeline" "test" {
+			project_id       = "%[1]s"
+			name			 = "%[3]s"
+			sink {
+				type = "DLS"
+				partition_fields {
+						field_name = "access"
+						order = 0
+				}
+			}	
+	
+
+			source {
+				type = "ON_DEMAND_CPS"
+				cluster_name = mongodbatlas_advanced_cluster.aws_conf.name
+				database_name = "sample_airbnb"
+				collection_name = "listingsAndReviews"
+			}
+
+			transformations {
+				field = "test"
+				type =  "EXCLUDE"
+			}
+		}
+	`, projectID, clusterName, pipelineName)
+}

--- a/test/acceptance-test/resource_mongodbatlas_data_lake_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_data_lake_test.go
@@ -1,0 +1,254 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSDataLake_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName        = "mongodbatlas_data_lake.test"
+		orgID               = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName         = acctest.RandomWithPrefix("test-acc")
+		name                = acctest.RandomWithPrefix("test-acc")
+		policyName          = acctest.RandomWithPrefix("test-acc")
+		roleName            = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket        = os.Getenv("AWS_S3_BUCKET")
+		testS3BucketUpdated = os.Getenv("AWS_S3_BUCKET_UPDATED")
+		dataLakeRegion      = "VIRGINIA_USA"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDataLakeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakeConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasDataLakeConfig(policyName, roleName, projectName, orgID, name, testS3BucketUpdated, dataLakeRegion, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSDataLake_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_data_lake.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasDataLakeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasDataLakeConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, "", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasDataLakeImportStateIDFunc(resourceName, testS3Bucket),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasDataLakeImportStateIDFunc(resourceName, s3Bucket string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["name"], s3Bucket), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasDataLakeExists(resourceName string, dataLake *matlas.DataLake) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if dataLakeResp, _, err := conn.DataLakes.Get(context.Background(), ids["project_id"], ids["name"]); err == nil {
+			*dataLake = *dataLakeResp
+			return nil
+		}
+
+		return fmt.Errorf("datalake (%s) does not exist", ids["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasDataLakeAttributes(dataLake *matlas.DataLake, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Printf("[DEBUG] difference dataLake.Name: %s , username : %s", dataLake.Name, name)
+		if dataLake.Name != name {
+			return fmt.Errorf("bad datalake name: %s", dataLake.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasDataLakeDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_data_lake" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		// Try to find the database user
+		_, _, err := conn.DataLakes.Get(context.Background(), ids["project_id"], ids["name"])
+		if err == nil {
+			return fmt.Errorf("datalake (%s) still exists", ids["project_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasDataLakeConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string, isUpdate bool) string {
+	stepDataLakeConfig := testAccMongoDBAtlasDataLakeConfigFirstStep(name, testS3Bucket)
+	if isUpdate {
+		stepDataLakeConfig = testAccMongoDBAtlasDataLakeConfigSecondStep(name, testS3Bucket, dataLakeRegion)
+	}
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}
+
+resource "mongodbatlas_project" "test" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepDataLakeConfig)
+}
+func testAccMongoDBAtlasDataLakeConfigFirstStep(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_data_lake" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+   aws {
+     role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+     test_s3_bucket = %[2]q
+   }
+}
+	`, name, testS3Bucket)
+}
+func testAccMongoDBAtlasDataLakeConfigSecondStep(name, testS3Bucket, dataLakeRegion string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_data_lake" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+   aws {
+     role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+     test_s3_bucket = %[2]q
+   }
+   data_process_region {
+      cloud_provider = "AWS"
+      region = %[3]q
+   }
+}
+	`, name, testS3Bucket, dataLakeRegion)
+}

--- a/test/acceptance-test/resource_mongodbatlas_event_trigger_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_event_trigger_test.go
@@ -1,0 +1,642 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	"go.mongodb.org/realm/realm"
+)
+
+func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE"},
+			Database:       "sample_airbnb",
+			Collection:     "listingsAndReviews",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+			FullDocument:   pointy.Bool(false),
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE", "DELETE"},
+			Database:       "sample_airbnb",
+			Collection:     "listingsAndReviews",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE"`, &event, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, &eventUpdated, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
+		awsRegion    = os.Getenv("AWS_REGION")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE"},
+			Database:       "sample_airbnb",
+			Collection:     "listingsAndReviews",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+			FullDocument:   pointy.Bool(false),
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "DATABASE",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE", "DELETE"},
+			Database:       "sample_airbnb",
+			Collection:     "listingsAndReviews",
+			ServiceID:      os.Getenv("MONGODB_REALM_SERVICE_ID"),
+			FullDocument:   pointy.Bool(false),
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE"`, awsAccountID, awsRegion, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, awsAccountID, awsRegion, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "AUTHENTICATION",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationType: "LOGIN",
+			Providers:     []string{"anon-user", "local-userpass"},
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "AUTHENTICATION",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE", "DELETE"},
+			OperationType:  "LOGIN",
+			Providers:      []string{"anon-user", "local-userpass"},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthentication(projectID, appID, `"anon-user", "local-userpass"`, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthentication(projectID, appID, `"anon-user", "local-userpass", "api-key"`, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
+		awsRegion    = os.Getenv("AWS_REGION")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "AUTHENTICATION",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationType: "LOGIN",
+			Providers:     []string{"anon-user", "local-userpass"},
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "AUTHENTICATION",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			OperationTypes: []string{"INSERT", "UPDATE", "DELETE"},
+			OperationType:  "LOGIN",
+			Providers:      []string{"anon-user", "local-userpass"},
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass"`, awsAccountID, awsRegion, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass", "api-key"`, awsAccountID, awsRegion, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "* * * * *",
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "* * * * *",
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigSchedule(projectID, appID, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigSchedule(projectID, appID, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
+		awsRegion    = os.Getenv("AWS_REGION")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "* * * * *",
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "* * * * *",
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, awsAccountID, awsRegion, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, awsAccountID, awsRegion, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSEventTriggerFunction_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_event_trigger.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		appID        = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp    = realm.EventTrigger{}
+	)
+	event := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "0 8 * * *",
+		},
+	}
+	eventUpdated := realm.EventTriggerRequest{
+		Name:       acctest.RandomWithPrefix("test-acc"),
+		Type:       "SCHEDULED",
+		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
+		Disabled:   pointy.Bool(false),
+		Config: &realm.EventTriggerConfig{
+			Schedule: "0 8 * * *",
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEventTriggerFunctionConfig(projectID, appID, &event),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEventTriggerFunctionConfig(projectID, appID, &eventUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasEventTriggerExists(resourceName string, eventTrigger *realm.EventTrigger) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ctx := context.Background()
+		conn, err := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).GetRealmClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if ids["trigger_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] trigger_id ID: %s", ids["trigger_id"])
+
+		res, _, err := conn.EventTriggers.Get(ctx, ids["project_id"], ids["app_id"], ids["trigger_id"])
+		if err == nil {
+			*eventTrigger = *res
+			return nil
+		}
+
+		return fmt.Errorf("cloudProviderSnapshot (%s) does not exist", rs.Primary.Attributes["snapshot_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasEventTriggerDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	conn, err := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).GetRealmClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_event_trigger" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		res, _, _ := conn.EventTriggers.Get(ctx, ids["project_id"], ids["app_id"], ids["trigger_id"])
+
+		if res != nil {
+			return fmt.Errorf("event trigger (%s) still exists", ids["trigger_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasEventTriggerImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s--%s--%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["app_id"], rs.Primary.Attributes["trigger_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabase(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest, fullDoc, fullDocBefore bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			function_id = %[5]q
+			disabled = %[6]t
+			config_operation_types = [%s]
+			config_database = %[8]q
+			config_collection = %[9]q
+			config_service_id = %[10]q
+			config_full_document = %[11]t
+			config_full_document_before = %[12]t
+			config_match = <<-EOF
+			{
+			  "updateDescription.updatedFields": {
+				"status": "blocked"
+			  }
+			}
+			EOF		
+}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled, operationTypes,
+		eventTrigger.Config.Database, eventTrigger.Config.Collection,
+		eventTrigger.Config.ServiceID, fullDoc, fullDocBefore)
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, operationTypes, awsAccID, awsRegion string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			disabled = %[5]t
+			config_operation_types = [%[6]s]
+			config_database = %[7]q
+			config_collection = %[8]q
+			config_service_id = %[9]q
+			config_match = "{\"updateDescription.updatedFields\":{\"status\":\"blocked\"}}"
+			event_processors{
+				aws_eventbridge{
+					config_account_id = %[10]q
+					config_region = %[11]q
+				}
+
+			}
+		}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, *eventTrigger.Disabled, operationTypes,
+		eventTrigger.Config.Database, eventTrigger.Config.Collection,
+		eventTrigger.Config.ServiceID, awsAccID, awsRegion)
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigAuthentication(projectID, appID, providers string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			function_id = %[5]q
+			disabled = %[6]t
+			config_operation_type = %[7]q
+			config_providers = [%[8]s]
+		}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled,
+		eventTrigger.Config.OperationType, providers)
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, providers, awsAccID, awsRegion string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			disabled = %[5]t
+			config_operation_type = %[6]q
+			config_providers = [%[7]s]
+			event_processors{
+				aws_eventbridge{
+					config_account_id = %[8]q
+					config_region = %[9]q
+				}
+			}
+		}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, *eventTrigger.Disabled, eventTrigger.Config.OperationType, providers,
+		awsAccID, awsRegion)
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigSchedule(projectID, appID string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			function_id = %[5]q
+			disabled = %[6]t
+			config_schedule = %[7]q
+		}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled,
+		eventTrigger.Config.Schedule)
+}
+
+func testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, awsAccID, awsRegion string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_event_trigger" "test" {
+			project_id = %[1]q
+			app_id = %[2]q
+			name = %[3]q
+			type = %[4]q
+			disabled = %[5]t
+			config_schedule = %[6]q
+			event_processors{
+				aws_eventbridge{
+					config_account_id = %[7]q
+					config_region = %[8]q
+				}
+			}
+		}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, *eventTrigger.Disabled, eventTrigger.Config.Schedule,
+		awsAccID, awsRegion)
+}
+
+func testAccMongoDBAtlasEventTriggerFunctionConfig(projectID, appID string, eventTrigger *realm.EventTriggerRequest) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_event_trigger" "test" {
+  project_id      = %[1]q
+  app_id          = %[2]q
+  name            = %[3]q
+  type            = %[4]q
+  function_id     = %[5]q
+  disabled        = %[6]t
+  config_schedule = %[7]q
+}
+	`, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID,
+		*eventTrigger.Disabled, eventTrigger.Config.Schedule)
+}

--- a/test/acceptance-test/resource_mongodbatlas_federated_database_instance_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_federated_database_instance_test.go
@@ -1,0 +1,403 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_federated_database_instance.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstanceConfigFirstSteps(name, projectName, orgID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				ResourceName:             resourceName,
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				ImportStateIdFunc:        testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFunc(resourceName),
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccFederatedDatabaseInstance_S3bucket(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_federated_database_instance.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		region       = "VIRGINIA_USA"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstanceConfigS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				ResourceName:             resourceName,
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				ImportStateIdFunc:        testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFuncS3Bucket(resourceName, testS3Bucket),
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_federated_database_instance.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName, orgID, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName, orgID, name string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "project-tf" {
+		name   = %[1]q
+		org_id = %[2]q
+	  }
+	  
+	  resource "mongodbatlas_cluster" "cluster-1" {
+		project_id = mongodbatlas_project.project-tf.id
+		provider_name               = "AWS"
+		name                        = "tfCluster0"
+		backing_provider_name       = "AWS"
+		provider_region_name        = "US_EAST_1"
+		provider_instance_size_name = "M10"
+	  }
+	  
+	  
+	  resource "mongodbatlas_cluster" "cluster-2" {
+		project_id = mongodbatlas_project.project-tf.id
+		provider_name               = "AWS"
+		name                        = "tfCluster1"
+		backing_provider_name       = "AWS"
+		provider_region_name        = "US_EAST_1"
+		provider_instance_size_name = "M10"
+	  }
+
+	  resource "mongodbatlas_federated_database_instance" "test" {
+		project_id = mongodbatlas_project.project-tf.id
+		name       = %[3]q
+		storage_databases {
+		  name = "VirtualDatabase0"
+		  collections {
+			name = "VirtualCollection0"
+			data_sources {
+			  collection = "listingsAndReviews"
+			  database   = "sample_airbnb"
+			  store_name = mongodbatlas_cluster.cluster-1.name
+			}
+			data_sources {
+
+			  collection = "listingsAndReviews"
+			  database   = "sample_airbnb"
+			  store_name = mongodbatlas_cluster.cluster-2.name
+			}
+		  }
+		}
+	  
+		storage_stores {
+		  name         = mongodbatlas_cluster.cluster-1.name
+		  cluster_name = mongodbatlas_cluster.cluster-1.name
+		  project_id   = mongodbatlas_project.project-tf.id
+		  provider     = "atlas"
+		  read_preference {
+			mode = "secondary"
+		  }
+		}
+	  
+		storage_stores {
+		  name         = mongodbatlas_cluster.cluster-2.name
+		  cluster_name = mongodbatlas_cluster.cluster-2.name
+		  project_id   = mongodbatlas_project.project-tf.id
+		  provider     = "atlas"
+		  read_preference {
+			mode = "secondary"
+		  }
+		}
+	  }
+	`, projectName, orgID, name)
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFuncS3Bucket(resourceName, s3Bucket string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["name"], s3Bucket), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s", ids["project_id"], ids["name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_federated_database_instance" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.DataFederation.Get(context.Background(), ids["project_id"], ids["name"])
+		if err == nil {
+			return fmt.Errorf("federated database instance (%s) still exists", ids["project_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstanceConfigS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseInstanceConfigFirstSteps3Bucket(name, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+func testAccMongoDBAtlasFederatedDatabaseInstanceConfigFirstSteps3Bucket(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+   
+   cloud_provider_config {
+	aws {
+		role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+		test_s3_bucket = %[2]q
+	  }
+   }
+
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[2]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[2]q
+	delimiter = "/"
+	name = %[2]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+	`, name, testS3Bucket)
+}
+
+func testAccMongoDBAtlasFederatedDatabaseInstanceConfigFirstSteps(federatedInstanceName, projectName, orgID string) string {
+	return fmt.Sprintf(`
+
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[3]q
+	}
+
+resource "mongodbatlas_federated_database_instance" "test" {
+   project_id         = mongodbatlas_project.test.id
+   name = %[1]q
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+	`, federatedInstanceName, projectName, orgID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_federated_query_limit_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_federated_query_limit_test.go
@@ -1,0 +1,225 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccFederatedDatabaseQueryLimit_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName = "mongodbatlas_federated_query_limit.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-project")
+		tenantName   = acctest.RandomWithPrefix("test-acc-tenant")
+		limitName    = "bytesProcessed.monthly"
+		policyName   = acctest.RandomWithPrefix("test-acc")
+		roleName     = acctest.RandomWithPrefix("test-acc")
+		testS3Bucket = os.Getenv("AWS_S3_BUCKET")
+		region       = "VIRGINIA_USA"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				Config:                   testAccMongoDBAtlasFederatedDatabaseQueryLimitConfig(policyName, roleName, projectName, orgID, tenantName, testS3Bucket, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "tenant_name"),
+					resource.TestCheckResourceAttr(resourceName, "limit_name", limitName),
+				),
+			},
+			{
+				ResourceName:             resourceName,
+				ProtoV6ProviderFactories: TestAccProviderV6Factories,
+				ImportStateIdFunc:        testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitImportStateIDFunc(resourceName),
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitConfig(policyName, roleName, projectName, orgID, name, testS3Bucket, dataLakeRegion string) string {
+	stepConfig := testAccMongoDBAtlasFederatedDatabaseQueryLimitConfigFirstStep(name, testS3Bucket)
+	return fmt.Sprintf(`
+resource "aws_iam_role_policy" "test_policy" {
+  name = %[1]q
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = %[2]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_aws_account_arn}"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config.0.atlas_assumed_role_external_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+}	
+resource "mongodbatlas_project" "test_project" {
+   name   = %[3]q
+   org_id = %[4]q
+}
+
+
+resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+   project_id = mongodbatlas_project.test_project.id
+   provider_name = "AWS"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+   project_id = mongodbatlas_project.test_project.id
+   role_id =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+
+   aws {
+      iam_assumed_role_arn = aws_iam_role.test_role.arn
+   }
+}
+
+%s
+	`, policyName, roleName, projectName, orgID, stepConfig)
+}
+
+func testAccMongoDBAtlasFederatedDatabaseQueryLimitConfigFirstStep(name, testS3Bucket string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_federated_database_instance" "db_instance" {
+   project_id         = mongodbatlas_project.test_project.id
+   name = %[1]q
+   cloud_provider_config {
+		aws {
+			role_id = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+			test_s3_bucket = %[2]q
+		}
+	}
+
+   storage_databases {
+	name = "VirtualDatabase0"
+	collections {
+			name = "VirtualCollection0"
+			data_sources {
+					collection = "listingsAndReviews"
+					database = "sample_airbnb"
+					store_name =  "ClusterTest"
+			}
+			data_sources {
+					store_name = %[2]q
+					path = "/{fileName string}.yaml"
+			}
+	}
+   }
+
+   storage_stores {
+	name = "ClusterTest"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+
+   storage_stores {
+	bucket = %[2]q
+	delimiter = "/"
+	name = %[2]q
+	prefix = "templates/"
+	provider = "s3"
+	region = "EU_WEST_1"
+   }
+
+   storage_stores {
+	name = "dataStore0"
+	cluster_name = "ClusterTest"
+	project_id = mongodbatlas_project.test_project.id
+	provider = "atlas"
+	read_preference {
+		mode = "secondary"
+	}
+   }
+}
+
+resource "mongodbatlas_federated_query_limit" "test" {
+	project_id = mongodbatlas_project.test_project.id
+	tenant_name = mongodbatlas_federated_database_instance.db_instance.name
+	limit_name = "bytesProcessed.monthly"
+	overrun_policy = "BLOCK"
+	value = 5147483648
+  }
+	`, name, testS3Bucket)
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["tenant_name"], ids["limit_name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_federated_query_limit" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"])
+		if err == nil {
+			return fmt.Errorf("federated database query limit (%s) for project (%s) and tenant (%s)still exists", ids["project_id"], ids["tenant_name"], ids["limit_name"])
+		}
+	}
+
+	return nil
+}

--- a/test/acceptance-test/resource_mongodbatlas_federated_settings_connected_organization_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_federated_settings_connected_organization_test.go
@@ -1,0 +1,123 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccFedRSFederatedSettingsOrganizationConfig_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		federatedSettingsIdentityProvider matlas.FederatedSettingsConnectedOrganization
+		resourceName                      = "mongodbatlas_federated_settings_org_config.test"
+		federationSettingsID              = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                             = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		idpID                             = os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationConfig(federationSettingsID, orgID, idpID),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigImportStateIDFunc(resourceName, federationSettingsID, orgID),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationConfig(federationSettingsID, orgID, idpID),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigImportStateIDFunc(resourceName, federationSettingsID, orgID),
+
+				ImportState: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigRExists(resourceName, &federatedSettingsIdentityProvider),
+					resource.TestCheckResourceAttr(resourceName, "federation_settings_id", federationSettingsID),
+					resource.TestCheckResourceAttr(resourceName, "name", "mongodb_federation_test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFedRSFederatedSettingsOrganizationConfig_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName         = "mongodbatlas_federated_settings_org_config.test"
+		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		idpID                = os.Getenv("MONGODB_ATLAS_FEDERATED_OKTA_IDP_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationConfig(federationSettingsID, orgID, idpID),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigImportStateIDFunc(resourceName, federationSettingsID, orgID),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigRExists(resourceName string,
+	federatedSettingsIdentityProvider *matlas.FederatedSettingsConnectedOrganization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		response, _, err := conn.FederatedSettings.GetConnectedOrg(context.Background(),
+			rs.Primary.Attributes["federation_settings_id"],
+			rs.Primary.Attributes["org_id"])
+		if err == nil {
+			*federatedSettingsIdentityProvider = *response
+			return nil
+		}
+
+		return fmt.Errorf("connected org  (%s) does not exist", rs.Primary.Attributes["org_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigImportStateIDFunc(resourceName, federationSettingsID, orgID string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		ID := encodeStateID(map[string]string{
+			"federation_settings_id": federationSettingsID,
+			"org_id":                 orgID,
+		})
+
+		ids := decodeStateID(ID)
+		return fmt.Sprintf("%s-%s", ids["federation_settings_id"], ids["org_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasFederatedSettingsOrganizationConfig(federationSettingsID, orgID, identityProviderID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_federated_settings_org_config" "test" {
+		federation_settings_id = "%[1]s"
+		org_id                 = "%[2]s"
+		domain_restriction_enabled = false
+		domain_allow_list          = ["reorganizeyourworld.com"]
+		identity_provider_id = "%[3]s"
+	  }`, federationSettingsID, orgID, identityProviderID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_federated_settings_identity_provider_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_federated_settings_identity_provider_test.go
@@ -1,0 +1,129 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccFedRSFederatedSettingsIdentityProvider_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		federatedSettingsIdentityProvider matlas.FederatedSettingsIdentityProvider
+		resourceName                      = "mongodbatlas_federated_settings_identity_provider.test"
+		federationSettingsID              = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		idpID                             = os.Getenv("MONGODB_ATLAS_FEDERATED_OKTA_IDP_ID")
+		ssoURL                            = os.Getenv("MONGODB_ATLAS_FEDERATED_SSO_URL")
+		issuerURI                         = os.Getenv("MONGODB_ATLAS_FEDERATED_ISSUER_URI")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsIdentityProviderConfig(federationSettingsID, ssoURL, issuerURI),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderImportStateIDFunc(resourceName, federationSettingsID, idpID),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsIdentityProviderConfig(federationSettingsID, ssoURL, issuerURI),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderImportStateIDFunc(resourceName, federationSettingsID, idpID),
+
+				ImportState: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderExists(resourceName, &federatedSettingsIdentityProvider, idpID),
+					resource.TestCheckResourceAttr(resourceName, "federation_settings_id", federationSettingsID),
+					resource.TestCheckResourceAttr(resourceName, "name", "mongodb_federation_test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFedRSFederatedSettingsIdentityProvider_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName         = "mongodbatlas_federated_settings_identity_provider.test"
+		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		idpID                = os.Getenv("MONGODB_ATLAS_FEDERATED_OKTA_IDP_ID")
+		ssoURL               = os.Getenv("MONGODB_ATLAS_FEDERATED_SSO_URL")
+		issuerURI            = os.Getenv("MONGODB_ATLAS_FEDERATED_ISSUER_URI")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsIdentityProviderConfig(federationSettingsID, ssoURL, issuerURI),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderImportStateIDFunc(resourceName, federationSettingsID, idpID),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderExists(resourceName string,
+	federatedSettingsIdentityProvider *matlas.FederatedSettingsIdentityProvider, idpID string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		response, _, err := conn.FederatedSettings.GetIdentityProvider(context.Background(),
+			rs.Primary.Attributes["federation_settings_id"],
+			idpID)
+		if err == nil {
+			*federatedSettingsIdentityProvider = *response
+			return nil
+		}
+
+		return fmt.Errorf("identity provider (%s) does not exist", idpID)
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderImportStateIDFunc(resourceName, federationSettingsID, idpID string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		ID := encodeStateID(map[string]string{
+			"federation_settings_id": federationSettingsID,
+			"okta_idp_id":            idpID,
+		})
+
+		ids := decodeStateID(ID)
+		return fmt.Sprintf("%s-%s", ids["federation_settings_id"], ids["okta_idp_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasFederatedSettingsIdentityProviderConfig(federationSettingsID, ssoURL, issuerURI string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_federated_settings_identity_provider" "test" {
+		federation_settings_id = "%[1]s"
+		name = "mongodb_federation_test"
+        associated_domains           = ["reorganizeyourworld.com"]
+        sso_debug_enabled = true
+        status = "ACTIVE"
+        sso_url = "%[2]s"
+        issuer_uri = "%[3]s"
+        request_binding = "HTTP-POST"
+        response_signature_algorithm = "SHA-256"
+	  }`, federationSettingsID, ssoURL, issuerURI)
+}

--- a/test/acceptance-test/resource_mongodbatlas_federated_settings_organization_role_mapping_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_federated_settings_organization_role_mapping_test.go
@@ -1,0 +1,146 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccFedRSFederatedSettingsOrganizationRoleMapping_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		federatedSettingsOrganizationRoleMapping matlas.FederatedSettingsOrganizationRoleMapping
+		resourceName                             = "mongodbatlas_federated_settings_org_role_mapping.test"
+		federationSettingsID                     = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                                    = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		groupID                                  = os.Getenv("MONGODB_ATLAS_FEDERATED_GROUP_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasFederatedSettingsOrganizationRoleMappingConfig(federationSettingsID, orgID, groupID),
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingExists(resourceName, &federatedSettingsOrganizationRoleMapping),
+					resource.TestCheckResourceAttr(resourceName, "federation_settings_id", federationSettingsID),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "external_group_name", "newtestgroup"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFedRSFederatedSettingsOrganizationRoleMapping_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceName         = "mongodbatlas_federated_settings_org_role_mapping.test"
+		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
+		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
+		groupID              = os.Getenv("MONGODB_ATLAS_FEDERATED_GROUP_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testCheckFederatedSettings(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationRoleMappingConfig(federationSettingsID, orgID, groupID),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingImportStateIDFunc(resourceName),
+				ImportState:       false,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingExists(resourceName string,
+	federatedSettingsOrganizationRoleMapping *matlas.FederatedSettingsOrganizationRoleMapping) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		response, _, err := conn.FederatedSettings.GetRoleMapping(context.Background(),
+			rs.Primary.Attributes["federation_settings_id"],
+			rs.Primary.Attributes["org_id"],
+			rs.Primary.Attributes["role_mapping_id"])
+		if err == nil {
+			*federatedSettingsOrganizationRoleMapping = *response
+
+			return nil
+		}
+
+		return fmt.Errorf("role mapping (%s) does not exist", rs.Primary.Attributes["role_mapping_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_federated_settings_org_role_mapping" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		roleMapping, _, err := conn.FederatedSettings.GetRoleMapping(context.Background(), ids["federation_settings_id"], ids["org_id"], ids["role_mapping_id"])
+		if err == nil && roleMapping != nil {
+			return fmt.Errorf("role mapping (%s) still exists", ids["okta_idp_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s", ids["federation_settings_id"], ids["org_id"], ids["role_mapping_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasFederatedSettingsOrganizationRoleMappingConfig(federationSettingsID, orgID, groupID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_federated_settings_org_role_mapping" "test" {
+		federation_settings_id = "%[1]s"
+		org_id                 = "%[2]s"
+		external_group_name    = "newtestgroup"
+		role_assignments {
+			org_id = "%[2]s"
+			roles  = ["ORG_MEMBER","ORG_GROUP_CREATOR"]
+		}
+		
+		  role_assignments {
+			group_id = "%[3]s"
+			roles    = ["GROUP_OWNER","GROUP_DATA_ACCESS_ADMIN","GROUP_SEARCH_INDEX_EDITOR","GROUP_DATA_ACCESS_READ_ONLY"]
+		}
+
+	  }`, federationSettingsID, orgID, groupID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_global_cluster_config_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_global_cluster_config_test.go
@@ -1,0 +1,485 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
+	var (
+		globalConfig matlas.GlobalCluster
+		resourceName = "mongodbatlas_global_cluster_config.config"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "true"),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSGlobalCluster_WithAWSCluster(t *testing.T) {
+	var (
+		globalConfig matlas.GlobalCluster
+		resourceName = "mongodbatlas_global_cluster_config.config"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(projectID, name, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSGlobalCluster_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_global_cluster_config.config"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasGlobalClusterConfig(projectID, name, "false", "false", "false"),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_zone_mappings"},
+			},
+		},
+	})
+}
+
+func TestAccClusterRSGlobalCluster_database(t *testing.T) {
+	var (
+		globalConfig matlas.GlobalCluster
+		resourceName = "mongodbatlas_global_cluster_config.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = acctest.RandomWithPrefix("test-acc-global")
+	)
+
+	customZone := `
+  custom_zone_mappings {
+    location = "US"
+    zone     = "US"
+  }
+  custom_zone_mappings {
+    location = "IE"
+    zone     = "EU"
+  }
+  custom_zone_mappings {
+    location = "DE"
+    zone     = "DE"
+  }`
+	customZoneUpdated := `
+  custom_zone_mappings {
+    location = "US"
+    zone     = "US"
+  }
+  custom_zone_mappings {
+    location = "IE"
+    zone     = "EU"
+  }
+  custom_zone_mappings {
+    location = "DE"
+    zone     = "DE"
+  }
+  custom_zone_mappings {
+    location = "JP"
+    zone     = "JP"
+  }`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasGlobalClusterWithDBConfig(projectID, name, "false", customZone),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.US"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.IE"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.DE"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 5),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasGlobalClusterWithDBConfig(projectID, name, "false", customZoneUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.US"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.IE"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.DE"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.JP"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 5),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_zone_mappings"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasGlobalClusterExists(resourceName string, globalConfig *matlas.GlobalCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		globalConfigResp, _, err := conn.GlobalClusters.Get(context.Background(), ids["project_id"], ids["cluster_name"])
+		if err == nil {
+			*globalConfig = *globalConfigResp
+
+			if len(globalConfig.CustomZoneMapping) > 0 || len(globalConfig.ManagedNamespaces) > 0 {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("global config for cluster(%s) does not exist", ids["cluster_name"])
+	}
+}
+
+func testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["cluster_name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasGlobalClusterAttributes(globalCluster *matlas.GlobalCluster, managedNamespacesCount int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(globalCluster.ManagedNamespaces) != managedNamespacesCount {
+			return fmt.Errorf("bad managed namespaces: %v", globalCluster.ManagedNamespaces)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasGlobalClusterDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_global_cluster_config" {
+			continue
+		}
+
+		// Try to find the cluster
+		globalConfig, _, err := conn.GlobalClusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
+		if err != nil {
+			if strings.Contains(err.Error(), fmt.Sprintf("No cluster named %s exists in group %s", rs.Primary.Attributes["cluster_name"], rs.Primary.Attributes["project_id"])) {
+				return nil
+			}
+
+			return err
+		}
+
+		if len(globalConfig.CustomZoneMapping) > 0 || len(globalConfig.ManagedNamespaces) > 0 {
+			return fmt.Errorf("global cluster configuration for cluster(%s) still exists", rs.Primary.Attributes["cluster_name"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasGlobalClusterConfig(projectID, name, backupEnabled, isCustomShard, isShardKeyUnique string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "test" {
+			project_id              = "%s"
+			name                    = "%s"
+			disk_size_gb            = 80
+			backup_enabled          = "%s"
+			provider_backup_enabled = true
+			cluster_type            = "GEOSHARDED"
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+ 			provider_instance_size_name = "M30"
+
+			replication_specs {
+				zone_name  = "Zone 1"
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+
+			replication_specs {
+				zone_name  = "Zone 2"
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_2"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+		}
+
+		resource "mongodbatlas_global_cluster_config" "config" {
+			project_id   = mongodbatlas_cluster.test.project_id
+			cluster_name = mongodbatlas_cluster.test.name
+
+			managed_namespaces {
+				db               		   = "mydata"
+				collection       		   = "publishers"
+				custom_shard_key		   = "city"
+				is_custom_shard_key_hashed = "%s"
+				is_shard_key_unique 	   = "%s"
+			}
+
+			custom_zone_mappings {
+				location = "CA"
+				zone     = "Zone 1"
+			}
+		}
+	`, projectID, name, backupEnabled, isCustomShard, isShardKeyUnique)
+}
+
+func testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(projectID, name, backupEnabled string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "test" {
+			project_id              = "%s"
+			name                    = "%s"
+			disk_size_gb            = 80
+			provider_backup_enabled = %s
+			cluster_type            = "GEOSHARDED"
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+ 			provider_instance_size_name = "M30"
+
+			replication_specs {
+				zone_name  = "Zone 1"
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+		}
+
+		resource "mongodbatlas_global_cluster_config" "config" {
+			project_id   = mongodbatlas_cluster.test.project_id
+			cluster_name = mongodbatlas_cluster.test.name
+
+			managed_namespaces {
+				db               = "mydata"
+				collection       = "publishers"
+				custom_shard_key = "city"
+			}
+
+			custom_zone_mappings {
+				location = "CA"
+				zone     = "Zone 1"
+			}
+		}
+	`, projectID, name, backupEnabled)
+}
+
+func testAccMongoDBAtlasGlobalClusterWithDBConfig(projectID, name, backupEnabled, zones string) string {
+	return fmt.Sprintf(`
+resource "mongodbatlas_database_user" "test" {
+  username           = "horizonv2-sg"
+  password           = "password testing something"
+  project_id         = %[1]q
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = "horizonv2-sg"
+  }
+}
+
+resource "mongodbatlas_cluster" "test" {
+  project_id   = %[1]q
+  name         = %[2]q
+  disk_size_gb = 80
+  cloud_backup = %[3]s
+  cluster_type = "GEOSHARDED"
+
+  // Provider Settings "block"
+  provider_name               = "AWS"
+  provider_instance_size_name = "M30"
+
+  replication_specs {
+    zone_name  = "US"
+    num_shards = 1
+    regions_config {
+      region_name     = "US_EAST_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+  replication_specs {
+    zone_name  = "EU"
+    num_shards = 1
+    regions_config {
+      region_name     = "EU_WEST_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+  replication_specs {
+    zone_name  = "DE"
+    num_shards = 1
+    regions_config {
+      region_name     = "EU_NORTH_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+  replication_specs {
+    zone_name  = "JP"
+    num_shards = 1
+    regions_config {
+      region_name     = "AP_NORTHEAST_1"
+      electable_nodes = 3
+      priority        = 7
+      read_only_nodes = 0
+    }
+  }
+}
+
+resource "mongodbatlas_global_cluster_config" "test" {
+  project_id = mongodbatlas_cluster.test.project_id
+  cluster_name = mongodbatlas_cluster.test.name
+
+  managed_namespaces {
+    db               = "horizonv2-sg"
+    collection       = "entitlements.entitlement"
+    custom_shard_key = "orgId"
+  }
+  managed_namespaces {
+    db               = "horizonv2-sg"
+    collection       = "entitlements.homesitemapping"
+    custom_shard_key = "orgId"
+  }
+  managed_namespaces {
+    db               = "horizonv2-sg"
+    collection       = "entitlements.site"
+    custom_shard_key = "orgId"
+  }
+  managed_namespaces {
+    db               = "horizonv2-sg"
+    collection       = "entitlements.userDesktopMapping"
+    custom_shard_key = "orgId"
+  }
+  managed_namespaces {
+    db               = "horizonv2-sg"
+    collection       = "session"
+    custom_shard_key = "orgId"
+  }
+  %s
+}
+	`, projectID, name, backupEnabled, zones)
+}

--- a/test/acceptance-test/resource_mongodbatlas_ldap_configuration_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_ldap_configuration_test.go
@@ -1,0 +1,262 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvRSLDAPConfiguration_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapConfiguration matlas.LDAPConfiguration
+		resourceName      = "mongodbatlas_ldap_configuration.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		hostname          = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username          = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password          = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		authEnabled       = true
+		port              = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPConfigurationConfig(projectName, orgID, hostname, username, password, authEnabled, cast.ToInt(port)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName, &ldapConfiguration),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "authentication_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvRSLDAPConfigurationWithVerify_CACertificateComplete(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapConfiguration  matlas.LDAPConfiguration
+		resourceName       = "mongodbatlas_ldap_configuration.test"
+		resourceVerifyName = "mongodbatlas_ldap_verify.test"
+		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName        = acctest.RandomWithPrefix("test-acc")
+		clusterName        = acctest.RandomWithPrefix("test-acc")
+		hostname           = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username           = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password           = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		port               = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+		caCertificate      = os.Getenv("MONGODB_ATLAS_LDAP_CA_CERTIFICATE")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPConfigurationWithVerifyConfig(projectName, orgID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName, &ldapConfiguration),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "authentication_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "status", "SUCCESS"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.0.validation_type", "SERVER_SPECIFIED"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.0.status", "OK"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.1.validation_type", "CONNECT"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.1.status", "OK"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.2.validation_type", "AUTHENTICATE"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.2.status", "OK"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.3.validation_type", "AUTHORIZATION_ENABLED"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.3.status", "OK"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.4.validation_type", "PARSE_AUTHZ_QUERY_TEMPLATE"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.4.status", "OK"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.5.validation_type", "QUERY_SERVER"),
+					resource.TestCheckResourceAttr(resourceVerifyName, "validations.5.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvRSLDAPConfiguration_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapConf     = matlas.LDAPConfiguration{}
+		resourceName = "mongodbatlas_ldap_configuration.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		hostname     = "3.138.245.82"
+		username     = "cn=admin,dc=space,dc=intern"
+		password     = "neuewelt32"
+		authEnabled  = true
+		port         = 7001
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPConfigurationConfig(projectName, orgID, hostname, username, password, authEnabled, port),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName, &ldapConf),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "authentication_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasLDAPConfigurationImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "bind_password"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ldapConfRes, _, err := conn.LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("ldapConfiguration (%s) does not exist", rs.Primary.ID)
+		}
+
+		ldapConf = ldapConfRes
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasLDAPConfigurationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_ldap_configuration" {
+			continue
+		}
+
+		_, _, err := conn.LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("ldapConfiguration (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasLDAPConfigurationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasLDAPConfigurationConfig(projectName, orgID, hostname, username, password string, authEnabled bool, port int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_ldap_configuration" "test" {
+			project_id                  =  mongodbatlas_project.test.id
+			authentication_enabled      =  %[6]t
+			hostname					= "%[3]s"
+			port                     	=  %[7]d
+			bind_username               = "%[4]s"
+			bind_password               = "%[5]s"
+		}`, projectName, orgID, hostname, username, password, authEnabled, port)
+}
+
+func testAccMongoDBAtlasLDAPConfigurationWithVerifyConfig(projectName, orgID, clusterName, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = mongodbatlas_project.test.id
+			name         = "%[3]s"
+			
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			provider_backup_enabled     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_ldap_verify" "test" {
+			project_id                  = mongodbatlas_project.test.id
+			hostname = "%[4]s"
+			port                     = %[7]d
+			bind_username                     = "%[5]s"
+			bind_password                     = "%[6]s"
+			ca_certificate = <<-EOF
+%[9]s
+			EOF
+			authz_query_template = "{USER}?memberOf?base"
+			depends_on = [mongodbatlas_cluster.test]
+		}
+
+		resource "mongodbatlas_ldap_configuration" "test" {
+			project_id                  = mongodbatlas_project.test.id
+			authentication_enabled                = %[8]t
+			authorization_enabled                = false
+			hostname = "%[4]s"
+			port                     = %[7]d
+			bind_username                     = "%[5]s"
+			bind_password                     = "%[6]s"
+			ca_certificate = <<-EOF
+%[9]s
+			EOF
+			authz_query_template = "{USER}?memberOf?base"
+			user_to_dn_mapping{
+				match = "(.+)"
+				ldap_query = "DC=example,DC=com??sub?(userPrincipalName={0})"
+			}
+			depends_on = [mongodbatlas_ldap_verify.test]
+		}`, projectName, orgID, clusterName, hostname, username, password, port, authEnabled, caCertificate)
+}

--- a/test/acceptance-test/resource_mongodbatlas_ldap_verify_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_ldap_verify_test.go
@@ -1,0 +1,260 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccAdvRSLDAPVerify_basic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapVerify   matlas.LDAPConfiguration
+		resourceName = "mongodbatlas_ldap_verify.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+		hostname     = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username     = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password     = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		port         = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPVerifyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPVerifyConfig(projectName, orgID, clusterName, hostname, username, password, cast.ToInt(port)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName, &ldapVerify),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvRSLDAPVerifyWithConfiguration_CACertificate(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapVerify    matlas.LDAPConfiguration
+		resourceName  = "mongodbatlas_ldap_verify.test"
+		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName   = acctest.RandomWithPrefix("test-acc")
+		clusterName   = acctest.RandomWithPrefix("test-acc")
+		hostname      = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username      = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password      = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		port          = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+		caCertificate = os.Getenv("MONGODB_ATLAS_LDAP_CA_CERTIFICATE")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPVerifyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPVerifyWithConfigurationConfig(projectName, orgID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName, &ldapVerify),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceName, "status", "SUCCESS"),
+					resource.TestCheckResourceAttr(resourceName, "validations.0.validation_type", "SERVER_SPECIFIED"),
+					resource.TestCheckResourceAttr(resourceName, "validations.0.status", "OK"),
+					resource.TestCheckResourceAttr(resourceName, "validations.1.validation_type", "CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "validations.1.status", "OK"),
+					resource.TestCheckResourceAttr(resourceName, "validations.2.validation_type", "AUTHENTICATE"),
+					resource.TestCheckResourceAttr(resourceName, "validations.2.status", "OK"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvRSLDAPVerify_importBasic(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		ldapConf     = matlas.LDAPConfiguration{}
+		resourceName = "mongodbatlas_ldap_verify.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		clusterName  = acctest.RandomWithPrefix("test-acc")
+		hostname     = os.Getenv("MONGODB_ATLAS_LDAP_HOSTNAME")
+		username     = os.Getenv("MONGODB_ATLAS_LDAP_USERNAME")
+		password     = os.Getenv("MONGODB_ATLAS_LDAP_PASSWORD")
+		port         = os.Getenv("MONGODB_ATLAS_LDAP_PORT")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckLDAP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasLDAPVerifyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasLDAPVerifyConfig(projectName, orgID, clusterName, hostname, username, password, cast.ToInt(port)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName, &ldapConf),
+
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "bind_username"),
+					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasLDAPVerifyImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "bind_password"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ldapConfRes, _, err := conn.LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
+		if err != nil {
+			return fmt.Errorf("ldapVerify (%s) does not exist", rs.Primary.ID)
+		}
+
+		ldapConf = ldapConfRes
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasLDAPVerifyDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_ldap_verify" {
+			continue
+		}
+
+		_, _, err := conn.LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
+		if err == nil {
+			return fmt.Errorf("ldapVerify (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasLDAPVerifyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasLDAPVerifyConfig(projectName, orgID, clusterName, hostname, username, password string, port int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = mongodbatlas_project.test.id
+			name         = "%[3]s"
+			
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			provider_backup_enabled     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_ldap_verify" "test" {
+			project_id               =  mongodbatlas_project.test.id
+			hostname 				 = "%[4]s"
+			port                     =  %[7]d
+			bind_username            = "%[5]s"
+			bind_password            = "%[6]s"
+			depends_on = ["mongodbatlas_cluster.test"]
+		}`, projectName, orgID, clusterName, hostname, username, password, port)
+}
+
+func testAccMongoDBAtlasLDAPVerifyWithConfigurationConfig(projectName, orgID, clusterName, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%[1]s"
+			org_id = "%[2]s"
+		}
+
+		resource "mongodbatlas_cluster" "test" {
+			project_id   = mongodbatlas_project.test.id
+			name         = "%[3]s"
+			
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_region_name        = "US_EAST_2"
+			provider_instance_size_name = "M10"
+			provider_backup_enabled     = true //enable cloud provider snapshots
+		}
+
+		resource "mongodbatlas_ldap_verify" "test" {
+			project_id                  = mongodbatlas_project.test.id
+			hostname = "%[4]s"
+			port                     = %[7]d
+			bind_username                     = "%[5]s"
+			bind_password                     = "%[6]s"
+			ca_certificate = <<-EOF
+%[9]s
+			EOF
+			depends_on = [mongodbatlas_cluster.test]
+		}
+
+		resource "mongodbatlas_ldap_configuration" "test" {
+			project_id                  = mongodbatlas_project.test.id
+			authentication_enabled                = %[8]t
+			authorization_enabled                = false
+			hostname = "%[4]s"
+			port                     = %[7]d
+			bind_username                     = "%[5]s"
+			bind_password                     = "%[6]s"
+			ca_certificate = <<-EOF
+%[9]s
+			EOF
+			depends_on = [mongodbatlas_ldap_verify.test]
+		}`, projectName, orgID, clusterName, hostname, username, password, port, authEnabled, caCertificate)
+}

--- a/test/acceptance-test/resource_mongodbatlas_maintenance_window_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_maintenance_window_test.go
@@ -1,0 +1,207 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
+	var (
+		maintenance      matlas.MaintenanceWindow
+		resourceName     = "mongodbatlas_maintenance_window.test"
+		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName      = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek        = 7
+		hourOfDay        = 3
+		dayOfWeekUpdated = 4
+		hourOfDayUpdated = 5
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
+					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeekUpdated, hourOfDayUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeekUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDayUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeekUpdated, &maintenance.DayOfWeek),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
+	var (
+		maintenance  matlas.MaintenanceWindow
+		resourceName = "mongodbatlas_maintenance_window.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek    = 1
+		hourOfDay    = 3
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
+					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+					resource.TestCheckResourceAttr(resourceName, "start_asap", "false"),
+					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasMaintenanceWindowImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
+	var (
+		maintenance  matlas.MaintenanceWindow
+		resourceName = "mongodbatlas_maintenance_window.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek    = 7
+		hourOfDay    = 3
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectName, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
+					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_defer_once_enabled", "true"),
+					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = mongodbatlas_project.test.id
+			day_of_week = %[3]d
+			hour_of_day = %[4]d
+			auto_defer_once_enabled = true
+		}`, orgID, projectName, dayOfWeek, hourOfDay)
+}
+
+func testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName string, maintenance *matlas.MaintenanceWindow) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] projectID: %s", rs.Primary.ID)
+
+		maintenanceWindow, _, err := conn.MaintenanceWindows.Get(context.Background(), rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("maintenance Window (%s) does not exist", rs.Primary.ID)
+		}
+
+		*maintenance = *maintenanceWindow
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasMaintenanceWindowAttributes(attr string, expected int, got *int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if diff := deep.Equal(expected, *got); diff != nil {
+			return fmt.Errorf("bad %s \n got = %#v\nwant = %#v \ndiff = %#v", attr, expected, *got, diff)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasMaintenanceWindowImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.ID, nil
+	}
+}
+
+func testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = mongodbatlas_project.test.id
+			day_of_week = %[3]d
+			hour_of_day = %[4]d
+		}`, orgID, projectName, dayOfWeek, hourOfDay)
+}

--- a/test/acceptance-test/resource_mongodbatlas_network_container_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_network_container_test.go
@@ -1,0 +1,366 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccNetworkRSNetworkContainer_basicAWS(t *testing.T) {
+	var (
+		container                matlas.Container
+		randInt                  = acctest.RandIntRange(0, 255)
+		randIntUpdated           = acctest.RandIntRange(0, 255)
+		resourceName             = "mongodbatlas_network_container.test"
+		dataSourceName           = "data.mongodbatlas_network_container.test"
+		dataSourceContainersName = "data.mongodbatlas_network_containers.test"
+		cidrBlock                = fmt.Sprintf("10.8.%d.0/24", randInt)
+		cidrBlockUpdated         = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
+		providerName             = "AWS"
+		orgID                    = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName              = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigAWS(projectName, orgID, cidrBlock, providerName, "US_EAST_1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.atlas_cidr_block"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.provisioned"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigAWS(projectName, orgID, cidrBlockUpdated, providerName, "US_WEST_2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkContainer_basicAzure(t *testing.T) {
+	var (
+		container        matlas.Container
+		randInt          = acctest.RandIntRange(0, 255)
+		randIntUpdated   = acctest.RandIntRange(0, 255)
+		resourceName     = "mongodbatlas_network_container.test"
+		cidrBlock        = fmt.Sprintf("192.168.%d.0/24", randInt)
+		cidrBlockUpdated = fmt.Sprintf("192.168.%d.0/24", randIntUpdated)
+		providerName     = "AZURE"
+		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName      = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigAzure(projectName, orgID, cidrBlock, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigAzure(projectName, orgID, cidrBlockUpdated, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkContainer_basicGCP(t *testing.T) {
+	var (
+		container        matlas.Container
+		randInt          = acctest.RandIntRange(0, 255)
+		randIntUpdated   = acctest.RandIntRange(0, 255)
+		resourceName     = "mongodbatlas_network_container.test"
+		cidrBlock        = fmt.Sprintf("10.%d.0.0/18", randInt)
+		cidrBlockUpdated = fmt.Sprintf("10.%d.0.0/18", randIntUpdated)
+		providerName     = "GCP"
+		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName      = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigGCP(projectName, orgID, cidrBlock, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigGCP(projectName, orgID, cidrBlockUpdated, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkContainer_WithRegionsGCP(t *testing.T) {
+	var (
+		container                matlas.Container
+		randInt                  = acctest.RandIntRange(0, 255)
+		resourceName             = "mongodbatlas_network_container.test"
+		dataSourceName           = "data.mongodbatlas_network_container.test"
+		dataSourceContainersName = "data.mongodbatlas_network_containers.test"
+		cidrBlock                = fmt.Sprintf("10.%d.0.0/21", randInt)
+		providerName             = "GCP"
+		orgID                    = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName              = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigGCPWithRegions(projectName, orgID, cidrBlock, providerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkContainerExists(resourceName, &container),
+					testAccCheckMongoDBAtlasNetworkContainerAttributes(&container, providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.#"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.atlas_cidr_block"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.provider_name"),
+					resource.TestCheckResourceAttrSet(dataSourceContainersName, "results.0.provisioned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkContainer_importBasic(t *testing.T) {
+	var (
+		randInt      = acctest.RandIntRange(0, 255)
+		resourceName = "mongodbatlas_network_container.test"
+		cidrBlock    = fmt.Sprintf("10.8.%d.0/24", randInt)
+		providerName = "AWS"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkContainerConfigAWS(projectName, orgID, cidrBlock, providerName, "US_EAST_1"),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasNetworkContainerImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasNetworkContainerImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["container_id"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasNetworkContainerExists(resourceName string, container *matlas.Container) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] projectID: %s", rs.Primary.Attributes["project_id"])
+
+		if containerResp, _, err := conn.Containers.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["container_id"]); err == nil {
+			*container = *containerResp
+			return nil
+		}
+
+		return fmt.Errorf("container(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["container_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasNetworkContainerAttributes(container *matlas.Container, providerName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if container.ProviderName != providerName {
+			return fmt.Errorf("bad provider name: %s", container.ProviderName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasNetworkContainerDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_container" {
+			continue
+		}
+
+		// Try to find the container
+		_, _, err := conn.Containers.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["container_id"])
+
+		if err == nil {
+			return fmt.Errorf("container (%s:%s) still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["container_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasNetworkContainerConfigAWS(projectName, orgID, cidrBlock, providerName, region string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		 = mongodbatlas_project.test.id
+			atlas_cidr_block = "%s"
+			provider_name		 = "%s"
+			region_name			 = "%s"
+		}
+
+		data "mongodbatlas_network_container" "test" {
+			project_id   		= mongodbatlas_network_container.test.project_id
+			container_id		= mongodbatlas_network_container.test.id
+		}
+
+		data "mongodbatlas_network_containers" "test" {
+			project_id = "${mongodbatlas_network_container.test.project_id}"
+			provider_name = "AWS"
+		}
+
+	`, projectName, orgID, cidrBlock, providerName, region)
+}
+
+func testAccMongoDBAtlasNetworkContainerConfigAzure(projectName, orgID, cidrBlock, providerName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		 = "${mongodbatlas_project.test.id}"
+			atlas_cidr_block = "%s"
+			provider_name		 = "%s"
+			region			     = "US_EAST_2"
+		}
+	`, projectName, orgID, cidrBlock, providerName)
+}
+
+func testAccMongoDBAtlasNetworkContainerConfigGCP(projectName, orgID, cidrBlock, providerName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		 = "${mongodbatlas_project.test.id}"
+			atlas_cidr_block = "%s"
+			provider_name		 = "%s"
+		}
+	`, projectName, orgID, cidrBlock, providerName)
+}
+
+func testAccMongoDBAtlasNetworkContainerConfigGCPWithRegions(projectName, orgID, cidrBlock, providerName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		 = mongodbatlas_project.test.id
+			atlas_cidr_block = "%s"
+			provider_name		 = "%s"
+			regions = ["US_EAST_4", "US_WEST_3"]
+		}
+
+		data "mongodbatlas_network_container" "test" {
+			project_id   		= mongodbatlas_network_container.test.project_id
+			container_id		= mongodbatlas_network_container.test.id
+		}
+
+		data "mongodbatlas_network_containers" "test" {
+			project_id = mongodbatlas_network_container.test.project_id
+			provider_name = "GCP"
+		}
+	`, projectName, orgID, cidrBlock, providerName)
+}

--- a/test/acceptance-test/resource_mongodbatlas_network_peering_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_network_peering_test.go
@@ -1,0 +1,339 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccNetworkRSNetworkPeering_basicAWS(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		peer         matlas.Peer
+		resourceName = "mongodbatlas_network_peering.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		vpcID        = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
+		awsRegion    = os.Getenv("AWS_REGION")
+		providerName = "AWS"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvAWS(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkPeeringConfigAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName, &peer),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(resourceName, "aws_account_id", awsAccountID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"accepter_region_name", "container_id"},
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		peer              matlas.Peer
+		resourceName      = "mongodbatlas_network_peering.test"
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
+		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+		vNetName          = os.Getenv("AZURE_VNET_NAME")
+		providerName      = "AZURE"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvAzure(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkPeeringConfigAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName, &peer),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
+					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"container_id"},
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		peer         matlas.Peer
+		resourceName = "mongodbatlas_network_peering.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		providerName = "GCP"
+		gcpProjectID = os.Getenv("GCP_PROJECT_ID")
+		networkName  = fmt.Sprintf("test-acc-name-%s", acctest.RandString(5))
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckPeeringEnvGCP(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkPeeringConfigGCP(projectID, providerName, gcpProjectID, networkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName, &peer),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
+
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
+					resource.TestCheckResourceAttr(resourceName, "network_name", networkName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkPeering_AWSDifferentRegionName(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		peer                  matlas.Peer
+		resourcePeerName      = "mongodbatlas_network_peering.diff_region"
+		resourceContainerName = "mongodbatlas_network_container.test"
+		projectID             = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		vpcID                 = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock          = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID          = os.Getenv("AWS_ACCOUNT_ID")
+		containerRegion       = "US_WEST_2"
+		peerRegion            = strings.ToLower(strings.ReplaceAll(os.Getenv("AWS_REGION"), "_", "-"))
+		providerName          = "AWS"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckPeeringEnvAWS(t)
+			func() {
+				if strings.EqualFold(containerRegion, peerRegion) {
+					t.Fatalf("the `AWS_REGION` (%s) must be different region than %s", peerRegion, containerRegion)
+				}
+			}()
+		},
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasNetworkPeeringConfigAWSWithDifferentRegionName(projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					// Peering test
+					testAccCheckMongoDBAtlasNetworkPeeringExists(resourcePeerName, &peer),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "accepter_region_name"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "container_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "route_table_cidr_block"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourcePeerName, "aws_account_id"),
+
+					resource.TestCheckResourceAttr(resourcePeerName, "accepter_region_name", peerRegion),
+					resource.TestCheckResourceAttr(resourcePeerName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourcePeerName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourcePeerName, "route_table_cidr_block", vpcCIDRBlock),
+					resource.TestCheckResourceAttr(resourcePeerName, "vpc_id", vpcID),
+					resource.TestCheckResourceAttr(resourcePeerName, "aws_account_id", awsAccountID),
+
+					// Container test
+					resource.TestCheckResourceAttrSet(resourceContainerName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "atlas_cidr_block"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceContainerName, "region_name"),
+
+					resource.TestCheckResourceAttr(resourceContainerName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceContainerName, "atlas_cidr_block", "192.168.200.0/21"),
+					resource.TestCheckResourceAttr(resourceContainerName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceContainerName, "region_name", containerRegion),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["peer_id"], ids["provider_name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName string, peer *matlas.Peer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		log.Printf("[DEBUG] projectID: %s", ids["project_id"])
+
+		if peerResp, _, err := conn.Peers.Get(context.Background(), ids["project_id"], ids["peer_id"]); err == nil {
+			*peer = *peerResp
+			peer.ProviderName = ids["provider_name"]
+
+			return nil
+		}
+
+		return fmt.Errorf("peer(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["peer_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasNetworkPeeringDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_network_peering" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.Peers.Get(context.Background(), ids["project_id"], ids["peer_id"])
+
+		if err == nil {
+			return fmt.Errorf("peer (%s) still exists", ids["peer_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasNetworkPeeringConfigAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.208.0/21"
+			provider_name		  = "%[2]s"
+			region_name			  = "%[6]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			accepter_region_name	  = lower(replace("%[6]s", "_", "-"))
+			project_id    			    = "%[1]s"
+			container_id            = mongodbatlas_network_container.test.id
+			provider_name           = "%[2]s"
+			route_table_cidr_block  = "%[5]s"
+			vpc_id					        = "%[3]s"
+			aws_account_id	        = "%[4]s"
+		}
+	`, projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion)
+}
+
+func testAccMongoDBAtlasNetworkPeeringConfigAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.208.0/21"
+			provider_name		  = "%[2]s"
+			region    			  = "US_EAST_2"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id   		      = "%[1]s"
+			container_id          = mongodbatlas_network_container.test.container_id
+			provider_name         = "%[2]s"
+			azure_directory_id    = "%[3]s"
+			azure_subscription_id = "%[4]s"
+			resource_group_name   = "%[5]s"
+			vnet_name	            = "%[6]s"
+		}
+	`, projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
+}
+
+func testAccMongoDBAtlasNetworkPeeringConfigGCP(projectID, providerName, gcpProjectID, networkName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id       = "%[1]s"
+			atlas_cidr_block = "192.168.192.0/18"
+			provider_name    = "%[2]s"
+		}
+
+		resource "mongodbatlas_network_peering" "test" {
+			project_id     = "%[1]s"
+			container_id   = mongodbatlas_network_container.test.container_id
+			provider_name  = "%[2]s"
+			gcp_project_id = "%[3]s"
+			network_name   = "%[4]s"
+		}
+	`, projectID, providerName, gcpProjectID, networkName)
+}
+
+func testAccMongoDBAtlasNetworkPeeringConfigAWSWithDifferentRegionName(projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_network_container" "test" {
+			project_id   		  = "%[1]s"
+			atlas_cidr_block  = "192.168.200.0/21"
+			provider_name		  = "%[2]s"
+			region_name			  = "%[3]s"
+		}
+
+		resource "mongodbatlas_network_peering" "diff_region" {
+			accepter_region_name	  = "%[4]s"
+			project_id    			    = "%[1]s"
+			container_id            = mongodbatlas_network_container.test.container_id
+			provider_name           = "%[2]s"
+			route_table_cidr_block  = "%[5]s"
+			vpc_id					        = "%[6]s"
+			aws_account_id	        = "%[7]s"
+		}
+	`, projectID, providerName, containerRegion, peerRegion, vpcCIDRBlock, vpcID, awsAccountID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_online_archive_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_online_archive_test.go
@@ -1,0 +1,473 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccBackupRSOnlineArchive(t *testing.T) {
+	var (
+		cluster                   matlas.Cluster
+		resourceName              = "mongodbatlas_cluster.online_archive_test"
+		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
+		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName               = acctest.RandomWithPrefix("test-acc")
+		name                      = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				// We need this step to pupulate the cluster with Sample Data
+				// The online archive won't work if the cluster does not have data
+				Config: testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					populateWithSampleData(resourceName, &cluster),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, name, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, name, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckNoResourceAttr(onlineArchiveResourceName, "schedule.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
+	var (
+		cluster                   matlas.Cluster
+		resourceName              = "mongodbatlas_cluster.online_archive_test"
+		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
+		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName               = acctest.RandomWithPrefix("test-acc")
+		name                      = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				// We need this step to pupulate the cluster with Sample Data
+				// The online archive won't work if the cluster does not have data
+				Config: testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					populateWithSampleData(resourceName, &cluster),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.type"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
+					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+				),
+			},
+		},
+	})
+}
+
+func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
+
+		clusterResp, _, err := conn.Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"])
+
+		if err != nil {
+			return fmt.Errorf("cluster(%s:%s) does not exist %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
+		}
+
+		*cluster = *clusterResp
+
+		job, _, err := conn.Clusters.LoadSampleDataset(context.Background(), ids["project_id"], ids["cluster_name"])
+
+		if err != nil {
+			return fmt.Errorf("cluster(%s:%s) loading sample data set error %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
+		}
+
+		ticker := time.NewTicker(30 * time.Second)
+
+	JOB:
+		for {
+			select {
+			case <-time.After(20 * time.Second):
+				log.Println("timeout elapsed ....")
+			case <-ticker.C:
+				job, _, err = conn.Clusters.GetSampleDatasetStatus(context.Background(), ids["project_id"], job.ID)
+				fmt.Println("querying for job ")
+				if job.State != "WORKING" {
+					break JOB
+				}
+			}
+		}
+
+		if err != nil {
+			return fmt.Errorf("cluster(%s:%s) loading sample data set error %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
+		}
+
+		if job.State != "COMPLETED" {
+			return fmt.Errorf("cluster(%s:%s) working sample data set error %s", rs.Primary.Attributes["project_id"], job.ID, job.State)
+		}
+		return nil
+	}
+}
+
+func testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, clusterName string, startHour int) string {
+	return fmt.Sprintf(`
+	%s
+	resource "mongodbatlas_online_archive" "users_archive" {
+		project_id = mongodbatlas_cluster.online_archive_test.project_id
+		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		coll_name = "listingsAndReviews"
+		collection_type = "STANDARD"
+		db_name = "sample_airbnb"
+	
+		criteria {
+			type = "DATE"
+			date_field = "last_review"
+			date_format = "ISODATE"
+			expire_after_days = 2
+		}
+
+		schedule {
+			type = "DAILY"
+			end_hour = 1
+			end_minute = 1
+			start_hour = %d
+			start_minute = 1
+		}
+
+		partition_fields {
+			field_name = "last_review"
+			order = 0
+		}
+	
+		partition_fields {
+			field_name = "maximum_nights"
+			order = 1
+		}
+	
+		partition_fields {
+			field_name = "name"
+			order = 2
+		}
+
+		sync_creation = true
+	}
+	
+	data "mongodbatlas_online_archive" "read_archive" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+		archive_id = mongodbatlas_online_archive.users_archive.archive_id
+	}
+	
+	data "mongodbatlas_online_archives" "all" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+	}
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
+}
+
+func testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, clusterName string) string {
+	return fmt.Sprintf(`
+	%s
+	resource "mongodbatlas_online_archive" "users_archive" {
+		project_id = mongodbatlas_cluster.online_archive_test.project_id
+		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		coll_name = "listingsAndReviews"
+		collection_type = "STANDARD"
+		db_name = "sample_airbnb"
+	
+		criteria {
+			type = "DATE"
+			date_field = "last_review"
+			date_format = "ISODATE"
+			expire_after_days = 2
+		}
+
+		partition_fields {
+			field_name = "last_review"
+			order = 0
+		}
+
+		partition_fields {
+			field_name = "maximum_nights"
+			order = 1
+		}
+	
+		partition_fields {
+			field_name = "name"
+			order = 2
+		}
+
+		sync_creation = true
+	}
+	
+	data "mongodbatlas_online_archive" "read_archive" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+		archive_id = mongodbatlas_online_archive.users_archive.archive_id
+	}
+	
+	data "mongodbatlas_online_archives" "all" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+	}
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName))
+}
+
+func testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "online_archive_test" {
+		project_id   = mongodbatlas_project.cluster_project.id
+		name         = %[3]q
+		disk_size_gb = 10
+
+		cluster_type = "REPLICASET"
+		replication_specs {
+		  num_shards = 1
+		  regions_config {
+			 region_name     = "US_EAST_1"
+			 electable_nodes = 3
+			 priority        = 7
+			 read_only_nodes = 0
+		   }
+		}
+
+		cloud_backup                 = false
+		auto_scaling_disk_gb_enabled = true
+
+		// Provider Settings "block"
+		provider_name               = "AWS"
+		provider_instance_size_name = "M10"
+
+		labels {
+			key   = "ArchiveTest"
+			value = "true"
+		}
+		labels {
+			key   = "Owner"
+			value = "acctest"
+		}
+	}
+
+	
+	`, orgID, projectName, clusterName)
+}
+
+func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName string, startHour int) string {
+	return fmt.Sprintf(`
+	%s
+	resource "mongodbatlas_online_archive" "users_archive" {
+		project_id = mongodbatlas_cluster.online_archive_test.project_id
+		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		coll_name = "listingsAndReviews"
+		collection_type = "STANDARD"
+		db_name = "sample_airbnb"
+	
+		criteria {
+			type = "DATE"
+			date_field = "last_review"
+			date_format = "ISODATE"
+			expire_after_days = 2
+		}
+
+		schedule {
+			type = "WEEKLY"
+			day_of_week = 1
+			end_hour = 1
+			end_minute = 1
+			start_hour = %d
+			start_minute = 1
+		}
+
+		partition_fields {
+			field_name = "last_review"
+			order = 0
+		}
+	
+		partition_fields {
+			field_name = "maximum_nights"
+			order = 1
+		}
+	
+		partition_fields {
+			field_name = "name"
+			order = 2
+		}
+
+		sync_creation = true
+	}
+	
+	data "mongodbatlas_online_archive" "read_archive" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+		archive_id = mongodbatlas_online_archive.users_archive.archive_id
+	}
+	
+	data "mongodbatlas_online_archives" "all" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+	}
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
+}
+
+func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName string, startHour int) string {
+	return fmt.Sprintf(`
+	%s
+	resource "mongodbatlas_online_archive" "users_archive" {
+		project_id = mongodbatlas_cluster.online_archive_test.project_id
+		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		coll_name = "listingsAndReviews"
+		collection_type = "STANDARD"
+		db_name = "sample_airbnb"
+	
+		criteria {
+			type = "DATE"
+			date_field = "last_review"
+			date_format = "ISODATE"
+			expire_after_days = 2
+		}
+
+		schedule {
+			type = "MONTHLY"
+			day_of_month = 1
+			end_hour = 1
+			end_minute = 1
+			start_hour = %d
+			start_minute = 1
+		}
+
+		partition_fields {
+			field_name = "last_review"
+			order = 0
+		}
+	
+		partition_fields {
+			field_name = "maximum_nights"
+			order = 1
+		}
+
+
+		partition_fields {
+			field_name = "name"
+			order = 2
+		}
+
+
+		sync_creation = true
+	}
+	
+	data "mongodbatlas_online_archive" "read_archive" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+		archive_id = mongodbatlas_online_archive.users_archive.archive_id
+	}
+	
+	data "mongodbatlas_online_archives" "all" {
+		project_id =  mongodbatlas_online_archive.users_archive.project_id
+		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
+	}
+	`, testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, clusterName), startHour)
+}

--- a/test/acceptance-test/resource_mongodbatlas_org_invitation_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_org_invitation_test.go
@@ -1,0 +1,194 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSOrgInvitation_basic(t *testing.T) {
+	var (
+		invitation   matlas.Invitation
+		resourceName = "mongodbatlas_org_invitation.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name         = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole  = []string{"ORG_OWNER"}
+		updateRoles  = []string{"ORG_GROUP_CREATOR", "ORG_BILLING_ADMIN"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrgInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrgInvitationConfig(orgID, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasOrgInvitationExists(t, resourceName, &invitation),
+					testAccCheckMongoDBAtlasOrgInvitationUsernameAttribute(&invitation, name),
+					testAccCheckMongoDBAtlasOrgInvitationRoleAttribute(&invitation, initialRole),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasOrgInvitationConfig(orgID, name, updateRoles),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasOrgInvitationExists(t, resourceName, &invitation),
+					testAccCheckMongoDBAtlasOrgInvitationUsernameAttribute(&invitation, name),
+					testAccCheckMongoDBAtlasOrgInvitationRoleAttribute(&invitation, updateRoles),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSOrgInvitation_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_org_invitation.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name         = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole  = []string{"ORG_OWNER"}
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrgInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrgInvitationConfig(orgID, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "username", name),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasOrgInvitationStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasOrgInvitationExists(t *testing.T, resourceName string, invitation *matlas.Invitation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		orgID := ids["org_id"]
+		username := ids["username"]
+		invitationID := ids["invitation_id"]
+
+		if orgID == "" && username == "" && invitationID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		t.Logf("orgID: %s", orgID)
+		t.Logf("username: %s", username)
+		t.Logf("invitationID: %s", invitationID)
+
+		invitationResp, _, err := conn.Organizations.Invitation(context.Background(), orgID, invitationID)
+		if err == nil {
+			*invitation = *invitationResp
+			return nil
+		}
+
+		return fmt.Errorf("invitation(%s) does not exist", invitationID)
+	}
+}
+
+func testAccCheckMongoDBAtlasOrgInvitationUsernameAttribute(invitation *matlas.Invitation, username string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if invitation.Username != username {
+			return fmt.Errorf("bad name: %s", invitation.Username)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasOrgInvitationRoleAttribute(invitation *matlas.Invitation, roles []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, role := range roles {
+			for _, currentRole := range invitation.Roles {
+				if currentRole == role {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("bad role: %s", invitation.Roles)
+	}
+}
+
+func testAccCheckMongoDBAtlasOrgInvitationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_invitations" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		orgID := ids["org_id"]
+		invitationID := ids["invitation_id"]
+
+		// Try to find the invitation
+		_, _, err := conn.Organizations.Invitation(context.Background(), orgID, invitationID)
+		if err == nil {
+			return fmt.Errorf("invitation (%s) still exists", invitationID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasOrgInvitationStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["org_id"], rs.Primary.Attributes["username"]), nil
+	}
+}
+
+func testAccMongoDBAtlasOrgInvitationConfig(orgID, username string, roles []string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_org_invitation" "test" {
+			org_id   = %[1]q
+			username = %[2]q
+			roles  	 = ["%[3]s"]
+		}`, orgID, username,
+		strings.Join(roles, `", "`),
+	)
+}

--- a/test/acceptance-test/resource_mongodbatlas_organization_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_organization_test.go
@@ -1,0 +1,147 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSOrganization_Basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_organization.test"
+		orgOwnerID   = os.Getenv("MONGODB_ATLAS_ORG_OWNER_ID")
+		name         = fmt.Sprintf("test-acc-organization-%s", acctest.RandString(5))
+		description  = "test Key for Acceptance tests"
+		roleName     = "ORG_OWNER"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSOrganization_importBasic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		resourceName = "mongodbatlas_organization.test"
+		orgOwnerID   = os.Getenv("MONGODB_ATLAS_ORG_OWNER_ID")
+		name         = fmt.Sprintf("test-acc-import-organization-%s", acctest.RandString(5))
+		description  = "test Key for Acceptance tests"
+		roleName     = "ORG_OWNER"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasOrganizationImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		organizationOptions := &matlas.OrganizationsListOptions{}
+		orgs, _, err := conn.Organizations.List(context.Background(), organizationOptions)
+		if err == nil {
+			for _, val := range orgs.Results {
+				if val.ID == ids["org_id"] {
+					return fmt.Errorf("Organization (%s) still exists", ids["role_name"])
+				}
+			}
+			return nil
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasOrganizationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_organization" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		organizationOptions := &matlas.OrganizationsListOptions{}
+		orgs, _, err := conn.Organizations.List(context.Background(), organizationOptions)
+		if err == nil {
+			for _, val := range orgs.Results {
+				if val.ID == ids["org_id"] {
+					return fmt.Errorf("Organization (%s) still exists", ids["role_name"])
+				}
+			}
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasOrganizationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["org_id"], nil
+	}
+}
+
+func testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleNames string) string {
+	return fmt.Sprintf(`
+	  resource "mongodbatlas_organization" "test" {
+		org_owner_id = "%s"
+		name = "%s"
+		description = "%s"
+		role_names = ["%s"]
+	  }
+	`, orgOwnerID, name, description, roleNames)
+}

--- a/test/acceptance-test/resource_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -1,0 +1,233 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccNetworkRSPrivateEndpointRegionalMode_conn(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		endpointResourceSuffix = "atlasple"
+		resourceSuffix         = "atlasrm"
+		resourceName           = fmt.Sprintf("mongodbatlas_private_endpoint_regional_mode.%s", resourceSuffix)
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		providerName = "AWS"
+		region       = os.Getenv("AWS_REGION")
+
+		clusterName         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+		clusterResourceName = "global_cluster"
+	)
+
+	clusterResource := testAccMongoDBAtlasClusterConfigGlobal(clusterResourceName, orgID, projectName, clusterName, "false")
+	clusterDataSource := testAccMongoDBAtlasPrivateEndpointRegionalModeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
+	endpointResources := testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(
+		awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,
+	)
+
+	dependencies := []string{clusterResource, clusterDataSource, endpointResources}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointRegionalModeConfigWithDependencies(resourceSuffix, projectID, false, dependencies),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName),
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate(projectID, clusterName, clusterResourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointRegionalModeConfigWithDependencies(resourceSuffix, projectID, true, dependencies),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName),
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate(projectID, clusterName, clusterResourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateEndpointRegionalMode_basic(t *testing.T) {
+	var (
+		resourceSuffix = "atlasrm"
+		resourceName   = fmt.Sprintf("mongodbatlas_private_endpoint_regional_mode.%s", resourceSuffix)
+		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointRegionalModeConfig(resourceSuffix, projectID, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointRegionalModeConfig(resourceSuffix, projectID, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeClusterData(clusterResourceName, regionalModeResourceName, privateLinkResourceName string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_cluster" %[1]q {
+			project_id = mongodbatlas_cluster.%[1]s.project_id
+			name       = mongodbatlas_cluster.%[1]s.name
+			depends_on = [
+				mongodbatlas_privatelink_endpoint_service.%[3]s,
+				mongodbatlas_private_endpoint_regional_mode.%[2]s
+			]
+		}
+	`, clusterResourceName, regionalModeResourceName, privateLinkResourceName)
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeConfigWithDependencies(resourceName, projectID string, enabled bool, dependencies []string) string {
+	resources := make([]string, len(dependencies)+1)
+
+	resources[0] = testAccMongoDBAtlasPrivateEndpointRegionalModeConfigNoProject(resourceName, projectID, enabled)
+	copy(resources[1:], dependencies)
+
+	return strings.Join(resources, "\n\n")
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeConfigNoProject(resourceName, projectID string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_private_endpoint_regional_mode" %[1]q {
+			project_id   = %[2]q
+			enabled      = %[3]t
+		}
+	`, resourceName, projectID, enabled)
+}
+
+func testAccMongoDBAtlasPrivateEndpointRegionalModeConfig(resourceName, projectID string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_private_endpoint_regional_mode" %[1]q {
+			project_id   = %[2]q
+			enabled      = %[3]t
+		}
+	`, resourceName, projectID, enabled)
+}
+
+func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		fmt.Printf("==========================================================================\n")
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		projectID := rs.Primary.ID
+
+		_, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
+
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("regional mode for project_id (%s) does not exist", projectID)
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate(projectID, clusterName, clusterResourceName string) resource.TestCheckFunc {
+	resourceName := strings.Join([]string{"data", "mongodbatlas_cluster", clusterResourceName}, ".")
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("Could not find resource state for cluster (%s) on project (%s)", clusterName, projectID)
+		}
+
+		var rsPrivateEndpointCount int
+		var err error
+
+		if rsPrivateEndpointCount, err = strconv.Atoi(rs.Primary.Attributes["connection_strings.0.private_endpoint.#"]); err != nil {
+			return fmt.Errorf("Connection strings private endpoint count is not a number")
+		}
+
+		cluster, _, _ := conn.Clusters.Get(context.Background(), projectID, clusterName)
+
+		fmt.Printf("testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate %#v \n", rs.Primary.Attributes)
+		fmt.Printf("cluster.ConnectionStrings %#v \n", mongodbatlas.FlattenConnectionStrings(cluster.ConnectionStrings))
+
+		if rsPrivateEndpointCount != len(cluster.ConnectionStrings.PrivateEndpoint) {
+			return fmt.Errorf("Cluster PrivateEndpoint count does not match resource")
+		}
+
+		if rs.Primary.Attributes["connection_strings.0.standard"] != cluster.ConnectionStrings.Standard {
+			return fmt.Errorf("Cluster standard connection_string does not match resource")
+		}
+
+		if rs.Primary.Attributes["connection_strings.0.standard_srv"] != cluster.ConnectionStrings.StandardSrv {
+			return fmt.Errorf("Cluster standard connection_string does not match resource")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_private_endpoint_regional_mode" {
+			continue
+		}
+
+		setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), rs.Primary.ID)
+
+		if err != nil {
+			return fmt.Errorf("Could not read regionalized private endpoint setting for project %q", rs.Primary.ID)
+		}
+
+		if setting.Enabled != false {
+			return fmt.Errorf("Regionalized private endpoint setting for project %q was not properly disabled", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_serverless_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_serverless_test.go
@@ -1,0 +1,136 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccServerlessPrivateLinkEndpoint_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint_serverless.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName = "serverlessplink"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServerlessPrivateLinkEndpoint_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint_serverless.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName = "serverlessimport"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
+				),
+			},
+			{
+				Config:                  testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, false),
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_strings_private_endpoint_srv"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint_serverless" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		privateLink, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		if err == nil && privateLink != nil {
+			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName string, ignoreConnectionStrings bool) string {
+	return fmt.Sprintf(`
+
+	resource "mongodbatlas_privatelink_endpoint_serverless" "test" {
+		project_id    = mongodbatlas_serverless_instance.test.project_id
+		instance_name = mongodbatlas_serverless_instance.test.name
+		provider_name = "AWS"
+	}
+
+	%s
+	`, testAccMongoDBAtlasServerlessInstanceConfig(orgID, projectName, instanceName, ignoreConnectionStrings))
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("endpoint_id (%s) does not exist", ids["endpoint_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["instance_name"], ids["endpoint_id"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_adl_test.go
@@ -1,0 +1,150 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccNetworkRSPrivateLinkEndpointServiceADL_basic(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
+		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		endpointID    = os.Getenv("MONGODB_ATLAS_ENDPOINT_ID")
+		commentOrigin = "this is a comment for adl private link endpoint"
+		commentUpdate = "this is a comment for adl private link endpoint UPDATED"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, commentOrigin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttr(resourceName, "type", "DATA_LAKE"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, commentUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttr(resourceName, "type", "DATA_LAKE"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateLinkEndpointServiceADL_importBasic(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_privatelink_endpoint_service_adl.test"
+		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		endpointID    = os.Getenv("MONGODB_ATLAS_ENDPOINT_ID")
+		commentOrigin = "this is a comment for adl private link endpoint"
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, commentOrigin),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttr(resourceName, "type", "DATA_LAKE"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
+				),
+			},
+			{
+				Config:            testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, commentOrigin),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint_service_adl" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		privateLink, _, err := conn.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+		if err == nil && privateLink != nil {
+			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServiceADLConfig(projectID, endpointID, comment string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_privatelink_endpoint_service_adl" "test" {
+			project_id    = "%[1]s"
+			endpoint_id   = "%[2]s"
+			comment       = "%[3]s"
+			type          = "DATA_LAKE"
+			provider_name = "AWS"
+		}
+	`, projectID, endpointID, comment)
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("endpoint_id (%s) does not exist", ids["endpoint_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceADLImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s", ids["project_id"], ids["endpoint_id"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -1,0 +1,115 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+var (
+	resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive = "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.test"
+	projectID                                                         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	endpointID                                                        = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
+)
+
+func TestAccMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t *testing.T) {
+	testCheckPrivateEndpointServiceDataFederationOnlineArchiveRun(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveConfig(projectID, endpointID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive),
+					resource.TestCheckResourceAttr(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive, "endpoint_id", endpointID),
+					resource.TestCheckResourceAttrSet(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive, "comment"),
+					resource.TestCheckResourceAttrSet(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive, "type"),
+					resource.TestCheckResourceAttrSet(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive, "provider_name"),
+				),
+			},
+			{
+				ResourceName:      resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveFunc(resourceNamePrivatelinkEdnpointServiceDataFederationOnlineArchive),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s", ids["project_id"], ids["endpoint_id"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy(s *terraform.State) error {
+	client := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+
+		if err == nil {
+			return fmt.Errorf("Private endpoint service data federation online archive still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("Private endpoint service data federation online archive not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Private endpoint service data federation online archive ID not set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveConfig(projectID, endpointID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
+	  project_id				= %[1]q
+	  endpoint_id				= %[2]q
+	  provider_name				= "AWS"
+	  comment					= "Terraform Acceptance Test"
+	}
+	`, projectID, endpointID)
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_serverless_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_serverless_test.go
@@ -1,0 +1,187 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccServerlessPrivateLinkEndpointService_basic(t *testing.T) {
+	var (
+		resourceName            = "mongodbatlas_privatelink_endpoint_service_serverless.test"
+		datasourceName          = "data.mongodbatlas_privatelink_endpoint_service_serverless.test"
+		datasourceEndpointsName = "data.mongodbatlas_privatelink_endpoints_service_serverless.test"
+		orgID                   = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName             = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName            = acctest.RandomWithPrefix("test-acc-serverless")
+		commentOrigin           = "this is a comment for serverless private link endpoint"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projectName, instanceName, commentOrigin),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
+					resource.TestCheckResourceAttr(datasourceName, "comment", commentOrigin),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "instance_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServerlessPrivateLinkEndpointService_importBasic(t *testing.T) {
+	var (
+		resourceName  = "mongodbatlas_privatelink_endpoint_service_serverless.test"
+		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName   = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName  = acctest.RandomWithPrefix("test-acc-serverless")
+		commentOrigin = "this is a comment for serverless private link endpoint"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projectName, instanceName, commentOrigin),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
+				),
+			},
+			{
+				Config:            testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projectName, instanceName, commentOrigin),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint_service_serverless" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		privateLink, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		if err == nil && privateLink != nil {
+			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projectName, instanceName, comment string) string {
+	return fmt.Sprintf(`
+
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+
+	resource "mongodbatlas_privatelink_endpoint_serverless" "test" {
+		project_id   = mongodbatlas_project.test.id
+		instance_name = mongodbatlas_serverless_instance.test.name
+		provider_name = "AWS"
+	}
+
+
+	resource "mongodbatlas_privatelink_endpoint_service_serverless" "test" {
+		project_id   = mongodbatlas_privatelink_endpoint_serverless.test.project_id
+		instance_name = mongodbatlas_privatelink_endpoint_serverless.test.instance_name
+		endpoint_id = mongodbatlas_privatelink_endpoint_serverless.test.endpoint_id
+		provider_name = "AWS"
+		comment = %[4]q
+	}
+
+	resource "mongodbatlas_serverless_instance" "test" {
+		project_id   = mongodbatlas_project.test.id
+		name         = %[3]q
+		provider_settings_backing_provider_name = "AWS"
+		provider_settings_provider_name = "SERVERLESS"
+		provider_settings_region_name = "US_EAST_1"
+		continuous_backup_enabled = true
+
+		lifecycle {
+			ignore_changes = [connection_strings_private_endpoint_srv]
+		}
+	}
+
+	data "mongodbatlas_serverless_instance" "test" {
+		project_id   = mongodbatlas_privatelink_endpoint_service_serverless.test.project_id
+		name         = mongodbatlas_serverless_instance.test.name
+	}
+
+	data "mongodbatlas_privatelink_endpoints_service_serverless" "test" {
+		project_id   = mongodbatlas_privatelink_endpoint_service_serverless.test.project_id
+		instance_name = mongodbatlas_serverless_instance.test.name
+	  }
+
+	data "mongodbatlas_privatelink_endpoint_service_serverless" "test" {
+		project_id   = mongodbatlas_privatelink_endpoint_service_serverless.test.project_id
+		instance_name = mongodbatlas_serverless_instance.test.name
+		endpoint_id = mongodbatlas_privatelink_endpoint_service_serverless.test.endpoint_id
+	}
+
+	`, orgID, projectName, instanceName, comment)
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("endpoint_id (%s) does not exist", ids["endpoint_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["instance_name"], ids["endpoint_id"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_service_test.go
@@ -1,0 +1,260 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceSuffix = "test"
+		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		providerName    = "AWS"
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		region          = os.Getenv("AWS_REGION")
+		vpcID           = os.Getenv("AWS_VPC_ID")
+		subnetID        = os.Getenv("AWS_SUBNET_ID")
+		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceSuffix = "test"
+		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		providerName    = "AWS"
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		region          = os.Getenv("AWS_REGION")
+		vpcID           = os.Getenv("AWS_VPC_ID")
+		subnetID        = os.Getenv("AWS_SUBNET_ID")
+		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_link_id"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s--%s", ids["project_id"], ids["private_link_id"], ids["endpoint_service_id"], ids["provider_name"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
+		if err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("the MongoDB Interface Endpoint(%s) for the project(%s) does not exist", rs.Primary.Attributes["endpoint_service_id"], rs.Primary.Attributes["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint_service" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
+		if err == nil {
+			return fmt.Errorf("the MongoDB Private Endpoint(%s) still exists", ids["endpoint_service_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, serviceResourceName string) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+			region        = "%[5]s"
+			access_key = "%[1]s"
+			secret_key = "%[2]s"
+		}
+
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = "%[3]s"
+			provider_name = "%[4]s"
+			region        = "%[5]s"
+		}
+
+		resource "aws_vpc_endpoint" "ptfe_service" {
+			vpc_id             = "%[6]s"
+			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
+			vpc_endpoint_type  = "Interface"
+			subnet_ids         = ["%[7]s"]
+			security_group_ids = ["%[8]s"]
+			
+		}
+
+		resource "mongodbatlas_privatelink_endpoint_service" %[9]q {
+			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
+			endpoint_service_id   =  aws_vpc_endpoint.ptfe_service.id
+			private_link_id       = mongodbatlas_privatelink_endpoint.test.id
+			provider_name         = "%[4]s"
+		}
+	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, serviceResourceName)
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, serviceResourceName string) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+			region     = "%[5]s"
+			access_key = "%[1]s"
+			secret_key = "%[2]s"
+		}
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = "%[3]s"
+			provider_name = "%[4]s"
+			region        = "%[5]s"
+		}
+		resource "aws_vpc_endpoint" "ptfe_service" {
+			vpc_id             = aws_vpc.primary.id
+			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
+			vpc_endpoint_type  = "Interface"
+			subnet_ids         = [aws_subnet.primary-az1.id]
+			security_group_ids = [aws_security_group.primary_default.id]
+			
+		}
+		resource "mongodbatlas_privatelink_endpoint_service" %[6]q {
+			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
+			endpoint_service_id   =  aws_vpc_endpoint.ptfe_service.id
+			private_link_id       = mongodbatlas_privatelink_endpoint.test.id
+			provider_name         = %[4]q
+		}
+		resource "aws_vpc" "primary" {
+			cidr_block           = "10.0.0.0/16"
+			enable_dns_hostnames = true
+			enable_dns_support   = true
+		}
+
+		resource "aws_internet_gateway" "primary" {
+			vpc_id = aws_vpc.primary.id
+		}
+
+		resource "aws_route" "primary-internet_access" {
+			route_table_id         = aws_vpc.primary.main_route_table_id
+			destination_cidr_block = "0.0.0.0/0"
+			gateway_id             = aws_internet_gateway.primary.id
+		}
+		  
+		  # Subnet-A
+		  resource "aws_subnet" "primary-az1" {
+			vpc_id                  = aws_vpc.primary.id
+			cidr_block              = "10.0.1.0/24"
+			map_public_ip_on_launch = true
+			availability_zone       = "%[5]sa"
+		  }
+		  
+		  # Subnet-B
+		  resource "aws_subnet" "primary-az2" {
+			vpc_id                  = aws_vpc.primary.id
+			cidr_block              = "10.0.2.0/24"
+			map_public_ip_on_launch = false
+			availability_zone       = "%[5]sb"
+		  }
+		  
+		  resource "aws_security_group" "primary_default" {
+			name_prefix = "default-"
+			description = "Default security group for all instances in vpc"
+			vpc_id      = aws_vpc.primary.id
+			ingress {
+			  from_port = 0
+			  to_port   = 0
+			  protocol  = "tcp"
+			  cidr_blocks = [
+				"0.0.0.0/0",
+			  ]
+			}
+			egress {
+			  from_port   = 0
+			  to_port     = 0
+			  protocol    = "-1"
+			  cidr_blocks = ["0.0.0.0/0"]
+			}
+		  }
+	`, awsAccessKey, awsSecretKey, projectID, providerName, region, serviceResourceName)
+}

--- a/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_privatelink_endpoint_test.go
@@ -1,0 +1,243 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+)
+
+func TestAccNetworkRSPrivateLinkEndpointAWS_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		region       = "us-east-1"
+		providerName = "AWS"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateLinkEndpointAWS_import(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		region       = "us-east-1"
+		providerName = "AWS"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccNetworkRSPrivateLinkEndpointAzure_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		region       = "US_EAST_2"
+		providerName = "AZURE"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateLinkEndpointAzure_import(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		region       = "US_EAST_2"
+		providerName = "AZURE"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSPrivateLinkEndpointGCP_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		region       = "us-central1"
+		providerName = "GCP"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "region"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s-%s-%s", ids["project_id"], ids["private_link_id"], ids["provider_name"], ids["region"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if _, _, err := conn.PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"]); err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("the MongoDB Private Endpoint(%s) for the project(%s) does not exist", rs.Primary.Attributes["private_link_id"], rs.Primary.Attributes["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_privatelink_endpoint" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"])
+		if err == nil {
+			return fmt.Errorf("the MongoDB Private Endpoint(%s) still exists", ids["private_link_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasPrivateLinkEndpointConfigBasic(orgID, projectName, providerName, region string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_privatelink_endpoint" "test" {
+			project_id    = mongodbatlas_project.test.id
+			provider_name = %[3]q
+			region        = %[4]q
+		}
+	`, orgID, projectName, providerName, region)
+}

--- a/test/acceptance-test/resource_mongodbatlas_project_api_key_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_project_api_key_test.go
@@ -1,0 +1,346 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		description  = fmt.Sprintf("test-acc-project-api_key-%s", acctest.RandString(5))
+		roleName     = "GROUP_OWNER"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_Multiple(t *testing.T) {
+	var (
+		resourceName    = "mongodbatlas_project_api_key.test"
+		dataSourceName  = "data.mongodbatlas_project_api_key.test"
+		dataSourcesName = "data.mongodbatlas_project_api_keys.test"
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName     = acctest.RandomWithPrefix("test-acc")
+		description     = fmt.Sprintf("test-acc-project-api_key-%s", acctest.RandString(5))
+		roleName        = "GROUP_OWNER"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigMultiple(orgID, projectName, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.role_names.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_assignment.0.role_names.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+					resource.TestCheckResourceAttrSet(dataSourcesName, "results.0.project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourcesName, "results.0.project_assignment.0.role_names.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
+	var (
+		resourceName       = "mongodbatlas_project_api_key.test"
+		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName        = acctest.RandomWithPrefix("test-acc")
+		description        = fmt.Sprintf("test-acc-project-api_key-%s", acctest.RandString(5))
+		updatedDescription = fmt.Sprintf("test-acc-project-api_key-updated-%s", acctest.RandString(5))
+		roleName           = "GROUP_OWNER"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, updatedDescription, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		description  = fmt.Sprintf("test-acc-import-project-api_key-%s", acctest.RandString(5))
+		roleName     = "GROUP_OWNER"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
+	var (
+		resourceName      = "mongodbatlas_project_api_key.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName       = acctest.RandomWithPrefix("test-acc")
+		descriptionPrefix = "test-acc-project-to-delete-api-key"
+		description       = fmt.Sprintf("%s-%s", descriptionPrefix, acctest.RandString(5))
+		roleName          = "GROUP_OWNER"
+	)
+
+	projectAPIKeyConfig := testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: projectAPIKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+				),
+			},
+			{
+				PreConfig: func() {
+					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
+						t.Fatalf("failed to manually delete API key resource: %s", err)
+					}
+				},
+				Config:             projectAPIKeyConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true, // should detect that api key has to be recreated
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_OrgRoles(t *testing.T) {
+	var (
+		resourceName      = "mongodbatlas_project_api_key.test"
+		dataSourceName    = "data.mongodbatlas_project_api_key.test"
+		dataSourcesName   = "data.mongodbatlas_project_api_keys.test"
+		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		firstProjectName  = acctest.RandomWithPrefix("test-acc")
+		secondProjectName = acctest.RandomWithPrefix("test-acc")
+		description       = fmt.Sprintf("test-acc-project-api_key-%s", acctest.RandString(5))
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigOrgRoles(orgID, firstProjectName, secondProjectName, description),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.role_names.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_assignment.0.role_names.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "description"),
+					resource.TestCheckResourceAttrSet(dataSourcesName, "results.0.project_assignment.0.project_id"),
+					resource.TestCheckResourceAttrSet(dataSourcesName, "results.0.project_assignment.0.role_names.0"),
+				),
+			},
+		},
+	})
+}
+
+func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+	list, _, err := conn.APIKeys.List(context.Background(), orgID, &matlas.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, key := range list {
+		if strings.HasPrefix(key.Desc, descriptionPrefix) {
+			if _, err := conn.APIKeys.Delete(context.Background(), orgID, key.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_project_api_key" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		projectAPIKeys, _, err := conn.ProjectAPIKeys.List(context.Background(), ids["project_id"], nil)
+		if err != nil {
+			return nil
+		}
+
+		for _, val := range projectAPIKeys {
+			if val.ID == ids["api_key_id"] {
+				return fmt.Errorf("Project API Key (%s) still exists", ids["role_name"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["api_key_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleNames string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_api_key" "test" {
+			project_id     = mongodbatlas_project.test.id
+			description  = %[3]q
+			role_names  = [%[4]q]
+		}
+	`, orgID, projectName, description, roleNames)
+}
+
+func testAccMongoDBAtlasProjectAPIKeyConfigMultiple(orgID, projectName, description, roleNames string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_api_key" "test" {
+			project_id     = mongodbatlas_project.test.id
+			description  = %[3]q
+			project_assignment  {
+				project_id = mongodbatlas_project.test.id
+				role_names = [%[4]q]
+			  }
+
+		}
+
+		data "mongodbatlas_project_api_key" "test" {
+			project_id      = mongodbatlas_project.test.id
+			api_key_id  = mongodbatlas_project_api_key.test.api_key_id
+		}
+		
+		data "mongodbatlas_project_api_keys" "test" {
+			project_id = mongodbatlas_project.test.id
+		}
+
+	`, orgID, projectName, description, roleNames)
+}
+
+func testAccMongoDBAtlasProjectAPIKeyConfigOrgRoles(orgID, firstProjectName, secondProjectName, description string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+
+		resource "mongodbatlas_project" "testProject" {
+			name   = %[3]q
+			org_id = %[1]q
+		}
+
+		resource "mongodbatlas_project_api_key" "test" {
+			project_id     = mongodbatlas_project.test.id
+			description  = %[4]q
+			project_assignment  {
+				project_id = mongodbatlas_project.test.id
+				role_names = ["ORG_BILLING_ADMIN", "GROUP_READ_ONLY"]
+			}
+			
+			project_assignment {
+				project_id = mongodbatlas_project.testProject.id
+				role_names = ["GROUP_OWNER"]
+			}
+
+		}
+
+		data "mongodbatlas_project_api_key" "test" {
+			project_id      = mongodbatlas_project.test.id
+			api_key_id  = mongodbatlas_project_api_key.test.api_key_id
+		}
+		
+		data "mongodbatlas_project_api_keys" "test" {
+			project_id = mongodbatlas_project.test.id
+		}
+
+	`, orgID, firstProjectName, secondProjectName, description)
+}

--- a/test/acceptance-test/resource_mongodbatlas_project_invitation_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_project_invitation_test.go
@@ -1,0 +1,206 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccProjectRSProjectInvitation_basic(t *testing.T) {
+	var (
+		invitation   matlas.Invitation
+		resourceName = "mongodbatlas_project_invitation.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole  = []string{"GROUP_OWNER"}
+		updateRoles  = []string{"GROUP_DATA_ACCESS_ADMIN", "GROUP_CLUSTER_MANAGER"}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectInvitationConfig(orgID, projectName, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectInvitationExists(t, resourceName, &invitation),
+					testAccCheckMongoDBAtlasProjectInvitationUsernameAttribute(&invitation, name),
+					testAccCheckMongoDBAtlasProjectInvitationRoleAttribute(&invitation, initialRole),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.#"),
+					resource.TestCheckResourceAttr(resourceName, "username", name),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasProjectInvitationConfig(orgID, projectName, name, updateRoles),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasProjectInvitationExists(t, resourceName, &invitation),
+					testAccCheckMongoDBAtlasProjectInvitationUsernameAttribute(&invitation, name),
+					testAccCheckMongoDBAtlasProjectInvitationRoleAttribute(&invitation, updateRoles),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.#"),
+					resource.TestCheckResourceAttr(resourceName, "username", name),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSProjectInvitation_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_project_invitation.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		name         = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
+		initialRole  = []string{"GROUP_OWNER"}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasProjectInvitationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasProjectInvitationConfig(orgID, projectName, name, initialRole),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "roles.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
+					resource.TestCheckResourceAttr(resourceName, "username", name),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectInvitationStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasProjectInvitationExists(t *testing.T, resourceName string, invitation *matlas.Invitation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		projectID := ids["project_id"]
+		username := ids["username"]
+		invitationID := ids["invitation_id"]
+
+		if projectID == "" && username == "" && invitationID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		t.Logf("projectID: %s", projectID)
+		t.Logf("username: %s", username)
+		t.Logf("invitationID: %s", invitationID)
+
+		invitationResp, _, err := conn.Projects.Invitation(context.Background(), projectID, invitationID)
+		if err == nil {
+			*invitation = *invitationResp
+			return nil
+		}
+
+		return fmt.Errorf("invitation(%s) does not exist", invitationID)
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectInvitationUsernameAttribute(invitation *matlas.Invitation, username string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if invitation.Username != username {
+			return fmt.Errorf("bad name: %s", invitation.Username)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectInvitationRoleAttribute(invitation *matlas.Invitation, roles []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(roles) > 0 {
+			for _, role := range roles {
+				for _, currentRole := range invitation.Roles {
+					if currentRole == role {
+						return nil
+					}
+				}
+			}
+		}
+
+		return fmt.Errorf("bad role: %s", invitation.Roles)
+	}
+}
+
+func testAccCheckMongoDBAtlasProjectInvitationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_invitations" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		projectID := ids["project_id"]
+		invitationID := ids["invitation_id"]
+
+		// Try to find the invitation
+		_, _, err := conn.Projects.Invitation(context.Background(), projectID, invitationID)
+		if err == nil {
+			return fmt.Errorf("invitation (%s) still exists", invitationID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasProjectInvitationStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["username"]), nil
+	}
+}
+
+func testAccMongoDBAtlasProjectInvitationConfig(orgID, projectName, username string, roles []string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_project_invitation" "test" {
+			project_id = mongodbatlas_project.test.id
+			username   = %[3]q
+			roles  	 = ["%[4]s"]
+		}`, orgID, projectName, username,
+		strings.Join(roles, `", "`),
+	)
+}

--- a/test/acceptance-test/resource_mongodbatlas_search_index_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_search_index_test.go
@@ -1,0 +1,434 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccClusterRSSearchIndex_basic(t *testing.T) {
+	var (
+		index                 matlas.SearchIndex
+		resourceName          = "mongodbatlas_search_index.test"
+		clusterName           = acctest.RandomWithPrefix("test-acc-index")
+		projectID             = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name                  = "name_test"
+		datasourceIndexesName = "data.mongodbatlas_search_indexes.data_index"
+		datasourceName        = "data.mongodbatlas_search_indexes.data_index"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasSearchIndexConfig(projectID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasSearchIndexExists(resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(datasourceName, "name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "collection_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "database"),
+					resource.TestCheckResourceAttrSet(datasourceName, "search_analyzer"),
+					resource.TestCheckResourceAttrSet(datasourceName, "synonyms.#"),
+					resource.TestCheckResourceAttr(datasourceName, "synonyms.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "synonyms.0.analyzer", "lucene.simple"),
+					resource.TestCheckResourceAttr(datasourceName, "synonyms.0.name", "synonym_test"),
+					resource.TestCheckResourceAttr(datasourceName, "synonyms.0.source_collection", "collection_test"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "database"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "results.0.index_id"),
+					resource.TestCheckResourceAttrSet(datasourceIndexesName, "results.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSSearchIndex_withMapping(t *testing.T) {
+	var (
+		index           matlas.SearchIndex
+		resourceName    = "mongodbatlas_search_index.test"
+		clusterName     = acctest.RandomWithPrefix("test-acc-index")
+		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name            = "name_test"
+		updatedAnalyzer = "lucene.simple"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasSearchIndexConfigAdvanced(projectID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasSearchIndexExists(resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "analyzer", updatedAnalyzer),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSSearchIndex_withSynonyms(t *testing.T) {
+	var (
+		index           matlas.SearchIndex
+		resourceName    = "mongodbatlas_search_index.test"
+		datasourceName  = "data.mongodbatlas_search_indexes.data_index"
+		clusterName     = acctest.RandomWithPrefix("test-acc-index")
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName     = acctest.RandomWithPrefix("test-acc")
+		name            = "name_test"
+		updatedAnalyzer = "lucene.standard"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasSearchIndexConfigSynonyms(orgID, projectName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasSearchIndexExists(resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "analyzer", updatedAnalyzer),
+					resource.TestCheckResourceAttr(resourceName, "synonyms.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "synonyms.0.analyzer", "lucene.simple"),
+					resource.TestCheckResourceAttr(resourceName, "synonyms.0.name", "synonym_test"),
+					resource.TestCheckResourceAttr(resourceName, "synonyms.0.source_collection", "collection_test"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "database"),
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.index_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "results.0.analyzer"),
+					resource.TestCheckResourceAttr(datasourceName, "results.0.synonyms.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "results.0.synonyms.0.analyzer", "lucene.simple"),
+					resource.TestCheckResourceAttr(datasourceName, "results.0.synonyms.0.name", "synonym_test"),
+					resource.TestCheckResourceAttr(datasourceName, "results.0.synonyms.0.source_collection", "collection_test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterRSSearchIndex_importBasic(t *testing.T) {
+	var (
+		index        matlas.SearchIndex
+		resourceName = "mongodbatlas_search_index.test"
+		clusterName  = acctest.RandomWithPrefix("test-acc-index")
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		name         = "name_test"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasSearchIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasSearchIndexConfig(projectID, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasSearchIndexExists(resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+				),
+			},
+			{
+				Config:            testAccMongoDBAtlasSearchIndexConfig(projectID, clusterName),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasSearchIndexImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasSearchIndexExists(resourceName string, index *matlas.SearchIndex) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		indexResponse, _, err := conn.Search.GetIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"])
+		if err == nil {
+			*index = *indexResponse
+			return nil
+		}
+
+		return fmt.Errorf("index (%s) does not exist", ids["index_id"])
+	}
+}
+
+func testAccMongoDBAtlasSearchIndexConfig(projectID, clusterName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "aws_conf" {
+			project_id   = "%[1]s"
+			name         = "%[2]s"
+			disk_size_gb = 10
+		
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_2"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled = false
+		
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+		}
+
+		resource "mongodbatlas_search_index" "test" {
+			project_id       = mongodbatlas_cluster.aws_conf.project_id
+			cluster_name     = mongodbatlas_cluster.aws_conf.name
+			collection_name  = "collection_test"
+			database         = "database_test"
+			mappings_dynamic = "true"
+			name             = "name_test"
+			search_analyzer  = "lucene.standard"
+		}
+
+		data "mongodbatlas_search_indexes" "data_index" {
+			cluster_name           = mongodbatlas_search_index.test.cluster_name
+			project_id         = mongodbatlas_search_index.test.project_id
+			database   = "database_test"
+			collection_name = "collection_test"
+			page_num = 1
+			items_per_page = 100
+			
+		}
+	`, projectID, clusterName)
+}
+
+func testAccMongoDBAtlasSearchIndexConfigAdvanced(projectID, clusterName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cluster" "aws_conf" {
+			project_id   = "%[1]s"
+			name         = "%[2]s"
+			disk_size_gb = 10
+
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_2"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled = false
+
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+
+		}
+
+		resource "mongodbatlas_search_index" "test" {
+			project_id   = mongodbatlas_cluster.aws_conf.project_id
+			cluster_name = mongodbatlas_cluster.aws_conf.name
+
+			analyzer         = "lucene.simple"
+			collection_name  = "collection_test"
+			database         = "database_test"
+			mappings_dynamic = false
+			mappings_fields  = <<-EOF
+			{
+				"address":{
+					"type":"document",
+					"fields":{
+						"city":{
+								"type":"string",
+								"analyzer":"lucene.simple",
+								"ignoreAbove":255
+						},
+						"state":{
+								"type":"string",
+								"analyzer":"lucene.english"
+						}
+					}
+				},
+				"company":{
+					"type":"string",
+					"analyzer":"lucene.whitespace",
+					"multi":{
+						"mySecondaryAnalyzer":{
+							"type":"string",
+							"analyzer":"lucene.french"
+						}
+					}
+				},
+				"employees":{
+					"type":"string",
+					"analyzer":"lucene.standard"
+				}
+			}
+			EOF
+			name             = "name_test"
+			search_analyzer  = "lucene.standard"
+			analyzers        = <<-EOF
+			[
+				{
+					"name":"index_analyzer_test_name",
+					"charFilters":[
+						 {
+								"type":"mapping",
+								"mappings":{
+									 "\\":"/"
+								}
+						 }
+					],
+					"tokenizer":[
+						 {
+								"type":"nGram",
+								"minGram":2,
+								"maxGram":5s
+						 }
+					],
+					"tokenFilters":[
+						 {
+								"type":"length",
+								"min":20,
+								"max":33
+						 }
+					]
+				}
+			]
+			EOF
+		}
+	`, projectID, clusterName)
+}
+
+func testAccMongoDBAtlasSearchIndexConfigSynonyms(orgID, projectName, clusterName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_cluster" "test_cluster" {
+			project_id   = mongodbatlas_project.test.id
+			name         = %[3]q
+			disk_size_gb = 10
+		
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+					region_name     = "US_EAST_2"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
+		
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled = false
+		
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+		
+		}
+		
+		resource "mongodbatlas_search_index" "test" {
+			project_id       = mongodbatlas_cluster.test_cluster.project_id
+			cluster_name     = mongodbatlas_cluster.test_cluster.name
+			analyzer         = "lucene.standard"
+			collection_name  = "collection_test"
+			database         = "database_test"
+			mappings_dynamic = "true"
+			name             = "name_test"
+			search_analyzer  = "lucene.standard"
+			synonyms {
+				analyzer          = "lucene.simple"
+				name              = "synonym_test"
+				source_collection = "collection_test"
+			}
+		}
+
+		data "mongodbatlas_search_indexes" "data_index" {
+			cluster_name           = mongodbatlas_search_index.test.cluster_name
+			project_id         = mongodbatlas_search_index.test.project_id
+			database   = "database_test"
+			collection_name = "collection_test"
+			page_num = 1
+			items_per_page = 100
+		}
+
+		data "mongodbatlas_search_index" "test_two" {
+			cluster_name        = mongodbatlas_search_index.test.cluster_name
+			project_id          = mongodbatlas_search_index.test.project_id
+			index_id 			= mongodbatlas_search_index.test.index_id
+		}
+	`, orgID, projectName, clusterName)
+}
+
+func testAccCheckMongoDBAtlasSearchIndexDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_search_index" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		searchIndex, _, err := conn.Search.GetIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"])
+		if err == nil && searchIndex != nil {
+			return fmt.Errorf("index id (%s) still exists", ids["index_id"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasSearchIndexImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["cluster_name"], ids["index_id"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_serverless_instance_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_serverless_instance_test.go
@@ -1,0 +1,193 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccServerlessInstance_basic(t *testing.T) {
+	var (
+		serverlessInstance      matlas.Cluster
+		resourceName            = "mongodbatlas_serverless_instance.test"
+		instanceName            = acctest.RandomWithPrefix("test-acc-serverless")
+		orgID                   = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName             = acctest.RandomWithPrefix("test-acc-serverless")
+		datasourceName          = "data.mongodbatlas_serverless_instance.test_two"
+		datasourceInstancesName = "data.mongodbatlas_serverless_instances.data_serverless"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasServerlessInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasServerlessInstanceConfig(orgID, projectName, instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasServerlessInstanceExists(resourceName, &serverlessInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", "false"),
+					resource.TestCheckResourceAttrSet(datasourceName, "name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "state_name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "create_date"),
+					resource.TestCheckResourceAttrSet(datasourceName, "mongo_db_version"),
+					resource.TestCheckResourceAttrSet(datasourceName, "continuous_backup_enabled"),
+					resource.TestCheckResourceAttrSet(datasourceName, "termination_protection_enabled"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.0.id"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.0.name"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.0.state_name"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.0.continuous_backup_enabled"),
+					resource.TestCheckResourceAttrSet(datasourceInstancesName, "results.0.termination_protection_enabled"),
+					testAccCheckConnectionStringPrivateEndpointIsPresentWithNoElement(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServerlessInstance_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_serverless_instance.test"
+		instanceName = acctest.RandomWithPrefix("test-acc-serverless")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-serverless")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasServerlessInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasServerlessInstanceConfig(orgID, projectName, instanceName, true),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasServerlessInstanceImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasServerlessInstanceExists(resourceName string, serverlessInstance *matlas.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		serverlessResponse, _, err := conn.ServerlessInstances.Get(context.Background(), ids["project_id"], ids["name"])
+		if err == nil {
+			*serverlessInstance = *serverlessResponse
+			return nil
+		}
+
+		return fmt.Errorf("serverless instance (%s) does not exist", ids["name"])
+	}
+}
+
+func testAccCheckMongoDBAtlasServerlessInstanceDestroy(state *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_serverless_instance" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		serverlessInstance, _, err := conn.ServerlessInstances.Get(context.Background(), ids["project_id"], ids["name"])
+		if err == nil && serverlessInstance != nil {
+			return fmt.Errorf("serverless instance (%s) still exists", ids["name"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasServerlessInstanceImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["name"]), nil
+	}
+}
+
+func testAccCheckConnectionStringPrivateEndpointIsPresentWithNoElement(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if connectionStringPrivateEndpoint := rs.Primary.Attributes["connection_strings_private_endpoint_srv.#"]; connectionStringPrivateEndpoint == "" {
+			return fmt.Errorf("expected connection_strings_private_endpoint_srv to be present")
+		}
+
+		return nil
+	}
+}
+
+func testAccMongoDBAtlasServerlessInstanceConfig(orgID, projectName, name string, ignoreConnectionStrings bool) string {
+	lifecycle := ""
+
+	if ignoreConnectionStrings {
+		lifecycle = `
+
+		lifecycle {
+			ignore_changes = [connection_strings_private_endpoint_srv]
+		}
+		`
+	}
+
+	return fmt.Sprintf(`
+	resource "mongodbatlas_project" "test" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_serverless_instance" "test" {
+		project_id   = mongodbatlas_project.test.id
+		name         = %[3]q
+
+		provider_settings_backing_provider_name = "AWS"
+		provider_settings_provider_name = "SERVERLESS"
+		provider_settings_region_name = "US_EAST_1"
+		continuous_backup_enabled = true
+		%[4]s
+	}
+
+	data "mongodbatlas_serverless_instance" "test_two" {
+		name        = mongodbatlas_serverless_instance.test.name
+		project_id  = mongodbatlas_serverless_instance.test.project_id
+	}
+
+	data "mongodbatlas_serverless_instances" "data_serverless" {
+		project_id         = mongodbatlas_serverless_instance.test.project_id
+	}
+
+	`, orgID, projectName, name, lifecycle)
+}

--- a/test/acceptance-test/resource_mongodbatlas_team_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_team_test.go
@@ -1,0 +1,199 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSTeam_basic(t *testing.T) {
+	var (
+		team         matlas.Team
+		resourceName = "mongodbatlas_teams.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		updatedName  = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		username     = os.Getenv("MONGODB_ATLAS_USERNAME_CLOUD_DEV")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasTeamConfig(orgID, name,
+					[]string{
+						username,
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasTeamExists(resourceName, &team),
+					testAccCheckMongoDBAtlasTeamAttributes(&team, name),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasTeamConfig(orgID, updatedName,
+					[]string{
+						username,
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasTeamExists(resourceName, &team),
+					testAccCheckMongoDBAtlasTeamAttributes(&team, updatedName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasTeamConfig(orgID, updatedName,
+					[]string{
+						username,
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasTeamExists(resourceName, &team),
+					testAccCheckMongoDBAtlasTeamAttributes(&team, updatedName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSTeam_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_teams.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		username     = os.Getenv("MONGODB_ATLAS_USERNAME_CLOUD_DEV")
+		name         = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasTeamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasTeamConfig(orgID, name, []string{username}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "usernames.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "team_id"),
+
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasTeamStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasTeamExists(resourceName string, team *matlas.Team) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		orgID := ids["org_id"]
+		id := ids["id"]
+
+		if orgID == "" && id == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		log.Printf("[DEBUG] orgID: %s", orgID)
+		log.Printf("[DEBUG] teamID: %s", id)
+
+		teamResp, _, err := conn.Teams.Get(context.Background(), orgID, id)
+		if err == nil {
+			*team = *teamResp
+			return nil
+		}
+
+		return fmt.Errorf("team(%s) does not exist", id)
+	}
+}
+
+func testAccCheckMongoDBAtlasTeamAttributes(team *matlas.Team, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if team.Name != name {
+			return fmt.Errorf("bad name: %s", team.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBAtlasTeamDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_teams" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		orgID := ids["org_id"]
+		id := ids["id"]
+
+		// Try to find the team
+		_, _, err := conn.Teams.Get(context.Background(), orgID, id)
+		if err == nil {
+			return fmt.Errorf("team (%s) still exists", id)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasTeamStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["org_id"], rs.Primary.Attributes["team_id"]), nil
+	}
+}
+
+func testAccMongoDBAtlasTeamConfig(orgID, name string, usernames []string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_teams" "test" {
+			org_id     = "%s"
+			name       = "%s"
+			usernames  = %s
+		}`, orgID, name,
+		strings.ReplaceAll(fmt.Sprintf("%+q", usernames), " ", ","),
+	)
+}

--- a/test/acceptance-test/resource_mongodbatlas_third_party_integration_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_third_party_integration_test.go
@@ -1,0 +1,186 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccConfigRSThirdPartyIntegration_basic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		targetIntegration = matlas.ThirdPartyIntegration{}
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
+		config            = testAccCreateThirdPartyIntegrationConfig()
+		testExecutionName = "test_3rd_party_" + config.AccountID
+		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
+	)
+
+	config.Type = "OPS_GENIE"
+	config.APIKey = apiKey
+
+	seedConfig := thirdPartyConfig{
+		Name:        testExecutionName,
+		ProjectID:   projectID,
+		Integration: *config,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(&seedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
+					resource.TestCheckResourceAttr(resourceName, "type", config.Type),
+					resource.TestCheckResourceAttr(resourceName, "api_key", config.APIKey),
+					resource.TestCheckResourceAttr(resourceName, "region", config.Region),
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSThirdPartyIntegration_importBasic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		targetIntegration = matlas.ThirdPartyIntegration{}
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
+		config            = testAccCreateThirdPartyIntegrationConfig()
+		testExecutionName = "test_3rd_party_" + config.AccountID
+		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
+	)
+
+	config.Type = "OPS_GENIE"
+	config.APIKey = apiKey
+
+	seedConfig := thirdPartyConfig{
+		Name:        testExecutionName,
+		ProjectID:   projectID,
+		Integration: *config,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(&seedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
+					resource.TestCheckResourceAttr(resourceName, "type", config.Type),
+					resource.TestCheckResourceAttr(resourceName, "region", config.Region),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasThirdPartyIntegrationImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: false, // API Obfuscation will always make import mismatch
+			},
+		},
+	},
+	)
+}
+
+func TestAccConfigRSThirdPartyIntegration_updateBasic(t *testing.T) {
+	SkipTestForCI(t)
+	var (
+		targetIntegration = matlas.ThirdPartyIntegration{}
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
+		config            = testAccCreateThirdPartyIntegrationConfig()
+		updatedConfig     = testAccCreateThirdPartyIntegrationConfig()
+		testExecutionName = "test_3rd_party_" + config.AccountID
+		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
+	)
+
+	// setting type
+	config.Type = "OPS_GENIE"
+	updatedConfig.Type = "OPS_GENIE"
+	updatedConfig.Region = "US"
+	config.APIKey = apiKey
+	updatedConfig.APIKey = apiKey
+
+	seedInitialConfig := thirdPartyConfig{
+		Name:        testExecutionName,
+		ProjectID:   projectID,
+		Integration: *config,
+	}
+
+	seedUpdatedConfig := thirdPartyConfig{
+		Name:        testExecutionName,
+		ProjectID:   projectID,
+		Integration: *updatedConfig,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(&seedInitialConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
+					resource.TestCheckResourceAttr(resourceName, "type", config.Type),
+					resource.TestCheckResourceAttr(resourceName, "api_key", config.APIKey),
+					resource.TestCheckResourceAttr(resourceName, "region", config.Region),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(&seedUpdatedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
+					resource.TestCheckResourceAttr(resourceName, "type", updatedConfig.Type),
+					resource.TestCheckResourceAttr(resourceName, "api_key", updatedConfig.APIKey),
+					resource.TestCheckResourceAttr(resourceName, "region", updatedConfig.Region),
+				),
+			},
+		},
+	},
+	)
+}
+
+func testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_third_party_integration" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		_, _, err := conn.Integrations.Get(context.Background(), ids["project_id"], ids["type"])
+
+		if err == nil {
+			return fmt.Errorf("third party integration service (%s) still exists", ids["type"])
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMongoDBAtlasThirdPartyIntegrationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["type"]), nil
+	}
+}

--- a/test/acceptance-test/resource_mongodbatlas_x509_authentication_database_user_test.go
+++ b/test/acceptance-test/resource_mongodbatlas_x509_authentication_database_user_test.go
@@ -1,0 +1,308 @@
+package acceptancetests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas"
+	"github.com/spf13/cast"
+)
+
+func TestAccGenericAdvRSX509AuthDBUser_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
+		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
+		username       = acctest.RandomWithPrefix("test-acc")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckBasic(t)
+		},
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGenericAdvRSX509AuthDBUser_WithCustomerX509(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
+		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
+		cas            = os.Getenv("CA_CERT")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "customer_x509_cas"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGenericAdvRSX509AuthDBUser_importBasic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_x509_authentication_database_user.test"
+		username     = acctest.RandomWithPrefix("test-acc")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckBasic(t)
+		},
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportState:       true,
+			},
+		},
+	})
+}
+
+func TestAccGenericAdvRSX509AuthDBUser_WithDatabaseUser(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_x509_authentication_database_user.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		username     = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		months       = acctest.RandIntRange(1, 24)
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithDatabaseUser(projectName, orgID, username, months),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttrSet(resourceName, "months_until_expiration"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "months_until_expiration", cast.ToString(months)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGenericAdvRSX509AuthDBUser_importWithCustomerX509(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_x509_authentication_database_user.test"
+		cas          = os.Getenv("CA_CERT")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
+		ProtoV6ProviderFactories: TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportState:       true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		return fmt.Sprintf("%s-%s", ids["project_id"], ids["username"]), nil
+	}
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.Attributes["project_id"] == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+		if ids["current_certificate"] != "" {
+			if _, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"], nil); err == nil {
+				return nil
+			}
+
+			return fmt.Errorf("the X509 Authentication Database User(%s) does not exist in the project(%s)", ids["username"], ids["project_id"])
+		}
+
+		if _, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
+			return nil
+		}
+
+		return fmt.Errorf("the Customer X509 Authentication does not exist in the project(%s)", ids["project_id"])
+	}
+}
+
+func testAccCheckMongoDBAtlasX509AuthDBUserDestroy(s *terraform.State) error {
+	conn := testAccProviderSdkV2.Meta().(*mongodbatlas.MongoDBClient).Atlas
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_x509_authentication_database_user" {
+			continue
+		}
+
+		ids := decodeStateID(rs.Primary.ID)
+
+		if ids["current_certificate"] != "" {
+			_, _, err := conn.X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"], nil)
+			if err == nil {
+				/*
+					There is no way to remove one user certificate so until this comes it will keep in this way
+				*/
+				return nil
+			}
+		}
+
+		if _, _, err := conn.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "basic_ds" {
+			username           = "%s"
+			project_id         = "${mongodbatlas_project.test.id}"
+			auth_database_name = "$external"
+			x509_type          = "MANAGED"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id              = "${mongodbatlas_project.test.id}"
+			username                = "${mongodbatlas_database_user.basic_ds.username}"
+			months_until_expiration = 5
+		}
+
+		data "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+		}
+	`, projectName, orgID, username)
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id        = "${mongodbatlas_project.test.id}"
+			customer_x509_cas = <<-EOT
+			%s
+			EOT
+		}
+
+		data "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+			username   = "${mongodbatlas_x509_authentication_database_user.test.username}"
+		}
+	`, projectName, orgID, cas)
+}
+
+func testAccMongoDBAtlasX509AuthDBUserConfigWithDatabaseUser(projectName, orgID, username string, months int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = "%s"
+			org_id = "%s"
+		}
+
+		resource "mongodbatlas_database_user" "user" {
+			project_id         = mongodbatlas_project.test.id
+			username           = "%s"
+			x509_type          = "MANAGED"
+			auth_database_name = "$external"
+
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+
+			labels {
+				key   = "My Key"
+				value = "My Value"
+			}
+		}
+
+		resource "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id              = "${mongodbatlas_database_user.user.project_id}"
+			username                = "${mongodbatlas_database_user.user.username}"
+			months_until_expiration = %d
+		}
+	`, projectName, orgID, username, months)
+}

--- a/test/mock/database-user.go
+++ b/test/mock/database-user.go
@@ -6,9 +6,9 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-type MockDatabaseUsersServiceOp struct{}
+type DatabaseUsersServiceOp struct{}
 
-func (s *MockDatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID, username string) (*matlas.DatabaseUser, *matlas.Response, error) {
+func (s *DatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID, username string) (*matlas.DatabaseUser, *matlas.Response, error) {
 	return &matlas.DatabaseUser{
 		GroupID:      groupID,
 		Username:     username,
@@ -26,11 +26,11 @@ func (s *MockDatabaseUsersServiceOp) Get(ctx context.Context, databaseName, grou
 	}, nil, nil
 }
 
-func (s *MockDatabaseUsersServiceOp) List(ctx context.Context, groupID string, listOptions *matlas.ListOptions) ([]matlas.DatabaseUser, *matlas.Response, error) {
+func (s *DatabaseUsersServiceOp) List(ctx context.Context, groupID string, listOptions *matlas.ListOptions) ([]matlas.DatabaseUser, *matlas.Response, error) {
 	return nil, nil, nil
 }
 
-func (s *MockDatabaseUsersServiceOp) Create(ctx context.Context, groupID string, createRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
+func (s *DatabaseUsersServiceOp) Create(ctx context.Context, groupID string, createRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
 	return &matlas.DatabaseUser{
 		GroupID:      groupID,
 		Username:     createRequest.Username,
@@ -48,7 +48,7 @@ func (s *MockDatabaseUsersServiceOp) Create(ctx context.Context, groupID string,
 	}, nil, nil
 }
 
-func (s *MockDatabaseUsersServiceOp) Update(ctx context.Context, groupID, username string, updateRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
+func (s *DatabaseUsersServiceOp) Update(ctx context.Context, groupID, username string, updateRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
 	return &matlas.DatabaseUser{
 		GroupID:      groupID,
 		Username:     updateRequest.Username,
@@ -66,6 +66,6 @@ func (s *MockDatabaseUsersServiceOp) Update(ctx context.Context, groupID, userna
 	}, nil, nil
 }
 
-func (s *MockDatabaseUsersServiceOp) Delete(ctx context.Context, databaseName, groupID, username string) (*matlas.Response, error) {
+func (s *DatabaseUsersServiceOp) Delete(ctx context.Context, databaseName, groupID, username string) (*matlas.Response, error) {
 	return nil, nil
 }

--- a/test/mock/database-user.go
+++ b/test/mock/database-user.go
@@ -1,0 +1,71 @@
+package mock
+
+import (
+	"context"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+type MockDatabaseUsersServiceOp struct{}
+
+func (s *MockDatabaseUsersServiceOp) Get(ctx context.Context, databaseName, groupID, username string) (*matlas.DatabaseUser, *matlas.Response, error) {
+	return &matlas.DatabaseUser{
+		GroupID:      groupID,
+		Username:     username,
+		DatabaseName: databaseName,
+		LDAPAuthType: "NONE",
+		AWSIAMType:   "NONE",
+		X509Type:     "NONE",
+		OIDCAuthType: "NONE",
+		Roles: []matlas.Role{
+			{
+				RoleName:     "atlasAdmin",
+				DatabaseName: "admin",
+			},
+		},
+	}, nil, nil
+}
+
+func (s *MockDatabaseUsersServiceOp) List(ctx context.Context, groupID string, listOptions *matlas.ListOptions) ([]matlas.DatabaseUser, *matlas.Response, error) {
+	return nil, nil, nil
+}
+
+func (s *MockDatabaseUsersServiceOp) Create(ctx context.Context, groupID string, createRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
+	return &matlas.DatabaseUser{
+		GroupID:      groupID,
+		Username:     createRequest.Username,
+		DatabaseName: createRequest.DatabaseName,
+		LDAPAuthType: "NONE",
+		AWSIAMType:   "NONE",
+		X509Type:     "NONE",
+		OIDCAuthType: "NONE",
+		Roles: []matlas.Role{
+			{
+				RoleName:     "atlasAdmin",
+				DatabaseName: "admin",
+			},
+		},
+	}, nil, nil
+}
+
+func (s *MockDatabaseUsersServiceOp) Update(ctx context.Context, groupID, username string, updateRequest *matlas.DatabaseUser) (*matlas.DatabaseUser, *matlas.Response, error) {
+	return &matlas.DatabaseUser{
+		GroupID:      groupID,
+		Username:     updateRequest.Username,
+		DatabaseName: updateRequest.DatabaseName,
+		LDAPAuthType: "NONE",
+		AWSIAMType:   "NONE",
+		X509Type:     "NONE",
+		OIDCAuthType: "NONE",
+		Roles: []matlas.Role{
+			{
+				RoleName:     "atlasAdmin",
+				DatabaseName: "admin",
+			},
+		},
+	}, nil, nil
+}
+
+func (s *MockDatabaseUsersServiceOp) Delete(ctx context.Context, databaseName, groupID, username string) (*matlas.Response, error) {
+	return nil, nil
+}

--- a/test/mock/mongo-client.go
+++ b/test/mock/mongo-client.go
@@ -1,0 +1,15 @@
+package mock
+
+import (
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/config"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func NewMockMongoDBClient() *config.MongoDBClient {
+	return &config.MongoDBClient{
+		Atlas: &matlas.Client{
+			DatabaseUsers: &MockDatabaseUsersServiceOp{},
+		},
+	}
+}

--- a/test/mock/mongo-client.go
+++ b/test/mock/mongo-client.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/config"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -9,7 +8,7 @@ import (
 func NewMockMongoDBClient() *config.MongoDBClient {
 	return &config.MongoDBClient{
 		Atlas: &matlas.Client{
-			DatabaseUsers: &MockDatabaseUsersServiceOp{},
+			DatabaseUsers: &DatabaseUsersServiceOp{},
 		},
 	}
 }


### PR DESCRIPTION
## Description

This PR is a POC on how we can leverage the acceptance tests for our unit tests. 
This PR proposes the following changes:

- Extracted the `config.go` to a new `config package`: This is needed to avoid hitting the cycle dependency error. config is used in mongodbatlas and when mocking the unit tests provider.
- Defined a new `frameworkTestProvider` which contains `MongodbtlasProvider` and a mock client to use during unit testing 
- Mocked the database user services. The logic is added in `test/mock` just as an example. We will discuss in the proposal doc a good place were we can store these files.
- Added `mongodbatlas/fw_resource_mongodbatlas_database_user_test.go` to leverage the acceptance tests framework by injecting `frameworkTestProvider` in the tests. Keep in mind that the test uses the mock client defined in `test/mock`


```bash
Running tool: /Users/andrea.angiolillo/.asdf/shims/go test -timeout 300000s -run ^TestDatabaseUser_basic$ github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas

ok  	github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas	5.704s
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments

### How to review this POC PR:

- feel free to ignore all the files under `test/acceptancetests`, they were just moved to a new dir 
- `test/mock` dir contains the logic to mock the MongoDB atlas sdk
- `config/config.go` contains the config used only by the resources that were migrated to the new framework. `mongodbatlas/config` was not deleted because the SDKv2 resources are still using it. I don't want to migrate them as the PR would be too big.
- `frameworkTestProvider` supports only the resources migrated to the new frameworks.

