### PR TITLE
PoC: extract project resource and data sources implementations into separate package

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -66,9 +66,11 @@ jobs:
           project:
             - 'mongodbatlas/data_source_mongodbatlas_project_invitation*.go'
             - 'mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list*.go'
+            - 'mongodbatlas/project/fw_data_source_mongodbatlas_project*.go'
             - 'mongodbatlas/resource_mongodbatlas_access_list_api_key*.go'
             - 'mongodbatlas/resource_mongodbatlas_project_invitation*.go'
             - 'mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list*.go'
+            - 'mongodbatlas/project/fw_resource_mongodbatlas_project*.go'
           serverless:
             - 'mongodbatlas/**_serverless**.go' 
           network:

--- a/mongodbatlas/client/client.go
+++ b/mongodbatlas/client/client.go
@@ -1,4 +1,4 @@
-package mongodbatlas
+package client
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/mongodb-forks/digest"
@@ -28,6 +29,18 @@ type Config struct {
 	PrivateKey   string
 	BaseURL      string
 	RealmBaseURL string
+}
+
+type AssumeRole struct {
+	Tags              map[string]string
+	RoleARN           string
+	ExternalID        string
+	Policy            string
+	SessionName       string
+	SourceIdentity    string
+	PolicyARNs        []string
+	TransitiveTagKeys []string
+	Duration          time.Duration
 }
 
 // MongoDBClient contains the mongodbatlas clients and configurations

--- a/mongodbatlas/data_source_mongodbatlas_accesslist_api_key.go
+++ b/mongodbatlas/data_source_mongodbatlas_accesslist_api_key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasAccessListAPIKey() *schema.Resource {
@@ -53,7 +54,7 @@ func dataSourceMongoDBAtlasAccessListAPIKey() *schema.Resource {
 
 func dataSourceMongoDBAtlasAccessListAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	orgID := d.Get("org_id").(string)
 	apiKeyID := d.Get("api_key_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_accesslist_api_keys.go
+++ b/mongodbatlas/data_source_mongodbatlas_accesslist_api_keys.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -69,7 +70,7 @@ func dataSourceMongoDBAtlasAccessListAPIKeys() *schema.Resource {
 
 func dataSourceMongoDBAtlasAccessListAPIKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	options := &matlas.ListOptions{
 		PageNum:      d.Get("page_num").(int),
 		ItemsPerPage: d.Get("items_per_page").(int),

--- a/mongodbatlas/data_source_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_cluster.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasAdvancedCluster() *schema.Resource {
@@ -246,7 +247,7 @@ var dsTagsSchema = schema.Schema{
 
 func dataSourceMongoDBAtlasAdvancedClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_advanced_clusters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -240,7 +241,7 @@ func dataSourceMongoDBAtlasAdvancedClusters() *schema.Resource {
 
 func dataSourceMongoDBAtlasAdvancedClustersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	d.SetId(id.UniqueId())
 

--- a/mongodbatlas/data_source_mongodbatlas_api_key.go
+++ b/mongodbatlas/data_source_mongodbatlas_api_key.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasAPIKey() *schema.Resource {
@@ -42,7 +43,7 @@ func dataSourceMongoDBAtlasAPIKey() *schema.Resource {
 
 func dataSourceMongoDBAtlasAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	orgID := d.Get("org_id").(string)
 	apiKeyID := d.Get("api_key_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_api_keys.go
+++ b/mongodbatlas/data_source_mongodbatlas_api_keys.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -60,7 +61,7 @@ func dataSourceMongoDBAtlasAPIKeys() *schema.Resource {
 
 func dataSourceMongoDBAtlasAPIKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	options := &matlas.ListOptions{
 		PageNum:      d.Get("page_num").(int),
 		ItemsPerPage: d.Get("items_per_page").(int),

--- a/mongodbatlas/data_source_mongodbatlas_auditing.go
+++ b/mongodbatlas/data_source_mongodbatlas_auditing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasAuditing() *schema.Resource {
@@ -37,7 +38,7 @@ func dataSourceMongoDBAtlasAuditing() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasAuditingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	auditing, _, err := conn.Auditing.Get(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_backup_compliance_policy.go
+++ b/mongodbatlas/data_source_mongodbatlas_backup_compliance_policy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -198,7 +199,7 @@ func dataSourceMongoDBAtlasBackupCompliancePolicy() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasBackupCompliancePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_schedule.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 // Note: the schema is the same as dataSourceMongoDBAtlasCloudProviderSnapshotBackupPolicy
@@ -219,7 +220,7 @@ func dataSourceMongoDBAtlasCloudBackupSchedule() *schema.Resource {
 // Almost the same as dataSourceMongoDBAtlasCloudProviderSnapshotBackupPolicyRead
 // just do not save the update_snapshots because is not specified in the DS
 func dataSourceMongoDBAtlasCloudBackupScheduleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -101,7 +102,7 @@ func dataSourceMongoDBAtlasCloudBackupSnapshot() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		SnapshotID:  d.Get("snapshot_id").(string),

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_bucket.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_bucket.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func datasourceMongoDBAtlasCloudBackupSnapshotExportBucket() *schema.Resource {
@@ -41,7 +42,7 @@ func datasourceMongoDBAtlasCloudBackupSnapshotExportBucket() *schema.Resource {
 }
 
 func datasourceMongoDBAtlasCloudBackupSnapshotExportBucketRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	bucketID := d.Get("id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_buckets.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_buckets.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -59,7 +60,7 @@ func datasourceMongoDBAtlasCloudBackupSnapshotExportBuckets() *schema.Resource {
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotsExportBucketsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_job.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func datasourceMongoDBAtlasCloudBackupSnapshotExportJob() *schema.Resource {
@@ -100,7 +101,7 @@ func datasourceMongoDBAtlasCloudBackupSnapshotExportJob() *schema.Resource {
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotsExportJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_jobs.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_export_jobs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -118,7 +119,7 @@ func datasourceMongoDBAtlasCloudBackupSnapshotExportJobs() *schema.Resource {
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotsExportJobsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -92,7 +93,7 @@ func dataSourceMongoDBAtlasCloudBackupSnapshotRestoreJob() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotRestoreJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		JobID:       getEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id"),

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_jobs.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshot_restore_jobs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -110,7 +111,7 @@ func dataSourceMongoDBAtlasCloudBackupSnapshotRestoreJobs() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotRestoreJobsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		GroupID:     d.Get("project_id").(string),

--- a/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshots.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_backup_snapshots.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -123,7 +124,7 @@ func dataSourceMongoDBAtlasCloudBackupSnapshots() *schema.Resource {
 
 func dataSourceMongoDBAtlasCloudBackupSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		GroupID:     d.Get("project_id").(string),

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_access.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -88,7 +89,7 @@ func featureUsagesSchema() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudProviderAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	roles, _, err := conn.CloudProviderAccess.ListRoles(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_cloud_provider_access_setup.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_provider_access_setup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasCloudProviderAccessSetup() *schema.Resource {
@@ -83,7 +84,7 @@ func dataSourceMongoDBAtlasCloudProviderAccessSetup() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudProviderAccessSetupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	roleID := d.Get("role_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_cloud_shared_tier_restore_job.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_shared_tier_restore_job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 // This datasource does not have a resource: we tested it manually
@@ -70,7 +71,7 @@ func dataSourceMongoDBAtlasCloudSharedTierRestoreJob() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudSharedTierRestoreJobsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).AtlasV2
+	conn := meta.(*client.MongoDBClient).AtlasV2
 
 	jobID := d.Get("job_id").(string)
 	projectID := d.Get("project_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_cloud_shared_tier_restore_jobs.go
+++ b/mongodbatlas/data_source_mongodbatlas_cloud_shared_tier_restore_jobs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 // This datasource does not have a resource: we tested it manually
@@ -85,7 +86,7 @@ func dataSourceMongoDBAtlasCloudSharedTierRestoreJobs() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCloudSharedTierRestoreJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).AtlasV2
+	conn := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_cluster.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -320,7 +321,7 @@ func dataSourceMongoDBAtlasCluster() *schema.Resource {
 
 func dataSourceMongoDBAtlasClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation.go
+++ b/mongodbatlas/data_source_mongodbatlas_cluster_outage_simulation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasClusterOutageSimulation() *schema.Resource {
@@ -57,7 +58,7 @@ func dataSourceMongoDBAtlasClusterOutageSimulation() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasClusterOutageSimulationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, projectIDOk := d.GetOk("project_id")
 	clusterName, clusterNameOk := d.GetOk("cluster_name")

--- a/mongodbatlas/data_source_mongodbatlas_clusters.go
+++ b/mongodbatlas/data_source_mongodbatlas_clusters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -326,7 +327,7 @@ func dataSourceMongoDBAtlasClusters() *schema.Resource {
 
 func dataSourceMongoDBAtlasClustersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	d.SetId(id.UniqueId())
 

--- a/mongodbatlas/data_source_mongodbatlas_custom_db_role.go
+++ b/mongodbatlas/data_source_mongodbatlas_custom_db_role.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasCustomDBRole() *schema.Resource {
@@ -73,7 +74,7 @@ func dataSourceMongoDBAtlasCustomDBRole() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCustomDBRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	roleName := d.Get("role_name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_custom_db_roles.go
+++ b/mongodbatlas/data_source_mongodbatlas_custom_db_roles.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -83,7 +84,7 @@ func dataSourceMongoDBAtlasCustomDBRoles() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCustomDBRolesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	customDBRoles, _, err := conn.CustomDBRoles.List(ctx, projectID, nil)

--- a/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/data_source_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasCustomDNSConfigurationAWS() *schema.Resource {
@@ -27,7 +28,7 @@ func dataSourceMongoDBAtlasCustomDNSConfigurationAWS() *schema.Resource {
 
 func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline.go
+++ b/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -221,7 +222,7 @@ func dataSourceSchemaDataLakePipelineSnapshots() *schema.Schema {
 }
 
 func dataSourceMongoDBAtlasDataLakePipelineRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_run.go
+++ b/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -86,7 +87,7 @@ func dataSourceMongoDBAtlasDataLakePipelineRun() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasDataLakeRunRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	name := d.Get("pipeline_name").(string)
 	pipelineRunID := d.Get("pipeline_run_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_runs.go
+++ b/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_runs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -90,7 +91,7 @@ func dataSourceMongoDBAtlasDataLakePipelineRuns() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasDataLakeRunsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	name := d.Get("pipeline_name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_data_lake_pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -39,7 +40,7 @@ func TestAccDataSourceClusterRSDataLakePipeline_basic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasDataLakePipelineDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_data_lake_pipeline" {

--- a/mongodbatlas/data_source_mongodbatlas_data_lake_pipelines.go
+++ b/mongodbatlas/data_source_mongodbatlas_data_lake_pipelines.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -138,7 +139,7 @@ func dataSourceMongoDBAtlasDataLakePipelines() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasDataLakePipelinesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	dataLakePipelines, _, err := conn.DataLakePipeline.List(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_trigger.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasEventTrigger() *schema.Resource {
@@ -131,7 +132,7 @@ func dataSourceMongoDBAtlasEventTrigger() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasEventTriggerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/mongodbatlas/data_source_mongodbatlas_event_triggers.go
+++ b/mongodbatlas/data_source_mongodbatlas_event_triggers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"go.mongodb.org/realm/realm"
 )
 
@@ -145,7 +146,7 @@ func dataSourceMongoDBAtlasEventTriggers() *schema.Resource {
 func dataSourceMongoDBAtlasEventTriggersRead(d *schema.ResourceData, meta any) error {
 	// Get client connection.
 	ctx := context.Background()
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/mongodbatlas/data_source_mongodbatlas_federated_database_instance.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_database_instance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedDatabaseInstance() *schema.Resource {
@@ -316,7 +317,7 @@ func schemaFederatedDatabaseInstanceStoresDataSource() *schema.Schema {
 }
 
 func dataSourceMongoDBAtlasFederatedDatabaseInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_federated_database_instance_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_database_instance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
 
@@ -89,7 +90,7 @@ func TestAccDataSourceFederatedDatabaseInstance_S3Bucket(t *testing.T) {
 
 func testAccCheckMongoDBAtlasFederatedDatabaseDataSourceInstanceExists(resourceName string, dataFederatedInstance *admin.DataLakeTenant) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := testAccProviderSdkV2.Meta().(*MongoDBClient).AtlasV2
+		connV2 := testAccProviderSdkV2.Meta().(*client.MongoDBClient).AtlasV2
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_database_instances.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_database_instances.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedDatabaseInstances() *schema.Resource {
@@ -111,7 +112,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstances() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasFederatedDatabaseInstancesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_query_limit.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_query_limit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedDatabaseQueryLimit() *schema.Resource {
@@ -57,7 +58,7 @@ func schemaMongoDBAtlasFederatedDatabaseQueryLimitDataSource() map[string]*schem
 }
 
 func dataSourceMongoDBAtlasFederatedDatabaseQueryLimitRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	tenantName := d.Get("tenant_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_federated_query_limit_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_query_limit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -200,7 +201,7 @@ resource "mongodbatlas_federated_query_limit" "test" {
 
 func testAccCheckMongoDBAtlasFederatedDatabaseDataSourceQueryLimitExists(resourceName string, queryLimit *matlas.DataFederationQueryLimit) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_query_limits.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_query_limits.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -34,7 +35,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseQueryLimits() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasFederatedDatabaseQueryLimitsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	tenantName := d.Get("tenant_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -47,7 +48,7 @@ func dataSourceMongoDBAtlasFederatedSettings() *schema.Resource {
 
 func dataSourceMongoDBAtlasFederatedSettingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	orgID, orgIDOk := d.GetOk("org_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organization.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organization.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationConfig() *schema.Resource {
@@ -112,7 +113,7 @@ func dataSourceMongoDBAtlasFederatedSettingsOrganizationConfig() *schema.Resourc
 }
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organization_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organization_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFedDSFederatedSettingsOrganizationConfig_basic(t *testing.T) {
@@ -49,7 +50,7 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigConfig(fede
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organizations.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organizations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -129,7 +130,7 @@ func dataSourceMongoDBAtlasFederatedSettingsOrganizationConfigs() *schema.Resour
 }
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationConfigsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organizations_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_connected_organizations_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFedDSFederatedSettingsOrganizationConfigs_basic(t *testing.T) {
@@ -48,7 +49,7 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigsConfig(fed
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigsExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_provider.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_provider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedSettingsIdentityProvider() *schema.Resource {
@@ -200,7 +201,7 @@ func dataSourceMongoDBAtlasFederatedSettingsIdentityProvider() *schema.Resource 
 }
 func dataSourceMongoDBAtlasFederatedSettingsIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_providers.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_providers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -214,7 +215,7 @@ func dataSourceMongoDBAtlasFederatedSettingsIdentityProviders() *schema.Resource
 }
 func dataSourceMongoDBAtlasFederatedSettingsIdentityProvidersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_providers_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_identity_providers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFedDSFederatedSettingsIdentityProviders_basic(t *testing.T) {
@@ -48,7 +49,7 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProvidersConfig(feder
 
 func testAccCheckMongoDBAtlasFederatedSettingsIdentityProvidersExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mapping.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mapping.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMapping() *schema.Resource {
@@ -59,7 +60,7 @@ func dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMapping() *schema.Re
 }
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mappings.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mappings.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -71,7 +72,7 @@ func dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMappings() *schema.R
 }
 func dataSourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mappings_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_organization_role_mappings_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFedDSFederatedSettingsOrganizationRoleMappings_basic(t *testing.T) {
@@ -49,7 +50,7 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingsConfi
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingsExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_federated_settings_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_federated_settings_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -48,7 +49,7 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsConfig(orgID string) string {
 
 func testAccCheckMongoDBAtlasFederatedSettingsExists(resourceName string, federatedSettings *matlas.FederatedSettings) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/data_source_mongodbatlas_global_cluster_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasGlobalCluster() *schema.Resource {
@@ -62,7 +63,7 @@ func dataSourceMongoDBAtlasGlobalCluster() *schema.Resource {
 
 func dataSourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_ldap_configuration.go
+++ b/mongodbatlas/data_source_mongodbatlas_ldap_configuration.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasLDAPConfiguration() *schema.Resource {
@@ -73,7 +74,7 @@ func dataSourceMongoDBAtlasLDAPConfiguration() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasLDAPConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	ldap, _, err := conn.LDAPConfigurations.Get(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_ldap_verify.go
+++ b/mongodbatlas/data_source_mongodbatlas_ldap_verify.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasLDAPVerify() *schema.Resource {
@@ -73,7 +74,7 @@ func dataSourceMongoDBAtlasLDAPVerify() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasLDAPVerifyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	requestID := d.Get("request_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_maintenance_window.go
+++ b/mongodbatlas/data_source_mongodbatlas_maintenance_window.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 )
 
@@ -42,7 +43,7 @@ func dataSourceMongoDBAtlasMaintenanceWindow() *schema.Resource {
 
 func dataSourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	maintenance, _, err := conn.MaintenanceWindows.Get(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_network_container.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasNetworkContainer() *schema.Resource {
@@ -74,7 +75,7 @@ func dataSourceMongoDBAtlasNetworkContainer() *schema.Resource {
 
 func dataSourceMongoDBAtlasNetworkContainerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	containerID := getEncodedID(d.Get("container_id").(string), "container_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_network_containers.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_containers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -87,7 +88,7 @@ func dataSourceMongoDBAtlasNetworkContainers() *schema.Resource {
 
 func dataSourceMongoDBAtlasNetworkContainersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	containers, _, err := conn.Containers.List(ctx, projectID, &matlas.ContainersListOptions{

--- a/mongodbatlas/data_source_mongodbatlas_network_peering.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_peering.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasNetworkPeering() *schema.Resource {
@@ -109,7 +110,7 @@ func dataSourceMongoDBAtlasNetworkPeering() *schema.Resource {
 
 func dataSourceMongoDBAtlasNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	peerID := getEncodedID(d.Get("peering_id").(string), "peer_id")
 

--- a/mongodbatlas/data_source_mongodbatlas_network_peerings.go
+++ b/mongodbatlas/data_source_mongodbatlas_network_peerings.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -115,7 +116,7 @@ func dataSourceMongoDBAtlasNetworkPeerings() *schema.Resource {
 
 func dataSourceMongoDBAtlasNetworkPeeringsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	peers, _, err := conn.Peers.List(ctx, projectID, nil)

--- a/mongodbatlas/data_source_mongodbatlas_online_archive.go
+++ b/mongodbatlas/data_source_mongodbatlas_online_archive.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasOnlineArchives() *schema.Resource {
@@ -198,7 +199,7 @@ func schemaOnlineArchive() map[string]*schema.Schema {
 }
 
 func dataSourceMongoDBAtlasOnlineArchiveRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 	archiveID := d.Get("archive_id").(string)
@@ -227,7 +228,7 @@ func dataSourceMongoDBAtlasOnlineArchiveRead(ctx context.Context, d *schema.Reso
 }
 
 func dataSourceMongoDBAtlasOnlineArchivesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_org_id.go
+++ b/mongodbatlas/data_source_mongodbatlas_org_id.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/project"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -25,7 +27,7 @@ func dataSourceMongoDBAtlasOrgID() *schema.Resource {
 
 func dataSourceMongoDBAtlasOrgIDRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	var (
 		err  error
@@ -41,7 +43,7 @@ func dataSourceMongoDBAtlasOrgIDRead(ctx context.Context, d *schema.ResourceData
 	for idx, role := range apiKeyOrgList.APIKey.Roles {
 		if strings.HasPrefix(role.RoleName, "ORG_") {
 			if err := d.Set("org_id", apiKeyOrgList.APIKey.Roles[idx].OrgID); err != nil {
-				return diag.Errorf(errorProjectSetting, `org_id`, root.APIKey.ID, err)
+				return diag.Errorf(project.ErrorProjectSetting, `org_id`, root.APIKey.ID, err)
 			}
 			d.SetId(apiKeyOrgList.APIKey.Roles[idx].OrgID)
 			return nil

--- a/mongodbatlas/data_source_mongodbatlas_org_invitation.go
+++ b/mongodbatlas/data_source_mongodbatlas_org_invitation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasOrgInvitation() *schema.Resource {
@@ -56,7 +57,7 @@ func dataSourceMongoDBAtlasOrgInvitation() *schema.Resource {
 
 func dataSourceMongoDBAtlasOrgInvitationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 	username := d.Get("username").(string)
 	invitationID := d.Get("invitation_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_organization.go
+++ b/mongodbatlas/data_source_mongodbatlas_organization.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasOrganization() *schema.Resource {
@@ -46,7 +47,7 @@ func dataSourceMongoDBAtlasOrganization() *schema.Resource {
 
 func dataSourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 
 	organization, _, err := conn.Organizations.Get(ctx, orgID)

--- a/mongodbatlas/data_source_mongodbatlas_organizations.go
+++ b/mongodbatlas/data_source_mongodbatlas_organizations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -78,7 +79,7 @@ func dataSourceMongoDBAtlasOrganizations() *schema.Resource {
 
 func dataSourceMongoDBAtlasOrganizationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	options := &matlas.ListOptions{
 		PageNum:      d.Get("page_num").(int),

--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasPrivateEndpointRegionalMode() *schema.Resource {
@@ -26,7 +27,7 @@ func dataSourceMongoDBAtlasPrivateEndpointRegionalMode() *schema.Resource {
 
 func dataSourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccNetworkDSPrivateEndpointRegionalMode_basic(t *testing.T) {
@@ -32,7 +33,7 @@ func TestAccNetworkDSPrivateEndpointRegionalMode_basic(t *testing.T) {
 
 func testAccMongoDBAtlasPrivateEndpointRegionalModeUnmanagedResource(resourceName, projectID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
 

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasPrivateLinkEndpoint() *schema.Resource {
@@ -85,7 +86,7 @@ func dataSourceMongoDBAtlasPrivateLinkEndpoint() *schema.Resource {
 
 func dataSourceMongoDBAtlasPrivateLinkEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	privateLinkID := getEncodedID(d.Get("private_link_id").(string), "private_link_id")

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 )
 
@@ -100,7 +101,7 @@ func dataSourceMongoDBAtlasPrivateEndpointServiceLink() *schema.Resource {
 
 func dataSourceMongoDBAtlasPrivateEndpointServiceLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	privateLinkID := getEncodedID(d.Get("private_link_id").(string), "private_link_id")

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive() *schema.Resource {
@@ -36,7 +37,7 @@ func dataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive
 }
 
 func dataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	endopointID := d.Get("endpoint_id").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archives.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_data_federation_online_archives.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -49,7 +50,7 @@ func dataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive
 }
 
 func dataSourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchivesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	privateEndpoints, _, err := conn.DataLakes.ListPrivateLinkEndpoint(context.Background(), projectID)

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasPrivateLinkEndpointServerless() *schema.Resource {
@@ -61,7 +62,7 @@ func dataSourceMongoDBAtlasPrivateLinkEndpointServerless() *schema.Resource {
 
 func dataSourceMongoDBAtlasPrivateEndpointServiceServerlessLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_privatelink_endpoints_service_serverless.go
+++ b/mongodbatlas/data_source_mongodbatlas_privatelink_endpoints_service_serverless.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -77,7 +78,7 @@ func dataSourceMongoDBAtlasPrivateLinkEndpointsServiceServerless() *schema.Resou
 
 func dataSourceMongoDBAtlasPrivateLinkEndpointsServiceServerlessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 

--- a/mongodbatlas/data_source_mongodbatlas_project_api_key.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_api_key.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/project"
 )
 
 func dataSourceMongoDBAtlasProjectAPIKey() *schema.Resource {
@@ -58,7 +60,7 @@ func dataSourceMongoDBAtlasProjectAPIKey() *schema.Resource {
 
 func dataSourceMongoDBAtlasProjectAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	apiKeyID := d.Get("api_key_id").(string)
@@ -86,7 +88,7 @@ func dataSourceMongoDBAtlasProjectAPIKeyRead(ctx context.Context, d *schema.Reso
 
 		if projectAssignments, err := newProjectAssignment(ctx, conn, apiKeyID); err == nil {
 			if err := d.Set("project_assignment", projectAssignments); err != nil {
-				return diag.Errorf(errorProjectSetting, `project_assignment`, projectID, err)
+				return diag.Errorf(project.ErrorProjectSetting, `project_assignment`, projectID, err)
 			}
 		}
 	}

--- a/mongodbatlas/data_source_mongodbatlas_project_api_keys.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_api_keys.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -76,7 +77,7 @@ func dataSourceMongoDBAtlasProjectAPIKeys() *schema.Resource {
 
 func dataSourceMongoDBAtlasProjectAPIKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	options := &matlas.ListOptions{
 		PageNum:      d.Get("page_num").(int),
 		ItemsPerPage: d.Get("items_per_page").(int),

--- a/mongodbatlas/data_source_mongodbatlas_project_invitation.go
+++ b/mongodbatlas/data_source_mongodbatlas_project_invitation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasProjectInvitation() *schema.Resource {
@@ -49,7 +50,7 @@ func dataSourceMongoDBAtlasProjectInvitation() *schema.Resource {
 
 func dataSourceMongoDBAtlasProjectInvitationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	username := d.Get("username").(string)
 	invitationID := d.Get("invitation_id").(string)

--- a/mongodbatlas/data_source_mongodbatlas_search_index.go
+++ b/mongodbatlas/data_source_mongodbatlas_search_index.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasSearchIndex() *schema.Resource {
@@ -108,7 +109,7 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("project_id, cluster_name and index_id must be configured")
 	}
 
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	searchIndex, _, err := connV2.AtlasSearchApi.GetAtlasSearchIndex(ctx, projectID.(string), clusterName.(string), indexID.(string)).Execute()
 	if err != nil {
 		return diag.Errorf("error getting search index information: %s", err)

--- a/mongodbatlas/data_source_mongodbatlas_search_indexes.go
+++ b/mongodbatlas/data_source_mongodbatlas_search_indexes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
 
@@ -65,7 +66,7 @@ func dataSourceMongoDBAtlasSearchIndexesRead(ctx context.Context, d *schema.Reso
 		return diag.Errorf("project_id, cluster_name, database and collection_name must be configured")
 	}
 
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	searchIndexes, _, err := connV2.AtlasSearchApi.ListAtlasSearchIndexes(ctx, projectID.(string), clusterName.(string), collectionName.(string), databaseName.(string)).Execute()
 
 	if err != nil {

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instance.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasServerlessInstance() *schema.Resource {
@@ -16,7 +17,7 @@ func dataSourceMongoDBAtlasServerlessInstance() *schema.Resource {
 
 func dataSourceMongoDBAtlasServerlessInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, projectIDOk := d.GetOk("project_id")
 	instanceName, instanceNameOk := d.GetOk("name")

--- a/mongodbatlas/data_source_mongodbatlas_serverless_instances.go
+++ b/mongodbatlas/data_source_mongodbatlas_serverless_instances.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -61,7 +62,7 @@ func getServerlessList(ctx context.Context, meta any, projectID string, options 
 	// Get client connection.
 	var list []*matlas.Cluster
 	options.PageNum++
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	serverlessInstances, _, err := conn.ServerlessInstances.List(ctx, projectID, options)
 	if err != nil {

--- a/mongodbatlas/data_source_mongodbatlas_shared_tier_snapshot.go
+++ b/mongodbatlas/data_source_mongodbatlas_shared_tier_snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 // This datasource does not have a resource: we tested it manually
@@ -54,7 +55,7 @@ func dataSourceMongoDBAtlasSharedTierSnapshot() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasSharedTierSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).AtlasV2
+	conn := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_shared_tier_snapshots.go
+++ b/mongodbatlas/data_source_mongodbatlas_shared_tier_snapshots.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 // This datasource does not have a resource: we tested it manually
@@ -69,7 +70,7 @@ func dataSourceMongoDBAtlasSharedTierSnapshots() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasSharedTierSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).AtlasV2
+	conn := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/mongodbatlas/data_source_mongodbatlas_team.go
+++ b/mongodbatlas/data_source_mongodbatlas_team.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -44,7 +45,7 @@ func dataSourceMongoDBAtlasTeam() *schema.Resource {
 
 func dataSourceMongoDBAtlasTeamRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var (
-		conn             = meta.(*MongoDBClient).Atlas
+		conn             = meta.(*client.MongoDBClient).Atlas
 		orgID            = d.Get("org_id").(string)
 		teamID, teamIDOk = d.GetOk("team_id")
 		name, nameOk     = d.GetOk("name")

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
@@ -108,7 +109,7 @@ func dataSourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *sch
 	projectID := d.Get("project_id").(string)
 	queryType := d.Get("type").(string)
 
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	integration, _, err := conn.Integrations.Get(ctx, projectID, queryType)
 

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -246,7 +247,7 @@ func testGenString(length int, charSet string) string {
 
 func testAccCheckThirdPartyIntegrationExists(resourceName string, integration *matlas.ThirdPartyIntegration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
+++ b/mongodbatlas/data_source_mongodbatlas_third_party_integrations.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -28,7 +29,7 @@ func dataSourceMongoDBAtlasThirdPartyIntegrations() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasThirdPartyIntegrationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	integrations, _, err := conn.Integrations.List(ctx, projectID)

--- a/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/data_source_mongodbatlas_x509_authentication_database_user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func dataSourceMongoDBAtlasX509AuthDBUser() *schema.Resource {
@@ -61,7 +62,7 @@ func dataSourceMongoDBAtlasX509AuthDBUser() *schema.Resource {
 
 func dataSourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	username := d.Get("username").(string)
 

--- a/mongodbatlas/framework/common/fw_common.go
+++ b/mongodbatlas/framework/common/fw_common.go
@@ -1,4 +1,4 @@
-package mongodbatlas
+package common
 
 import (
 	"context"
@@ -6,6 +6,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
+)
+
+const (
+	errorConfigureSummary = "Unexpected Resource Configure Type"
+	errorConfigure        = "expected *MongoDBClient, got: %T. Please report this issue to the provider developers"
 )
 
 // RSCommon is used as an embedded struct for all framework resources. Implements the following plugin-framework defined functions:
@@ -14,21 +20,21 @@ import (
 // client is left empty and populated by the framework when envoking Configure method.
 // resourceName must be defined when creating an instance of a resource.
 type RSCommon struct {
-	client       *MongoDBClient
-	resourceName string
+	Client       *client.MongoDBClient
+	ResourceName string
 }
 
 func (r *RSCommon) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, r.resourceName)
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, r.ResourceName)
 }
 
 func (r *RSCommon) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	client, err := configureClient(req.ProviderData)
+	c, err := configureClient(req.ProviderData)
 	if err != nil {
 		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
 		return
 	}
-	r.client = client
+	r.Client = c
 }
 
 // DSCommon is used as an embedded struct for all framework data sources. Implements the following plugin-framework defined functions:
@@ -37,30 +43,30 @@ func (r *RSCommon) Configure(ctx context.Context, req resource.ConfigureRequest,
 // client is left empty and populated by the framework when envoking Configure method.
 // dataSourceName must be defined when creating an instance of a data source.
 type DSCommon struct {
-	client         *MongoDBClient
-	dataSourceName string
+	Client         *client.MongoDBClient
+	DataSourceName string
 }
 
 func (d *DSCommon) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.dataSourceName)
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.DataSourceName)
 }
 
 func (d *DSCommon) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	client, err := configureClient(req.ProviderData)
+	c, err := configureClient(req.ProviderData)
 	if err != nil {
 		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
 		return
 	}
-	d.client = client
+	d.Client = c
 }
 
-func configureClient(providerData any) (*MongoDBClient, error) {
+func configureClient(providerData any) (*client.MongoDBClient, error) {
 	if providerData == nil {
 		return nil, nil
 	}
 
-	if client, ok := providerData.(*MongoDBClient); ok {
-		return client, nil
+	if c, ok := providerData.(*client.MongoDBClient); ok {
+		return c, nil
 	}
 
 	return nil, fmt.Errorf(errorConfigure, providerData)

--- a/mongodbatlas/framework/fw_common.go
+++ b/mongodbatlas/framework/fw_common.go
@@ -1,4 +1,4 @@
-package common
+package framework
 
 import (
 	"context"

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/zclconf/go-cty/cty"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
@@ -42,14 +42,14 @@ type tfAlertConfigurationOutputModel struct {
 
 func NewAlertConfigurationDS() datasource.DataSource {
 	return &AlertConfigurationDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: alertConfigurationResourceName,
 		},
 	}
 }
 
 type AlertConfigurationDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 var alertConfigDSSchemaBlocks = map[string]schema.Block{

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configuration.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/zclconf/go-cty/cty"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
@@ -41,14 +42,14 @@ type tfAlertConfigurationOutputModel struct {
 
 func NewAlertConfigurationDS() datasource.DataSource {
 	return &AlertConfigurationDS{
-		DSCommon: DSCommon{
-			dataSourceName: alertConfigurationResourceName,
+		DSCommon: common.DSCommon{
+			DataSourceName: alertConfigurationResourceName,
 		},
 	}
 }
 
 type AlertConfigurationDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 var alertConfigDSSchemaBlocks = map[string]schema.Block{
@@ -260,7 +261,7 @@ func (d *AlertConfigurationDS) Read(ctx context.Context, req datasource.ReadRequ
 	alertID := getEncodedID(alertConfigurationConfig.AlertConfigurationID.ValueString(), encodedIDKeyAlertID)
 	outputs := alertConfigurationConfig.Output
 
-	connV2 := d.client.AtlasV2
+	connV2 := d.Client.AtlasV2
 	alert, _, err := connV2.AlertConfigurationsApi.GetAlertConfiguration(ctx, projectID, alertID).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(errorReadAlertConf, err.Error())

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
 
@@ -35,14 +36,14 @@ type tfListOptionsModel struct {
 
 func NewAlertConfigurationsDS() datasource.DataSource {
 	return &AlertConfigurationsDS{
-		DSCommon: DSCommon{
-			dataSourceName: alertConfigurationsDataSourceName,
+		DSCommon: common.DSCommon{
+			DataSourceName: alertConfigurationsDataSourceName,
 		},
 	}
 }
 
 type AlertConfigurationsDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func (d *AlertConfigurationsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -131,7 +132,7 @@ func (d *AlertConfigurationsDS) Read(ctx context.Context, req datasource.ReadReq
 
 	alertConfigurationsConfig.ListOptions = setDefaultValuesInListOptions(alertConfigurationsConfig.ListOptions)
 
-	connV2 := d.client.AtlasV2
+	connV2 := d.Client.AtlasV2
 	params := newListParams(projectID, alertConfigurationsConfig.ListOptions)
 	alerts, _, err := connV2.AlertConfigurationsApi.ListAlertConfigurationsWithParams(ctx, params).Execute()
 	if err != nil {

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
 
@@ -36,14 +36,14 @@ type tfListOptionsModel struct {
 
 func NewAlertConfigurationsDS() datasource.DataSource {
 	return &AlertConfigurationsDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: alertConfigurationsDataSourceName,
 		},
 	}
 }
 
 type AlertConfigurationsDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func (d *AlertConfigurationsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_alert_configurations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -27,7 +28,7 @@ func TestAccConfigDSAlertConfigurations_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: config(orgID, projectName),
+				Config: configAlert(orgID, projectName),
 				Check: resource.ComposeTestCheckFunc(
 					checkCount(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -103,7 +104,7 @@ func TestAccConfigDSAlertConfigurations_totalCount(t *testing.T) {
 	})
 }
 
-func config(orgID, projectName string) string {
+func configAlert(orgID, projectName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = %[2]q
@@ -150,7 +151,7 @@ func configTotalCount(orgID, projectName string) string {
 
 func checkCount(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_user.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -52,14 +52,14 @@ type tfAtlasUserRoleModel struct {
 
 func NewAtlasUserDS() datasource.DataSource {
 	return &AtlasUserDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: AtlasUserDataSourceName,
 		},
 	}
 }
 
 type AtlasUserDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func (d *AtlasUserDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -51,14 +52,14 @@ type tfAtlasUserRoleModel struct {
 
 func NewAtlasUserDS() datasource.DataSource {
 	return &AtlasUserDS{
-		DSCommon: DSCommon{
-			dataSourceName: AtlasUserDataSourceName,
+		DSCommon: common.DSCommon{
+			DataSourceName: AtlasUserDataSourceName,
 		},
 	}
 }
 
 type AtlasUserDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func (d *AtlasUserDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -139,7 +140,7 @@ func (d *AtlasUserDS) Schema(ctx context.Context, req datasource.SchemaRequest, 
 }
 
 func (d *AtlasUserDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	connV2 := d.client.AtlasV2
+	connV2 := d.Client.AtlasV2
 
 	var atlasUserConfig tfAtlasUserDSModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &atlasUserConfig)...)

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_user_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_user_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -84,7 +85,7 @@ func TestAccConfigDSAtlasUser_InvalidAttrCombination(t *testing.T) {
 }
 
 func fetchUser(userID string, t *testing.T) *admin.CloudAppUser {
-	connV2 := testMongoDBClient.(*MongoDBClient).AtlasV2
+	connV2 := testMongoDBClient.(*client.MongoDBClient).AtlasV2
 	userResp, _, err := connV2.MongoDBCloudUsersApi.GetUser(context.Background(), userID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas User (%s) could not be fetched: %v", userID, err)
@@ -93,7 +94,7 @@ func fetchUser(userID string, t *testing.T) *admin.CloudAppUser {
 }
 
 func fetchUserByUsername(username string, t *testing.T) *admin.CloudAppUser {
-	connV2 := testMongoDBClient.(*MongoDBClient).AtlasV2
+	connV2 := testMongoDBClient.(*client.MongoDBClient).AtlasV2
 
 	userResp, _, err := connV2.MongoDBCloudUsersApi.GetUserByUsername(context.Background(), username).Execute()
 	if err != nil {

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_users.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -27,14 +28,14 @@ var _ datasource.DataSourceWithConfigure = &AtlasUsersDS{}
 
 func NewAtlasUsersDS() datasource.DataSource {
 	return &AtlasUsersDS{
-		DSCommon: DSCommon{
-			dataSourceName: AtlasUsersDataSourceName,
+		DSCommon: common.DSCommon{
+			DataSourceName: AtlasUsersDataSourceName,
 		},
 	}
 }
 
 type AtlasUsersDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 type tfAtlasUsersDSModel struct {
@@ -160,7 +161,7 @@ func (d *AtlasUsersDS) Schema(ctx context.Context, req datasource.SchemaRequest,
 }
 
 func (d *AtlasUsersDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	connV2 := d.client.AtlasV2
+	connV2 := d.Client.AtlasV2
 
 	var atlasUsersConfig tfAtlasUsersDSModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &atlasUsersConfig)...)

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_users.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -28,14 +28,14 @@ var _ datasource.DataSourceWithConfigure = &AtlasUsersDS{}
 
 func NewAtlasUsersDS() datasource.DataSource {
 	return &AtlasUsersDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: AtlasUsersDataSourceName,
 		},
 	}
 }
 
 type AtlasUsersDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 type tfAtlasUsersDSModel struct {

--- a/mongodbatlas/fw_data_source_mongodbatlas_atlas_users_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_atlas_users_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
 
@@ -200,7 +201,7 @@ func TestAccConfigDSAtlasUsers_InvalidAttrCombinations(t *testing.T) {
 }
 
 func fetchOrgUsers(orgID string, t *testing.T) *admin.PaginatedAppUser {
-	connV2 := testMongoDBClient.(*MongoDBClient).AtlasV2
+	connV2 := testMongoDBClient.(*client.MongoDBClient).AtlasV2
 	users, _, err := connV2.OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas Users for Org(%s) could not be fetched: %v", orgID, err)
@@ -282,7 +283,7 @@ func testAccDSMongoDBAtlasUsersByTeamWithPagination(orgID, teamName, username st
 
 func testAccCheckMongoDBAtlasOrgWithUsersExists(dataSourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := testMongoDBClient.(*MongoDBClient).AtlasV2
+		connV2 := testMongoDBClient.(*client.MongoDBClient).AtlasV2
 
 		rs, ok := s.RootModule().Resources[dataSourceName]
 		if !ok {

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
@@ -8,17 +8,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 type DatabaseUserDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func NewDatabaseUserDS() datasource.DataSource {
 	return &DatabaseUserDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: databaseUserResourceName,
 		},
 	}

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_user.go
@@ -8,17 +8,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 type DatabaseUserDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func NewDatabaseUserDS() datasource.DataSource {
 	return &DatabaseUserDS{
-		DSCommon: DSCommon{
-			dataSourceName: databaseUserResourceName,
+		DSCommon: common.DSCommon{
+			DataSourceName: databaseUserResourceName,
 		},
 	}
 }
@@ -130,7 +131,7 @@ func (d *DatabaseUserDS) Read(ctx context.Context, req datasource.ReadRequest, r
 	projectID := databaseDSUserModel.ProjectID.ValueString()
 	authDatabaseName := databaseDSUserModel.AuthDatabaseName.ValueString()
 
-	conn := d.client.Atlas
+	conn := d.Client.Atlas
 	dbUser, _, err := conn.DatabaseUsers.Get(ctx, authDatabaseName, projectID, username)
 	if err != nil {
 		resp.Diagnostics.AddError("error getting database user information", err.Error())

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -16,13 +17,13 @@ const (
 )
 
 type DatabaseUsersDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func NewDatabaseUsersDS() datasource.DataSource {
 	return &DatabaseUsersDS{
-		DSCommon: DSCommon{
-			dataSourceName: databaseUsersDSName,
+		DSCommon: common.DSCommon{
+			DataSourceName: databaseUsersDSName,
 		},
 	}
 }
@@ -136,7 +137,7 @@ func (d *DatabaseUsersDS) Read(ctx context.Context, req datasource.ReadRequest, 
 	}
 
 	projectID := databaseUsersModel.ProjectID.ValueString()
-	conn := d.client.Atlas
+	conn := d.Client.Atlas
 	dbUser, _, err := conn.DatabaseUsers.List(ctx, projectID, nil)
 	if err != nil {
 		resp.Diagnostics.AddError("error getting database user information", err.Error())

--- a/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_database_users.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -17,12 +17,12 @@ const (
 )
 
 type DatabaseUsersDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func NewDatabaseUsersDS() datasource.DataSource {
 	return &DatabaseUsersDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: databaseUsersDSName,
 		},
 	}

--- a/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -21,12 +21,12 @@ const (
 )
 
 type ProjectIPAccessListDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func NewProjectIPAccessListDS() datasource.DataSource {
 	return &ProjectIPAccessListDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: projectIPAccessList,
 		},
 	}

--- a/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -20,13 +21,13 @@ const (
 )
 
 type ProjectIPAccessListDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func NewProjectIPAccessListDS() datasource.DataSource {
 	return &ProjectIPAccessListDS{
-		DSCommon: DSCommon{
-			dataSourceName: projectIPAccessList,
+		DSCommon: common.DSCommon{
+			DataSourceName: projectIPAccessList,
 		},
 	}
 }
@@ -112,7 +113,7 @@ func (d *ProjectIPAccessListDS) Read(ctx context.Context, req datasource.ReadReq
 		entry.WriteString(databaseDSUserConfig.AWSSecurityGroup.ValueString())
 	}
 
-	conn := d.client.Atlas
+	conn := d.Client.Atlas
 	accessList, _, err := conn.ProjectIPAccessList.Get(ctx, databaseDSUserConfig.ProjectID.ValueString(), entry.String())
 	if err != nil {
 		resp.Diagnostics.AddError("error getting access list entry", err.Error())

--- a/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list_migration_test.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_project_ip_access_list_migration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
 
 func TestAccMigrationProjectDSProjectIPAccessList_SettingIPAddress(t *testing.T) {
@@ -42,7 +43,7 @@ func TestAccMigrationProjectDSProjectIPAccessList_SettingIPAddress(t *testing.T)
 				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -83,7 +84,7 @@ func TestAccMigrationProjectDSProjectIPAccessList_SettingCIDRBlock(t *testing.T)
 				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -133,7 +134,7 @@ func TestAccMigrationProjectDSProjectIPAccessList_SettingAWSSecurityGroup(t *tes
 				Config:                   testAccDataMongoDBAtlasProjectIPAccessListConfigSettingAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/fw_data_source_mongodbatlas_search_deployment.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_search_deployment.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 )
 
 var _ datasource.DataSource = &SearchDeploymentDS{}
@@ -14,7 +14,7 @@ var _ datasource.DataSourceWithConfigure = &SearchDeploymentDS{}
 
 func NewSearchDeploymentDS() datasource.DataSource {
 	return &SearchDeploymentDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: searchDeploymentName,
 		},
 	}
@@ -29,7 +29,7 @@ type tfSearchDeploymentDSModel struct {
 }
 
 type SearchDeploymentDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 func (d *SearchDeploymentDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/mongodbatlas/fw_data_source_mongodbatlas_search_deployment.go
+++ b/mongodbatlas/fw_data_source_mongodbatlas_search_deployment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 )
 
 var _ datasource.DataSource = &SearchDeploymentDS{}
@@ -13,8 +14,8 @@ var _ datasource.DataSourceWithConfigure = &SearchDeploymentDS{}
 
 func NewSearchDeploymentDS() datasource.DataSource {
 	return &SearchDeploymentDS{
-		DSCommon: DSCommon{
-			dataSourceName: searchDeploymentName,
+		DSCommon: common.DSCommon{
+			DataSourceName: searchDeploymentName,
 		},
 	}
 }
@@ -28,7 +29,7 @@ type tfSearchDeploymentDSModel struct {
 }
 
 type SearchDeploymentDS struct {
-	DSCommon
+	common.DSCommon
 }
 
 func (d *SearchDeploymentDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -70,7 +71,7 @@ func (d *SearchDeploymentDS) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	connV2 := d.client.AtlasV2
+	connV2 := d.Client.AtlasV2
 	projectID := searchDeploymentConfig.ProjectID.ValueString()
 	clusterName := searchDeploymentConfig.ClusterName.ValueString()
 	deploymentResp, _, err := connV2.AtlasSearchApi.GetAtlasSearchDeployment(ctx, projectID, clusterName).Execute()

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/mwielbut/pointy"
@@ -43,14 +44,14 @@ var _ resource.ResourceWithImportState = &AlertConfigurationRS{}
 
 func NewAlertConfigurationRS() resource.Resource {
 	return &AlertConfigurationRS{
-		RSCommon: RSCommon{
-			resourceName: alertConfigurationResourceName,
+		RSCommon: common.RSCommon{
+			ResourceName: alertConfigurationResourceName,
 		},
 	}
 }
 
 type AlertConfigurationRS struct {
-	RSCommon
+	common.RSCommon
 }
 
 type tfAlertConfigurationRSModel struct {
@@ -370,7 +371,7 @@ func (r *AlertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 }
 
 func (r *AlertConfigurationRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	var alertConfigPlan tfAlertConfigurationRSModel
 
@@ -416,7 +417,7 @@ func (r *AlertConfigurationRS) Create(ctx context.Context, req resource.CreateRe
 }
 
 func (r *AlertConfigurationRS) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	var alertConfigState tfAlertConfigurationRSModel
 
@@ -446,7 +447,7 @@ func (r *AlertConfigurationRS) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (r *AlertConfigurationRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	var alertConfigState, alertConfigPlan tfAlertConfigurationRSModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &alertConfigState)...)
@@ -521,7 +522,7 @@ func (r *AlertConfigurationRS) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *AlertConfigurationRS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	var alertConfigState tfAlertConfigurationRSModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &alertConfigState)...)

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/mwielbut/pointy"
@@ -44,14 +44,14 @@ var _ resource.ResourceWithImportState = &AlertConfigurationRS{}
 
 func NewAlertConfigurationRS() resource.Resource {
 	return &AlertConfigurationRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: alertConfigurationResourceName,
 		},
 	}
 }
 
 type AlertConfigurationRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 type tfAlertConfigurationRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_migration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_migration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
 
 func TestAccMigrationConfigRSAlertConfiguration_NotificationsWithMetricThreshold(t *testing.T) {
@@ -45,7 +46,7 @@ func TestAccMigrationConfigRSAlertConfiguration_NotificationsWithMetricThreshold
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -89,7 +90,7 @@ func TestAccMigrationConfigRSAlertConfiguration_WithThreshold(t *testing.T) {
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -134,7 +135,7 @@ func TestAccMigrationConfigRSAlertConfiguration_EmptyOptionalBlocks(t *testing.T
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -186,7 +187,7 @@ func TestAccMigrationConfigRSAlertConfiguration_MultipleMatchers(t *testing.T) {
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -228,7 +229,7 @@ func TestAccMigrationConfigRSAlertConfiguration_EmptyOptionalAttributes(t *testi
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_alert_configuration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -540,7 +541,7 @@ func TestAccConfigRSAlertConfiguration_VictorOps(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName string, alert *matlas.AlertConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -565,7 +566,7 @@ func testAccCheckMongoDBAtlasAlertConfigurationExists(resourceName string, alert
 }
 
 func testAccCheckMongoDBAtlasAlertConfigurationDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_alert_configuration" {

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -29,13 +30,13 @@ var _ resource.ResourceWithConfigure = &DatabaseUserRS{}
 var _ resource.ResourceWithImportState = &DatabaseUserRS{}
 
 type DatabaseUserRS struct {
-	RSCommon
+	common.RSCommon
 }
 
 func NewDatabaseUserRS() resource.Resource {
 	return &DatabaseUserRS{
-		RSCommon: RSCommon{
-			resourceName: databaseUserResourceName,
+		RSCommon: common.RSCommon{
+			ResourceName: databaseUserResourceName,
 		},
 	}
 }
@@ -219,7 +220,7 @@ func (r *DatabaseUserRS) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	dbUser, _, err := conn.DatabaseUsers.Create(ctx, databaseUserPlan.ProjectID.ValueString(), dbUserReq)
 	if err != nil {
 		resp.Diagnostics.AddError("error during database user creation", err.Error())
@@ -259,7 +260,7 @@ func (r *DatabaseUserRS) Read(ctx context.Context, req resource.ReadRequest, res
 		}
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	dbUser, httpResponse, err := conn.DatabaseUsers.Get(ctx, authDatabaseName, projectID, username)
 	if err != nil {
 		// case 404
@@ -300,7 +301,7 @@ func (r *DatabaseUserRS) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	dbUser, _, err := conn.DatabaseUsers.Update(ctx, databaseUserPlan.ProjectID.ValueString(), databaseUserPlan.Username.ValueString(), dbUserReq)
 	if err != nil {
 		resp.Diagnostics.AddError("error during database user creation", err.Error())
@@ -327,7 +328,7 @@ func (r *DatabaseUserRS) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	_, err := conn.DatabaseUsers.Delete(ctx, databaseUserState.AuthDatabaseName.ValueString(), databaseUserState.ProjectID.ValueString(), databaseUserState.Username.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("error when destroying the database user resource", err.Error())

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -30,12 +30,12 @@ var _ resource.ResourceWithConfigure = &DatabaseUserRS{}
 var _ resource.ResourceWithImportState = &DatabaseUserRS{}
 
 type DatabaseUserRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 func NewDatabaseUserRS() resource.Resource {
 	return &DatabaseUserRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: databaseUserResourceName,
 		},
 	}

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_migration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_migration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
 
 func TestAccMigrationConfigRSDatabaseUser_Basic(t *testing.T) {
@@ -45,7 +46,7 @@ func TestAccMigrationConfigRSDatabaseUser_Basic(t *testing.T) {
 				Config:                   testAccMongoDBAtlasDatabaseUserConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -88,7 +89,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithX509TypeCustomer(t *testing.T) {
 				Config:                   testAccMongoDBAtlasDatabaseUserWithX509TypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value", x509Type),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -129,7 +130,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithAWSIAMType(t *testing.T) {
 				Config:                   testAccMongoDBAtlasDatabaseUserWithAWSIAMTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -197,7 +198,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithLabels(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -238,7 +239,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithEmptyLabels(t *testing.T) {
 				Config:                   testAccMongoDBAtlasDatabaseUserWithLabelsConfig(projectName, orgID, "atlasAdmin", username, []matlas.Label{}),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -307,7 +308,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithRoles(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -365,7 +366,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithScopes(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -413,7 +414,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithScopesAndEmpty(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -455,7 +456,7 @@ func TestAccMigrationConfigRSDatabaseUser_WithLDAPAuthType(t *testing.T) {
 				Config:                   testAccMongoDBAtlasDatabaseUserWithLDAPAuthTypeConfig(projectName, orgID, "atlasAdmin", username, "First Key", "First value"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_database_user_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -608,7 +609,7 @@ func testAccCheckMongoDBAtlasDatabaseUserImportStateIDFunc(resourceName string) 
 
 func testAccCheckMongoDBAtlasDatabaseUserExists(resourceName string, dbUser *matlas.DatabaseUser) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -652,7 +653,7 @@ func testAccCheckMongoDBAtlasDatabaseUserAttributes(dbUser *matlas.DatabaseUser,
 }
 
 func testAccCheckMongoDBAtlasDatabaseUserDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_database_user" {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
@@ -41,14 +41,14 @@ var _ resource.ResourceWithImportState = &EncryptionAtRestRS{}
 
 func NewEncryptionAtRestRS() resource.Resource {
 	return &EncryptionAtRestRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: encryptionAtRestResourceName,
 		},
 	}
 }
 
 type EncryptionAtRestRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 type tfEncryptionAtRestRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest.go
@@ -19,9 +19,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	validators "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/project"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -39,14 +41,14 @@ var _ resource.ResourceWithImportState = &EncryptionAtRestRS{}
 
 func NewEncryptionAtRestRS() resource.Resource {
 	return &EncryptionAtRestRS{
-		RSCommon: RSCommon{
-			resourceName: encryptionAtRestResourceName,
+		RSCommon: common.RSCommon{
+			ResourceName: encryptionAtRestResourceName,
 		},
 	}
 }
 
 type EncryptionAtRestRS struct {
-	RSCommon
+	common.RSCommon
 }
 
 type tfEncryptionAtRestRSModel struct {
@@ -204,7 +206,7 @@ func (r *EncryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 func (r *EncryptionAtRestRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var encryptionAtRestPlan *tfEncryptionAtRestRSModel
 	var encryptionAtRestConfig *tfEncryptionAtRestRSModel
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &encryptionAtRestPlan)...)
 	resp.Diagnostics.Append(req.Config.Get(ctx, &encryptionAtRestConfig)...)
@@ -289,7 +291,7 @@ func (r *EncryptionAtRestRS) Read(ctx context.Context, req resource.ReadRequest,
 		isImport = true
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	encryptionResp, _, err := conn.EncryptionsAtRest.Get(context.Background(), projectID)
 	if err != nil {
@@ -313,7 +315,7 @@ func (r *EncryptionAtRestRS) Update(ctx context.Context, req resource.UpdateRequ
 	var encryptionAtRestState *tfEncryptionAtRestRSModel
 	var encryptionAtRestConfig *tfEncryptionAtRestRSModel
 	var encryptionAtRestPlan *tfEncryptionAtRestRSModel
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 
 	// get current config
 	resp.Diagnostics.Append(req.Config.Get(ctx, &encryptionAtRestConfig)...)
@@ -337,7 +339,7 @@ func (r *EncryptionAtRestRS) Update(ctx context.Context, req resource.UpdateRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("error when getting encryption at rest resource during update", fmt.Sprintf(errorProjectRead, projectID, err.Error()))
+		resp.Diagnostics.AddError("error when getting encryption at rest resource during update", fmt.Sprintf(project.ErrorProjectRead, projectID, err.Error()))
 		return
 	}
 
@@ -375,7 +377,7 @@ func (r *EncryptionAtRestRS) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	projectID := encryptionAtRestState.ProjectID.ValueString()
 	_, err := conn.EncryptionsAtRest.Delete(ctx, projectID)
 

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest_migration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest_migration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	"github.com/mwielbut/pointy"
 )
 
@@ -52,7 +53,7 @@ func TestAccMigrationAdvRS_EncryptionAtRest_basicAWS(t *testing.T) {
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -115,7 +116,7 @@ func TestAccMigrationAdvRS_EncryptionAtRest_WithRole_basicAWS(t *testing.T) {
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -170,7 +171,7 @@ func TestAccMigrationAdvRS_EncryptionAtRest_basicAzure(t *testing.T) {
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -216,7 +217,7 @@ func TestAccMigrationAdvRS_EncryptionAtRest_basicGCP(t *testing.T) {
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -271,7 +272,7 @@ func TestAccMigrationAdvRS_EncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) 
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_encryption_at_rest_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 )
 
@@ -331,7 +332,7 @@ func TestAccAdvRSEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 
 func testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -351,7 +352,7 @@ func testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resourc
 }
 
 func testAccCheckMongoDBAtlasEncryptionAtRestDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_encryption_at_rest" {

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -43,13 +44,13 @@ type tfProjectIPAccessListModel struct {
 }
 
 type ProjectIPAccessListRS struct {
-	RSCommon
+	common.RSCommon
 }
 
 func NewProjectIPAccessListRS() resource.Resource {
 	return &ProjectIPAccessListRS{
-		RSCommon: RSCommon{
-			resourceName: projectIPAccessList,
+		RSCommon: common.RSCommon{
+			ResourceName: projectIPAccessList,
 		},
 	}
 }
@@ -141,7 +142,7 @@ func (r *ProjectIPAccessListRS) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	projectID := projectIPAccessListModel.ProjectID.ValueString()
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
@@ -259,7 +260,7 @@ func (r *ProjectIPAccessListRS) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		accessList, httpResponse, err := conn.ProjectIPAccessList.Get(ctx, decodedIDMap["project_id"], decodedIDMap["entry"])
 		if err != nil {
@@ -304,7 +305,7 @@ func (r *ProjectIPAccessListRS) Delete(ctx context.Context, req resource.DeleteR
 		entry = projectIPAccessListModelState.AWSSecurityGroup.ValueString()
 	}
 
-	conn := r.client.Atlas
+	conn := r.Client.Atlas
 	projectID := projectIPAccessListModelState.ProjectID.ValueString()
 
 	timeout, diags := projectIPAccessListModelState.Timeouts.Delete(ctx, projectIPAccessListTimeout)

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	cstmvalidator "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/validator"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -44,12 +44,12 @@ type tfProjectIPAccessListModel struct {
 }
 
 type ProjectIPAccessListRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 func NewProjectIPAccessListRS() resource.Resource {
 	return &ProjectIPAccessListRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: projectIPAccessList,
 		},
 	}

--- a/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_ip_access_list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccProjectRSProjectIPAccesslist_SettingIPAddress(t *testing.T) {
@@ -248,7 +249,7 @@ func TestAccProjectRSProjectIPAccessList_importIncorrectId(t *testing.T) {
 
 func testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -271,7 +272,7 @@ func testAccCheckMongoDBAtlasProjectIPAccessListExists(resourceName string) reso
 }
 
 func testAccCheckMongoDBAtlasProjectIPAccessListDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project_ip_access_list" {

--- a/mongodbatlas/fw_resource_mongodbatlas_project_migration_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_migration_test.go
@@ -1,8 +1,6 @@
 package mongodbatlas
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -11,27 +9,11 @@ import (
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
-
-var _ plancheck.PlanCheck = debugPlan{}
-
-type debugPlan struct{}
-
-func (e debugPlan) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
-	rd, err := json.Marshal(req.Plan)
-	if err != nil {
-		tflog.Debug(ctx, fmt.Sprintf("error marshaling machine-readable plan output: %s", err))
-	}
-	tflog.Info(ctx, fmt.Sprintf("req.Plan - %s\n", string(rd)))
-}
-
-func DebugPlan() plancheck.PlanCheck {
-	return debugPlan{}
-}
 
 func TestAccMigrationProjectRS_NoProps(t *testing.T) {
 	var (
@@ -67,7 +49,7 @@ func TestAccMigrationProjectRS_NoProps(t *testing.T) {
 				  }`, projectName, orgID),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -127,7 +109,7 @@ func TestAccMigrationProjectRS_Teams(t *testing.T) {
 				Config:                   configWithTeams,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -171,7 +153,7 @@ func TestAccMigrationProjectRS_WithFalseDefaultSettings(t *testing.T) {
 				Config:                   configWithTeams,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -224,7 +206,7 @@ func TestAccMigrationProjectRS_WithLimits(t *testing.T) {
 				Config:                   config,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -266,7 +248,7 @@ func TestAccMigrationProjectRSProjectIPAccesslist_SettingIPAddress(t *testing.T)
 				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingIPAddress(orgID, projectName, ipAddress, comment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -308,7 +290,7 @@ func TestAccMigrationProjectRSProjectIPAccessList_SettingCIDRBlock(t *testing.T)
 				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingCIDRBlock(orgID, projectName, cidrBlock, comment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -365,7 +347,7 @@ func TestAccMigrationProjectRSProjectIPAccessList_Multiple_SettingMultiple(t *te
 				Config:                   testAccMongoDBAtlasProjectIPAccessListConfigSettingMultiple(projectName, orgID, accessList, false),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/fw_resource_mongodbatlas_project_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_project_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -443,7 +444,7 @@ func TestAccProjectRSProject_withInvalidLimitNameOnUpdate(t *testing.T) {
 
 func testAccCheckMongoDBAtlasProjectExists(resourceName string, project *matlas.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -476,7 +477,7 @@ func testAccCheckMongoDBAtlasProjectAttributes(project *matlas.Project, projectN
 }
 
 func testAccCheckMongoDBAtlasProjectDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project" {

--- a/mongodbatlas/fw_resource_mongodbatlas_search_deployment.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_search_deployment.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	retrystrategy "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/retry"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
@@ -37,14 +37,14 @@ const (
 
 func NewSearchDeploymentRS() resource.Resource {
 	return &SearchDeploymentRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: searchDeploymentName,
 		},
 	}
 }
 
 type SearchDeploymentRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 type tfSearchDeploymentRSModel struct {

--- a/mongodbatlas/fw_resource_mongodbatlas_search_deployment_test.go
+++ b/mongodbatlas/fw_resource_mongodbatlas_search_deployment_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccSearchDeployment_basic(t *testing.T) {
@@ -124,7 +125,7 @@ func testAccCheckMongoDBAtlasSearchNodeExists(resourceName string) resource.Test
 			return fmt.Errorf("not found: %s", resourceName)
 		}
 
-		connV2 := testAccProviderSdkV2.Meta().(*MongoDBClient).AtlasV2
+		connV2 := testAccProviderSdkV2.Meta().(*client.MongoDBClient).AtlasV2
 		_, _, err := connV2.AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
 		if err != nil {
 			return fmt.Errorf("search deployment (%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
@@ -140,7 +141,7 @@ func testAccCheckMongoDBAtlasSearchNodeDestroy(state *terraform.State) error {
 	if clusterDestroyedErr := testAccCheckMongoDBAtlasAdvancedClusterDestroy(state); clusterDestroyedErr != nil {
 		return clusterDestroyedErr
 	}
-	connV2 := testAccProviderSdkV2.Meta().(*MongoDBClient).AtlasV2
+	connV2 := testAccProviderSdkV2.Meta().(*client.MongoDBClient).AtlasV2
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type == "mongodbatlas_search_deployment" {
 			_, _, err := connV2.AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()

--- a/mongodbatlas/project/fw_data_source_mongodbatlas_project.go
+++ b/mongodbatlas/project/fw_data_source_mongodbatlas_project.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 )
 
 var _ datasource.DataSource = &projectDS{}
@@ -21,14 +21,14 @@ var _ datasource.DataSourceWithConfigure = &projectDS{}
 
 func NewProjectDS() datasource.DataSource {
 	return &projectDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: projectResourceName,
 		},
 	}
 }
 
 type projectDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 type tfProjectDSModel struct {

--- a/mongodbatlas/project/fw_data_source_mongodbatlas_project.go
+++ b/mongodbatlas/project/fw_data_source_mongodbatlas_project.go
@@ -1,4 +1,4 @@
-package mongodbatlas
+package project
 
 import (
 	"context"
@@ -13,21 +13,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 )
 
-var _ datasource.DataSource = &ProjectDS{}
-var _ datasource.DataSourceWithConfigure = &ProjectDS{}
+var _ datasource.DataSource = &projectDS{}
+var _ datasource.DataSourceWithConfigure = &projectDS{}
 
 func NewProjectDS() datasource.DataSource {
-	return &ProjectDS{
-		DSCommon: DSCommon{
-			dataSourceName: projectResourceName,
+	return &projectDS{
+		DSCommon: common.DSCommon{
+			DataSourceName: projectResourceName,
 		},
 	}
 }
 
-type ProjectDS struct {
-	DSCommon
+type projectDS struct {
+	common.DSCommon
 }
 
 type tfProjectDSModel struct {
@@ -53,7 +54,7 @@ type tfTeamDSModel struct {
 	RoleNames types.List   `tfsdk:"role_names"`
 }
 
-func (d *ProjectDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *projectDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -141,10 +142,10 @@ func (d *ProjectDS) Schema(ctx context.Context, req datasource.SchemaRequest, re
 	}
 }
 
-func (d *ProjectDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *projectDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var projectState tfProjectDSModel
-	conn := d.client.Atlas
-	connV2 := d.client.AtlasV2
+	conn := d.Client.Atlas
+	connV2 := d.Client.AtlasV2
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &projectState)...)
 
@@ -162,21 +163,21 @@ func (d *ProjectDS) Read(ctx context.Context, req datasource.ReadRequest, resp *
 		projectID := projectState.ProjectID.ValueString()
 		project, _, err = conn.Projects.GetOneProject(ctx, projectID)
 		if err != nil {
-			resp.Diagnostics.AddError("error when getting project from Atlas", fmt.Sprintf(errorProjectRead, projectID, err.Error()))
+			resp.Diagnostics.AddError("error when getting project from Atlas", fmt.Sprintf(ErrorProjectRead, projectID, err.Error()))
 			return
 		}
 	} else {
 		name := projectState.Name.ValueString()
 		project, _, err = conn.Projects.GetOneProjectByName(ctx, name)
 		if err != nil {
-			resp.Diagnostics.AddError("error when getting project from Atlas", fmt.Sprintf(errorProjectRead, name, err.Error()))
+			resp.Diagnostics.AddError("error when getting project from Atlas", fmt.Sprintf(ErrorProjectRead, name, err.Error()))
 			return
 		}
 	}
 
 	atlasTeams, atlasLimits, atlasProjectSettings, err := getProjectPropsFromAPI(ctx, conn, connV2, project.ID)
 	if err != nil {
-		resp.Diagnostics.AddError("error when getting project properties", fmt.Sprintf(errorProjectRead, project.ID, err.Error()))
+		resp.Diagnostics.AddError("error when getting project properties", fmt.Sprintf(ErrorProjectRead, project.ID, err.Error()))
 		return
 	}
 

--- a/mongodbatlas/project/fw_data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/project/fw_data_source_mongodbatlas_projects.go
@@ -1,4 +1,4 @@
-package mongodbatlas
+package project
 
 import (
 	"context"
@@ -8,25 +8,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const projectsDataSourceName = "projects"
 
-var _ datasource.DataSource = &ProjectsDS{}
-var _ datasource.DataSourceWithConfigure = &ProjectsDS{}
+var _ datasource.DataSource = &projectsDS{}
+var _ datasource.DataSourceWithConfigure = &projectsDS{}
 
 func NewProjectsDS() datasource.DataSource {
-	return &ProjectsDS{
-		DSCommon: DSCommon{
-			dataSourceName: projectsDataSourceName,
+	return &projectsDS{
+		DSCommon: common.DSCommon{
+			DataSourceName: projectsDataSourceName,
 		},
 	}
 }
 
-type ProjectsDS struct {
-	DSCommon
+type projectsDS struct {
+	common.DSCommon
 }
 
 type tfProjectsDSModel struct {
@@ -37,7 +38,7 @@ type tfProjectsDSModel struct {
 	TotalCount   types.Int64         `tfsdk:"total_count"`
 }
 
-func (d *ProjectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *projectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			// https://github.com/hashicorp/terraform-plugin-testing/issues/84#issuecomment-1480006432
@@ -140,10 +141,10 @@ func (d *ProjectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, r
 	}
 }
 
-func (d *ProjectsDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (d *projectsDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var stateModel tfProjectsDSModel
-	conn := d.client.Atlas
-	connV2 := d.client.AtlasV2
+	conn := d.Client.Atlas
+	connV2 := d.Client.AtlasV2
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &stateModel)...)
 	options := &matlas.ListOptions{

--- a/mongodbatlas/project/fw_data_source_mongodbatlas_projects.go
+++ b/mongodbatlas/project/fw_data_source_mongodbatlas_projects.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -20,14 +20,14 @@ var _ datasource.DataSourceWithConfigure = &projectsDS{}
 
 func NewProjectsDS() datasource.DataSource {
 	return &projectsDS{
-		DSCommon: common.DSCommon{
+		DSCommon: framework.DSCommon{
 			DataSourceName: projectsDataSourceName,
 		},
 	}
 }
 
 type projectsDS struct {
-	common.DSCommon
+	framework.DSCommon
 }
 
 type tfProjectsDSModel struct {

--- a/mongodbatlas/project/fw_resource_mongodbatlas_project.go
+++ b/mongodbatlas/project/fw_resource_mongodbatlas_project.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/common"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework"
 	conversion "github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/framework/conversion"
 )
 
@@ -48,14 +48,14 @@ var _ resource.ResourceWithImportState = &projectRS{}
 
 func NewProjectRS() resource.Resource {
 	return &projectRS{
-		RSCommon: common.RSCommon{
+		RSCommon: framework.RSCommon{
 			ResourceName: projectResourceName,
 		},
 	}
 }
 
 type projectRS struct {
-	common.RSCommon
+	framework.RSCommon
 }
 
 type tfProjectRSModel struct {

--- a/mongodbatlas/provider_test.go
+++ b/mongodbatlas/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 
 var testAccProviderV6Factories map[string]func() (tfprotov6.ProviderServer, error)
 
-// only being used in tests obtaining client: .Meta().(*MongoDBClient)
+// only being used in tests obtaining client: .Meta().(*config.MongoDBClient)
 // this provider instance has to be passed into mux server factory for its configure method to be invoked
 var testAccProviderSdkV2 *schema.Provider
 
@@ -36,7 +37,7 @@ func init() {
 		},
 	}
 
-	config := Config{
+	config := client.Config{
 		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),

--- a/mongodbatlas/resource_mongodbatlas_access_list_api_key.go
+++ b/mongodbatlas/resource_mongodbatlas_access_list_api_key.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -71,7 +72,7 @@ func resourceMongoDBAtlasAccessListAPIKey() *schema.Resource {
 }
 
 func resourceMongoDBAtlasAccessListAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 	apiKeyID := d.Get("api_key_id").(string)
 	IPAddress := d.Get("ip_address").(string)
@@ -121,7 +122,7 @@ func resourceMongoDBAtlasAccessListAPIKeyCreate(ctx context.Context, d *schema.R
 
 func resourceMongoDBAtlasAccessListAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
@@ -161,7 +162,7 @@ func resourceMongoDBAtlasAccessListAPIKeyUpdate(ctx context.Context, d *schema.R
 }
 
 func resourceMongoDBAtlasAccessListAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
@@ -174,7 +175,7 @@ func resourceMongoDBAtlasAccessListAPIKeyDelete(ctx context.Context, d *schema.R
 }
 
 func resourceMongoDBAtlasAccessListAPIKeyImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 3)
 	if len(parts) != 3 {

--- a/mongodbatlas/resource_mongodbatlas_access_list_api_key_test.go
+++ b/mongodbatlas/resource_mongodbatlas_access_list_api_key_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
@@ -113,7 +114,7 @@ func TestAccProjectRSAccessListAPIKey_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -136,7 +137,7 @@ func testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName string) resourc
 }
 
 func testAccCheckMongoDBAtlasAccessListAPIKeyDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_access_list_api_key" {

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 )
@@ -382,7 +383,7 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 		}
 	}
 
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 
@@ -501,7 +502,7 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 
 func resourceMongoDBAtlasAdvancedClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -632,7 +633,7 @@ func resourceMongoDBAtlasAdvancedClusterUpdateOrUpgrade(ctx context.Context, d *
 }
 
 func resourceMongoDBAtlasAdvancedClusterUpgrade(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -660,7 +661,7 @@ func resourceMongoDBAtlasAdvancedClusterUpgrade(ctx context.Context, d *schema.R
 
 func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -789,7 +790,7 @@ func resourceMongoDBAtlasAdvancedClusterUpdate(ctx context.Context, d *schema.Re
 
 func resourceMongoDBAtlasAdvancedClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -827,7 +828,7 @@ func resourceMongoDBAtlasAdvancedClusterDelete(ctx context.Context, d *schema.Re
 }
 
 func resourceMongoDBAtlasAdvancedClusterImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, name, err := splitSClusterAdvancedImportID(d.Id())
 	if err != nil {
@@ -1267,9 +1268,9 @@ func flattenAdvancedReplicationSpecAutoScaling(apiObject *matlas.AdvancedAutoSca
 	return tfList
 }
 
-func resourceClusterAdvancedRefreshFunc(ctx context.Context, name, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceClusterAdvancedRefreshFunc(ctx context.Context, name, projectID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		c, resp, err := client.AdvancedClusters.Get(ctx, projectID, name)
+		c, resp, err := conn.AdvancedClusters.Get(ctx, projectID, name)
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil
@@ -1297,9 +1298,9 @@ func resourceClusterAdvancedRefreshFunc(ctx context.Context, name, projectID str
 	}
 }
 
-func resourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		clusters, resp, err := client.AdvancedClusters.List(ctx, projectID, nil)
+		clusters, resp, err := conn.AdvancedClusters.List(ctx, projectID, nil)
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_migration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_migration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -47,7 +48,7 @@ func TestAccMigrationAdvancedClusterRS_singleAWSProvider(t *testing.T) {
 				Config:                   testAccMongoDBAtlasAdvancedClusterConfigSingleProvider(orgID, projectName, rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,
@@ -93,7 +94,7 @@ func TestAccMigrationAdvancedClusterRS_multiCloud(t *testing.T) {
 				Config:                   testAccMongoDBAtlasAdvancedClusterConfigMultiCloud(orgID, projectName, rName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_advanced_cluster_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -679,7 +680,7 @@ var tagsMap3 = map[string]string{
 
 func testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName string, cluster *matlas.AdvancedCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -734,7 +735,7 @@ func testAccCheckMongoDBAtlasAdvancedClusterAnalyticsScaling(cluster *matlas.Adv
 }
 
 func testAccCheckMongoDBAtlasAdvancedClusterDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_advanced_cluster" {

--- a/mongodbatlas/resource_mongodbatlas_api_key.go
+++ b/mongodbatlas/resource_mongodbatlas_api_key.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -56,7 +57,7 @@ func resourceMongoDBAtlasAPIKey() *schema.Resource {
 }
 
 func resourceMongoDBAtlasAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 	createRequest := new(matlas.APIKeyInput)
 
@@ -88,7 +89,7 @@ func resourceMongoDBAtlasAPIKeyCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceMongoDBAtlasAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
@@ -123,7 +124,7 @@ func resourceMongoDBAtlasAPIKeyRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceMongoDBAtlasAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
@@ -145,7 +146,7 @@ func resourceMongoDBAtlasAPIKeyUpdate(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceMongoDBAtlasAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
@@ -158,7 +159,7 @@ func resourceMongoDBAtlasAPIKeyDelete(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceMongoDBAtlasAPIKeyImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_api_key_test.go
+++ b/mongodbatlas/resource_mongodbatlas_api_key_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccConfigRSAPIKey_Basic(t *testing.T) {
@@ -78,7 +79,7 @@ func TestAccConfigRSAPIKey_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAPIKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -101,7 +102,7 @@ func testAccCheckMongoDBAtlasAPIKeyExists(resourceName string) resource.TestChec
 }
 
 func testAccCheckMongoDBAtlasAPIKeyDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_api_key" {

--- a/mongodbatlas/resource_mongodbatlas_auditing.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -56,7 +57,7 @@ func resourceMongoDBAtlasAuditing() *schema.Resource {
 }
 
 func resourceMongoDBAtlasAuditingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	auditingReq := &matlas.Auditing{}
@@ -84,7 +85,7 @@ func resourceMongoDBAtlasAuditingCreate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceMongoDBAtlasAuditingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	auditing, resp, err := conn.Auditing.Get(context.Background(), d.Id())
 	if err != nil {
@@ -117,7 +118,7 @@ func resourceMongoDBAtlasAuditingRead(ctx context.Context, d *schema.ResourceDat
 
 func resourceMongoDBAtlasAuditingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	auditingReq := &matlas.Auditing{}
 
@@ -143,7 +144,7 @@ func resourceMongoDBAtlasAuditingUpdate(ctx context.Context, d *schema.ResourceD
 
 func resourceMongoDBAtlasAuditingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	auditingReq := &matlas.Auditing{}
 

--- a/mongodbatlas/resource_mongodbatlas_auditing_test.go
+++ b/mongodbatlas/resource_mongodbatlas_auditing_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -104,7 +105,7 @@ func TestAccAdvRSAuditing_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAuditingExists(resourceName string, auditing *matlas.Auditing) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -127,7 +128,7 @@ func testAccCheckMongoDBAtlasAuditingExists(resourceName string, auditing *matla
 }
 
 func testAccCheckMongoDBAtlasAuditingDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_auditing" {

--- a/mongodbatlas/resource_mongodbatlas_backup_compliance_policy.go
+++ b/mongodbatlas/resource_mongodbatlas_backup_compliance_policy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -216,7 +217,7 @@ func resourceMongoDBAtlasBackupCompliancePolicy() *schema.Resource {
 }
 
 func resourceMongoDBAtlasBackupCompliancePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	backupPolicy := matlas.BackupCompliancePolicy{}
@@ -300,7 +301,7 @@ func resourceMongoDBAtlasBackupCompliancePolicyCreate(ctx context.Context, d *sc
 
 func resourceMongoDBAtlasBackupCompliancePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -375,7 +376,7 @@ func resourceMongoDBAtlasBackupCompliancePolicyRead(ctx context.Context, d *sche
 }
 
 func resourceMongoDBAtlasBackupCompliancePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -473,7 +474,7 @@ func resourceMongoDBAtlasBackupCompliancePolicyDelete(ctx context.Context, d *sc
 }
 
 func resourceMongoDBAtlasBackupCompliancePolicyImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 1 {

--- a/mongodbatlas/resource_mongodbatlas_backup_compliance_policy_test.go
+++ b/mongodbatlas/resource_mongodbatlas_backup_compliance_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccGenericBackupRSBackupCompliancePolicy_basic(t *testing.T) {
@@ -109,7 +110,7 @@ func TestAccGenericBackupRSBackupCompliancePolicy_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -133,7 +134,7 @@ func testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName string) r
 }
 
 func testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_backup_compliance_policy" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -281,7 +282,7 @@ func resourceMongoDBAtlasCloudBackupSchedule() *schema.Resource {
 
 func resourceMongoDBAtlasCloudBackupScheduleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -313,7 +314,7 @@ func resourceMongoDBAtlasCloudBackupScheduleCreate(ctx context.Context, d *schem
 
 func resourceMongoDBAtlasCloudBackupScheduleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -384,7 +385,7 @@ func resourceMongoDBAtlasCloudBackupScheduleRead(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasCloudBackupScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -406,7 +407,7 @@ func resourceMongoDBAtlasCloudBackupScheduleUpdate(ctx context.Context, d *schem
 
 func resourceMongoDBAtlasCloudBackupScheduleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -422,7 +423,7 @@ func resourceMongoDBAtlasCloudBackupScheduleDelete(ctx context.Context, d *schem
 }
 
 func resourceMongoDBAtlasCloudBackupScheduleImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_schedule_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -393,7 +394,7 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -418,7 +419,7 @@ func testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName string) reso
 }
 
 func testAccCheckMongoDBAtlasCloudBackupScheduleDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_schedule" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -125,7 +126,7 @@ func resourceMongoDBAtlasCloudBackupSnapshot() *schema.Resource {
 
 func resourceMongoDBAtlasCloudBackupSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
@@ -201,7 +202,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRead(ctx context.Context, d *schema.
 
 func resourceMongoDBAtlasCloudBackupSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		GroupID:     d.Get("project_id").(string),
@@ -261,7 +262,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotCreate(ctx context.Context, d *schem
 
 func resourceMongoDBAtlasCloudBackupSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
@@ -278,9 +279,9 @@ func resourceMongoDBAtlasCloudBackupSnapshotDelete(ctx context.Context, d *schem
 	return nil
 }
 
-func resourceCloudBackupSnapshotRefreshFunc(ctx context.Context, requestParameters *matlas.SnapshotReqPathParameters, client *matlas.Client) retry.StateRefreshFunc {
+func resourceCloudBackupSnapshotRefreshFunc(ctx context.Context, requestParameters *matlas.SnapshotReqPathParameters, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		c, resp, err := client.CloudProviderSnapshots.GetOneCloudProviderSnapshot(ctx, requestParameters)
+		c, resp, err := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(ctx, requestParameters)
 
 		switch {
 		case err != nil:
@@ -300,7 +301,7 @@ func resourceCloudBackupSnapshotRefreshFunc(ctx context.Context, requestParamete
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters, err := splitSnapshotImportID(d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_bucket_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -67,7 +68,7 @@ func TestAccBackupRSBackupSnapshotExportBucket_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName string, snapshotExportBucket *matlas.CloudProviderSnapshotExportBucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -91,7 +92,7 @@ func testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName strin
 }
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_bucket" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -120,7 +121,7 @@ func returnCloudBackupSnapshotExportJobSchema() map[string]*schema.Schema {
 
 func resourceMongoDBAtlasCloudBackupSnapshotExportJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -229,7 +230,7 @@ func flattenExportJobsCustomData(data []*matlas.CloudProviderSnapshotExportJobCu
 
 func resourceMongoDBAtlasCloudBackupSnapshotExportJobCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -269,7 +270,7 @@ func expandExportJobCustomData(d *schema.ResourceData) []*matlas.CloudProviderSn
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotExportJobImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_export_job_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -67,7 +68,7 @@ func TestAccBackupRSBackupSnapshotExportJob_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportJobExists(resourceName string, snapshotExportJob *matlas.CloudProviderSnapshotExportJob) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -91,7 +92,7 @@ func testAccCheckMongoDBAtlasBackupSnapshotExportJobExists(resourceName string, 
 }
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_job" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -129,7 +130,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJob() *schema.Resource {
 
 func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
 		GroupID:     d.Get("project_id").(string),
@@ -159,7 +160,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobCreate(ctx context.Context
 
 func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
@@ -214,7 +215,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobRead(ctx context.Context, 
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	requestParameters := &matlas.SnapshotReqPathParameters{
@@ -247,7 +248,7 @@ func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobDelete(ctx context.Context
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotRestoreJobImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, clusterName, snapshotJobID, err := splitSnapshotRestoreJobImportID(d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_restore_job_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -112,7 +113,7 @@ func TestAccBackupRSCloudBackupSnapshotRestoreJobWithPointTime_basic(t *testing.
 
 func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobExists(resourceName string, cloudBackupSnapshotRestoreJob *matlas.CloudProviderSnapshotRestoreJob) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -153,7 +154,7 @@ func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobAttributes(cloudBackup
 }
 
 func testAccCheckMongoDBAtlasCloudBackupSnapshotRestoreJobDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot_restore_job" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_backup_snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -61,7 +62,7 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCloudBackupSnapshotExists(resourceName string, cloudBackupSnapshot *matlas.CloudProviderSnapshot) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -103,7 +104,7 @@ func testAccCheckMongoDBAtlasCloudBackupSnapshotAttributes(cloudBackupSnapshot *
 }
 
 func testAccCheckMongoDBAtlasCloudBackupSnapshotDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot" {

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -83,7 +84,7 @@ func resourceMongoDBAtlasCloudProviderAccess() *schema.Resource {
 func resourceMongoDBAtlasCloudProviderAccessCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	projectID := d.Get("project_id").(string)
 
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.CloudProviderAccessRoleRequest{
 		ProviderName: d.Get("provider_name").(string),
@@ -114,7 +115,7 @@ func resourceMongoDBAtlasCloudProviderAccessCreate(ctx context.Context, d *schem
 
 func resourceMongoDBAtlasCloudProviderAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// sadly there is no just get API
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	roleID := ids["id"]
@@ -140,7 +141,7 @@ func resourceMongoDBAtlasCloudProviderAccessRead(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasCloudProviderAccessUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]
@@ -170,7 +171,7 @@ func resourceMongoDBAtlasCloudProviderAccessUpdate(ctx context.Context, d *schem
 }
 
 func resourceMongoDBAtlasCloudProviderAccessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_setup.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_setup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -91,7 +92,7 @@ func resourceMongoDBAtlasCloudProviderAccessSetup() *schema.Resource {
 }
 
 func resourceMongoDBAtlasCloudProviderAccessSetupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	roleID := ids["id"]
@@ -119,7 +120,7 @@ func resourceMongoDBAtlasCloudProviderAccessSetupRead(ctx context.Context, d *sc
 func resourceMongoDBAtlasCloudProviderAccessSetupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	projectID := d.Get("project_id").(string)
 
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	requestParameters := &matlas.CloudProviderAccessRoleRequest{
 		ProviderName: d.Get("provider_name").(string),
@@ -178,7 +179,7 @@ func resourceMongoDBAtlasCloudProviderAccessSetupCreate(ctx context.Context, d *
 }
 
 func resourceMongoDBAtlasCloudProviderAccessSetupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]

--- a/mongodbatlas/resource_mongodbatlas_cloud_provider_access_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cloud_provider_access_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -89,7 +90,7 @@ func testAccCheckMongoDBAtlasCloudProviderAccessImportStateIDFunc(resourceName s
 }
 
 func testAccCheckMongoDBAtlasProviderAccessDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_provider_access" {
 			continue
@@ -125,7 +126,7 @@ func testAccCheckMongoDBAtlasProviderAccessDestroy(s *terraform.State) error {
 
 func testAccCheckMongoDBAtlasProviderAccessExists(resourceName string, targetRole *matlas.CloudProviderAccessRole) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -78,7 +79,7 @@ func resourceMongoDBAtlasClusterOutageSimulation() *schema.Resource {
 }
 
 func resourceMongoDBClusterOutageSimulationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
@@ -131,7 +132,7 @@ func newOutageFilters(d *schema.ResourceData) []matlas.ClusterOutageSimulationOu
 }
 
 func resourceMongoDBAClusterOutageSimulationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -159,7 +160,7 @@ func resourceMongoDBAClusterOutageSimulationRead(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasClusterOutageSimulationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -193,9 +194,9 @@ func resourceMongoDBClusterOutageSimulationUpdate(ctx context.Context, d *schema
 	return diag.FromErr(fmt.Errorf("updating a Cluster Outage Simulation is not supported"))
 }
 
-func resourceClusterOutageSimulationRefreshFunc(ctx context.Context, clusterName, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceClusterOutageSimulationRefreshFunc(ctx context.Context, clusterName, projectID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		outageSimulation, resp, err := client.ClusterOutageSimulation.GetOutageSimulation(ctx, projectID, clusterName)
+		outageSimulation, resp, err := conn.ClusterOutageSimulation.GetOutageSimulation(ctx, projectID, clusterName)
 
 		if err != nil {
 			if resp.StatusCode == 404 {

--- a/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_outage_simulation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
@@ -148,7 +149,7 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(proje
 }
 
 func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster_outage_simulation" {

--- a/mongodbatlas/resource_mongodbatlas_cluster_test.go
+++ b/mongodbatlas/resource_mongodbatlas_cluster_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -1475,7 +1476,7 @@ func testAccGetMongoDBAtlasMajorVersion() string {
 
 func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -1510,7 +1511,7 @@ func testAccCheckMongoDBAtlasClusterAttributes(cluster *matlas.Cluster, name str
 }
 
 func testAccCheckMongoDBAtlasClusterDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster" {

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -109,7 +110,7 @@ var (
 func resourceMongoDBAtlasCustomDBRoleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	customRoleLock.Lock()
 	defer customRoleLock.Unlock()
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	customDBRoleReq := &matlas.CustomDBRole{
@@ -156,7 +157,7 @@ func resourceMongoDBAtlasCustomDBRoleCreate(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasCustomDBRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	roleName := ids["role_name"]
@@ -189,7 +190,7 @@ func resourceMongoDBAtlasCustomDBRoleRead(ctx context.Context, d *schema.Resourc
 func resourceMongoDBAtlasCustomDBRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	customRoleLock.Lock()
 	defer customRoleLock.Unlock()
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	roleName := ids["role_name"]
@@ -219,7 +220,7 @@ func resourceMongoDBAtlasCustomDBRoleUpdate(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasCustomDBRoleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	roleName := ids["role_name"]
@@ -259,7 +260,7 @@ func resourceMongoDBAtlasCustomDBRoleDelete(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasCustomDBRoleImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_db_role_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -587,7 +588,7 @@ func TestAccConfigRSCustomDBRoles_UpdatedInheritRoles(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -610,7 +611,7 @@ func testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName string) resource.T
 }
 
 func testAccCheckMongoDBAtlasCustomDBRolesDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_custom_db_role" {

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -43,7 +44,7 @@ func resourceMongoDBAtlasCustomDNSConfiguration() *schema.Resource {
 }
 
 func resourceMongoDBAtlasCustomDNSConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("project_id").(string)
 
 	// Creating(Updating) the Custom DNS Configuration for Atlas Clusters on AWS
@@ -61,7 +62,7 @@ func resourceMongoDBAtlasCustomDNSConfigurationCreate(ctx context.Context, d *sc
 }
 
 func resourceMongoDBAtlasCustomDNSConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	dnsResp, resp, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
 	if err != nil {
@@ -85,7 +86,7 @@ func resourceMongoDBAtlasCustomDNSConfigurationRead(ctx context.Context, d *sche
 }
 
 func resourceMongoDBAtlasCustomDNSConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	if d.HasChange("enabled") {
 		_, _, err := conn.CustomAWSDNS.Update(ctx, d.Id(), &matlas.AWSCustomDNSSetting{
@@ -100,7 +101,7 @@ func resourceMongoDBAtlasCustomDNSConfigurationUpdate(ctx context.Context, d *sc
 }
 
 func resourceMongoDBAtlasCustomDNSConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	_, _, err := conn.CustomAWSDNS.Update(ctx, d.Id(), &matlas.AWSCustomDNSSetting{
 		Enabled: false,

--- a/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
+++ b/mongodbatlas/resource_mongodbatlas_custom_dns_configuration_cluster_aws_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
@@ -82,7 +83,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -102,7 +103,7 @@ func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string
 	}
 }
 func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_custom_dns_configuration_cluster_aws" {

--- a/mongodbatlas/resource_mongodbatlas_data_lake_pipeline.go
+++ b/mongodbatlas/resource_mongodbatlas_data_lake_pipeline.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -254,7 +255,7 @@ func schemaDataLakePipelineSnapshots() *schema.Schema {
 }
 
 func resourceMongoDBAtlasDataLakePipelineCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
 
@@ -280,7 +281,7 @@ func resourceMongoDBAtlasDataLakePipelineCreate(ctx context.Context, d *schema.R
 }
 
 func resourceMongoDBAtlasDataLakePipelineRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	name := ids["name"]
@@ -350,7 +351,7 @@ func resourceMongoDBAtlasDataLakePipelineRead(ctx context.Context, d *schema.Res
 }
 
 func resourceMongoDBAtlasDataLakePipelineUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
 
@@ -371,7 +372,7 @@ func resourceMongoDBAtlasDataLakePipelineUpdate(ctx context.Context, d *schema.R
 }
 
 func resourceMongoDBAtlasDataLakePipelineDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	name := ids["name"]
@@ -385,7 +386,7 @@ func resourceMongoDBAtlasDataLakePipelineDelete(ctx context.Context, d *schema.R
 }
 
 func resourceMongoDBAtlasDataLakePipelineImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, name, err := splitDataLakePipelineImportID(d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_data_lake_pipeline_test.go
+++ b/mongodbatlas/resource_mongodbatlas_data_lake_pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -59,7 +60,7 @@ func testAccCheckMongoDBAtlasDataLakePipelineImportStateIDFunc(resourceName stri
 
 func testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName string, pipeline *matlas.DataLakePipeline) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_event_trigger.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	"go.mongodb.org/realm/realm"
@@ -211,7 +212,7 @@ func resourceMongoDBAtlasEventTriggers() *schema.Resource {
 }
 
 func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -313,7 +314,7 @@ func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -404,7 +405,7 @@ func resourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.Resour
 
 func resourceMongoDBAtlasEventTriggersUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -458,7 +459,7 @@ func resourceMongoDBAtlasEventTriggersUpdate(ctx context.Context, d *schema.Reso
 
 func resourceMongoDBAtlasEventTriggersDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -519,7 +520,7 @@ func flattenTriggerEventProcessorAWSEventBridge(eventProcessor map[string]any) [
 }
 
 func resourceMongoDBAtlasEventTriggerImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn, err := meta.(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := meta.(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
+++ b/mongodbatlas/resource_mongodbatlas_event_trigger_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"github.com/mwielbut/pointy"
 	"go.mongodb.org/realm/realm"
@@ -430,7 +431,7 @@ func TestEventTriggerFunction_basic(t *testing.T) {
 func testAccCheckMongoDBAtlasEventTriggerExists(resourceName string, eventTrigger *realm.EventTrigger) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := context.Background()
-		conn, err := testAccProviderSdkV2.Meta().(*MongoDBClient).GetRealmClient(ctx)
+		conn, err := testAccProviderSdkV2.Meta().(*client.MongoDBClient).GetRealmClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -460,7 +461,7 @@ func testAccCheckMongoDBAtlasEventTriggerExists(resourceName string, eventTrigge
 
 func testAccCheckMongoDBAtlasEventTriggerDestroy(s *terraform.State) error {
 	ctx := context.Background()
-	conn, err := testAccProviderSdkV2.Meta().(*MongoDBClient).GetRealmClient(ctx)
+	conn, err := testAccProviderSdkV2.Meta().(*client.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/mongodbatlas/resource_mongodbatlas_federated_database_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_database_instance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 const (
@@ -336,7 +337,7 @@ func schemaFederatedDatabaseInstanceStores() *schema.Schema {
 }
 
 func resourceMongoDBFederatedDatabaseInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	name := d.Get("name").(string)
@@ -359,7 +360,7 @@ func resourceMongoDBFederatedDatabaseInstanceCreate(ctx context.Context, d *sche
 }
 
 func resourceMongoDBAFederatedDatabaseInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	name := ids["name"]
@@ -407,7 +408,7 @@ func resourceMongoDBAFederatedDatabaseInstanceRead(ctx context.Context, d *schem
 }
 
 func resourceMongoDBFederatedDatabaseInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -433,7 +434,7 @@ func resourceMongoDBFederatedDatabaseInstanceUpdate(ctx context.Context, d *sche
 }
 
 func resourceMongoDBAtlasFederatedDatabaseInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -447,7 +448,7 @@ func resourceMongoDBAtlasFederatedDatabaseInstanceDelete(ctx context.Context, d 
 }
 
 func resourceMongoDBAtlasFederatedDatabaseInstanceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	projectID, name, s3Bucket, err := splitDataFederatedInstanceImportID(d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_federated_database_instance_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_database_instance_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
@@ -264,7 +265,7 @@ func testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFunc(resource
 }
 
 func testAccCheckMongoDBAtlasFederatedDatabaseInstanceDestroy(s *terraform.State) error {
-	connV2 := testAccProviderSdkV2.Meta().(*MongoDBClient).AtlasV2
+	connV2 := testAccProviderSdkV2.Meta().(*client.MongoDBClient).AtlasV2
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_federated_database_instance" {

--- a/mongodbatlas/resource_mongodbatlas_federated_query_limit.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_query_limit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -71,7 +72,7 @@ func resourceMongoDBAtlasFederatedDatabaseQueryLimit() *schema.Resource {
 }
 
 func resourceMongoDBFederatedDatabaseQueryLimitCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get(string("project_id")).(string)
 	tenantName := d.Get("tenant_name").(string)
@@ -96,7 +97,7 @@ func resourceMongoDBFederatedDatabaseQueryLimitCreate(ctx context.Context, d *sc
 }
 
 func resourceMongoDBFederatedDatabaseQueryLimitRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	tenantName := ids["tenant_name"]
@@ -125,7 +126,7 @@ func resourceMongoDBFederatedDatabaseQueryLimitRead(ctx context.Context, d *sche
 }
 
 func resourceMongoDBFederatedDatabaseQueryLimitUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -145,7 +146,7 @@ func resourceMongoDBFederatedDatabaseQueryLimitUpdate(ctx context.Context, d *sc
 }
 
 func resourceMongoDBFederatedDatabaseQueryLimitDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -160,7 +161,7 @@ func resourceMongoDBFederatedDatabaseQueryLimitDelete(ctx context.Context, d *sc
 }
 
 func resourceMongoDBAtlasFederatedDatabaseQueryLimitImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	parts := strings.Split(d.Id(), "--")
 
 	var projectID, tenantName, limitName string

--- a/mongodbatlas/resource_mongodbatlas_federated_query_limit_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_query_limit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccFederatedDatabaseQueryLimit_basic(t *testing.T) {
@@ -206,7 +207,7 @@ func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitImportStateIDFunc(resour
 }
 
 func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_federated_query_limit" {

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_connected_organization.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_connected_organization.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 )
 
@@ -58,7 +59,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationConfig() *schema.Resource 
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	if d.Id() == "" {
 		d.SetId("")
@@ -102,7 +103,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationConfigRead(ctx context.Con
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
 	orgID := ids["org_id"]
@@ -142,7 +143,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationConfigUpdate(ctx context.C
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
 	orgID := ids["org_id"]
@@ -156,7 +157,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationConfigDelete(ctx context.C
 }
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationConfigImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	federationSettingsID, orgID, err := splitFederatedSettingsOrganizationConfigImportID(d.Id())
 	if err != nil {
 		return nil, err

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_connected_organization_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_connected_organization_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -75,7 +76,7 @@ func TestAccFedRSFederatedSettingsOrganizationConfig_importBasic(t *testing.T) {
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigRExists(resourceName string,
 	federatedSettingsIdentityProvider *matlas.FederatedSettingsConnectedOrganization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_identity_provider.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_identity_provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 )
 
@@ -71,7 +72,7 @@ func resourceMongoDBAtlasFederatedSettingsIdentityProvider() *schema.Resource {
 
 func resourceMongoDBAtlasFederatedSettingsIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	if d.Id() == "" {
 		d.SetId("")
@@ -136,7 +137,7 @@ func resourceMongoDBAtlasFederatedSettingsIdentityProviderRead(ctx context.Conte
 
 func resourceMongoDBAtlasFederatedSettingsIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
 	oktaIdpID := ids["okta_idp_id"]
@@ -202,7 +203,7 @@ func resourceMongoDBAtlasFederatedSettingsIdentityProviderDelete(ctx context.Con
 }
 
 func resourceMongoDBAtlasFederatedSettingsIdentityProviderImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	federationSettingsID, oktaIdpID, err := splitFederatedSettingsIdentityProviderImportID(d.Id())
 	if err != nil {
 		return nil, err

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_identity_provider_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_identity_provider_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -77,7 +78,7 @@ func TestAccFedRSFederatedSettingsIdentityProvider_importBasic(t *testing.T) {
 func testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderExists(resourceName string,
 	federatedSettingsIdentityProvider *matlas.FederatedSettingsIdentityProvider, idpID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_organization_role_mapping.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_organization_role_mapping.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -70,7 +71,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMapping() *schema.Reso
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
@@ -109,7 +110,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingRead(ctx contex
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	federationSettingsID, federationSettingsIDOk := d.GetOk("federation_settings_id")
 
 	if !federationSettingsIDOk {
@@ -160,7 +161,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingCreate(ctx cont
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
 	orgID := ids["org_id"]
@@ -199,7 +200,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingUpdate(ctx cont
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	federationSettingsID := ids["federation_settings_id"]
 	orgID := ids["org_id"]
@@ -214,7 +215,7 @@ func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingDelete(ctx cont
 }
 
 func resourceMongoDBAtlasFederatedSettingsOrganizationRoleMappingImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	federationSettingsID, orgID, roleMappingID, err := splitFederatedSettingsOrganizationRoleMappingImportID(d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_federated_settings_organization_role_mapping_test.go
+++ b/mongodbatlas/resource_mongodbatlas_federated_settings_organization_role_mapping_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -68,7 +69,7 @@ func TestAccFedRSFederatedSettingsOrganizationRoleMapping_importBasic(t *testing
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingExists(resourceName string,
 	federatedSettingsOrganizationRoleMapping *matlas.FederatedSettingsOrganizationRoleMapping) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -94,7 +95,7 @@ func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingExists(reso
 }
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_federated_settings_org_role_mapping" {

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -101,7 +102,7 @@ func resourceMongoDBAtlasGlobalCluster() *schema.Resource {
 
 func resourceMongoDBAtlasGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -169,7 +170,7 @@ func resourceMongoDBAtlasGlobalClusterCreate(ctx context.Context, d *schema.Reso
 
 func resourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -197,7 +198,7 @@ func resourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.Resour
 
 func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -258,7 +259,7 @@ func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.Reso
 
 func resourceMongoDBAtlasGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]

--- a/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
+++ b/mongodbatlas/resource_mongodbatlas_global_cluster_config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -207,7 +208,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 
 func testAccCheckMongoDBAtlasGlobalClusterExists(resourceName string, globalConfig *matlas.GlobalCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -257,7 +258,7 @@ func testAccCheckMongoDBAtlasGlobalClusterAttributes(globalCluster *matlas.Globa
 }
 
 func testAccCheckMongoDBAtlasGlobalClusterDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_global_cluster_config" {

--- a/mongodbatlas/resource_mongodbatlas_ldap_configuration.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_configuration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -99,7 +100,7 @@ func resourceMongoDBAtlasLDAPConfiguration() *schema.Resource {
 }
 
 func resourceMongoDBAtlasLDAPConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	ldap := &matlas.LDAP{}
@@ -155,7 +156,7 @@ func resourceMongoDBAtlasLDAPConfigurationCreate(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasLDAPConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ldapResp, resp, err := conn.LDAPConfigurations.Get(context.Background(), d.Id())
 	if err != nil {
@@ -197,7 +198,7 @@ func resourceMongoDBAtlasLDAPConfigurationRead(ctx context.Context, d *schema.Re
 
 func resourceMongoDBAtlasLDAPConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ldap := &matlas.LDAP{}
 
@@ -251,7 +252,7 @@ func resourceMongoDBAtlasLDAPConfigurationUpdate(ctx context.Context, d *schema.
 
 func resourceMongoDBAtlasLDAPConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	_, _, err := conn.LDAPConfigurations.Delete(ctx, d.Id())
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorLDAPConfigurationDelete, d.Id(), err))

--- a/mongodbatlas/resource_mongodbatlas_ldap_configuration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_configuration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -142,7 +143,7 @@ func TestAccAdvRSLDAPConfiguration_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -165,7 +166,7 @@ func testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName string, ldapCo
 }
 
 func testAccCheckMongoDBAtlasLDAPConfigurationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_ldap_configuration" {

--- a/mongodbatlas/resource_mongodbatlas_ldap_verify.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_verify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -112,7 +113,7 @@ func resourceMongoDBAtlasLDAPVerify() *schema.Resource {
 }
 
 func resourceMongoDBAtlasLDAPVerifyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	ldapReq := &matlas.LDAP{}
@@ -165,7 +166,7 @@ func resourceMongoDBAtlasLDAPVerifyCreate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceMongoDBAtlasLDAPVerifyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -237,7 +238,7 @@ func flattenValidations(validationsArray []*matlas.LDAPValidation) []map[string]
 }
 
 func resourceMongoDBAtlasLDAPVerifyImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {
@@ -268,9 +269,9 @@ func resourceMongoDBAtlasLDAPVerifyImportState(ctx context.Context, d *schema.Re
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceLDAPGetStatusRefreshFunc(ctx context.Context, projectID, requestID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceLDAPGetStatusRefreshFunc(ctx context.Context, projectID, requestID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		p, resp, err := client.LDAPConfigurations.GetStatus(ctx, projectID, requestID)
+		p, resp, err := conn.LDAPConfigurations.GetStatus(ctx, projectID, requestID)
 		if err != nil {
 			if resp.Response.StatusCode == 404 {
 				return "", "DELETED", nil

--- a/mongodbatlas/resource_mongodbatlas_ldap_verify_test.go
+++ b/mongodbatlas/resource_mongodbatlas_ldap_verify_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -137,7 +138,7 @@ func TestAccAdvRSLDAPVerify_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -160,7 +161,7 @@ func testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName string, ldapConf *mat
 }
 
 func testAccCheckMongoDBAtlasLDAPVerifyDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_ldap_verify" {

--- a/mongodbatlas/resource_mongodbatlas_maintenance_window.go
+++ b/mongodbatlas/resource_mongodbatlas_maintenance_window.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -90,7 +91,7 @@ func resourceMongoDBAtlasMaintenanceWindow() *schema.Resource {
 
 func resourceMongoDBAtlasMaintenanceWindowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 
@@ -138,7 +139,7 @@ func resourceMongoDBAtlasMaintenanceWindowCreate(ctx context.Context, d *schema.
 
 func resourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	maintenanceWindow, resp, err := conn.MaintenanceWindows.Get(context.Background(), d.Id())
 	if err != nil {
@@ -183,7 +184,7 @@ func resourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.Re
 
 func resourceMongoDBAtlasMaintenanceWindowUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	maintenanceWindowReq := &matlas.MaintenanceWindow{}
 
@@ -227,7 +228,7 @@ func resourceMongoDBAtlasMaintenanceWindowUpdate(ctx context.Context, d *schema.
 
 func resourceMongoDBAtlasMaintenanceWindowDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	_, err := conn.MaintenanceWindows.Reset(ctx, d.Id())
 	if err != nil {

--- a/mongodbatlas/resource_mongodbatlas_maintenance_window_test.go
+++ b/mongodbatlas/resource_mongodbatlas_maintenance_window_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -147,7 +148,7 @@ func testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectNa
 
 func testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName string, maintenance *matlas.MaintenanceWindow) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_network_container_test.go
+++ b/mongodbatlas/resource_mongodbatlas_network_container_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -229,7 +230,7 @@ func testAccCheckMongoDBAtlasNetworkContainerImportStateIDFunc(resourceName stri
 
 func testAccCheckMongoDBAtlasNetworkContainerExists(resourceName string, container *matlas.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -262,7 +263,7 @@ func testAccCheckMongoDBAtlasNetworkContainerAttributes(container *matlas.Contai
 }
 
 func testAccCheckMongoDBAtlasNetworkContainerDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_container" {

--- a/mongodbatlas/resource_mongodbatlas_network_peering_test.go
+++ b/mongodbatlas/resource_mongodbatlas_network_peering_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -212,7 +213,7 @@ func testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName string
 
 func testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName string, peer *matlas.Peer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -238,7 +239,7 @@ func testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName string, peer *mat
 }
 
 func testAccCheckMongoDBAtlasNetworkPeeringDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_network_peering" {

--- a/mongodbatlas/resource_mongodbatlas_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_online_archive_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccBackupRSOnlineArchive(t *testing.T) {
@@ -167,7 +168,7 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 
 func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_org_invitation.go
+++ b/mongodbatlas/resource_mongodbatlas_org_invitation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -66,7 +67,7 @@ func resourceMongoDBAtlasOrgInvitation() *schema.Resource {
 
 func resourceMongoDBAtlasOrgInvitationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	username := ids["username"]
@@ -79,7 +80,7 @@ func resourceMongoDBAtlasOrgInvitationRead(ctx context.Context, d *schema.Resour
 			// deleted in the backend case
 
 			if strings.Contains(err.Error(), "404") {
-				accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*MongoDBClient), username, orgID)
+				accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*client.MongoDBClient), username, orgID)
 				if accepted {
 					d.SetId("")
 					return nil
@@ -133,7 +134,7 @@ func resourceMongoDBAtlasOrgInvitationRead(ctx context.Context, d *schema.Resour
 
 func resourceMongoDBAtlasOrgInvitationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 
 	invitationReq := &matlas.Invitation{
@@ -142,7 +143,7 @@ func resourceMongoDBAtlasOrgInvitationCreate(ctx context.Context, d *schema.Reso
 		Username: d.Get("username").(string),
 	}
 
-	accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*MongoDBClient), invitationReq.Username, orgID)
+	accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*client.MongoDBClient), invitationReq.Username, orgID)
 	if accepted {
 		d.SetId(encodeStateID(map[string]string{
 			"username":      invitationReq.Username,
@@ -165,7 +166,7 @@ func resourceMongoDBAtlasOrgInvitationCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasOrgInvitationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	username := ids["username"]
@@ -177,7 +178,7 @@ func resourceMongoDBAtlasOrgInvitationDelete(ctx context.Context, d *schema.Reso
 		// deleted in the backend case
 
 		if strings.Contains(err.Error(), "404") {
-			accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*MongoDBClient), username, orgID)
+			accepted, _ := validateOrgInvitationAlreadyAccepted(ctx, meta.(*client.MongoDBClient), username, orgID)
 			if accepted {
 				d.SetId("")
 				return nil
@@ -194,7 +195,7 @@ func resourceMongoDBAtlasOrgInvitationDelete(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasOrgInvitationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	username := ids["username"]
@@ -213,7 +214,7 @@ func resourceMongoDBAtlasOrgInvitationUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasOrgInvitationImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID, username, err := splitOrgInvitationImportID(d.Id())
 	if err != nil {
 		return nil, err
@@ -264,7 +265,7 @@ func splitOrgInvitationImportID(id string) (orgID, username string, err error) {
 	return
 }
 
-func validateOrgInvitationAlreadyAccepted(ctx context.Context, conn *MongoDBClient, username, orgID string) (bool, error) {
+func validateOrgInvitationAlreadyAccepted(ctx context.Context, conn *client.MongoDBClient, username, orgID string) (bool, error) {
 	user, _, err := conn.Atlas.AtlasUsers.GetByName(ctx, username)
 	if err != nil {
 		return false, err

--- a/mongodbatlas/resource_mongodbatlas_org_invitation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_org_invitation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -92,7 +93,7 @@ func TestAccConfigRSOrgInvitation_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasOrgInvitationExists(t *testing.T, resourceName string, invitation *matlas.Invitation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -148,7 +149,7 @@ func testAccCheckMongoDBAtlasOrgInvitationRoleAttribute(invitation *matlas.Invit
 }
 
 func testAccCheckMongoDBAtlasOrgInvitationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_invitations" {

--- a/mongodbatlas/resource_mongodbatlas_organization.go
+++ b/mongodbatlas/resource_mongodbatlas_organization.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -64,7 +65,7 @@ func resourceMongoDBAtlasOrganization() *schema.Resource {
 }
 
 func resourceMongoDBAtlasOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	organization, resp, err := conn.Organizations.Create(ctx, newCreateOrganizationRequest(d))
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -96,14 +97,14 @@ func resourceMongoDBAtlasOrganizationCreate(ctx context.Context, d *schema.Resou
 
 func resourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	config := Config{
+	config := client.Config{
 		PublicKey:  d.Get("public_key").(string),
 		PrivateKey: d.Get("private_key").(string),
-		BaseURL:    meta.(*MongoDBClient).Config.BaseURL,
+		BaseURL:    meta.(*client.MongoDBClient).Config.BaseURL,
 	}
 
 	clients, _ := config.NewClient(ctx)
-	conn := clients.(*MongoDBClient).Atlas
+	conn := clients.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
@@ -125,14 +126,14 @@ func resourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.Resourc
 
 func resourceMongoDBAtlasOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	config := Config{
+	config := client.Config{
 		PublicKey:  d.Get("public_key").(string),
 		PrivateKey: d.Get("private_key").(string),
-		BaseURL:    meta.(*MongoDBClient).Config.BaseURL,
+		BaseURL:    meta.(*client.MongoDBClient).Config.BaseURL,
 	}
 
 	clients, _ := config.NewClient(ctx)
-	conn := clients.(*MongoDBClient).Atlas
+	conn := clients.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 
@@ -149,14 +150,14 @@ func resourceMongoDBAtlasOrganizationUpdate(ctx context.Context, d *schema.Resou
 
 func resourceMongoDBAtlasOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	config := Config{
+	config := client.Config{
 		PublicKey:  d.Get("public_key").(string),
 		PrivateKey: d.Get("private_key").(string),
-		BaseURL:    meta.(*MongoDBClient).Config.BaseURL,
+		BaseURL:    meta.(*client.MongoDBClient).Config.BaseURL,
 	}
 
 	clients, _ := config.NewClient(ctx)
-	conn := clients.(*MongoDBClient).Atlas
+	conn := clients.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 
@@ -167,7 +168,7 @@ func resourceMongoDBAtlasOrganizationDelete(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasOrganizationImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Id()
 
 	r, _, err := conn.Organizations.Get(ctx, orgID)

--- a/mongodbatlas/resource_mongodbatlas_organization_test.go
+++ b/mongodbatlas/resource_mongodbatlas_organization_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -70,7 +71,7 @@ func TestAccConfigRSOrganization_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -99,7 +100,7 @@ func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.Te
 }
 
 func testAccCheckMongoDBAtlasOrganizationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_organization" {

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 type permCtxKey string
@@ -62,7 +63,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeCreate(ctx context.Context, 
 }
 
 func resourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Id()
 
@@ -84,7 +85,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d 
 }
 
 func resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Id()
 	enabled := d.Get("enabled").(bool)
@@ -135,7 +136,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeDelete(ctx context.Context, 
 }
 
 func resourceMongoDBAtlasPrivateEndpointRegionalModeImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Id()
 
 	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)

--- a/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
+++ b/mongodbatlas/resource_mongodbatlas_private_endpoint_regional_mode_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccNetworkRSPrivateEndpointRegionalMode_conn(t *testing.T) {
@@ -146,7 +147,7 @@ func testAccMongoDBAtlasPrivateEndpointRegionalModeConfig(resourceName, projectI
 func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		fmt.Printf("==========================================================================\n")
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 
@@ -173,7 +174,7 @@ func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeExists(resourceName stri
 func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate(projectID, clusterName, clusterResourceName string) resource.TestCheckFunc {
 	resourceName := strings.Join([]string{"data", "mongodbatlas_cluster", clusterResourceName}, ".")
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 
@@ -210,7 +211,7 @@ func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeClustersUpToDate(project
 }
 
 func testAccCheckMongoDBAtlasPrivateEndpointRegionalModeDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_private_endpoint_regional_mode" {

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -113,7 +114,7 @@ func resourceMongoDBAtlasPrivateLinkEndpoint() *schema.Resource {
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	providerName := d.Get("provider_name").(string)
 	region := d.Get("region").(string)
@@ -154,7 +155,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointCreate(ctx context.Context, d *schem
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -228,7 +229,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointRead(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	privateLinkID := ids["private_link_id"]
@@ -264,7 +265,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointDelete(ctx context.Context, d *schem
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.Split(d.Id(), "-")
 
@@ -302,9 +303,9 @@ func resourceMongoDBAtlasPrivateLinkEndpointImportState(ctx context.Context, d *
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourcePrivateLinkEndpointRefreshFunc(ctx context.Context, client *matlas.Client, projectID, providerName, privateLinkID string) retry.StateRefreshFunc {
+func resourcePrivateLinkEndpointRefreshFunc(ctx context.Context, conn *matlas.Client, projectID, providerName, privateLinkID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		p, resp, err := client.PrivateEndpoints.Get(ctx, projectID, providerName, privateLinkID)
+		p, resp, err := conn.PrivateEndpoints.Get(ctx, projectID, providerName, privateLinkID)
 		if err != nil {
 			if resp.Response.StatusCode == 404 {
 				return "", "DELETED", nil

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 const (
@@ -72,7 +73,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerless() *schema.Resource {
 
 func resourceMongoDBAtlasPrivateLinkEndpointServerlessCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 
@@ -111,7 +112,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessCreate(ctx context.Context
 
 func resourceMongoDBAtlasPrivateLinkEndpointServerlessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
@@ -154,7 +155,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessRead(ctx context.Context, 
 
 func resourceMongoDBAtlasPrivateLinkEndpointServerlessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
@@ -195,7 +196,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessDelete(ctx context.Context
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointServerlessImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
@@ -245,9 +246,9 @@ func resourceMongoDBAtlasPrivateLinkEndpointServerlessImportState(ctx context.Co
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourcePrivateLinkEndpointServerlessRefreshFunc(ctx context.Context, client *matlas.Client, projectID, instanceName, privateLinkID string) retry.StateRefreshFunc {
+func resourcePrivateLinkEndpointServerlessRefreshFunc(ctx context.Context, conn *matlas.Client, projectID, instanceName, privateLinkID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		p, resp, err := client.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, privateLinkID)
+		p, resp, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, privateLinkID)
 		if err != nil {
 			if resp.Response.StatusCode == 404 || resp.Response.StatusCode == 400 {
 				return "", "DELETED", nil

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_serverless_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccServerlessPrivateLinkEndpoint_basic(t *testing.T) {
@@ -66,7 +67,7 @@ func TestAccServerlessPrivateLinkEndpoint_importBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_serverless" {
@@ -99,7 +100,7 @@ func testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, 
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -138,7 +139,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLink() *schema.Resource {
 }
 
 func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	privateLinkID := getEncodedID(d.Get("private_link_id").(string), "private_link_id")
 	providerName := d.Get("provider_name").(string)
@@ -211,7 +212,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkCreate(ctx context.Context, d
 }
 
 func resourceMongoDBAtlasPrivateEndpointServiceLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -281,7 +282,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkRead(ctx context.Context, d *
 }
 
 func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -329,7 +330,7 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkDelete(ctx context.Context, d
 }
 
 func resourceMongoDBAtlasPrivateEndpointServiceLinkImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "--", 4)
 	if len(parts) != 4 {
@@ -372,9 +373,9 @@ func resourceMongoDBAtlasPrivateEndpointServiceLinkImportState(ctx context.Conte
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceServiceEndpointRefreshFunc(ctx context.Context, client *matlas.Client, projectID, providerName, privateLinkID, endpointServiceID string) retry.StateRefreshFunc {
+func resourceServiceEndpointRefreshFunc(ctx context.Context, conn *matlas.Client, projectID, providerName, privateLinkID, endpointServiceID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		i, resp, err := client.PrivateEndpoints.GetOnePrivateEndpoint(ctx, projectID, providerName, privateLinkID, endpointServiceID)
+		i, resp, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(ctx, projectID, providerName, privateLinkID, endpointServiceID)
 		if err != nil {
 			if resp != nil && resp.StatusCode == 404 {
 				return "", "DELETED", nil

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 const (
@@ -64,7 +65,7 @@ func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive()
 }
 
 func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	endpointID := d.Get("endpoint_id").(string)
 
@@ -82,7 +83,7 @@ func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveCr
 }
 
 func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	endopointID := ids["endpoint_id"]
@@ -113,7 +114,7 @@ func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveRe
 }
 
 func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	endpointID := ids["endpoint_id"]
@@ -129,7 +130,7 @@ func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveDe
 }
 
 func resourceMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchiveImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID, endpointID, err := splitAtlasPrivatelinkEndpointServiceDataFederationOnlineArchive(d.Id())
 	if err != nil {
 		return nil, err

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 var (
@@ -58,7 +59,7 @@ func testAccCheckMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchi
 }
 
 func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy(s *terraform.State) error {
-	client := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" {
@@ -67,7 +68,7 @@ func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDe
 
 		ids := decodeStateID(rs.Primary.ID)
 
-		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+		_, _, err := conn.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
 
 		if err == nil {
 			return fmt.Errorf("Private endpoint service data federation online archive still exists")
@@ -79,7 +80,7 @@ func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDe
 
 func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 
@@ -92,7 +93,7 @@ func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveEx
 		}
 
 		ids := decodeStateID(rs.Primary.ID)
-		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
+		_, _, err := conn.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
 
 		if err != nil {
 			return err

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_migration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_migration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
 
 func TestAccMigrationNetworkRSPrivateLinkEndpointService_Complete(t *testing.T) {
@@ -65,7 +66,7 @@ func TestAccMigrationNetworkRSPrivateLinkEndpointService_Complete(t *testing.T) 
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						DebugPlan(),
+						testutils.DebugPlan(),
 					},
 				},
 				PlanOnly: true,

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -85,7 +86,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerless() *schema.Resource
 
 func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 	endpointID := d.Get("endpoint_id").(string)
@@ -148,7 +149,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 
 func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
@@ -205,7 +206,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead(ctx context.Co
 
 func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
@@ -229,7 +230,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessDelete(ctx context.
 }
 
 func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
@@ -276,9 +277,9 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, client *matlas.Client, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
+func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, conn *matlas.Client, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		i, resp, err := client.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointServiceID)
+		i, resp, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointServiceID)
 		if err != nil {
 			if resp != nil && resp.StatusCode == 404 || resp.Response.StatusCode == 400 {
 				return "", "DELETED", nil

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_serverless_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccServerlessPrivateLinkEndpointService_basic(t *testing.T) {
@@ -75,7 +76,7 @@ func TestAccServerlessPrivateLinkEndpointService_importBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service_serverless" {
@@ -150,7 +151,7 @@ func testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projec
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
@@ -118,7 +119,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourc
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testMongoDBClient.(*MongoDBClient).Atlas
+		conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -141,7 +142,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName strin
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy(s *terraform.State) error {
-	conn := testMongoDBClient.(*MongoDBClient).Atlas
+	conn := testMongoDBClient.(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service" {

--- a/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_test.go
+++ b/mongodbatlas/resource_mongodbatlas_privatelink_endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 func TestAccNetworkRSPrivateLinkEndpointAWS_basic(t *testing.T) {
@@ -188,7 +189,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName s
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -210,7 +211,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName string) reso
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint" {

--- a/mongodbatlas/resource_mongodbatlas_project_api_key.go
+++ b/mongodbatlas/resource_mongodbatlas_project_api_key.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/project"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -73,7 +75,7 @@ type APIProjectAssignmentKeyInput struct {
 }
 
 func resourceMongoDBAtlasProjectAPIKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	createRequest := new(matlas.APIKeyInput)
 
@@ -131,7 +133,7 @@ func resourceMongoDBAtlasProjectAPIKeyCreate(ctx context.Context, d *schema.Reso
 
 func resourceMongoDBAtlasProjectAPIKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	apiKeyID := ids["api_key_id"]
@@ -161,7 +163,7 @@ func resourceMongoDBAtlasProjectAPIKeyRead(ctx context.Context, d *schema.Resour
 
 		if projectAssignments, err := newProjectAssignment(ctx, conn, apiKeyID); err == nil {
 			if err := d.Set("project_assignment", projectAssignments); err != nil {
-				return diag.Errorf(errorProjectSetting, `created`, projectID, err)
+				return diag.Errorf(project.ErrorProjectSetting, `created`, projectID, err)
 			}
 		}
 	}
@@ -184,8 +186,8 @@ func resourceMongoDBAtlasProjectAPIKeyRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceMongoDBAtlasProjectAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	conn := meta.(*client.MongoDBClient).Atlas
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -244,7 +246,7 @@ func resourceMongoDBAtlasProjectAPIKeyUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasProjectAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	apiKeyID := ids["api_key_id"]
@@ -302,7 +304,7 @@ func resourceMongoDBAtlasProjectAPIKeyDelete(ctx context.Context, d *schema.Reso
 }
 
 func resourceMongoDBAtlasProjectAPIKeyImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_project_api_key_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_api_key_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -176,7 +177,7 @@ func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
 }
 
 func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 	list, _, err := conn.APIKeys.List(context.Background(), orgID, &matlas.ListOptions{})
 	if err != nil {
 		return err
@@ -192,7 +193,7 @@ func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
 }
 
 func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project_api_key" {

--- a/mongodbatlas/resource_mongodbatlas_project_invitation.go
+++ b/mongodbatlas/resource_mongodbatlas_project_invitation.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -61,7 +62,7 @@ func resourceMongoDBAtlasProjectInvitation() *schema.Resource {
 
 func resourceMongoDBAtlasProjectInvitationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
@@ -118,7 +119,7 @@ func resourceMongoDBAtlasProjectInvitationRead(ctx context.Context, d *schema.Re
 
 func resourceMongoDBAtlasProjectInvitationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	invitationReq := &matlas.Invitation{
@@ -141,7 +142,7 @@ func resourceMongoDBAtlasProjectInvitationCreate(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasProjectInvitationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
@@ -156,7 +157,7 @@ func resourceMongoDBAtlasProjectInvitationDelete(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasProjectInvitationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	username := ids["username"]
@@ -175,7 +176,7 @@ func resourceMongoDBAtlasProjectInvitationUpdate(ctx context.Context, d *schema.
 }
 
 func resourceMongoDBAtlasProjectInvitationImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID, username, err := splitProjectInvitationImportID(d.Id())
 	if err != nil {
 		return nil, err

--- a/mongodbatlas/resource_mongodbatlas_project_invitation_test.go
+++ b/mongodbatlas/resource_mongodbatlas_project_invitation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -98,7 +99,7 @@ func TestAccProjectRSProjectInvitation_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasProjectInvitationExists(t *testing.T, resourceName string, invitation *matlas.Invitation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -156,7 +157,7 @@ func testAccCheckMongoDBAtlasProjectInvitationRoleAttribute(invitation *matlas.I
 }
 
 func testAccCheckMongoDBAtlasProjectInvitationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_invitations" {

--- a/mongodbatlas/resource_mongodbatlas_search_index.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/util"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
 )
@@ -141,7 +142,7 @@ func resourceMongoDBAtlasSearchIndexImportState(ctx context.Context, d *schema.R
 	clusterName := parts[1]
 	indexID := parts[2]
 
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	_, _, err := connV2.AtlasSearchApi.GetAtlasSearchIndex(ctx, projectID, clusterName, indexID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import search index (%s) in projectID (%s) and Cluster (%s), error: %s", indexID, projectID, clusterName, err)
@@ -174,7 +175,7 @@ func resourceMongoDBAtlasSearchIndexDelete(ctx context.Context, d *schema.Resour
 	clusterName := ids["cluster_name"]
 	indexID := ids["index_id"]
 
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	_, _, err := connV2.AtlasSearchApi.DeleteAtlasSearchIndex(ctx, projectID, clusterName, indexID).Execute()
 	if err != nil {
 		return diag.Errorf("error deleting search index (%s): %s", d.Get("name").(string), err)
@@ -183,7 +184,7 @@ func resourceMongoDBAtlasSearchIndexDelete(ctx context.Context, d *schema.Resour
 }
 
 func resourceMongoDBAtlasSearchIndexUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -296,7 +297,7 @@ func resourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resource
 	clusterName := ids["cluster_name"]
 	indexID := ids["index_id"]
 
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	searchIndex, resp, err := connV2.AtlasSearchApi.GetAtlasSearchIndex(ctx, projectID, clusterName, indexID).Execute()
 	if err != nil {
 		// deleted in the backend case
@@ -399,7 +400,7 @@ func marshalSearchIndex(fields any) (string, error) {
 }
 
 func resourceMongoDBAtlasSearchIndexCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*MongoDBClient).AtlasV2
+	connV2 := meta.(*client.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 	indexType := d.Get("type").(string)

--- a/mongodbatlas/resource_mongodbatlas_search_index_test.go
+++ b/mongodbatlas/resource_mongodbatlas_search_index_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/testutils"
 )
 
@@ -286,7 +287,7 @@ func testAccCheckSearchIndexExists(resourceName string) resource.TestCheckFunc {
 		}
 		ids := decodeStateID(rs.Primary.ID)
 
-		connV2 := testAccProviderSdkV2.Meta().(*MongoDBClient).AtlasV2
+		connV2 := testAccProviderSdkV2.Meta().(*client.MongoDBClient).AtlasV2
 		_, _, err := connV2.AtlasSearchApi.GetAtlasSearchIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"]).Execute()
 		if err != nil {
 			return fmt.Errorf("index (%s) does not exist", ids["index_id"])
@@ -457,7 +458,7 @@ func testAccCheckMongoDBAtlasSearchIndexDestroy(state *terraform.State) error {
 	if os.Getenv("MONGODB_ATLAS_CLUSTER_NAME") != "" {
 		return nil
 	}
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_search_index" {

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -36,7 +37,7 @@ func resourceMongoDBAtlasServerlessInstance() *schema.Resource {
 
 func resourceMongoDBAtlasServerlessInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["name"]
@@ -161,7 +162,7 @@ func returnServerlessInstanceSchema() map[string]*schema.Schema {
 }
 
 func resourceMongoDBAtlasServerlessInstanceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, name, err := splitServerlessInstanceImportID(d.Id())
 	if err != nil {
@@ -195,7 +196,7 @@ func resourceMongoDBAtlasServerlessInstanceImportState(ctx context.Context, d *s
 
 func resourceMongoDBAtlasServerlessInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	serverlessName := ids["name"]
@@ -228,7 +229,7 @@ func resourceMongoDBAtlasServerlessInstanceDelete(ctx context.Context, d *schema
 
 func resourceMongoDBAtlasServerlessInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["name"]
@@ -304,7 +305,7 @@ func resourceMongoDBAtlasServerlessInstanceRead(ctx context.Context, d *schema.R
 
 func resourceMongoDBAtlasServerlessInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 
 	name := d.Get("name").(string)
@@ -359,9 +360,9 @@ func resourceMongoDBAtlasServerlessInstanceCreate(ctx context.Context, d *schema
 	return resourceMongoDBAtlasServerlessInstanceRead(ctx, d, meta)
 }
 
-func resourceServerlessInstanceRefreshFunc(ctx context.Context, name, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceServerlessInstanceRefreshFunc(ctx context.Context, name, projectID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		c, resp, err := client.ServerlessInstances.Get(ctx, projectID, name)
+		c, resp, err := conn.ServerlessInstances.Get(ctx, projectID, name)
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil
@@ -387,9 +388,9 @@ func resourceServerlessInstanceRefreshFunc(ctx context.Context, name, projectID 
 	}
 }
 
-func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID string, conn *matlas.Client) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		c, resp, err := client.ServerlessInstances.List(ctx, projectID, nil)
+		c, resp, err := conn.ServerlessInstances.List(ctx, projectID, nil)
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil

--- a/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
+++ b/mongodbatlas/resource_mongodbatlas_serverless_instance_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -156,7 +157,7 @@ func TestAccServerlessInstance_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasServerlessInstanceExists(resourceName string, serverlessInstance *matlas.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -180,7 +181,7 @@ func testAccCheckMongoDBAtlasServerlessInstanceExists(resourceName string, serve
 }
 
 func testAccCheckMongoDBAtlasServerlessInstanceDestroy(state *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_serverless_instance" {

--- a/mongodbatlas/resource_mongodbatlas_team.go
+++ b/mongodbatlas/resource_mongodbatlas_team.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -60,7 +61,7 @@ func resourceMongoDBAtlasTeam() *schema.Resource {
 }
 
 func resourceMongoDBAtlasTeamCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	orgID := d.Get("org_id").(string)
 
 	// Creating the team
@@ -82,7 +83,7 @@ func resourceMongoDBAtlasTeamCreate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceMongoDBAtlasTeamRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
@@ -126,7 +127,7 @@ func resourceMongoDBAtlasTeamRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceMongoDBAtlasTeamUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
@@ -216,7 +217,7 @@ func resourceMongoDBAtlasTeamUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceMongoDBAtlasTeamDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 	orgID := ids["org_id"]
 	id := ids["id"]
@@ -248,7 +249,7 @@ func resourceMongoDBAtlasTeamDelete(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceMongoDBAtlasTeamImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_team_test.go
+++ b/mongodbatlas/resource_mongodbatlas_team_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -113,7 +114,7 @@ func TestAccConfigRSTeam_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasTeamExists(resourceName string, team *matlas.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -153,7 +154,7 @@ func testAccCheckMongoDBAtlasTeamAttributes(team *matlas.Team, name string) reso
 }
 
 func testAccCheckMongoDBAtlasTeamDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_teams" {

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 )
 
 var integrationTypes = []string{
@@ -122,7 +123,7 @@ func resourceMongoDBAtlasThirdPartyIntegration() *schema.Resource {
 }
 
 func resourceMongoDBAtlasThirdPartyIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	integrationType := d.Get("type").(string)
 
@@ -155,7 +156,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationCreate(ctx context.Context, d *sch
 }
 
 func resourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]
@@ -188,7 +189,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *schem
 }
 
 func resourceMongoDBAtlasThirdPartyIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]
@@ -214,7 +215,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationUpdate(ctx context.Context, d *sch
 }
 
 func resourceMongoDBAtlasThirdPartyIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 	ids := decodeStateID(d.Id())
 
 	projectID := ids["project_id"]
@@ -230,7 +231,7 @@ func resourceMongoDBAtlasThirdPartyIntegrationDelete(ctx context.Context, d *sch
 }
 
 func resourceMongoDBAtlasThirdPartyIntegrationImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID, integrationType, err := splitIntegrationTypeID(d.Id())
 

--- a/mongodbatlas/resource_mongodbatlas_third_party_integration_test.go
+++ b/mongodbatlas/resource_mongodbatlas_third_party_integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -154,7 +155,7 @@ func TestAccConfigRSThirdPartyIntegration_updateBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_third_party_integration" {
 			continue

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -97,7 +98,7 @@ func resourceMongoDBAtlasX509AuthDBUser() *schema.Resource {
 }
 
 func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
 	username := d.Get("username").(string)
@@ -132,7 +133,7 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 }
 
 func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -174,7 +175,7 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasX509AuthDBUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	ids := decodeStateID(d.Id())
 	currentCertificate := ids["current_certificate"]
@@ -193,7 +194,7 @@ func resourceMongoDBAtlasX509AuthDBUserDelete(ctx context.Context, d *schema.Res
 }
 
 func resourceMongoDBAtlasX509AuthDBUserImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*MongoDBClient).Atlas
+	conn := meta.(*client.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 1 && len(parts) != 2 {

--- a/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
+++ b/mongodbatlas/resource_mongodbatlas_x509_authentication_database_user_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/mongodbatlas/client"
 	"github.com/spf13/cast"
 )
 
@@ -166,7 +167,7 @@ func testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName s
 
 func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+		conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -195,7 +196,7 @@ func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.
 }
 
 func testAccCheckMongoDBAtlasX509AuthDBUserDestroy(s *terraform.State) error {
-	conn := testAccProviderSdkV2.Meta().(*MongoDBClient).Atlas
+	conn := testAccProviderSdkV2.Meta().(*client.MongoDBClient).Atlas
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_x509_authentication_database_user" {


### PR DESCRIPTION
## Description

**Summary**: This PoC shows the necessary changes need to enable grouping our resource and data source implementations into separate packages.

**Changes made**:
- Defining project resource and data source implementation in new `mongodbatlas/project` package.
- Use new `mongodbatlas/client` and  existing `mongodbatlas/framework` package for code that is required and defined in `mongodbatlas`. This code needs to be extract to a separate package to avoid `mongodbatlas/project` depending on `mongodbatlas` which results in cyclic import error.

**Benefits of having separate packages for each resource**:
- helps general organization, we avoid having all our implementation files in a single directory.
- gives us the flexibility of separating certain business logic into other files, with their associated unit testing files.

**Changes that were left out**:
- When trying to move the associated acceptance test and migration test files in the `mongodbatlas/project` package I did not find a way to break the cyclic import as tests rely on `testAccProviderV6Factories` which is tied to `mongodbatlas` package. As a follow up we can look more into other repos such as https://github.com/digitalocean/terraform-provider-digitalocean/pull/927 which include acceptance tests within each package in case we want to move in this direction.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
