### PR TITLE
feat: INTMDB-1190: Update message added to github issue in the automation to create Jira ticket

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -58,7 +58,7 @@
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            Thanks for opening this issue! Please make sure to provide the following information to help us reproduce the issue:
+            Thanks for opening this issue! Please make sure you've followed [our guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/new?assignees=&labels=&projects=&template=Bug_Report.md) when opening the issue. In short, to help us reproduce the issue we need:
               - Terraform configuration file used to reproduce the issue
               - Terraform log files from the run where the issue occurred
               - Terraform Atlas provider version used to reproduce the issue

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -58,4 +58,11 @@
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            Thanks for opening this issue. The ticket [${{ steps.create.outputs.jira-ticket-id }}](https://jira.mongodb.org/browse/${{ steps.create.outputs.jira-ticket-id }}) was created for internal tracking.
+            Thanks for opening this issue! Please make sure to provide the following information to help us reproduce the issue:
+              - Terraform configuration file used to reproduce the issue
+              - Terraform log files from the run where the issue occurred
+              - Terraform Atlas provider version used to reproduce the issue
+              - Terraform version used to reproduce the issue
+              - Confirmation if Terraform OSS, Terraform Cloud, or Terraform Enterprise deployment 
+
+            The ticket [${{ steps.create.outputs.jira-ticket-id }}](https://jira.mongodb.org/browse/${{ steps.create.outputs.jira-ticket-id }}) was created for internal tracking.


### PR DESCRIPTION
## Description

This PR updates the description of our automation to add a message to the issue asking to provide all the needed info to reproduce the issue. 

Example of the new message: https://github.com/andreaangiolillo/cdk-test/issues/36#issuecomment-1759889472
![Screenshot 2023-10-12 at 16 50 16](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/5663078/6781d20e-6a94-40b7-b193-273029dfcb29)

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments

## Next Steps
Opening the same PR for other integrations:
- https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/781
- https://github.com/mongodb/awscdk-resources-mongodbatlas/pull/139