### PR TITLE
fix: reduce stale days to 5 and close after 2 day of stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
           stale-pr-message: 'This PR has gone 7 days without any activity and meets the project’s definition of "stale". This will be auto-closed if there is no new activity over the next 7 days. If the issue is still relevant and active, you can simply comment with a "bump" to keep it open, or add the label "not_stale". Thanks for keeping our repository healthy!'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          days-before-stale: 7
-          days-before-close: 7
+          days-before-stale: 5
+          days-before-close: 5
           exempt-pr-labels: 'not_stale'
           exempt-issue-labels: 'not_stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           days-before-stale: 5
-          days-before-close: 5
+          days-before-close: 2
           exempt-pr-labels: 'not_stale'
           exempt-issue-labels: 'not_stale'


### PR DESCRIPTION
## Description

This PR reduces the stale days to 5 days and close the state PR/issues after 2 days.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
