### PR TITLE
feat: Enables assume_role acceptance tests with temporary credentials

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -108,29 +108,6 @@ jobs:
             - 'mongodbatlas/resource_mongodbatlas_event_trigger*.go'
             - 'mongodbatlas/data_source_mongodbatlas_event_trigger*.go'
 
-
-  fetch-sts-assume-role-creds:
-    runs-on: ubuntu-latest
-    outputs:
-      aws_access_key_id: ${{ steps.sts-assume-role-step.outputs.aws_access_key_id }}
-      aws_secret_access_key: ${{ steps.sts-assume-role-step.outputs.aws_secret_access_key }}
-      aws_session_token: ${{ steps.sts-assume-role-step.outputs.aws_session_token }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts
-      - id: sts-assume-role-step
-        name: Generate STS Temporary credential for acceptance testing
-        shell: bash
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-        run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-
   cluster_outage_simulation:
     needs: [ change-detection ]
     if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-cluster-outage-simulation' || inputs.parent-event-name == 'release'  }}
@@ -453,35 +430,44 @@ jobs:
           TEST_REGEX: "^TestAccConfig"
         run: make testacc
 
-  # assume_role: # See INTMDB-1245
-  #   needs: [ change-detection, fetch-sts-assume-role-creds]
-  #   if: ${{ needs.change-detection.outputs.config == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' || inputs.parent-event-name == 'release' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version-file: 'go.mod'
-  #     - name: Acceptance Tests
-  #       env:
-  #         ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-  #         AWS_REGION: ${{ vars.AWS_REGION }}
-  #         STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
-  #         SECRET_NAME: ${{ vars.AWS_SECRET_NAME }}
-  #         AWS_ACCESS_KEY_ID: ${{ needs.fetch-sts-assume-role-creds.outputs.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ needs.fetch-sts-assume-role-creds.outputs.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_SESSION_TOKEN: ${{ needs.fetch-sts-assume-role-creds.outputs.AWS_SESSION_TOKEN }}
-  #         MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
-  #         MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
-  #         ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
-  #         TF_LOG: ${{ vars.LOG_LEVEL }}
-  #         TF_ACC: 1
-  #         PARALLEL_GO_TEST: 20
-  #         CI: true
-  #         TEST_REGEX: "^TestAccSTSAssumeRole"
-  #       run: make testacc
+  assume_role:
+    needs: [ change-detection]
+    if: ${{ needs.change-detection.outputs.assume_role == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' || inputs.parent-event-name == 'release' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - id: sts-assume-role
+        name: Generate STS Temporary credential for acceptance testing
+        shell: bash
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
+        run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
+      - name: Acceptance Tests
+        env:
+          ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
+          SECRET_NAME: ${{ vars.AWS_SECRET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
+          MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
+          MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
+          ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
+          TF_LOG: ${{ vars.LOG_LEVEL }}
+          TF_ACC: 1
+          PARALLEL_GO_TEST: 20
+          CI: true
+          TEST_REGEX: "^TestAccSTSAssumeRole"
+        run: make testacc
 
   event_trigger:
     needs: [ change-detection ]

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -432,7 +432,6 @@ jobs:
 
   assume_role:
     needs: [ change-detection]
-    if: ${{ needs.change-detection.outputs.assume_role == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' || inputs.parent-event-name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -432,6 +432,7 @@ jobs:
 
   assume_role:
     needs: [ change-detection]
+    if: ${{ needs.change-detection.outputs.assume_role == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' || inputs.parent-event-name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/scripts/generate-credentials-with-sts-assume-role.sh
+++ b/scripts/generate-credentials-with-sts-assume-role.sh
@@ -25,6 +25,10 @@ AWS_ACCESS_KEY_ID=$(echo "$CREDENTIALS" | awk '{print $1}')
 AWS_SECRET_ACCESS_KEY=$(echo "$CREDENTIALS" | awk '{print $2}')
 AWS_SESSION_TOKEN=$(echo "$CREDENTIALS" | awk '{print $3}')
 
+echo "::add-mask::${AWS_ACCESS_KEY_ID}"
+echo "::add-mask::${AWS_SECRET_ACCESS_KEY}"
+echo "::add-mask::${AWS_SESSION_TOKEN}"
+
 {
   echo "aws_access_key_id=${AWS_ACCESS_KEY_ID}"
   echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
## Description

Following the [official documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-masking-a-generated-output-within-a-single-job), in order to fix the [security breach we spotted yesterday](https://jira.mongodb.org/browse/INTMDB-1245) and in order to re-activate the assume-role tests that were just being created, there are two actions taken in this PR:
* Create temporary AWS credentials **as a step of the job** and not as an independent job
* Use `::add-mask::` as recommended by official documentation to mask the credentials
  *  because it's within the same job, this become safer since the credentials don't have to be passed through different jobs/machines. 
  * Just FYI, the alternative way would have required using some credential storage solution like Vault.

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-1247

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
