### PR TITLE
fix: 'computed' and 'default' usage based on the documentation

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -79,7 +79,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"backup_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
 				Description: "Clusters running MongoDB FCV 4.2 or later and any new Atlas clusters of any type do not support this parameter",
 			},
 			"retain_backups_enabled": {
@@ -90,19 +90,16 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"bi_connector_config": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Computed: true,
 						},
 						"read_preference": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},
@@ -293,7 +290,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"paused": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 			},
 			"srv_address": {
 				Type:     schema.TypeString,
@@ -308,19 +305,16 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 				Type:       schema.TypeSet,
 				Optional:   true,
 				Set:        HashFunctionForKeyValuePair,
-				Computed:   true,
 				Deprecated: fmt.Sprintf(DeprecationByDateWithReplacement, "September 2024", "tags"),
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 						"value": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},
@@ -339,7 +333,7 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"version_release_system": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "LTS",
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"LTS", "CONTINUOUS"}, false),
 			},
 		},
@@ -1615,7 +1609,6 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/mongodbatlas/resource_mongodbatlas_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster.go
@@ -90,16 +90,19 @@ func resourceMongoDBAtlasCluster() *schema.Resource {
 			"bi_connector_config": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"read_preference": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -1609,6 +1612,7 @@ func clusterAdvancedConfigurationSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
+		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Description

Customer is complaining that using TF 1.0.8 certain fields are returning error because the provider (Atlas) is returning values but fields are not marked as "Computed". In other cases fields are marked as "Computed" but as per documentation these fields don't return values defined from the backend itself.

Documentation: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v1/#tag/Clusters/operation/updateClusterAdvancedConfiguration

Definition of "Computed": `Computed indicates whether the provider may return its own value for this attribute or not. Computed cannot be used with Required. If Required and Optional are both false, the attribute will be considered "read only" for the practitioner, with only the provider able to set its value.`

This needs to go after https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1548

Link to any related issue(s): https://jira.mongodb.org/browse/HELP-51509

**Customer cannot upgrade TF version**

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
