### PR TITLE
feat: fixes the realm URL when it is set.

### DIFF
--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -100,8 +100,9 @@ func (c *MongoDBClient) GetRealmClient(ctx context.Context) (*realm.Client, erro
 	optsRealm := []realm.ClientOpt{realm.SetUserAgent(userAgent)}
 	authConfig := realmAuth.NewConfig(nil)
 	if c.Config.BaseURL != "" && c.Config.RealmBaseURL != "" {
-		optsRealm = append(optsRealm, realm.SetBaseURL(c.Config.RealmBaseURL+"api/admin/v3.0/"))
-		authConfig.AuthURL, _ = url.Parse(c.Config.RealmBaseURL + "api/admin/v3.0/auth/providers/mongodb-cloud/login")
+		adminURL := c.Config.RealmBaseURL + "api/admin/v3.0/"
+		optsRealm = append(optsRealm, realm.SetBaseURL(adminURL))
+		authConfig.AuthURL, _ = url.Parse(adminURL + "auth/providers/mongodb-cloud/login")
 	}
 
 	token, err := authConfig.NewTokenFromCredentials(ctx, c.Config.PublicKey, c.Config.PrivateKey)

--- a/mongodbatlas/config.go
+++ b/mongodbatlas/config.go
@@ -100,7 +100,7 @@ func (c *MongoDBClient) GetRealmClient(ctx context.Context) (*realm.Client, erro
 	optsRealm := []realm.ClientOpt{realm.SetUserAgent(userAgent)}
 	authConfig := realmAuth.NewConfig(nil)
 	if c.Config.BaseURL != "" && c.Config.RealmBaseURL != "" {
-		optsRealm = append(optsRealm, realm.SetBaseURL(c.Config.RealmBaseURL))
+		optsRealm = append(optsRealm, realm.SetBaseURL(c.Config.RealmBaseURL+"api/admin/v3.0/"))
 		authConfig.AuthURL, _ = url.Parse(c.Config.RealmBaseURL + "api/admin/v3.0/auth/providers/mongodb-cloud/login")
 	}
 


### PR DESCRIPTION
## Description

When the realm URL is set from our configuration, it was wrongly setting the baseURL without considering the `api/admin/v3.0/` part of it. [Docs](https://www.mongodb.com/docs/atlas/app-services/admin/api/v3/)

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-1010

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
