### PR TITLE
deprecate: optional root `project_id` attribute in `mongdbatlas_project_api_key` is deprecated

### DIFF
--- a/mongodbatlas/resource_project_api_key.go
+++ b/mongodbatlas/resource_project_api_key.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115001/admin"
@@ -30,8 +31,9 @@ func ResourceProjectAPIKey() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.16.0"),
 			},
 			"api_key_id": {
 				Type:     schema.TypeString,

--- a/website/docs/r/project_api_key.html.markdown
+++ b/website/docs/r/project_api_key.html.markdown
@@ -46,7 +46,7 @@ resource "mongodbatlas_project_api_key" "test" {
 ## Argument Reference
 
 * `description` - (Required) Description of this Project API key.
-* `project_id` - Unique 24-hexadecimal digit string that identifies your project.
+* `project_id` - Unique 24-hexadecimal digit string that identifies your project. **WARNING:** this parameter is deprecated as it no longer needs to be defined. It will be removed in version 1.16.0.
 
 ~> **NOTE:** Project created by API Keys must belong to an existing organization.
 


### PR DESCRIPTION
## Description

As a follow up to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1664, this PR marks the adjusted attribute as deprecated. Created in separate PR to have explicit entry in change log.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
