### PR TITLE
fix: adjust format of database user resource id as defined in previous versions

### DIFF
--- a/mongodbatlas/fw_resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user.go
@@ -3,7 +3,6 @@ package mongodbatlas
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"regexp"
 
@@ -391,9 +390,14 @@ func newTFDatabaseUserModel(ctx context.Context, model *tfDatabaseUserModel, dbU
 		return nil, diagnostic
 	}
 
-	id := fmt.Sprintf("%s-%s-%s", dbUser.GroupID, dbUser.Username, dbUser.DatabaseName)
+	// ID is encoded to preserve format defined in previous versions.
+	encodedID := encodeStateID(map[string]string{
+		"project_id":         dbUser.GroupID,
+		"username":           dbUser.Username,
+		"auth_database_name": dbUser.DatabaseName,
+	})
 	databaseUserModel := &tfDatabaseUserModel{
-		ID:               types.StringValue(id),
+		ID:               types.StringValue(encodedID),
 		ProjectID:        types.StringValue(dbUser.GroupID),
 		AuthDatabaseName: types.StringValue(dbUser.DatabaseName),
 		Username:         types.StringValue(dbUser.Username),

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
@@ -600,12 +600,9 @@ func testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName string) 
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 
-		projectID, username, authDatabaseName, err := splitDatabaseUserImportID(rs.Primary.ID)
-		if err != nil {
-			return "", fmt.Errorf("error splitting database User info from ID: %s", rs.Primary.ID)
-		}
+		ids := decodeStateID(rs.Primary.ID)
 
-		return fmt.Sprintf("%s-%s-%s", projectID, username, authDatabaseName), nil
+		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["username"], ids["auth_database_name"]), nil
 	}
 }
 


### PR DESCRIPTION
## Description

Ticket: [INTMDB-1172](https://jira.mongodb.org/browse/INTMDB-1172)

Format defined in `1.11.1`: https://github.com/mongodb/terraform-provider-mongodbatlas/blob/v1.11.1/mongodbatlas/resource_mongodbatlas_database_user.go#L256 

**Note**: as of `1.12.x` there is no usage of the id value within the database user resource, so it can be modified safely back to the format defined in `1.11.1`.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
