### PR TITLE
fix: Terraform encryption at rest error when upgrading to 1.12.2

### DIFF
--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -445,7 +446,9 @@ func handleAwsKmsConfigDefaults(ctx context.Context, currentStateFile, newStateF
 	}
 
 	// Secret access key is not returned by the API response
-	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
+	if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
+		newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
+	}
 }
 
 func handleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSNew, earRSConfig *tfEncryptionAtRestRSModel) {


### PR DESCRIPTION
## Description
Ticket: [INTMDB-1277](https://jira.mongodb.org/browse/INTMDB-1277)

This issue came from [HELP-52173](https://jira.mongodb.org/browse/HELP-52173) where customers are getting the following error when upgrading from `v1.11.0` to `v1.12.3`.

```
│ Error: Provider produced inconsistent result after apply
--
│
│ When applying changes to mongodbatlas_encryption_at_rest.test, provider "provider[\"registry.terraform.io/mongodb/mongodbatlas\"]"
│ produced an unexpected new value: .aws_kms_config[0].secret_access_key: inconsistent values for sensitive attribute.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

### Root Cause: 

## Context: 
- The encryption at rest resource was migrated to the new framework in v1.12.0
- The user did not define the `secret_access_key` in the encryption at rest resource but provided the `role_id`
- the `secret_access_key` is never returned by the API response so we added a logic in the TF resource that stores the value of `secret_access_key` in the TF configuration file inside the state file.

Issue: When upgrading from old framework to the new framework, the state file saves the empty `secret_access_key` string with the state `ValueStateKnown`  with the empty string instead of using the `ValueStateUnKnown` which is what is returned with the new framework.
<img width="375" alt="Screenshot 2023-11-10 at 17 32 13" src="https://github.com/mongodb/terraform-provider-mongodbatlas/assets/5663078/dbd45fa7-1d17-4d8b-adde-86e027f2d4dd">

Fix: I updated the logic to update the value of `secret_access_key` in the state file only it is not empty. 


## Testing
I tested the logic locally with and without the change and checked that the issue is gone.
```
2023-11-10T15:55:01.017Z [DEBUG] pruneUnusedNodes: provider["registry.terraform.io/mongodb/mongodbatlas"] is no longer needed, removing
2023-11-10T15:55:01.017Z [DEBUG] pruneUnusedNodes: provider["registry.terraform.io/hashicorp/aws"] is no longer needed, removing
2023-11-10T15:55:01.017Z [DEBUG] Starting graph walk: walkApply

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

I added a migration test to check that is possible to migrate from v1.11.0 to the latest release. 
I checked that the test fails when running without the changes
```
Running tool: /Users/andrea.angiolillo/.asdf/shims/go test -timeout 300000s -run ^TestAccMigrationAdvRS_EncryptionAtRest_basicAWS_from_v1_11_0$ github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas
FAIL    github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 32.276s
```
and it is successful with my changes
```
Running tool: /Users/andrea.angiolillo/.asdf/shims/go test -timeout 300000s -run ^TestAccMigrationAdvRS_EncryptionAtRest_basicAWS_from_v1_11_0$ github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas

ok      github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas 35.599s
```


## Type of change:
- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
