### PR TITLE
chore: remove references of legacy mongodbatlas package in make file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,6 @@ TEST?=$$(go list ./... | grep -v /integrationtesting)
 ACCTEST_TIMEOUT?=300m
 PARALLEL_GO_TEST?=5
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-PKG_NAME=mongodbatlas
 
 BINARY_NAME=terraform-provider-mongodbatlas
 DESTINATION=./bin/$(BINARY_NAME)
@@ -82,11 +81,6 @@ check: test lint
 
 .PHONY: test-compile
 test-compile:
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./$(PKG_NAME)"; \
-		exit 1; \
-	fi
 	go test -c $(TEST) $(TESTARGS)
 
 .PHONY: website-lint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -50,8 +50,7 @@ testaccgov: fmtcheck
 .PHONY: fmt
 fmt:
 	@echo "==> Fixing source code with gofmt..."
-	gofmt -s -w ./main.go
-	gofmt -s -w ./$(PKG_NAME)
+	gofmt -s -w .
 
 .PHONY: fmtcheck
 fmtcheck: # Currently required by tf-deploy compile


### PR DESCRIPTION
## Description

- adjusted `gofmt` command to format all files recursively (https://stackoverflow.com/a/13333931)
- remove PKG_NAME as usage was not needed.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
