### PR TITLE
define common pagination schema, and share schema definition for data source implementations

### DIFF
--- a/internal/common/dsschema/pagination_schema.go
+++ b/internal/common/dsschema/pagination_schema.go
@@ -1,0 +1,34 @@
+package dsschema
+
+import (
+	"maps"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func PaginatedDSSchema(arguments, resultAttributes map[string]schema.Attribute) schema.Schema {
+	result := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"page_num": schema.Int64Attribute{
+				Optional: true,
+			},
+			"items_per_page": schema.Int64Attribute{
+				Optional: true,
+			},
+			"total_count": schema.Int64Attribute{
+				Computed: true,
+			},
+			"results": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: resultAttributes,
+				},
+			},
+		},
+	}
+	maps.Copy(result.Attributes, arguments)
+	return result
+}

--- a/internal/common/dsschema/pagination_schema_test.go
+++ b/internal/common/dsschema/pagination_schema_test.go
@@ -1,0 +1,63 @@
+package dsschema_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
+)
+
+func TestPaginatedDSSchema(t *testing.T) {
+	expectedSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Required: true,
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"page_num": schema.Int64Attribute{
+				Optional: true,
+			},
+			"items_per_page": schema.Int64Attribute{
+				Optional: true,
+			},
+			"total_count": schema.Int64Attribute{
+				Computed: true,
+			},
+			"results": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"instance_name": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resultSchema := dsschema.PaginatedDSSchema(
+		map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"instance_name": schema.StringAttribute{
+				Computed: true,
+			},
+		})
+
+	if !reflect.DeepEqual(resultSchema, expectedSchema) {
+		t.Errorf("created schema does not matched expected")
+	}
+}

--- a/internal/service/streaminstance/data_source_stream_instance.go
+++ b/internal/service/streaminstance/data_source_stream_instance.go
@@ -26,31 +26,37 @@ type streamInstanceDS struct {
 
 func (d *streamInstanceDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed: true,
-			},
-			"instance_name": schema.StringAttribute{
-				Required: true,
-			},
-			"project_id": schema.StringAttribute{
-				Required: true,
-			},
-			"data_process_region": schema.SingleNestedAttribute{
-				Computed: true,
-				Attributes: map[string]schema.Attribute{
-					"cloud_provider": schema.StringAttribute{
-						Computed: true,
-					},
-					"region": schema.StringAttribute{
-						Computed: true,
-					},
+		Attributes: DSAttributes(true),
+	}
+}
+
+func DSAttributes(definingArguments bool) map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed: true,
+		},
+		"instance_name": schema.StringAttribute{
+			Required: definingArguments,
+			Computed: !definingArguments,
+		},
+		"project_id": schema.StringAttribute{
+			Required: definingArguments,
+			Computed: !definingArguments,
+		},
+		"data_process_region": schema.SingleNestedAttribute{
+			Computed: true,
+			Attributes: map[string]schema.Attribute{
+				"cloud_provider": schema.StringAttribute{
+					Computed: true,
+				},
+				"region": schema.StringAttribute{
+					Computed: true,
 				},
 			},
-			"hostnames": schema.ListAttribute{
-				ElementType: types.StringType,
-				Computed:    true,
-			},
+		},
+		"hostnames": schema.ListAttribute{
+			ElementType: types.StringType,
+			Computed:    true,
 		},
 	}
 }

--- a/internal/service/streaminstance/data_source_stream_instances.go
+++ b/internal/service/streaminstance/data_source_stream_instances.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115002/admin"
 )
@@ -37,56 +38,13 @@ type TFStreamInstancesModel struct {
 }
 
 func (d *streamInstancesDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = schema.Schema{
-		Attributes: map[string]schema.Attribute{
+	resp.Schema = dsschema.PaginatedDSSchema(
+		map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Required: true,
 			},
-			"id": schema.StringAttribute{ // TODO extract to common paginated schema
-				Computed: true,
-			},
-			"page_num": schema.Int64Attribute{
-				Optional: true,
-			},
-			"items_per_page": schema.Int64Attribute{
-				Optional: true,
-			},
-			"total_count": schema.Int64Attribute{
-				Computed: true,
-			},
-			"results": schema.ListNestedAttribute{
-				Computed: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"id": schema.StringAttribute{ // TODO extract to common schema using singular ds schema
-							Computed: true,
-						},
-						"instance_name": schema.StringAttribute{
-							Computed: true,
-						},
-						"project_id": schema.StringAttribute{
-							Computed: true,
-						},
-						"data_process_region": schema.SingleNestedAttribute{
-							Computed: true,
-							Attributes: map[string]schema.Attribute{
-								"cloud_provider": schema.StringAttribute{
-									Computed: true,
-								},
-								"region": schema.StringAttribute{
-									Computed: true,
-								},
-							},
-						},
-						"hostnames": schema.ListAttribute{
-							ElementType: types.StringType,
-							Computed:    true,
-						},
-					},
-				},
-			},
 		},
-	}
+		DSAttributes(false))
 }
 
 func (d *streamInstancesDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {


### PR DESCRIPTION
## Description

This PR shows 2 improvements we can make to simplify the schema definition of plural data sources:

- Define a template for pagination used in plural data sources: This will ensure consistency in our plural data source implementations and remove boilerplate from schema definitions.
- Use schema definition of individual data source in plural data source: This will make sure that the singular and plural data sources will always maintain alignment.

As an end result the schema definition of the plural data source for stream_instance would be the following:
```
resp.Schema = tfschema.PaginatedDSSchema(
		map[string]schema.Attribute{
			"project_id": schema.StringAttribute{
				Required: true,
			},
		},
		DSAttributes(false))
```

As a downside, the general readability of the schema definition is impacted.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
