### PR TITLE
fix: avoid including provider_disk_type_name property in cluster update request if attribute was removed

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1128,8 +1128,8 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 	}
 
 	if d.HasChange("provider_disk_type_name") {
-		_, new := d.GetChange("provider_disk_type_name")
-		diskTypeName := cast.ToString(new)
+		_, newdiskTypeName := d.GetChange("provider_disk_type_name")
+		diskTypeName := cast.ToString(newdiskTypeName)
 		if diskTypeName != "" { // ensure disk type is not included in request if attribute is removed, prevents errors in NVME intances
 			providerSettings.DiskTypeName = diskTypeName
 		}

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -1125,7 +1125,14 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 		ProviderName:     providerName,
 		RegionName:       region,
 		VolumeType:       cast.ToString(d.Get("provider_volume_type")),
-		DiskTypeName:     cast.ToString(d.Get("provider_disk_type_name")),
+	}
+
+	if d.HasChange("provider_disk_type_name") {
+		_, new := d.GetChange("provider_disk_type_name")
+		diskTypeName := cast.ToString(new)
+		if diskTypeName != "" { // ensure disk type is not included in request if attribute is removed, prevents errors in NVME intances
+			providerSettings.DiskTypeName = diskTypeName
+		}
 	}
 
 	if providerName == "TENANT" {
@@ -1144,12 +1151,6 @@ func expandProviderSetting(d *schema.ResourceData) (*matlas.ProviderSettings, er
 		}
 
 		providerSettings.EncryptEBSVolume = pointy.Bool(true)
-	}
-
-	if d.Get("provider_name") == "AZURE" {
-		if v, ok := d.GetOk("provider_disk_type_name"); ok && !strings.Contains(providerSettings.InstanceSizeName, "NVME") {
-			providerSettings.DiskTypeName = cast.ToString(v)
-		}
 	}
 
 	return providerSettings, nil


### PR DESCRIPTION
## Description

Ticket: [INTMDB-1177](https://jira.mongodb.org/browse/INTMDB-1177)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments

<details>
  <summary>Verifying acceptance test fails in master ensuring regression will be detected</summary>

```
--- FAIL: TestAccClusterRSCluster_AzureUpdateToNVME (681.03s)
    /Users/agustin.bettati/mongodb/terraform-provider-mongodbatlas/mongodbatlas/resource_mongodbatlas_cluster_test.go:403: Step 2/2 error: Error running apply: exit status 1
        
        Error: error updating MongoDB Cluster (test-acc-fz9kmu2nl1): error updating MongoDB Cluster (test-acc-fz9kmu2nl1): PATCH https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/651ef84804b6d81727d5f158/clusters/test-acc-fz9kmu2nl1: 400 (request "CANNOT_MODIFY_DISK_TYPE_FOR_AZURE_NVME_CLUSTER") Cannot modify disk type for Azure NVMe cluster.
```

</details>

<details>
  <summary>Verifying update is successful with local build</summary>

```
Terraform will perform the following actions:

  # mongodbatlas_cluster.cluster3 will be updated in-place
  ~ resource "mongodbatlas_cluster" "cluster3" {
        id                                      = "<id>"
        name                                    = "AzureM80Cluster"
      ~ provider_instance_size_name             = "M80" -> "M80_NVME"
        # (29 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


mongodbatlas_cluster.cluster3: Modifying... [id=<id>]
mongodbatlas_cluster.cluster3: Modifications complete after 30m44s [id=<id>]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

</details>


