### PR TITLE
chore: fix so cleanup-test-env script continues if delete of one project fails

### DIFF
--- a/scripts/cleanup-test-env.sh
+++ b/scripts/cleanup-test-env.sh
@@ -36,6 +36,9 @@ echo "${projects}" | jq -c '.results[].id' | while read -r id; do
     fi
 
     echo "Deleting projectId ${clean_project_id}"
-    # This command will fail if the project has a cluster inside
-    atlas project delete "${clean_project_id}" --force
+    # This command can fail if project has a cluster, a private endpoint, or general failure. The echo command always succeeds so the subshell will succeed and continue
+    (
+        atlas project delete "${clean_project_id}" --force || \
+        echo "Failed to delete project with ID ${clean_project_id}"
+    )
 done


### PR DESCRIPTION
## Description

Jira ticket: [INTMDB-1123](https://jira.mongodb.org/browse/INTMDB-1123)

Looking into the history of this ticket, I see that core idea is to properly handle deletion of projects that have existing clusters or private endpoints while also having unified code with other integrations. We can include this fix but as something temporary to cleanup the majority of empty project we currently have (which will ublock PRs). Would not consider the jira ticket as finished.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments

Example execution running locally showing failed delete and script continues:
![Screenshot 2023-10-10 at 10 07 44](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/20469408/ecf0c1c8-db8e-4332-999d-7a2e67eec159)

