### PR TITLE
fix: (INTMDB-1312) It is not possible to add breaking change label to PR

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,7 +1,8 @@
 version: 1
+appendOnly: true
 labels:
   - label: "breaking-change"
-    title: "*!*"
+    title: "!"
   - label: "enhancement"
     title: "feat:*"
   - label: "enhancement"

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,5 +1,4 @@
 version: 1
-appendOnly: true
 labels:
   - label: "breaking-change"
     title: "!"


### PR DESCRIPTION
## Description

### Bug

It is not possible to add the breaking change label to the PR because the labeler automation automatically removes it.

### Why
The default behaviour is to remove all the other labels as soon as one match

### Fix
Updating the breaking change regex to be correctly identify the `!` in the title so that is not removed

Tested the regex in this PR https://github.com/andreaangiolillo/cdk-test/pull/39

Link to any related issue(s): [INTMDB-1312](https://jira.mongodb.org/browse/INTMDB-1312)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
