### PR TITLE
fix: alert configuration data source nil pointer with third party notifications

### DIFF
--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration_test.go
@@ -105,17 +105,18 @@ func TestAccConfigDSAlertConfiguration_withPagerDuty(t *testing.T) {
 	var (
 		alert          = &matlas.AlertConfiguration{}
 		dataSourceName = "data.mongodbatlas_alert_configuration.test"
-		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey     = "dummykey111111111111111111111111"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+		serviceKey     = dummy32CharKey
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(projectID, serviceKey, true),
+				Config: testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(orgID, projectName, serviceKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(dataSourceName, alert),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -244,16 +245,20 @@ func testAccDSMongoDBAtlasAlertConfigurationWithOutputs(orgID, projectName, outp
 	`, orgID, projectName, outputLabel)
 }
 
-func testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(projectID, serviceKey string, enabled bool) string {
+func testAccDSMongoDBAtlasAlertConfigurationConfigWithPagerDuty(orgID, projectName, serviceKey string, enabled bool) string {
 	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
 resource "mongodbatlas_alert_configuration" "test" {
-  project_id = %[1]q
+  project_id = mongodbatlas_project.test.id
   event_type = "NO_PRIMARY"
-  enabled    = "%[3]t"
+  enabled    = "%[4]t"
 
   notification {
     type_name    = "PAGER_DUTY"
-    service_key  = %[2]q
+    service_key  = %[3]q
     delay_min    = 0
   }
 }
@@ -262,5 +267,5 @@ data "mongodbatlas_alert_configuration" "test" {
   project_id             = "${mongodbatlas_alert_configuration.test.project_id}"
   alert_configuration_id = "${mongodbatlas_alert_configuration.test.id}"
 }
-	`, projectID, serviceKey, enabled)
+	`, orgID, projectName, serviceKey, enabled)
 }

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration_test.go
@@ -102,12 +102,11 @@ func TestAccConfigDSAlertConfiguration_withOutput(t *testing.T) {
 }
 
 func TestAccConfigDSAlertConfiguration_withPagerDuty(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
 	var (
 		alert          = &matlas.AlertConfiguration{}
 		dataSourceName = "data.mongodbatlas_alert_configuration.test"
 		projectID      = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey     = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+		serviceKey     = "dummykey111111111111111111111111"
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/mwielbut/pointy"
 	"go.mongodb.org/atlas-sdk/v20230201006/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -744,9 +745,9 @@ func newTFNotificationModelListV2(n []admin.AlertsNotificationRootForGroup, curr
 				Roles:          value.Roles,
 				ChannelName:    conversion.StringPtrNullIfEmpty(value.ChannelName),
 				DatadogRegion:  conversion.StringPtrNullIfEmpty(value.DatadogRegion),
-				DelayMin:       types.Int64Value(int64(*value.DelayMin)),
+				DelayMin:       types.Int64PointerValue(util.IntPtrToInt64Ptr(value.DelayMin)),
 				EmailAddress:   conversion.StringPtrNullIfEmpty(value.EmailAddress),
-				IntervalMin:    types.Int64Value(int64(*value.IntervalMin)),
+				IntervalMin:    types.Int64PointerValue(util.IntPtrToInt64Ptr(value.IntervalMin)),
 				MobileNumber:   conversion.StringPtrNullIfEmpty(value.MobileNumber),
 				OpsGenieRegion: conversion.StringPtrNullIfEmpty(value.OpsGenieRegion),
 				TeamID:         conversion.StringPtrNullIfEmpty(value.TeamId),
@@ -804,8 +805,8 @@ func newTFNotificationModelListV2(n []admin.AlertsNotificationRootForGroup, curr
 			newState.Username = conversion.StringPtrNullIfEmpty(value.Username)
 		}
 
-		newState.IntervalMin = types.Int64Value(int64(*value.IntervalMin))
-		newState.DelayMin = types.Int64Value(int64(*value.DelayMin))
+		newState.IntervalMin = types.Int64PointerValue(util.IntPtrToInt64Ptr(value.IntervalMin))
+		newState.DelayMin = types.Int64PointerValue(util.IntPtrToInt64Ptr(value.DelayMin))
 		newState.EmailEnabled = types.BoolValue(value.EmailEnabled != nil && *value.EmailEnabled)
 		newState.SMSEnabled = types.BoolValue(value.SmsEnabled != nil && *value.SmsEnabled)
 

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -364,12 +364,16 @@ func TestAccConfigRSAlertConfiguration_importConfigNotifications(t *testing.T) {
 	})
 }
 
+// dummy keys used for credential values in third party notifications
+const dummy32CharKey = "11111111111111111111111111111111"
+const dummy36CharKey = "11111111-1111-1111-1111-111111111111"
+
 // used for testing notification that does not define interval_min attribute
 func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey   = "dummykey111111111111111111111111"
+		serviceKey   = dummy32CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -400,7 +404,7 @@ func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		ddAPIKey     = "11111111111111111111111111111111"
+		ddAPIKey     = dummy32CharKey
 		ddRegion     = "US"
 		alert        = &matlas.AlertConfiguration{}
 	)
@@ -425,7 +429,7 @@ func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey   = "dummykey111111111111111111111111"
+		serviceKey   = dummy32CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -449,7 +453,7 @@ func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		apiKey       = "11111111-1111-1111-1111-111111111111"
+		apiKey       = dummy36CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -473,7 +477,7 @@ func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		apiKey       = "11111111-1111-1111-1111-111111111111"
+		apiKey       = dummy36CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -366,11 +366,10 @@ func TestAccConfigRSAlertConfiguration_importConfigNotifications(t *testing.T) {
 
 // used for testing notification that does not define interval_min attribute
 func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey   = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+		serviceKey   = "dummykey111111111111111111111111"
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -398,12 +397,10 @@ func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 }
 
 func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
-	SkipTest(t)        // Will force skip if enabled
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		ddAPIKey     = os.Getenv("DD_API_KEY")
+		ddAPIKey     = "11111111111111111111111111111111"
 		ddRegion     = "US"
 		alert        = &matlas.AlertConfiguration{}
 	)
@@ -425,11 +422,10 @@ func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
 }
 
 func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		serviceKey   = os.Getenv("PAGER_DUTY_SERVICE_KEY")
+		serviceKey   = "dummykey111111111111111111111111"
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -450,11 +446,10 @@ func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
 }
 
 func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		apiKey       = os.Getenv("OPS_GENIE_API_KEY")
+		apiKey       = "11111111-1111-1111-1111-111111111111"
 		alert        = &matlas.AlertConfiguration{}
 	)
 
@@ -475,11 +470,10 @@ func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
 }
 
 func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
-	SkipTestExtCred(t) // Will skip because requires external credentials aka api key
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		apiKey       = os.Getenv("VICTOR_OPS_API_KEY")
+		apiKey       = "11111111-1111-1111-1111-111111111111"
 		alert        = &matlas.AlertConfiguration{}
 	)
 

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -372,7 +372,8 @@ const dummy36CharKey = "11111111-1111-1111-1111-111111111111"
 func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
 		serviceKey   = dummy32CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
@@ -383,7 +384,7 @@ func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey, true),
+				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(orgID, projectName, serviceKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -403,19 +404,20 @@ func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
 		ddAPIKey     = dummy32CharKey
 		ddRegion     = "US"
 		alert        = &matlas.AlertConfiguration{}
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(projectID, ddAPIKey, ddRegion, true),
+				Config: testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(orgID, projectName, ddAPIKey, ddRegion, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -428,18 +430,19 @@ func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
 func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
 		serviceKey   = dummy32CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey, true),
+				Config: testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(orgID, projectName, serviceKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -452,18 +455,19 @@ func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
 func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
 		apiKey       = dummy36CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(projectID, apiKey, true),
+				Config: testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(orgID, projectName, apiKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -476,18 +480,19 @@ func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
 func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_alert_configuration.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
 		apiKey       = dummy36CharKey
 		alert        = &matlas.AlertConfiguration{}
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(projectID, apiKey, true),
+				Config: testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(orgID, projectName, apiKey, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName, alert),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -775,19 +780,23 @@ func testAccMongoDBAtlasAlertConfigurationConfigWithThresholdUpdated(orgID, proj
 	`, orgID, projectName, enabled, threshold)
 }
 
-func testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(projectID, dataDogAPIKey, dataDogRegion string, enabled bool) string {
+func testAccMongoDBAtlasAlertConfigurationConfigWithDataDog(orgID, projectName, dataDogAPIKey, dataDogRegion string, enabled bool) string {
 	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
 resource "mongodbatlas_third_party_integration" "atlas_datadog" {
-  project_id = "%[1]s"
+  project_id = mongodbatlas_project.test.id
   type = "DATADOG"
-  api_key = "%[3]s"
-  region = "%[4]s"
+  api_key = "%[4]s"
+  region = "%[5]s"
 }
 
 resource "mongodbatlas_alert_configuration" "test" {
-  project_id = "%[1]s"
+  project_id = mongodbatlas_project.test.id
   event_type = "REPLICATION_OPLOG_WINDOW_RUNNING_OUT"
-  enabled    = %t
+  enabled    = %[3]t
 
   notification {
     type_name     = "GROUP"
@@ -818,57 +827,69 @@ resource "mongodbatlas_alert_configuration" "test" {
     units       = "HOURS"
   }
 }
-	`, projectID, enabled, dataDogAPIKey, dataDogRegion)
+	`, orgID, projectName, enabled, dataDogAPIKey, dataDogRegion)
 }
 
-func testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(projectID, serviceKey string, enabled bool) string {
+func testAccMongoDBAtlasAlertConfigurationPagerDutyConfig(orgID, projectName, serviceKey string, enabled bool) string {
 	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
 resource "mongodbatlas_alert_configuration" "test" {
-  project_id = %[1]q
+  project_id = mongodbatlas_project.test.id
   event_type = "NO_PRIMARY"
-  enabled    = "%[3]t"
+  enabled    = "%[4]t"
 
   notification {
     type_name    = "PAGER_DUTY"
-    service_key  = %[2]q
+    service_key  = %[3]q
     delay_min    = 0
   }
 }
-	`, projectID, serviceKey, enabled)
+	`, orgID, projectName, serviceKey, enabled)
 }
 
-func testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(projectID, apiKey string, enabled bool) string {
+func testAccMongoDBAtlasAlertConfigurationOpsGenieConfig(orgID, projectName, apiKey string, enabled bool) string {
 	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
 resource "mongodbatlas_alert_configuration" "test" {
-  project_id = %[1]q
+  project_id = mongodbatlas_project.test.id
   event_type = "NO_PRIMARY"
-  enabled    = "%[3]t"
+  enabled    = "%[4]t"
 
   notification {
     type_name          = "OPS_GENIE"
-    ops_genie_api_key  = %[2]q
+    ops_genie_api_key  = %[3]q
     ops_genie_region   = "US"
     delay_min          = 0
   }
 }
-	`, projectID, apiKey, enabled)
+	`, orgID, projectName, apiKey, enabled)
 }
 
-func testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(projectID, apiKey string, enabled bool) string {
+func testAccMongoDBAtlasAlertConfigurationVictorOpsConfig(orgID, projectName, apiKey string, enabled bool) string {
 	return fmt.Sprintf(`
+resource "mongodbatlas_project" "test" {
+	name   = %[2]q
+	org_id = %[1]q
+}
 resource "mongodbatlas_alert_configuration" "test" {
-  project_id = %[1]q
+  project_id = mongodbatlas_project.test.id
   event_type = "NO_PRIMARY"
-  enabled    = "%[3]t"
+  enabled    = "%[4]t"
 
   notification {
     type_name              = "VICTOR_OPS"
-    victor_ops_api_key     = %[2]q
+    victor_ops_api_key     = %[3]q
     victor_ops_routing_key = "testing"
     delay_min              = 0
   }
 }
-	`, projectID, apiKey, enabled)
+	`, orgID, projectName, apiKey, enabled)
 }
 
 func testAccMongoDBAtlasAlertConfigurationConfigEmptyMetricThresholdConfig(orgID, projectName string, enabled bool) string {

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -411,7 +411,7 @@ func TestAccConfigRSAlertConfiguration_DataDog(t *testing.T) {
 		alert        = &matlas.AlertConfiguration{}
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
@@ -436,7 +436,7 @@ func TestAccConfigRSAlertConfiguration_PagerDuty(t *testing.T) {
 		alert        = &matlas.AlertConfiguration{}
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
@@ -461,7 +461,7 @@ func TestAccConfigRSAlertConfiguration_OpsGenie(t *testing.T) {
 		alert        = &matlas.AlertConfiguration{}
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,
@@ -486,7 +486,7 @@ func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
 		alert        = &matlas.AlertConfiguration{}
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheckBasic(t) },
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasAlertConfigurationDestroy,

--- a/mongodbatlas/util/type_conversion.go
+++ b/mongodbatlas/util/type_conversion.go
@@ -28,6 +28,15 @@ func Int64PtrToIntPtr(i64 *int64) *int {
 	return &i
 }
 
+func IntPtrToInt64Ptr(i *int) *int64 {
+	if i == nil {
+		return nil
+	}
+
+	i64 := int64(*i)
+	return &i64
+}
+
 // IsStringPresent returns true if the string is non-empty.
 func IsStringPresent(strPtr *string) bool {
 	return strPtr != nil && len(*strPtr) > 0


### PR DESCRIPTION
## Description

Jira ticket: [INTMDB-1182](https://jira.mongodb.org/browse/INTMDB-1182)
Bug found when validating fix for [INTMDB-981](https://jira.mongodb.org/browse/INTMDB-981).

This nil pointer error is encountered when using the alert configuration data source for a third party alert configuration notification that does not define the `interval_min` attribute.
An acceptance test reproducing this issue was defined but skipped in CI as it relies on external credentials. Was able to verify that dummy credentials can be used to successfully create third party alert notifications so adjusted the corresponding tests so they all run in our CI moving forward.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
