### PR TITLE
fix: define `project_assignment` block in `mongodbatlas_project_api_key` as required to avoid plugin crash

### DIFF
--- a/mongodbatlas/resource_mongodbatlas_project_api_key.go
+++ b/mongodbatlas/resource_mongodbatlas_project_api_key.go
@@ -46,7 +46,8 @@ func resourceMongoDBAtlasProjectAPIKey() *schema.Resource {
 			},
 			"project_assignment": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Required: true,
+				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project_id": {

--- a/website/docs/r/project_api_key.html.markdown
+++ b/website/docs/r/project_api_key.html.markdown
@@ -53,7 +53,7 @@ resource "mongodbatlas_project_api_key" "test" {
 ~> **NOTE:** Project created by API Keys must belong to an existing organization.
 
 ### project_assignment
-List of Project roles that the Programmatic API key needs to have. `project_assignment` attribute is optional.
+List of Project roles that the Programmatic API key needs to have. At least one `project_assignment` block must be defined.
 
 * `project_id` - (Required) Project ID to assign to Access Key
 * `role_names` - (Required) List of Project roles that the Programmatic API key needs to have. Ensure you provide: at least one role and ensure all roles are valid for the Project. You must specify an array even if you are only associating a single role with the Programmatic API key. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#project-roles) describes the valid roles that can be assigned.


### PR DESCRIPTION
## Description

Link to any related issue(s): Not strictly related to [INTMDB-1296](https://jira.mongodb.org/browse/INTMDB-1296), but helps understand how this resource is being used.

Given the current definition of the `project_api_key` resource, it is only usable if at least one `project_assignment` block is defined.

Example:
```
resource "mongodbatlas_project_api_key" "test" {
	project_id     = mongodbatlas_project.test.id
	description  = %[3]q
	project_assignment  {
		project_id = mongodbatlas_project.test.id
		role_names = [%[4]q]
	}
}
```

If project_assignment is not defined, there is no way to create an API Key as no role_names are defined. The error returned in this case is: 
```
Error: The terraform-provider-mongodbatlas plugin crashed!
panic: runtime error: invalid memory address or nil pointer dereference
```

This is not considered a breaking change as it is simply improving the error message users receive if they do not define the `project_assignment` block.

For reference this attribute was originally defined as optional because `role_names` could be defined at root level. However this attribute was deleted in 1.12.0 (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1418).

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
