### PR TITLE
fix: improved error handling for cloud_backup_schedule resource.

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -454,14 +454,16 @@ func resourceMongoDBAtlasCloudBackupScheduleImportState(ctx context.Context, d *
 }
 
 func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client, d *schema.ResourceData, projectID, clusterName string) error {
+	policy := matlas.Policy{}
 	// Get policies items
 	resp, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(ctx, projectID, clusterName)
 	if err != nil {
 		log.Printf("error getting MongoDB Cloud Backup Schedule (%s): %s", clusterName, err)
+	} else if len(resp.Policies) == 1 {
+		policy.ID = resp.Policies[0].ID
 	}
 
 	req := &matlas.CloudProviderSnapshotBackupPolicy{}
-	policy := matlas.Policy{}
 	policyItem := matlas.PolicyItem{}
 	var policiesItem []matlas.PolicyItem
 	export := matlas.Export{}
@@ -533,10 +535,6 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, conn *matlas.Client,
 
 	if d.HasChange("use_org_and_group_names_in_export_prefix") {
 		req.UseOrgAndGroupNamesInExportPrefix = pointy.Bool(d.Get("use_org_and_group_names_in_export_prefix").(bool))
-	}
-
-	if len(resp.Policies) == 1 {
-		policy.ID = resp.Policies[0].ID
 	}
 
 	policy.PolicyItems = policiesItem

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -16,6 +16,8 @@ description: |-
 
 -> **NOTE:** If Backup Compliance Policy is enabled for the project for which this backup schedule is defined, you cannot modify the backup schedule for an individual cluster below the minimum requirements set in the Backup Compliance Policy.  See [Backup Compliance Policy Prohibited Actions and Considerations](https://www.mongodb.com/docs/atlas/backup/cloud-backup/backup-compliance-policy/#configure-a-backup-compliance-policy).
 
+-> **NOTE:** When creating a backup schedule you **must either** use the `depends_on` clause to indicate the cluster to which it refers **or** specify the values of `project_id` and `cluster_name` as reference of the cluster resource (e.g. `cluster_name = mongodbatlas_cluster.my_cluster.name` - see the example below). Failure in doing so will result in an error when executing the plan.
+
 In the Terraform MongoDB Atlas Provider 1.0.0 we have re-architected the way in which Cloud Backup Policies are manged with Terraform to significantly reduce the complexity. Due to this change we've provided multiple examples below to help express how this new resource functions.
 
 


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): https://jira.mongodb.org/browse/HELP-50083

Originally we discovered this issue because client was creating a cloud_backup_schedule concurrently with the creation of the cluster but without specifying a "dependency" (either by using depends_on or by using cluster variable as input param values for the cloud_backup_schedule resource).

Behind the scenes though the plugin was crashing during this workflow because of a bug occurring when trying to check any existing policy and trying to read the response. In fact, we were trying to read the response of the request even when error was returned. This made the plugin to fully crash.

With this fix, we actually achieve what I believe is the correct state:
- if customer **does not specify a dependency** between the two resource it will get an error of this type:
```
│ Error: error creating a Cloud Backup Schedule: PATCH https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/6504522396b90345de085a13/clusters/clusterTest4/backup/schedule: 404 (request "CLUSTER_NAME_NOT_FOUND") No cluster with name "clusterTest4" exists in group 6504522396b90345de085a13.
│ 
│   with mongodbatlas_cloud_backup_schedule.test,
│   on main.tf line 29, in resource "mongodbatlas_cloud_backup_schedule" "test":
│   29: resource "mongodbatlas_cloud_backup_schedule" "test" {
```

which should be clear to understand. Eventually, if they retry it will actually work. But no matter what we are updating the documentation to make sure this is clear.

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code

## Further comments
