### PR TITLE
fix: changes naming convention for data_source event trigger tests.

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/realm/realm"
 )
 
-func TestAccConfigDSEventTriggers_basic(t *testing.T) {
+func TestEventTriggers_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")


### PR DESCRIPTION
## Description

Tests are still failing https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/6745681852/job/18340114709 because we were missing one last test from the event_trigger data_source to be changed (its naming convention)

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-1010

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
