### PR TITLE
fix: disables data_source event_trigger tests since they are failing

### DIFF
--- a/mongodbatlas/data_source_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_trigger_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestEventTrigger_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_triggers_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestEventTriggers_basic(t *testing.T) {
+	SkipTestForCI(t)
 	var (
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")


### PR DESCRIPTION
## Description

some event_trigger [tests are failing](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/6747577723/job/18345990451) and so we are re-disabling now from CI to avoid acceptance tests to fail as a whole

Link to any related issue(s): https://jira.mongodb.org/browse/INTMDB-1010

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
