### PR TITLE
fix: handle incorrect ids when importing alert_configuration or project_ip_access_list resources

### DIFF
--- a/mongodbatlas/fw_data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_projects.go
@@ -160,6 +160,7 @@ func (d *ProjectsDS) Read(ctx context.Context, req datasource.ReadRequest, resp 
 	err = populateProjectsDataSourceModel(ctx, conn, connV2, &stateModel, projectsRes)
 	if err != nil {
 		resp.Diagnostics.AddError("error in monogbatlas_projects data source", err.Error())
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -534,7 +534,8 @@ func (r *AlertConfigurationRS) ImportState(ctx context.Context, req resource.Imp
 	parts := strings.SplitN(req.ID, "-", 2)
 
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("import format error: to import a cluster, use the format {project_id}-{id}", "")
+		resp.Diagnostics.AddError("import format error: to import an alert configuration, use the format {project_id}-{alert_configuration_id}", "")
+		return
 	}
 
 	projectID := parts[0]

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -534,7 +534,7 @@ func (r *AlertConfigurationRS) ImportState(ctx context.Context, req resource.Imp
 	parts := strings.SplitN(req.ID, "-", 2)
 
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("import format error: to import an alert configuration, use the format {project_id}-{alert_configuration_id}", "")
+		resp.Diagnostics.AddError("import format error", "to import an alert configuration, use the format {project_id}-{alert_configuration_id}")
 		return
 	}
 

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -329,12 +329,10 @@ func TestAccConfigRSAlertConfiguration_importIncorrectId(t *testing.T) {
 				Config: testAccMongoDBAtlasAlertConfigurationConfig(orgID, projectName, true),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasAlertConfigurationImportStateIncorrectIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id"},
-				ExpectError:             regexp.MustCompile("import format error"),
+				ResourceName:  resourceName,
+				ImportState:   true,
+				ImportStateId: "incorrect_id_without_project_id_and_dash",
+				ExpectError:   regexp.MustCompile("import format error"),
 			},
 		},
 	})
@@ -554,18 +552,6 @@ func testAccCheckMongoDBAtlasAlertConfigurationImportStateIDFunc(resourceName st
 		}
 
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["alert_configuration_id"]), nil
-	}
-}
-
-func testAccCheckMongoDBAtlasAlertConfigurationImportStateIncorrectIDFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("not found: %s", resourceName)
-		}
-
-		// incorrect format without project_id and dash
-		return rs.Primary.Attributes["alert_configuration_id"], nil
 	}
 }
 

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
@@ -354,6 +354,7 @@ func (r *ProjectIPAccessListRS) ImportState(ctx context.Context, req resource.Im
 
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("import format error", "to import a projectIP Access List, use the format {project_id}-{entry}")
+		return
 	}
 
 	projectID := parts[0]

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list_test.go
@@ -237,11 +237,10 @@ func TestAccProjectRSProjectIPAccessList_importIncorrectId(t *testing.T) {
 				Config: testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectIPAccessListImportStateIncorrectIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-				ExpectError:       regexp.MustCompile("import format error"),
+				ResourceName:  resourceName,
+				ImportState:   true,
+				ImportStateId: "incorrect_id_without_project_id_and_dash",
+				ExpectError:   regexp.MustCompile("import format error"),
 			},
 		},
 	})
@@ -300,20 +299,6 @@ func testAccCheckMongoDBAtlasProjectIPAccessListImportStateIDFunc(resourceName s
 		ids := decodeStateID(rs.Primary.ID)
 
 		return fmt.Sprintf("%s-%s", ids["project_id"], ids["entry"]), nil
-	}
-}
-
-func testAccCheckMongoDBAtlasProjectIPAccessListImportStateIncorrectIDFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("not found: %s", resourceName)
-		}
-
-		ids := decodeStateID(rs.Primary.ID)
-
-		// incorrect format without project_id and dash
-		return ids["entry"], nil
 	}
 }
 


### PR DESCRIPTION
## Description

Ticket: [INTMDB-1113](https://jira.mongodb.org/browse/INTMDB-1113)

- Handle incorrect ids when importing alert_configuration or project_ip_access_list resources. 
- Minor fix in error handling for project data source read.

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments
