### PR TITLE
feat: Update PR action to automatically add labels based on the PR title

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,3 @@
 enhancement: ['feature:*', 'feat:*']
 bug: ['fix:*']
-breaking-change: ['*!*'] 
+breaking-change: ['*!*']

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+enhancement: ['feature:*', 'feat:*']
+bug: ['fix:*']
+breaking-change: ['*!*'] 

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,11 +9,11 @@ on:
       - ready_for_review
       - edited
 jobs:
- pr-labeler:
-     permissions:
-       contents: read
-       pull-requests: write
-     runs-on: ubuntu-latest
+  pr-labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
      steps:
        - uses: TimonVS/pr-labeler-action@v4
          with:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,16 +9,6 @@ on:
       - ready_for_review
       - edited
 jobs:
-  pr-labeler:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-     steps:
-       - uses: TimonVS/pr-labeler-action@v4
-         with:
-           repo-token: ${{ secrets.GITHUB_TOKEN }}
-           configuration-path: .github/pr-labeler.yml
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
@@ -67,4 +57,15 @@ jobs:
         with:   
           header: pr-title-lint-error
           delete: true
-
+  pr-labeler:
+    name: Add Label
+    needs: [ validate ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+     steps:
+       - uses: TimonVS/pr-labeler-action@v4
+         with:
+           repo-token: ${{ secrets.GITHUB_TOKEN }}
+           configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,16 @@ on:
       - ready_for_review
       - edited
 jobs:
+ pr-labeler:
+     permissions:
+       contents: read
+       pull-requests: write
+     runs-on: ubuntu-latest
+     steps:
+       - uses: TimonVS/pr-labeler-action@v4
+         with:
+           repo-token: ${{ secrets.GITHUB_TOKEN }}
+           configuration-path: .github/pr-labeler.yml
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -446,9 +445,10 @@ func handleAwsKmsConfigDefaults(ctx context.Context, currentStateFile, newStateF
 	}
 
 	// Secret access key is not returned by the API response
-	if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
-		newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
-	}
+	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
+	// if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
+	// 	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
+	// }
 }
 
 func handleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSNew, earRSConfig *tfEncryptionAtRestRSModel) {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -446,9 +448,9 @@ func handleAwsKmsConfigDefaults(ctx context.Context, currentStateFile, newStateF
 
 	// Secret access key is not returned by the API response
 	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
-	// if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
-	// 	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
-	// }
+	if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
+		newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
+	}
 }
 
 func handleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSNew, earRSConfig *tfEncryptionAtRestRSModel) {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"time"
-	
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -8,9 +8,7 @@ import (
 	"net/http"
 	"reflect"
 	"time"
-
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
-
+	
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -447,7 +445,6 @@ func handleAwsKmsConfigDefaults(ctx context.Context, currentStateFile, newStateF
 	}
 
 	// Secret access key is not returned by the API response
-	newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
 	if len(currentStateFile.AwsKmsConfig) == 1 && util.IsStringPresent(currentStateFile.AwsKmsConfig[0].SecretAccessKey.ValueStringPointer()) {
 		newStateFile.AwsKmsConfig[0].SecretAccessKey = currentStateFile.AwsKmsConfig[0].SecretAccessKey
 	}


### PR DESCRIPTION
## Description

### Context
We use labels on PRs during the creation of the CHANGELOG: a PR is listed under a specific section of the changelog based on the label assigned to it.

### Issue
We often forget to add the label to the PR which results in more time spent to manually update the CHANGELOG

### Solution
This PR updates our PR linter to automatically add the correct label based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)


**FYI: I need to merge the changes to test that the action works as expected.**

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
