### PR TITLE
Fix errata

### DIFF
--- a/website/docs/r/cloud_provider_access.markdown
+++ b/website/docs/r/cloud_provider_access.markdown
@@ -14,10 +14,6 @@ The Terraform MongoDB Atlas Provider offers two either-or/mutually exclusive pat
 the initial configuration (create, delete operations). The second resource, `mongodbatlas_cloud_provider_access_authorization`, helps to perform the authorization using the role_id of the first resource. This path is helpful in a multi-provider Terraform file, and allows for a single and decoupled apply. See example of this Two Resource path option with AWS Cloud [here](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-cloud-provider-access/aws) and AZURE Cloud [here](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-cloud-provider-access/azure). 
 
 * A Single Resource path: using the `mongodbatlas_cloud_provider_access` that at provision time sets up all the required configuration for a given provider, then with a subsequent update it can perform the authorize of the role. Note this path requires two `terraform apply` commands, once for setup and once for auth. This resource supports only `AWS`.
-* A Two Resource path: consisting of `mongodbatlas_cloud_provider_access_setup` and `mongodbatlas_cloud_provider_access_authorization`. The first resource, `mongodbatlas_cloud_provider_access_setup`, only generates
-the initial configuration (create, delete operations). The second resource, `mongodbatlas_cloud_provider_access_authorization`, helps to perform the authorization using the role_id of the first resource. This path is helpful in a multi-provider Terraform file, and allows for a single and decoupled apply. See example of this Two Resource path option with AWS Cloud [here](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-cloud-provider-access/aws) and AZURE Cloud [here](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/atlas-cloud-provider-access/azure). 
-
-* A Single Resource path: using the `mongodbatlas_cloud_provider_access` that at provision time sets up all the required configuration for a given provider, then with a subsequent update it can perform the authorize of the role. Note this path requires two `terraform apply` commands, once for setup and once for auth. This resource supports only `AWS`.
 **WARNING:** The resource `mongodbatlas_cloud_provider_access` is deprecated and will be removed in version v1.14.0, use the Two Resource path instead.
 
 -> **IMPORTANT** If you want to move from the single resource path to the two resources path see the [migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/0.9.1-upgrade-guide#migration-to-cloud-provider-access-setup)
@@ -77,6 +73,8 @@ resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
 * `last_updated_date`                - Date and time when this Azure Service Principal was last updated. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
 * `role_id`                        - Unique ID of this role.
 
+* -> **NOTE:** the two sub-attributes of the aws_config block will likely be needed on the external AWS account side as the constraints on the trust policy of an IAM role you're granting Atlas access to. They can be accessed via `mongodbatlas_cloud_provider_access_setup.<role>`, for example the trust policy will reference `mongodbatlas_cloud_provider_access_setup.<role>.aws_config[0].atlas_aws_account_arn` in its `Principle` statement, and the `mongodbatlas_cloud_provider_access_setup.<role>.aws_config[0].atlas_assumed_role_external_id` in its `Condition.StringEquals.sts:ExternalId` statement.
+
 ## Import: mongodbatlas_cloud_provider_access_setup
 For consistency is has the same format as the regular mongodbatlas_cloud_provider_access resource 
 can be imported using project ID and the provider name and mongodbatlas role id, in the format 
@@ -86,7 +84,7 @@ can be imported using project ID and the provider name and mongodbatlas role id,
 $ terraform import mongodbatlas_cloud_provider_access_setup.my_role 1112222b3bf99403840e8934-AWS-5fc17d476f7a33224f5b224e
 ```
 
-## mongodbatlas_cloud_provider_authorization
+## mongodbatlas_cloud_provider_access_authorization
 
 This is the second resource in the two-resource path as described above.
 `mongodbatlas_cloud_provider_access_authorization`  Allows you to authorize an AWS or AZURE IAM roles in Atlas.
@@ -104,8 +102,8 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
    project_id =  mongodbatlas_cloud_provider_access_setup.setup_only.project_id
    role_id    =  mongodbatlas_cloud_provider_access_setup.setup_only.role_id
 
-   aws_config {
-      atlas_aws_account_arn = "arn:aws:iam::772401394250:role/test-user-role"
+   aws {
+      iam_assumed_role_arn = "arn:aws:iam::772401394250:role/test-user-role"
    }
 }
 


### PR DESCRIPTION
## Description

Fix incorrect terraform resource names, fix incorrect syntax in examples, attempt to explain how some of the attributes provided by the mongodbatlas_cloud_provider_access_setup object are used in setting up an IAM role for assumption by Atlas in other AWS accounts.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
