### PR TITLE
fix: Fix mongodbatlas_clusters plural data source to set auto_scaling_disk_gb_enabled attribute correctly

### DIFF
--- a/internal/service/cluster/data_source_clusters.go
+++ b/internal/service/cluster/data_source_clusters.go
@@ -375,7 +375,7 @@ func flattenClusters(ctx context.Context, d *schema.ResourceData, conn *matlas.C
 			"advanced_configuration":                  advancedcluster.FlattenProcessArgs(processArgs),
 			"auto_scaling_compute_enabled":            clusters[i].AutoScaling.Compute.Enabled,
 			"auto_scaling_compute_scale_down_enabled": clusters[i].AutoScaling.Compute.ScaleDownEnabled,
-			"auto_scaling_disk_gb_enabled":            clusters[i].BackupEnabled,
+			"auto_scaling_disk_gb_enabled":            clusters[i].AutoScaling.DiskGBEnabled,
 			"backup_enabled":                          clusters[i].BackupEnabled,
 			"provider_backup_enabled":                 clusters[i].ProviderBackupEnabled,
 			"cluster_type":                            clusters[i].ClusterType,


### PR DESCRIPTION
## Description

This PR fixes auto_scaling_disk_gb_enabled to be set correctly in the plural mongodbatlas_clusters data source for all results. Currently this is being set to BackupEnabled attribute from the API response.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
