### PR TITLE
chore: change region used in online archive process region to one supported in cloud dev

### DIFF
--- a/mongodbatlas/resource_online_archive_test.go
+++ b/mongodbatlas/resource_online_archive_test.go
@@ -219,6 +219,27 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 	})
 }
 
+func TestAccBackupRSOnlineArchiveInvalidProcessRegion(t *testing.T) {
+	var (
+		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName   = acctest.RandomWithPrefix("test-acc")
+		name          = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		cloudProvider = "AWS"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBackupRSOnlineArchiveConfigWithProcessRegion(orgID, projectName, name, cloudProvider, "UNKNOWN"),
+				ExpectError: regexp.MustCompile("INVALID_ATTRIBUTE"),
+			},
+		},
+	})
+}
+
 func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acc.TestMongoDBClient.(*config.MongoDBClient).Atlas

--- a/mongodbatlas/resource_online_archive_test.go
+++ b/mongodbatlas/resource_online_archive_test.go
@@ -179,6 +179,7 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 		projectName                 = acctest.RandomWithPrefix("test-acc")
 		name                        = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
 		cloudProvider               = "AWS"
+		processRegion               = "US_EAST_1"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -195,12 +196,12 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRSOnlineArchiveConfigWithProcessRegion(orgID, projectName, name, cloudProvider, "SA_EAST_1"),
+				Config: testAccBackupRSOnlineArchiveConfigWithProcessRegion(orgID, projectName, name, cloudProvider, processRegion),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", "AWS"),
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", "SA_EAST_1"),
-					resource.TestCheckResourceAttr(onlineArchiveDataSourceName, "data_process_region.0.cloud_provider", "AWS"),
-					resource.TestCheckResourceAttr(onlineArchiveDataSourceName, "data_process_region.0.region", "SA_EAST_1"),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
+					resource.TestCheckResourceAttr(onlineArchiveDataSourceName, "data_process_region.0.cloud_provider", cloudProvider),
+					resource.TestCheckResourceAttr(onlineArchiveDataSourceName, "data_process_region.0.region", processRegion),
 				),
 			},
 			{
@@ -210,8 +211,8 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 			{
 				Config: testAccBackupRSOnlineArchiveConfigWithoutSchedule(orgID, projectName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", "AWS"),
-					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", "SA_EAST_1"),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
+					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Only us-east-1 and eu-west-1 regions are supported in dev env.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
