### PR TITLE
fix: changes naming convention for event trigger tests.

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -503,5 +503,5 @@ jobs:
           TF_ACC: 1
           PARALLEL_GO_TEST: 20
           CI: true
-          TEST_REGEX: "^TestAccConfigRSEventTrigger"
+          TEST_REGEX: "^TestEventTrigger"
         run: make testacc

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/realm/realm"
 )
 
-func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
+func TestEventTriggerDatabase_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -77,7 +77,7 @@ func TestAccConfigRSEventTriggerDatabase_basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
+func TestEventTriggerDatabase_eventProccesor(t *testing.T) {
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -142,7 +142,7 @@ func TestAccConfigRSEventTriggerDatabase_eventProccesor(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
+func TestEventTriggerAuth_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -200,7 +200,7 @@ func TestAccConfigRSEventTriggerAuth_basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
+func TestEventTriggerAuth_eventProcessor(t *testing.T) {
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -260,7 +260,7 @@ func TestAccConfigRSEventTriggerAuth_eventProcessor(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
+func TestEventTriggerSchedule_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -315,7 +315,7 @@ func TestAccConfigRSEventTriggerSchedule_basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
+func TestEventTriggerSchedule_eventProcessor(t *testing.T) {
 	var (
 		resourceName            = "mongodbatlas_event_trigger.test"
 		projectID               = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -372,7 +372,7 @@ func TestAccConfigRSEventTriggerSchedule_eventProcessor(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSEventTriggerFunction_basic(t *testing.T) {
+func TestEventTriggerFunction_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")


### PR DESCRIPTION
## Description

Event trigger tests were being executed **also** as part of the `config` GH Workflow job test. This was causing unexpected failures in the test suite because environment variables were missing.
E.g. look at https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/6743203457/job/18333072712

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-1010

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
