### PR TITLE
deprecate: Deprecates page_num and items_per_page in datasource mongodbatlas_search_indexes

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_search_indexes.go
+++ b/mongodbatlas/data_source_mongodbatlas_search_indexes.go
@@ -2,6 +2,7 @@ package mongodbatlas
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -30,12 +31,14 @@ func dataSourceMongoDBAtlasSearchIndexes() *schema.Resource {
 				Required: true,
 			},
 			"page_num": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: fmt.Sprintf(DeprecationByVersionMessageParameter, "1.15.0"),
 			},
 			"items_per_page": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: fmt.Sprintf(DeprecationByVersionMessageParameter, "1.15.0"),
 			},
 			"results": {
 				Type:     schema.TypeList,

--- a/mongodbatlas/fw_provider.go
+++ b/mongodbatlas/fw_provider.go
@@ -28,6 +28,7 @@ const (
 	DeprecationMessageParameterToResource = "this parameter is deprecated and will be removed in %s, please transition to %s"
 	DeprecationByDateMessageParameter     = "this parameter is deprecated and will be removed by %s"
 	DeprecationByDateWithReplacement      = "this parameter is deprecated and will be removed by %s, please transition to %s"
+	DeprecationByVersionMessageParameter  = "this parameter is deprecated and will be removed in version %s"
 	DeprecationMessage                    = "this resource is deprecated and will be removed in %s, please transition to %s"
 	endPointSTSDefault                    = "https://sts.amazonaws.com"
 	MissingAuthAttrError                  = "either Atlas Programmatic API Keys or AWS Secrets Manager attributes must be set"

--- a/website/docs/d/search_indexes.html.markdown
+++ b/website/docs/d/search_indexes.html.markdown
@@ -34,8 +34,8 @@ data "mongodbatlas_search_index" "test" {
 * `cluster_name` - (Required) Name of the cluster containing the collection with one or more Atlas Search indexes.
 * `database_name` - (Required) Name of the database containing the collection with one or more Atlas Search indexes.
 * `collection_name` - (Required) Name of the collection with one or more Atlas Search indexes.
-* `page_num` - Page number, starting with one, that Atlas returns of the total number of objects.
-* `items_per_page` - Number of items that Atlas returns per page, up to a maximum of 500.
+* `page_num` - Page number, starting with one, that Atlas returns of the total number of objects. **WARNING:** this parameter is deprecated and will be removed in version 1.15.0
+* `items_per_page` - Number of items that Atlas returns per page, up to a maximum of 500. **WARNING:** this parameter is deprecated and will be removed in version 1.15.0
 
 ## Attributes Reference
 * `total_count` - Represents the total of the search indexes


### PR DESCRIPTION
## Description

Jira ticket: [INTMDB-1211](https://jira.mongodb.org/browse/INTMDB-1211)

Deprecates page_num and items_per_page in datasource mongodbatlas_search_indexes


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
