### PR TITLE
fix: Interrupted creation of new cluster

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -422,6 +422,11 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 		return diag.FromErr(fmt.Errorf(errorClusterAdvancedCreate, err))
 	}
 
+	d.SetId(conversion.EncodeStateID(map[string]string{
+		"project_id":   projectID,
+		"cluster_name": cluster.Name,
+	}))
+
 	timeout := d.Timeout(schema.TimeoutCreate)
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING"},
@@ -465,12 +470,6 @@ func resourceMongoDBAtlasAdvancedClusterCreate(ctx context.Context, d *schema.Re
 			return diag.FromErr(fmt.Errorf(errorClusterAdvancedUpdate, d.Get("name").(string), err))
 		}
 	}
-
-	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":   cluster.ID,
-		"project_id":   projectID,
-		"cluster_name": cluster.Name,
-	}))
 
 	return resourceMongoDBAtlasAdvancedClusterRead(ctx, d, meta)
 }
@@ -626,7 +625,6 @@ func resourceMongoDBAtlasAdvancedClusterUpgrade(ctx context.Context, d *schema.R
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":   upgradeResponse.ID,
 		"project_id":   projectID,
 		"cluster_name": clusterName,
 	}))
@@ -815,7 +813,6 @@ func resourceMongoDBAtlasAdvancedClusterImportState(ctx context.Context, d *sche
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":   u.ID,
 		"project_id":   *projectID,
 		"cluster_name": u.Name,
 	}))

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -527,6 +527,12 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf(errorClusterCreate, err))
 	}
 
+	d.SetId(conversion.EncodeStateID(map[string]string{
+		"project_id":    projectID,
+		"cluster_name":  cluster.Name,
+		"provider_name": providerName,
+	}))
+
 	timeout := d.Timeout(schema.TimeoutCreate)
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING"},
@@ -570,13 +576,6 @@ func resourceMongoDBAtlasClusterCreate(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(fmt.Errorf(errorClusterUpdate, d.Get("name").(string), err))
 		}
 	}
-
-	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":    cluster.ID,
-		"project_id":    projectID,
-		"cluster_name":  cluster.Name,
-		"provider_name": providerName,
-	}))
 
 	return resourceMongoDBAtlasClusterRead(ctx, d, meta)
 }
@@ -924,7 +923,6 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 
 		d.SetId(conversion.EncodeStateID(map[string]string{
-			"cluster_id":    updatedCluster.ID,
 			"project_id":    projectID,
 			"cluster_name":  updatedCluster.Name,
 			"provider_name": updatedCluster.ProviderSettings.ProviderName,
@@ -1042,7 +1040,6 @@ func resourceMongoDBAtlasClusterImportState(ctx context.Context, d *schema.Resou
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":    u.ID,
 		"project_id":    *projectID,
 		"cluster_name":  u.Name,
 		"provider_name": u.ProviderSettings.ProviderName,


### PR DESCRIPTION
## Description

When new cluster is created and interrupted during the creation process, the `SetId` function (set resource identifier) will not be called. It is only called when the cluster is successfully created. Re-running tf apply will fail (cluster exist with same name).

This PR will call `SetId` directly after the create call to API whatever cluster is created successfully or not. This will ensure that the cluster resource is imported in case of interrupted creation, which is beneficial in case of automated CI/CD, pipelines, etc (no need to import resource manually in case of the cluster already exist).

Further, to achieve this we get rid of the cluster ID encoded property as `project_id`, `cluster_name` and `provider_name` are fairly enough to uniquely identify the cluster resource.

Good example of similar behavior for example when create EKS cluster using [AWS tf provider](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/cluster.go#L360), where cluster name is enough to identify the cluster and the `waitClusterCreated` is called after `SetId` which allow better handling for interrupted creation of resources.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
