### PR TITLE
feat: Fixes linter cache

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-          cache: false
+          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -61,6 +61,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -65,10 +65,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: v1.55.0
+          skip-cache: true
           args: --timeout 10m
   website-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -65,11 +65,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
           version: v1.55.0
-          skip-cache: true
           args: --timeout 10m
   website-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -61,11 +61,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:


### PR DESCRIPTION
## Description

Jira ticket: [INTMDB-1222](https://jira.mongodb.org/browse/INTMDB-1222)

Disables linter cache as it generates more than 20,000 lines in the log. Also reduces time from 90s to 40s.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
