### PR TITLE
feat: fixes region and aws account to be used for trigger acc test

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -206,12 +206,12 @@ func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
 func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 	SkipTestForCI(t)
 	var (
-		resourceName = "mongodbatlas_event_trigger.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		awsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
-		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
+		resourceName            = "mongodbatlas_event_trigger.test"
+		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		eventBridgeAwsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
+		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acctest.RandomWithPrefix("test-acc"),
@@ -241,14 +241,14 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass"`, awsAccountID, awsRegion, &event),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass", "api-key"`, awsAccountID, awsRegion, &eventUpdated),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigAuthenticationEP(projectID, appID, `"anon-user", "local-userpass", "api-key"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -323,12 +323,12 @@ func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
 func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 	SkipTestForCI(t)
 	var (
-		resourceName = "mongodbatlas_event_trigger.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		awsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
-		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
+		resourceName            = "mongodbatlas_event_trigger.test"
+		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		eventBridgeAwsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
+		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acctest.RandomWithPrefix("test-acc"),
@@ -355,14 +355,14 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, awsAccountID, awsRegion, &event),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, awsAccountID, awsRegion, &eventUpdated),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigScheduleEP(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -81,12 +81,12 @@ func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
 func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 	SkipTestForCI(t)
 	var (
-		resourceName = "mongodbatlas_event_trigger.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
-		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
+		resourceName            = "mongodbatlas_event_trigger.test"
+		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		eventBridgeAwsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
+		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
+		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acctest.RandomWithPrefix("test-acc"),
@@ -121,14 +121,14 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEventTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE"`, awsAccountID, awsRegion, &event),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, awsAccountID, awsRegion, &eventUpdated),
+				Config: testAccMongoDBAtlasEventTriggerDatabaseConfigDatabaseEP(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasEventTriggerExists(resourceName, &eventResp),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -78,6 +79,7 @@ func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -143,6 +145,7 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -201,6 +204,7 @@ func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -261,6 +265,7 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -316,6 +321,7 @@ func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -373,6 +379,7 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerFunction_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -79,7 +78,6 @@ func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -145,7 +143,6 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -204,7 +201,6 @@ func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -265,7 +261,6 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -321,7 +316,6 @@ func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -379,7 +373,6 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 }
 
 func TestAccConfigRSEventTriggerFunction_basic(t *testing.T) {
-	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/mwielbut/pointy"
 	"go.mongodb.org/realm/realm"
 )
@@ -84,7 +84,7 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		eventBridgeAwsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
+		eventBridgeAwsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp               = realm.EventTrigger{}
 	)
@@ -209,7 +209,7 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
+		awsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp    = realm.EventTrigger{}
 	)
@@ -326,7 +326,7 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
-		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
+		awsRegion    = util.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp    = realm.EventTrigger{}
 	)

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -82,8 +83,8 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
-		awsRegion    = os.Getenv("AWS_REGION")
+		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp    = realm.EventTrigger{}
 	)
@@ -207,8 +208,8 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
-		awsRegion    = os.Getenv("AWS_REGION")
+		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp    = realm.EventTrigger{}
 	)
@@ -324,8 +325,8 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		awsAccountID = os.Getenv("AWS_ACCOUNT_ID")
-		awsRegion    = os.Getenv("AWS_REGION")
+		awsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
+		awsRegion    = strings.ReplaceAll(strings.ToLower(os.Getenv("AWS_REGION")), "_", "-")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
 		eventResp    = realm.EventTrigger{}
 	)


### PR DESCRIPTION
Related to: https://jira.mongodb.org/browse/INTMDB-1010

As part of enabling trigger creation acceptance tests we need to correctly set up the existing tests. With this change we are using the correct aws_region and aws_account_id when using `AWS_EVENTBRIDGE` during tests and calling our dev endpoint.



## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
