### PR TITLE
fix: Update cluster update handler to update advanced_configuration first and make oplog_min_retention_hours non-computed

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -719,9 +719,6 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
-	/*
-		Update advanced configuration options if needed
-	*/
 	if d.HasChange("advanced_configuration") {
 		ac := d.Get("advanced_configuration")
 		if aclist, ok := ac.([]interface{}); ok && len(aclist) > 0 {

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -12,14 +12,15 @@ import (
 	"strings"
 	"time"
 
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"golang.org/x/exp/slices"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
-	"golang.org/x/exp/slices"
 )
 
 type acCtxKey string
@@ -718,6 +719,22 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
 
+	/*
+		Update advanced configuration options if needed
+	*/
+	if d.HasChange("advanced_configuration") {
+		ac := d.Get("advanced_configuration")
+		if aclist, ok := ac.([]interface{}); ok && len(aclist) > 0 {
+			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
+			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
+				_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)
+				if err != nil {
+					return diag.FromErr(fmt.Errorf(errorAdvancedClusterAdvancedConfUpdate, clusterName, err))
+				}
+			}
+		}
+	}
+
 	// Has changes
 	if !reflect.DeepEqual(cluster, clusterChangeDetect) {
 		err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
@@ -741,22 +758,6 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, clusterName, err))
-		}
-	}
-
-	/*
-		Update advanced configuration options if needed
-	*/
-	if d.HasChange("advanced_configuration") {
-		ac := d.Get("advanced_configuration")
-		if aclist, ok := ac.([]interface{}); ok && len(aclist) > 0 {
-			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]interface{}))
-			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
-				_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)
-				if err != nil {
-					return diag.FromErr(fmt.Errorf(errorAdvancedClusterAdvancedConfUpdate, clusterName, err))
-				}
-			}
 		}
 	}
 

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1651,10 +1651,12 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 				"oplog_size_mb": {
 					Type:     schema.TypeInt,
 					Optional: true,
+					Computed: true,
 				},
 				"oplog_min_retention_hours": {
 					Type:     schema.TypeInt,
 					Optional: true,
+					Computed: true,
 				},
 				"sample_size_bi_connector": {
 					Type:     schema.TypeInt,

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1656,7 +1656,6 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 				"oplog_min_retention_hours": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					Computed: true,
 				},
 				"sample_size_bi_connector": {
 					Type:     schema.TypeInt,


### PR DESCRIPTION
## Description

- advanced_configuration `oplog_min_retention_hours` is [Optional & Computed](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/mongodbatlas/resource_mongodbatlas_cluster.go#L1658) TypeInt attribute due to which change is not detected during planning ([see issue|https://discuss.hashicorp.com/t/schema-for-optional-computed-to-support-correct-removal-plan-in-framework/49055/3]).  We make this Optional only so changes in configs are detected for plans.
- Update handler in the resource calls PATCH update request for processArgs AFTER updating the cluster (hence auto_scaling_disk_gb_enabled is attempted to be updated to FALSE while oplog_min_retention_hours are still configured to a certain previous value) which causes PATCH API for Cluster update to return 400 error with reason ""Your oplogMinRetentionHours cannot be configured without disk autoscaling"
         - Expectation is that oplog_min_retention_hours should be unset before updating auto_scaling_disk_gb_enabled to FALSE.

Link to any related issue(s): [INTMDB-1139](https://jira.mongodb.org/browse/INTMDB-1139)

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
Plan generated now detects change to oplog_min_retention_hours if removed from config, to trigger update:
![image](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/122359335/1c8467f0-e1e0-43e8-ab2a-ace5c30c2a13)

