### PR TITLE
fix: Removes delete partition_fields statements.

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive.go
@@ -513,7 +513,6 @@ func fromOnlineArchiveToMap(in *matlas.OnlineArchive) map[string]interface{} {
 
 func fromOnlineArchiveToMapInCreate(in *matlas.OnlineArchive) map[string]interface{} {
 	localSchema := fromOnlineArchiveToMap(in)
-	delete(localSchema, "partition_fields")
 	return localSchema
 }
 

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -10,9 +10,63 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
+
+func TestAccBackupRSOnlineArchiveWithNoChangeBetweenVersions(t *testing.T) {
+	var (
+		cluster                   matlas.Cluster
+		resourceName              = "mongodbatlas_cluster.online_archive_test"
+		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
+		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName               = acctest.RandomWithPrefix("test-acc")
+		name                      = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBasic(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					populateWithSampleData(resourceName, &cluster),
+				),
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: "1.11.0",
+						Source:            "mongodb/mongodbatlas",
+					},
+				},
+				Config: testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: testAccProviderV6Factories,
+				Config:                   testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						testutils.DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
 
 func TestAccBackupRSOnlineArchive(t *testing.T) {
 	var (

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -87,6 +87,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_field.0.field_name", "last_review"),
 				),
 			},
 			{
@@ -131,6 +132,7 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_field.0.field_name", "last_review"),
 				),
 			},
 			{

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -87,7 +87,6 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.end_minute"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_hour"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "schedule.0.start_minute"),
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_field.0.field_name", "last_review"),
 				),
 			},
 			{
@@ -97,6 +96,12 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
 					resource.TestCheckNoResourceAttr(onlineArchiveResourceName, "schedule.#"),
+				),
+			},
+			{
+				Config: testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
 				),
 			},
 		},
@@ -132,7 +137,6 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_field.0.field_name", "last_review"),
 				),
 			},
 			{

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -10,63 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
-
-func TestAccBackupRSOnlineArchiveWithNoChangeBetweenVersions(t *testing.T) {
-	var (
-		cluster                   matlas.Cluster
-		resourceName              = "mongodbatlas_cluster.online_archive_test"
-		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
-		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName               = acctest.RandomWithPrefix("test-acc")
-		name                      = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckBasic(t) },
-		CheckDestroy: testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"mongodbatlas": {
-						VersionConstraint: "1.11.0",
-						Source:            "mongodb/mongodbatlas",
-					},
-				},
-				Config: testAccBackupRSOnlineArchiveConfigFirstStep(orgID, projectName, name),
-				Check: resource.ComposeTestCheckFunc(
-					populateWithSampleData(resourceName, &cluster),
-				),
-			},
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"mongodbatlas": {
-						VersionConstraint: "1.11.0",
-						Source:            "mongodb/mongodbatlas",
-					},
-				},
-				Config: testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
-				),
-			},
-			{
-				ProtoV6ProviderFactories: testAccProviderV6Factories,
-				Config:                   testAccBackupRSOnlineArchiveConfigWithDailySchedule(orgID, projectName, name, 1),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPreRefresh: []plancheck.PlanCheck{
-						testutils.DebugPlan(),
-					},
-				},
-				PlanOnly: true,
-			},
-		},
-	})
-}
 
 func TestAccBackupRSOnlineArchive(t *testing.T) {
 	var (


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 
https://jira.mongodb.org/browse/INTMDB-1136 

https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1492



### TESTING

Ran the following `main.tf`:
```
resource "mongodbatlas_online_archive" "this" {
  project_id   = var.project_id
  cluster_name = var.cluster_name
  coll_name    = var.collection_name
  db_name      = var.database_name

    partition_fields {
        field_name = var.partition_field_one
        order = 0
    }

    criteria {
      type              = "DATE"
      date_field        = "created"
      date_format       = "ISODATE"
      expire_after_days = 2
    }

    schedule {
        type = "DAILY"
        end_hour = 11
        end_minute = 0
        start_hour = 8
        start_minute = 0
    }  
}
```

and then executed the commands as mentioned in the issue.

```
➜  INTMDB-1136 terraform import "mongodbatlas_online_archive.this" "6513cd8f1a0e213da8cf71e2"-"clustertest1"-"6513d53c55aafa7b2bb03a20"
mongodbatlas_online_archive.this: Importing from ID "6513cd8f1a0e213da8cf71e2-clustertest1-6513d53c55aafa7b2bb03a20"...
mongodbatlas_online_archive.this: Import prepared!
  Prepared mongodbatlas_online_archive for import
mongodbatlas_online_archive.this: Refreshing state... [id=YXJjaGl2ZV9pZA==:NjUxM2Q1M2M1NWFhZmE3YjJiYjAzYTIw-Y2x1c3Rlcl9uYW1l:Y2x1c3RlcnRlc3Qx-cHJvamVjdF9pZA==:NjUxM2NkOGYxYTBlMjEzZGE4Y2Y3MWUy]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

➜  INTMDB-1136 terraform state show "mongodbatlas_online_archive.this"
# mongodbatlas_online_archive.this:
resource "mongodbatlas_online_archive" "this" {
    archive_id      = "6513d53c55aafa7b2bb03a20"
    cluster_name    = "clustertest1"
    coll_name       = "collectiontest"
    collection_type = "STANDARD"
    id              = "YXJjaGl2ZV9pZA==:NjUxM2Q1M2M1NWFhZmE3YjJiYjAzYTIw-Y2x1c3Rlcl9uYW1l:Y2x1c3RlcnRlc3Qx-cHJvamVjdF9pZA==:NjUxM2NkOGYxYTBlMjEzZGE4Y2Y3MWUy"
    paused          = false
    project_id      = "6513cd8f1a0e213da8cf71e2"
    state           = "ACTIVE"

    criteria {
        date_field        = "created"
        date_format       = "ISODATE"
        expire_after_days = 2
        type              = "DATE"
    }

    partition_fields {
        field_name = "created"
        order      = 0
    }
    partition_fields {
        field_name = "field_1"
        order      = 1
    }
}
```

With the fix you can see `parition_fields` are there.

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
