### PR TITLE
fix: : Provider crash when an invalid role name is specified to `mongodbatlas_project_api_key`

### DIFF
--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -304,9 +304,10 @@ func resourceMongoDBAtlasProjectAPIKeyDelete(ctx context.Context, d *schema.Reso
 		}
 	}
 
-	_, err = conn.APIKeys.Delete(ctx, orgID, apiKeyID)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error unable to delete Key (%s): %s", apiKeyID, err))
+	if orgID != "" {
+		if _, err = conn.APIKeys.Delete(ctx, orgID, apiKeyID); err != nil {
+			return diag.FromErr(fmt.Errorf("error unable to delete Key (%s): %s", apiKeyID, err))
+		}
 	}
 
 	d.SetId("")

--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -104,6 +104,8 @@ func resourceMongoDBAtlasProjectAPIKeyCreate(ctx context.Context, d *schema.Reso
 				d.SetId("")
 				return nil
 			}
+
+			return diag.FromErr(err)
 		}
 
 		// assign created api key to remaining project assignments

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -345,11 +345,10 @@ func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
 
 func TestAccConfigRSProjectAPIKey_Invalid_Role(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
-		description  = fmt.Sprintf("test-acc-project-api_key-%s", acctest.RandString(5))
-		roleName     = "INVALID_ROLE"
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		description = projectName
+		roleName    = "INVALID_ROLE"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -358,12 +357,7 @@ func TestAccConfigRSProjectAPIKey_Invalid_Role(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
-					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
-				),
+				Config:      testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
 				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
 			},
 		},


### PR DESCRIPTION
## Description

Ticket: [CLOUDP-216402](https://jira.mongodb.org/browse/CLOUDP-216402)
Issue: Provider crashes when an invalid role name is specified to `mongodbatlas_project_api_key`

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Testing

### Local testing
I reproduced the error with v1.13.1
```bash
│ Error: Plugin did not respond
--
│
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
```

I run the same TF config with my changes
```bash 
│ Error: POST https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/6571a9637db22d780f3cec0c/apiKeys: 400 (request "INVALID_ENUM_VALUE") An invalid enumeration value GROUP_s was specified.
```

### Acceptance Test
I added the acceptance test `TestAccConfigRSProjectAPIKey_Invalid_Role`

```bash
--- PASS: TestAccConfigRSProjectAPIKey_Invalid_Role (407.53s)
PASS
ok      github.com/mongodb/terraform-provider-mongodbatlas/internal/service/projectapikey       407.977s
```


