### PR TITLE
fix: define ConfigMode for computed nest block attribute in privatelink_endpoint_service to support tf 1.0.8

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -103,6 +103,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLink() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"private_endpoint_ip_address"},
+				ConfigMode:    schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"status": {

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_migration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_migration_test.go
@@ -1,0 +1,75 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestAccMigrationNetworkRSPrivateLinkEndpointService_Complete(t *testing.T) {
+	SkipTestExtCred(t)
+	var (
+		resourceSuffix = "test"
+		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
+
+		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+
+		providerName          = "AWS"
+		projectID             = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		region                = os.Getenv("AWS_REGION")
+		vpcID                 = os.Getenv("AWS_VPC_ID")
+		subnetID              = os.Getenv("AWS_SUBNET_ID")
+		securityGroupID       = os.Getenv("AWS_SECURITY_GROUP_ID")
+		lastVersionConstraint = os.Getenv("MONGODB_ATLAS_LAST_VERSION")
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"mongodbatlas": {
+						VersionConstraint: lastVersionConstraint,
+						Source:            "mongodb/mongodbatlas",
+					},
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
+				),
+			},
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: testAccProviderV6Factories,
+				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
+					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						DebugPlan(),
+					},
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
@@ -28,17 +28,17 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
-		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		ProtoV6ProviderFactories: testAccProviderV6Factories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"aws": {
+				VersionConstraint: "5.1.0",
+				Source:            "hashicorp/aws",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						VersionConstraint: "5.1.0",
-						Source:            "hashicorp/aws",
-					},
-				},
-				ProtoV6ProviderFactories: testAccProviderV6Factories,
 				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
 				),
@@ -71,17 +71,17 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
-		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		ProtoV6ProviderFactories: testAccProviderV6Factories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"aws": {
+				VersionConstraint: "5.1.0",
+				Source:            "hashicorp/aws",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						VersionConstraint: "5.1.0",
-						Source:            "hashicorp/aws",
-					},
-				},
-				ProtoV6ProviderFactories: testAccProviderV6Factories,
 				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
 				),
@@ -93,18 +93,11 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
 				),
 			},
 			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						VersionConstraint: "5.1.0",
-						Source:            "hashicorp/aws",
-					},
-				},
-				ProtoV6ProviderFactories: testAccProviderV6Factories,
-				ResourceName:             resourceName,
-				ImportStateIdFunc:        testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"private_link_id"},
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_link_id"},
 			},
 		},
 	})

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
@@ -28,11 +28,17 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
-		ProtoV6ProviderFactories: testAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: testAccProviderV6Factories,
 				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
 				),
@@ -65,11 +71,17 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t); testCheckAwsEnv(t) },
-		ProtoV6ProviderFactories: testAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
+		PreCheck:     func() { testAccPreCheck(t); testCheckAwsEnv(t) },
+		CheckDestroy: testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
 		Steps: []resource.TestStep{
 			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: testAccProviderV6Factories,
 				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
 				),
@@ -81,11 +93,18 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"private_link_id"},
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						VersionConstraint: "5.1.0",
+						Source:            "hashicorp/aws",
+					},
+				},
+				ProtoV6ProviderFactories: testAccProviderV6Factories,
+				ResourceName:             resourceName,
+				ImportStateIdFunc:        testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),
+				ImportState:              true,
+				ImportStateVerify:        true,
+				ImportStateVerifyIgnore:  []string{"private_link_id"},
 			},
 		},
 	})
@@ -106,7 +125,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourc
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -129,7 +148,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName strin
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service" {


### PR DESCRIPTION
## Description

Context of issue defined in [INTMDB-1291](https://jira.mongodb.org/browse/INTMDB-1291)

Summary: In order to preserve backward compatibility to old TF versions (< 1.1.5), `ConfigMode: schema.SchemaConfigModeAttr` is added to `endpoints` attribute that enables us to use `Computed: true` in nested blocks.

Scenario and fix is identical to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1572.

Have verified fix using terraform version `1.0.8` and `1.6.2`. As part of testing, executed acceptance tests and migrations tests locally.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
