### PR TITLE
fix: project delete function uses correct string representation of id

### DIFF
--- a/internal/service/project/resource_project.go
+++ b/internal/service/project/resource_project.go
@@ -760,12 +760,8 @@ func ResourceProjectDependentsDeletingRefreshFunc(ctx context.Context, projectID
 		clusters, _, listClustersErr := client.ListClusters(ctx, projectID)
 		dependents := AtlasProjectDependants{AdvancedClusters: clusters}
 
-		if _, ok := admin.AsError(listClustersErr); ok {
-			return nil, "", listClustersErr
-		}
-
 		if listClustersErr != nil {
-			return nil, projectDependentsStateRetry, nil
+			return nil, "", listClustersErr
 		}
 
 		if *dependents.AdvancedClusters.TotalCount == 0 {

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -430,7 +430,7 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 				clusterReponse: &admin.PaginatedAdvancedClusterDescription{},
 				Err:            errors.New("Non-API error"),
 			},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			name: "Error from the API",

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -42,7 +42,7 @@ var (
 	projectStateNameDiff = project.TfProjectRSModel{
 		Name: diffName,
 	}
-	dummyProjectID = "projectId"
+	dummyProjectID = "6575af27f93c7a6a4b50b239"
 )
 
 func TestGetProjectPropsFromAPI(t *testing.T) {
@@ -460,7 +460,7 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testObject := new(MockProjectService)
 
-			testObject.On("ListClusters", mock.Anything, mock.Anything).Return(tc.mockResponses)
+			testObject.On("ListClusters", mock.Anything, dummyProjectID).Return(tc.mockResponses)
 
 			_, _, err := project.ResourceProjectDependentsDeletingRefreshFunc(context.Background(), dummyProjectID, testObject)()
 

--- a/internal/service/project/service_project.go
+++ b/internal/service/project/service_project.go
@@ -17,6 +17,7 @@ type GroupProjectService interface {
 	RemoveProjectTeam(ctx context.Context, groupID, teamID string) (*http.Response, error)
 	UpdateTeamRoles(ctx context.Context, groupID, teamID string, teamRole *admin.TeamRole) (*admin.PaginatedTeamRole, *http.Response, error)
 	AddAllTeamsToProject(ctx context.Context, groupID string, teamRole *[]admin.TeamRole) (*admin.PaginatedTeamRole, *http.Response, error)
+	ListClusters(ctx context.Context, groupID string) (*admin.PaginatedAdvancedClusterDescription, *http.Response, error)
 }
 
 type GroupProjectServiceFromClient struct {
@@ -58,6 +59,10 @@ func (a *GroupProjectServiceFromClient) UpdateTeamRoles(ctx context.Context, gro
 
 func (a *GroupProjectServiceFromClient) AddAllTeamsToProject(ctx context.Context, groupID string, teamRole *[]admin.TeamRole) (*admin.PaginatedTeamRole, *http.Response, error) {
 	return a.client.TeamsApi.AddAllTeamsToProject(ctx, groupID, teamRole).Execute()
+}
+
+func (a *GroupProjectServiceFromClient) ListClusters(ctx context.Context, groupID string) (*admin.PaginatedAdvancedClusterDescription, *http.Response, error) {
+	return a.client.ClustersApi.ListClusters(ctx, groupID).Execute()
 }
 
 func ServiceFromClient(client *admin.APIClient) GroupProjectService {


### PR DESCRIPTION
## Description

Project delete was using wrong string representation of Id, with quotes (`"projectId"`) instead of plain string (`projectId`). 

Within our project delete function we have a logic that waits for all "dependants" to be deleted.
During the SDK migration there was a change with how to obtain the project id that is used to list the cluster of a project, which is now passing an incorrect value. [This API call](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/internal/service/project/resource_project.go#L761) uses nonNullProjectID of type types.String, so nonNullProjectID.String() was responding with "6575af27f93c7a6a4b50b239" resulting in an error by the SDK: "groupId must have less than 24 elements”. Due to whats seems like incorrect logic, this error simply lead to retrying constantly until eventually the timeout is reached.


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
