### PR TITLE
feat: Allows to run acc/mig tests in GH action choosing version and test group.

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       terraform_version:
-        description: 'Terraform version to use, empty for latest'     
+        description: 'Terraform version to use, e.g. 1.5.6, empty for latest'     
         type: string
         required: false
       test_group:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -29,27 +29,26 @@ env:
 jobs:  
   change-detection:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-      repository-projects: read
+    env:
+      mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '')  }}
     outputs:
-      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation }}
-      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster }}
-      cluster: ${{ steps.filter.outputs.cluster }}
-      search_deployment: ${{ steps.filter.outputs.search_deployment }}
-      stream: ${{ steps.filter.outputs.stream }}
-      generic: ${{ steps.filter.outputs.generic }}
-      backup_online_archive: ${{ steps.filter.outputs.backup_online_archive }}
-      backup_snapshots: ${{ steps.filter.outputs.backup_snapshots }}
-      federation: ${{ steps.filter.outputs.federation }}
-      backup_schedule: ${{ steps.filter.outputs.backup_schedule }}
-      project: ${{ steps.filter.outputs.project }}
-      serverless: ${{ steps.filter.outputs.serverless }}
-      network: ${{ steps.filter.outputs.network }}
-      config: ${{ steps.filter.outputs.config }}
-      assume_role: ${{ steps.filter.outputs.assume_role }}
-      event_trigger: ${{ steps.filter.outputs.event_trigger }}
-      search_index: ${{ steps.filter.outputs.search_index }}
+      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
+      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
+      search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
+      backup_online_archive: ${{ steps.filter.outputs.backup_online_archive == 'true' || env.mustTrigger == 'true' }}
+      backup_snapshots: ${{ steps.filter.outputs.backup_snapshots == 'true' || env.mustTrigger == 'true' }}
+      federation: ${{ steps.filter.outputs.federation == 'true' || env.mustTrigger == 'true' }}
+      backup_schedule: ${{ steps.filter.outputs.backup_schedule == 'true' || env.mustTrigger == 'true' }}
+      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
+      network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
+      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
+      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
+      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
@@ -120,7 +119,7 @@ jobs:
   
   cluster_outage_simulation:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || inputs.test_group == 'cluster_outage_simulation' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || inputs.test_group == 'cluster_outage_simulation' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -144,7 +143,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -168,7 +167,7 @@ jobs:
 
   cluster:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.cluster == 'true' || inputs.test_group == 'cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.cluster == 'true' || inputs.test_group == 'cluster' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -192,7 +191,7 @@ jobs:
 
   search_deployment:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -216,7 +215,7 @@ jobs:
 
   stream:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -240,7 +239,7 @@ jobs:
 
   generic: # Acceptance tests that do not use any time-consuming resource (example: cluster)
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.generic == 'true' || inputs.test_group == 'generic' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.generic == 'true' || inputs.test_group == 'generic' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -267,7 +266,7 @@ jobs:
 
   backup_online_archive:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -292,7 +291,7 @@ jobs:
 
   backup_snapshots:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_snapshots == 'true' || inputs.test_group == 'backup_snapshots' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.backup_snapshots == 'true' || inputs.test_group == 'backup_snapshots' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -317,7 +316,7 @@ jobs:
         
   backup_schedule:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_schedule == 'true' || inputs.test_group == 'backup_schedule' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.backup_schedule == 'true' || inputs.test_group == 'backup_schedule' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -341,7 +340,7 @@ jobs:
         run: make testacc
   project: 
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -366,7 +365,7 @@ jobs:
         run: make testacc
   serverless:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.serverless == 'true' || inputs.test_group == 'serverless' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.serverless == 'true' || inputs.test_group == 'serverless' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -389,7 +388,7 @@ jobs:
         run: make testacc
   network:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.network == 'true' || inputs.test_group == 'network' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.network == 'true' || inputs.test_group == 'network' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -417,7 +416,7 @@ jobs:
 
   federation:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.federation == 'true' || inputs.test_group == 'federation' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.federation == 'true' || inputs.test_group == 'federation' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -441,7 +440,7 @@ jobs:
       
   config:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -470,7 +469,7 @@ jobs:
 
   assume_role:
     needs: [ change-detection]
-    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -508,7 +507,7 @@ jobs:
 
   search_index:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.search_index == 'true' || inputs.test_group == 'search_index' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.search_index == 'true' || inputs.test_group == 'search_index' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -7,14 +7,16 @@ on:
         description: 'Terraform version to use, empty for latest'     
         type: string
         required: false
+      test_group:
+        description: 'Test group to run, e.g. advanced_cluster, empty for all'
+        type: string
+        required: false
   workflow_call: # workflow runs after Test Suite or code-health
     inputs:
       terraform_version:
         description: 'Terraform version to use, empty for latest'     
         type: string
         required: false
-  pull_request: # you can run a specic job in your PR using GitHub labels
-    types: [ labeled ]
 
 env:
   terraform_version: ${{ inputs.terraform_version || vars.TF_VERSION_LATEST }}
@@ -50,7 +52,6 @@ jobs:
       search_index: ${{ steps.filter.outputs.search_index }}
     steps:
     - uses: actions/checkout@v4
-      if: ${{ github.event_name == 'push' ||  github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -119,7 +120,7 @@ jobs:
   
   cluster_outage_simulation:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-cluster-outage-simulation' }}
+    if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || inputs.test_group == 'cluster_outage_simulation' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -143,7 +144,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-advanced-cluster' }}
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -167,7 +168,7 @@ jobs:
 
   cluster:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.cluster == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-cluster' }}
+    if: ${{ needs.change-detection.outputs.cluster == 'true' || inputs.test_group == 'cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -191,7 +192,7 @@ jobs:
 
   search_deployment:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.search_deployment == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-search-deployment' }}
+    if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -215,7 +216,7 @@ jobs:
 
   stream:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.stream == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-stream' }}
+    if: ${{ needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -239,7 +240,7 @@ jobs:
 
   generic: # Acceptance tests that do not use any time-consuming resource (example: cluster)
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.generic == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-generic' }}
+    if: ${{ needs.change-detection.outputs.generic == 'true' || inputs.test_group == 'generic' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -266,7 +267,7 @@ jobs:
 
   backup_online_archive:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-backup-online-archive' }}
+    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -291,7 +292,7 @@ jobs:
 
   backup_snapshots:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_snapshots == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-backup-snapshots' }}
+    if: ${{ needs.change-detection.outputs.backup_snapshots == 'true' || inputs.test_group == 'backup_snapshots' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -316,7 +317,7 @@ jobs:
         
   backup_schedule:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.backup_schedule == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-backup-schedule' }}
+    if: ${{ needs.change-detection.outputs.backup_schedule == 'true' || inputs.test_group == 'backup_schedule' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -340,7 +341,7 @@ jobs:
         run: make testacc
   project: 
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.project == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-project' }}
+    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -365,7 +366,7 @@ jobs:
         run: make testacc
   serverless:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.serverless == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-serverless' }}
+    if: ${{ needs.change-detection.outputs.serverless == 'true' || inputs.test_group == 'serverless' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -388,7 +389,7 @@ jobs:
         run: make testacc
   network:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.network == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-network' }}
+    if: ${{ needs.change-detection.outputs.network == 'true' || inputs.test_group == 'network' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -416,7 +417,7 @@ jobs:
 
   federation:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.federation == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-federation' }}
+    if: ${{ needs.change-detection.outputs.federation == 'true' || inputs.test_group == 'federation' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -440,7 +441,7 @@ jobs:
       
   config:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.config == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' }}
+    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -469,7 +470,7 @@ jobs:
 
   assume_role:
     needs: [ change-detection]
-    if: ${{ needs.change-detection.outputs.assume_role == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-config' }}
+    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -507,7 +508,7 @@ jobs:
 
   search_index:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.search_index == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.label.name == 'run-testacc' || github.event.label.name == 'run-testacc-search-index' }}
+    if: ${{ needs.change-detection.outputs.search_index == 'true' || inputs.test_group == 'search_index' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -52,11 +52,8 @@ jobs:
 
   change-detection:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-      repository-projects: read
     env:
-      mustTrigger: ${{ github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '')  }}
+      mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '')  }}
     outputs:
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
       config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -55,12 +55,13 @@ jobs:
     permissions:
       pull-requests: read
       repository-projects: read
+    env:
+      mustTrigger: ${{ github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '')  }}
     outputs:
-      project: ${{ steps.filter.outputs.project }}
-      config: ${{ steps.filter.outputs.config }}
-      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster }}
-      backup_online_archive: ${{ steps.filter.outputs.backup_online_archive }}
-      shouldTriggerResourceTest: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+      project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
+      advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      backup_online_archive: ${{ steps.filter.outputs.backup_online_archive == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
@@ -82,7 +83,7 @@ jobs:
 
   project: 
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -109,7 +110,7 @@ jobs:
   
   config:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -139,7 +140,7 @@ jobs:
 
   backup_online_archive:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -165,7 +166,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
+    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -163,7 +163,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' }}
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -25,8 +25,6 @@ on:
         description: 'MongoDB Atlas Provider version to use, empty for latest'     
         type: string
         required: false
-  pull_request: # you can run a specic job in your PR using GitHub labels
-    types: [ labeled ]
 
 env:
     terraform_version: ${{ inputs.terraform_version || vars.TF_VERSION_LATEST }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -11,6 +11,10 @@ on:
         description: 'MongoDB Atlas Provider version to use, empty for latest'     
         type: string
         required: false
+      test_group:
+        description: 'Test group to run, e.g. advanced_cluster, empty for all'
+        type: string
+        required: false
   workflow_call: # workflow runs after Test Suite or code-health
     inputs:
       terraform_version:
@@ -61,7 +65,6 @@ jobs:
       shouldTriggerResourceTest: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     steps:
     - uses: actions/checkout@v4
-      if: ${{ github.event_name == 'push' ||  github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     - uses: dorny/paths-filter@v2
       id: filter
       with:
@@ -81,7 +84,7 @@ jobs:
 
   project: 
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.project == 'true' || github.event.label.name == 'run-testacc-project'||  needs.change-detection.outputs.shouldTriggerResourceTest == 'true'}}
+    if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -108,7 +111,7 @@ jobs:
   
   config:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.config == 'true' || github.event.label.name == 'run-testacc-config'||  needs.change-detection.outputs.shouldTriggerResourceTest == 'true'}}
+    if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -138,7 +141,7 @@ jobs:
 
   backup_online_archive:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || github.event.label.name == 'run-testacc-backup-online-archive'||  needs.change-detection.outputs.shouldTriggerResourceTest == 'true'}}
+    if: ${{ needs.change-detection.outputs.backup_online_archive == 'true' || inputs.test_group == 'backup_online_archive' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -164,7 +167,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || github.event.label.name == 'run-testacc-advanced-cluster'||  needs.change-detection.outputs.shouldTriggerResourceTest == 'true'}}
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' || github.event_name == 'schedule'|| (github.event_name == 'workflow_dispatch' && inputs.test_group == '') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       terraform_version:
-        description: 'Terraform version to use, empty for latest'     
+        description: 'Terraform version to use, e.g. 1.5.6, empty for latest'     
         type: string
         required: false
       provider_version:
-        description: 'MongoDB Atlas Provider version to use, empty for latest'     
+        description: 'MongoDB Atlas Provider version to use, e.g. 1.13.1, empty for latest'     
         type: string
         required: false
       test_group:


### PR DESCRIPTION
## Description

Allows to run acc/mig tests in GH action choosing version and test group.

The main cons with the current label approach are:
- Terraform versions can not be chosen.
- You can only use a label in a PR once, after that if you deassign and assign the label again the workflow is not triggered any more.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-216372

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
