### PR TITLE
fix: Update go releaser to include the v in the title of the release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  name_template: "{{.Version}}"
+  name_template: "v{{.Version}}"
   prerelease: auto
 changelog:
   skip: false


### PR DESCRIPTION
## Description

We recently pre-released the provider with go releaser and noticed that the release title was `1.11.1-pre` instead of `v1.11.1-pre1`. This PR updates go releaser to add the v to the release title

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code

## Further comments
