### PR TITLE
doc: Close code block in "Resource: Cloud Provider Access Configuration Paths" documentation page

### DIFF
--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -61,7 +61,7 @@ resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project
-* `provider_name` - (Required) The cloud provider for which to create a new role. Currently only AWS and AZURE are supported. **WARNING** Changing the `provider_name`` will result in destruction of the existing resource and the creation of a new resource.
+* `provider_name` - (Required) The cloud provider for which to create a new role. Currently only AWS and AZURE are supported. **WARNING** Changing the `provider_name` will result in destruction of the existing resource and the creation of a new resource.
 * `azure_config` - azure related configurations 
    * `atlas_azure_app_id` - Azure Active Directory Application ID of Atlas. This property is required when `provider_name = "AZURE".`
    * `service_principal_id`- UUID string that identifies the Azure Service Principal. This property is required when `provider_name = "AZURE".`

--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -136,6 +136,8 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
    }
 }
 
+```
+
 
 ## Argument Reference
 


### PR DESCRIPTION
## Description

The [Resource: Cloud Provider Access Configuration Paths](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_provider_access) documentation page currently does not render correctly due to missing closing code block.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
