### PR TITLE
fix: changes validation of empty provider credentials from Error to Warning

### DIFF
--- a/mongodbatlas/fw_provider.go
+++ b/mongodbatlas/fw_provider.go
@@ -297,7 +297,7 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, awsRoleD
 			"MCLI_PUBLIC_API_KEY",
 		}, "").(string))
 		if data.PublicKey.ValueString() == "" && !awsRoleDefined {
-			resp.Diagnostics.AddError(ProviderConfigError, MissingAuthAttrError)
+			resp.Diagnostics.AddWarning(ProviderConfigError, MissingAuthAttrError)
 		}
 	}
 
@@ -307,7 +307,7 @@ func setDefaultValuesWithValidations(data *tfMongodbAtlasProviderModel, awsRoleD
 			"MCLI_PRIVATE_API_KEY",
 		}, "").(string))
 		if data.PrivateKey.ValueString() == "" && !awsRoleDefined {
-			resp.Diagnostics.AddError(ProviderConfigError, MissingAuthAttrError)
+			resp.Diagnostics.AddWarning(ProviderConfigError, MissingAuthAttrError)
 		}
 	}
 


### PR DESCRIPTION
## Description

Jira ticket: [INTMDB-1127](https://jira.mongodb.org/browse/INTMDB-1127)
GH issue: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1483

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments

Found limitations when trying to define an acceptance test to verify warning is correctly returned:
- terraform-plugin-testing currently does not support asserting warning results https://github.com/hashicorp/terraform-plugin-testing/issues/69

<details>
  <summary>Manual testing verification</summary>

TF config with no environment variables defined:
```
provider "mongodbatlas" {
  base_url = "https://cloud-dev.mongodb.com/"
}

resource "mongodbatlas_project" "test" {
  name  			 = "some-name"
  org_id 			 = "<ORG-ID>"
}
```

```terraform plan```
```
Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: either Atlas Programmatic API Keys or AWS Secrets Manager attributes must be set
│ 
│   with provider["registry.terraform.io/mongodb/mongodbatlas"],
│   on main.tf line 11, in provider "mongodbatlas":
│   11: provider "mongodbatlas" {
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: error in configuring the provider.
│ 
│   with provider["registry.terraform.io/mongodb/mongodbatlas"],
│   on main.tf line 11, in provider "mongodbatlas":
│   11: provider "mongodbatlas" {
│ 
│ either Atlas Programmatic API Keys or AWS Secrets Manager attributes must be set
```

```terraform apply```
```
mongodbatlas_project.test: Creating...
╷
│ Warning: either Atlas Programmatic API Keys or AWS Secrets Manager attributes must be set
│ 
│   with provider["registry.terraform.io/mongodb/mongodbatlas"],
│   on main.tf line 11, in provider "mongodbatlas":
│   11: provider "mongodbatlas" {
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: error in configuring the provider.
│ 
│   with provider["registry.terraform.io/mongodb/mongodbatlas"],
│   on main.tf line 11, in provider "mongodbatlas":
│   11: provider "mongodbatlas" {
│ 
│ either Atlas Programmatic API Keys or AWS Secrets Manager attributes must be set
╵
╷
│ Error: error creating Project: %s
│ 
│   with mongodbatlas_project.test,
│   on main.tf line 15, in resource "mongodbatlas_project" "test":
│   15: resource "mongodbatlas_project" "test" {
│ 
│ POST https://cloud-dev.mongodb.com/api/atlas/v1.0/groups: 401 (request "") You are not authorized for this resource.
```

</details>
