### PR TITLE
revert: "chore: add acceptance tests and migration tests to report in merge queue"

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -11,7 +11,6 @@ on:
         type: string
   pull_request: # you can run a specic job in your PR using GitHub labels
     types: [ labeled ]
-  merge_group: # needed for merge queue
 
 jobs:  
   change-detection:
@@ -40,8 +39,6 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        base: ${{ github.event.merge_group.base_ref}}
-        ref: ${{ github.event.merge_group.head_ref }}
         filters: |
           assume_role:
             - 'mongodbatlas/**provider**.go'

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -10,7 +10,6 @@ on:
       - 'LICENSE'
   pull_request: {}
   workflow_dispatch: {}
-  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -9,7 +9,6 @@ on:
         type: string
   pull_request:
     types: [ labeled ]
-  merge_group: # needed for merge queue
 
 jobs: 
   change-detection:
@@ -28,8 +27,6 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        base: ${{ github.event.merge_group.base_ref}}
-        ref: ${{ github.event.merge_group.head_ref }}
         filters: |
           project:
             - 'mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list*.go'


### PR DESCRIPTION
Reverts mongodb/terraform-provider-mongodbatlas#1590


Disabling merge queue for TF because of the issue https://github.com/dorny/paths-filter/issues/183 with dorny.

I will create a ticket to investigate how we can fix the issue and enable the merge queue