### PR TITLE
chore: new scaffold command for creating resources/data sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,20 @@
 # Contributing
 
+Thanks for your interest in contributing to MongoDB Atlas Terraform Provider, this document describes some guidelines necessary to participate in the community.
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+  - [Prerequisite Tools](#prerequisite-tools)
+  - [Environment](#prerequisite-tools)
+  - [Open a Pull Request](#open-a-pull-request)
+  - [Testing the Provider](#testing-the-provider)
+  - [Running Acceptance Tests](#running-acceptance-tests)
+- [Code and Test Best Practices](#code-and-test-best-practices)
+  - [Creating New Resource and Data Sources](#creating-new-resources-and-data-sources)
+- [Documentation Best Practices](#documentation-best-practices)
+- [Discovering New API features](#discovering-new-api-features)
+
 
 ## Development Setup
 ### Prerequisite Tools
@@ -47,6 +62,26 @@ For more explained information about plugin override check [Development Override
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
 - A repo maintainer will review the your pull request, and may either request additional changes or merge the pull request.
 
+#### PR Title Format
+We use [*Conventional Commits*](https://www.conventionalcommits.org/):
+- `fix: description of the PR`: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
+- `chore: description of the PR`: the commit includes a technical or preventative maintenance task that is necessary for managing the product or the repository, but it is not tied to any specific feature or user story (this correlates with PATCH in Semantic Versioning).
+- `doc: description of the PR`: The commit adds, updates, or revises documentation that is stored in the repository (this correlates with PATCH in Semantic Versioning).
+- `test: description of the PR`: The commit enhances, adds to, revised, or otherwise changes the suite of automated tests for the product (this correlates with PATCH in Semantic Versioning).
+- `security: description of the PR`: The commit improves the security of the product or resolves a security issue that has been reported (this correlates with PATCH in Semantic Versioning).
+- `refactor: description of the PR`: The commit refactors existing code in the product, but does not alter or change existing behavior in the product (this correlates with Minor in Semantic Versioning).
+- `perf: description of the PR`: The commit improves the performance of algorithms or general execution time of the product, but does not fundamentally change an existing feature (this correlates with Minor in Semantic Versioning).
+- `ci: description of the PR`: The commit makes changes to continuous integration or continuous delivery scripts or configuration files (this correlates with Minor in Semantic Versioning).
+- `revert: description of the PR`: The commit reverts one or more commits that were previously included in the product, but were accidentally merged or serious issues were discovered that required their removal from the main branch (this correlates with Minor in Semantic Versioning).
+- `style: description of the PR`: The commit updates or reformats the style of the source code, but does not otherwise change the product implementation (this correlates with Minor in Semantic Versioning).
+- `feat: description of the PR`: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
+- `deprecate: description of the PR`: The commit deprecates existing functionality, but does not remove it from the product (this correlates with MINOR in Semantic Versioning).
+- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+Examples:
+  - `fix!: description of the ticket`
+  - If the PR has `BREAKING CHANGE`: in its description is a breaking change
+- `remove!: description of the PR`: The commit removes a feature from the product. Typically features are deprecated first for a period of time before being removed. Removing a feature is a breaking change (correlating with MAJOR in Semantic Versioning).
+
 ### Testing the Provider
 
 In order to test the provider, you can run `make test`. You can use [meta-arguments](https://www.terraform.io/docs/configuration/providers.html) such as `alias` and `version`. The following arguments are supported in the MongoDB Atlas `provider` block:
@@ -61,7 +96,7 @@ In order to test the provider, you can run `make test`. You can use [meta-argume
 
 ~> **Notice:**  If you do not have a `public_key` and `private_key` you must create a programmatic API key to configure the provider (see [Creating Programmatic API key](#Programmatic-API-key)). If you already have one, you can continue with [Configuring environment variables](#Configuring-environment-variables)
 
-### Running the acceptance test
+### Running Acceptance Tests
 
 #### Programmatic API key
 
@@ -269,29 +304,22 @@ To do this you can:
 - `internal/testutils/acc` contains helper test methods for Acceptance and Migration tests.
 - Tests that need the provider binary like End-to-End tests don’t belong to the source code packages and go in `test/e2e`.
 
-## Documentation Best Practises
+### Creating New Resource and Data Sources
+
+A scaffolding command was defined with the intention of speeding up development process, while also preserving common conventions throughout our codebase.
+
+This command can be used the following way:
+```bash
+make scaffold name=streamInstance type=resource
+```
+- **name**: The name of the resource, which must be defined in camel case.
+- **type**: Describes the type of resource being created. There are 3 different types: `resource`, `data-source`, `plural-data-source`.
+
+This will generate resource/data source files and accompanying test files needed for starting the development, and will contain multiple comments with `TODO:` statements which give guidance for the development.
+
+## Documentation Best Practices
 
 - In our documentation, when a resource field allows a maximum of only one item, we do not format that field as an array. Instead, we create a subsection specifically for this field. Within this new subsection, we enumerate all the attributes of the field. Let's illustrate this with an example: [cloud_backup_schedule.html.markdown](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/website/docs/r/cloud_backup_schedule.html.markdown?plain=1#L207)
-
-## PR Title Format
-We use [*Conventional Commits*](https://www.conventionalcommits.org/):
-- `fix: description of the PR`: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
-- `chore: description of the PR`: the commit includes a technical or preventative maintenance task that is necessary for managing the product or the repository, but it is not tied to any specific feature or user story (this correlates with PATCH in Semantic Versioning).
-- `doc: description of the PR`: The commit adds, updates, or revises documentation that is stored in the repository (this correlates with PATCH in Semantic Versioning).
-- `test: description of the PR`: The commit enhances, adds to, revised, or otherwise changes the suite of automated tests for the product (this correlates with PATCH in Semantic Versioning).
-- `security: description of the PR`: The commit improves the security of the product or resolves a security issue that has been reported (this correlates with PATCH in Semantic Versioning).
-- `refactor: description of the PR`: The commit refactors existing code in the product, but does not alter or change existing behavior in the product (this correlates with Minor in Semantic Versioning).
-- `perf: description of the PR`: The commit improves the performance of algorithms or general execution time of the product, but does not fundamentally change an existing feature (this correlates with Minor in Semantic Versioning).
-- `ci: description of the PR`: The commit makes changes to continuous integration or continuous delivery scripts or configuration files (this correlates with Minor in Semantic Versioning).
-- `revert: description of the PR`: The commit reverts one or more commits that were previously included in the product, but were accidentally merged or serious issues were discovered that required their removal from the main branch (this correlates with Minor in Semantic Versioning).
-- `style: description of the PR`: The commit updates or reformats the style of the source code, but does not otherwise change the product implementation (this correlates with Minor in Semantic Versioning).
-- `feat: description of the PR`: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
-- `deprecate: description of the PR`: The commit deprecates existing functionality, but does not remove it from the product (this correlates with MINOR in Semantic Versioning).
-- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
-Examples:
-  - `fix!: description of the ticket`
-  - If the PR has `BREAKING CHANGE`: in its description is a breaking change
-- `remove!: description of the PR`: The commit removes a feature from the product. Typically features are deprecated first for a period of time before being removed. Removing a feature is a breaking change (correlating with MAJOR in Semantic Versioning).
 
 ## Discovering New API features
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -110,3 +110,9 @@ link-git-hooks: ## Install git hooks
 update-atlas-sdk: ## Update the atlas-sdk dependency
 	./scripts/update-sdk.sh
 
+# details on usage can be found in CONTRIBUTING.md under "Creating New Resource and Data Sources"
+.PHONY: scaffold
+scaffold:
+	@go run ./tools/scaffold/*.go $(name) $(type)
+	@echo "Reminder: configure the new $(type) in provider.go"
+

--- a/tools/scaffold/scaffold.go
+++ b/tools/scaffold/scaffold.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const (
+	ResourceCmd         = "resource"
+	DataSourceCmd       = "data-source"
+	PluralDataSourceCmd = "plural-data-source"
+)
+
+// struct which is applied to go template files
+type ScaffoldParams struct {
+	GenerationType    string
+	NamePascalCase    string
+	NameCamelCase     string
+	NameSnakeCase     string
+	NameLowerNoSpaces string
+}
+
+type FileGeneration struct {
+	TemplatePath string
+	OutputPath   string
+}
+
+func main() {
+	nameCamelCase := os.Args[1]
+	generationType := os.Args[2]
+
+	params := ScaffoldParams{
+		GenerationType:    generationType,
+		NamePascalCase:    ToPascalCase(nameCamelCase),
+		NameCamelCase:     nameCamelCase,
+		NameSnakeCase:     ToSnakeCase(nameCamelCase),
+		NameLowerNoSpaces: strings.ToLower(nameCamelCase),
+	}
+
+	files, err := filesToGenerate(&params)
+	if err != nil {
+		panic(err)
+	}
+	for _, file := range files {
+		if err := generateFileFromTemplate(file, &params); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func filesToGenerate(params *ScaffoldParams) ([]FileGeneration, error) {
+	folderPath := fmt.Sprintf("internal/service/%s", params.NameLowerNoSpaces)
+
+	switch params.GenerationType {
+	case ResourceCmd:
+		return []FileGeneration{
+			{
+				TemplatePath: "tools/scaffold/template/resource.tmpl",
+				OutputPath:   fmt.Sprintf("%s/resource_%s.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s_test.go", folderPath, params.NameSnakeCase),
+			},
+		}, nil
+	case DataSourceCmd:
+		return []FileGeneration{
+			{
+				TemplatePath: "tools/scaffold/template/datasource.tmpl",
+				OutputPath:   fmt.Sprintf("%s/data_source_%s.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s_test.go", folderPath, params.NameSnakeCase),
+			},
+		}, nil
+	case PluralDataSourceCmd:
+		return []FileGeneration{
+			{
+				TemplatePath: "tools/scaffold/template/pluraldatasource.tmpl",
+				OutputPath:   fmt.Sprintf("%s/data_source_%ss.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/model_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/model_%s_test.go", folderPath, params.NameSnakeCase),
+			},
+		}, nil
+	default:
+		return nil, errors.New("unknown generation type provided")
+	}
+}
+
+func generateFileFromTemplate(generation FileGeneration, params *ScaffoldParams) error {
+	tmpl, err := template.ParseFiles(generation.TemplatePath)
+	if err != nil {
+		return err
+	}
+
+	// ensure content of existing files is not overwritten
+	if _, err := os.Stat(generation.OutputPath); err == nil {
+		log.Printf("File already exists: %s", generation.OutputPath)
+		return nil
+	}
+	file := createDirsAndFile(generation.OutputPath)
+
+	if err := tmpl.Execute(file, params); err != nil {
+		return err
+	}
+	file.Close()
+	return nil
+}
+
+func createDirsAndFile(path string) *os.File {
+	dirPath := filepath.Dir(path)
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		log.Fatalf("Failed to create directories: %s", err)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		log.Fatalf("Failed to create file: %s", err)
+	}
+	return file
+}

--- a/tools/scaffold/scaffold.go
+++ b/tools/scaffold/scaffold.go
@@ -64,6 +64,10 @@ func filesToGenerate(params *ScaffoldParams) ([]FileGeneration, error) {
 				OutputPath:   fmt.Sprintf("%s/resource_%s.go", folderPath, params.NameSnakeCase),
 			},
 			{
+				TemplatePath: "tools/scaffold/template/acc_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/resource_%s_test.go", folderPath, params.NameSnakeCase),
+			},
+			{
 				TemplatePath: "tools/scaffold/template/model.tmpl",
 				OutputPath:   fmt.Sprintf("%s/model_%s.go", folderPath, params.NameSnakeCase),
 			},
@@ -79,6 +83,10 @@ func filesToGenerate(params *ScaffoldParams) ([]FileGeneration, error) {
 				OutputPath:   fmt.Sprintf("%s/data_source_%s.go", folderPath, params.NameSnakeCase),
 			},
 			{
+				TemplatePath: "tools/scaffold/template/acc_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/data_source_%s_test.go", folderPath, params.NameSnakeCase),
+			},
+			{
 				TemplatePath: "tools/scaffold/template/model.tmpl",
 				OutputPath:   fmt.Sprintf("%s/model_%s.go", folderPath, params.NameSnakeCase),
 			},
@@ -92,6 +100,10 @@ func filesToGenerate(params *ScaffoldParams) ([]FileGeneration, error) {
 			{
 				TemplatePath: "tools/scaffold/template/pluraldatasource.tmpl",
 				OutputPath:   fmt.Sprintf("%s/data_source_%ss.go", folderPath, params.NameSnakeCase),
+			},
+			{
+				TemplatePath: "tools/scaffold/template/acc_test.tmpl",
+				OutputPath:   fmt.Sprintf("%s/data_source_%ss_test.go", folderPath, params.NameSnakeCase),
 			},
 			{
 				TemplatePath: "tools/scaffold/template/model.tmpl",

--- a/tools/scaffold/string_cases.go
+++ b/tools/scaffold/string_cases.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"unicode"
+)
+
+// toPascalCase converts camel case to pascal case.
+func ToPascalCase(input string) string {
+	return strings.ToUpper(input[:1]) + input[1:]
+}
+
+// toSnakeCase converts camel case to snake case.
+func ToSnakeCase(input string) string {
+	var result []rune
+	for i, r := range input {
+		if unicode.IsUpper(r) && i > 0 {
+			result = append(result, '_')
+		}
+		result = append(result, unicode.ToLower(r))
+	}
+	return string(result)
+}

--- a/tools/scaffold/template/acc_test.tmpl
+++ b/tools/scaffold/template/acc_test.tmpl
@@ -1,0 +1,36 @@
+package {{.NameLowerNoSpaces}}_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
+// In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
+func TestAcc{{.NamePascalCase}}{{if eq .GenerationType "resource"}}RS{{else}}DS{{end}}_basic(t *testing.T) {
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+//		CheckDestroy:             checkDestroy{{.NamePascalCase}},
+		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
+//			{
+//				Config: {{.NameCamelCase}}Config(),
+//				Check:  {{.NameCamelCase}}AttributeChecks(),
+//			},
+//          {
+//				Config: {{.NameCamelCase}}Config(),
+//				Check:  {{.NameCamelCase}}AttributeChecks(),
+//			},
+//			{
+//				Config:            {{.NameCamelCase}}Config(),
+//				ResourceName:      resourceName,
+//				ImportStateIdFunc: check{{.NamePascalCase}}ImportStateIDFunc,
+//				ImportState:       true,
+//				ImportStateVerify: true,
+			},
+		},
+	)
+}

--- a/tools/scaffold/template/datasource.tmpl
+++ b/tools/scaffold/template/datasource.tmpl
@@ -1,0 +1,68 @@
+package {{.NameLowerNoSpaces}}
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+const {{.NameCamelCase}}Name = "{{.NameSnakeCase}}" // TODO: if resource exists this can be deleted
+
+var _ datasource.DataSource = &{{.NameCamelCase}}DS{}
+var _ datasource.DataSourceWithConfigure = &{{.NameCamelCase}}DS{}
+
+func DataSource() datasource.DataSource {
+	return &{{.NameCamelCase}}DS{
+		DSCommon: config.DSCommon{
+			DataSourceName: {{.NameCamelCase}}Name,
+		},
+	}
+}
+
+type {{.NameCamelCase}}DS struct {
+	config.DSCommon
+}
+
+// TODO: if resource exists and TF{{.NamePascalCase}}Model is identical to data source attributes the existing model should be reutilized
+// type TF{{.NamePascalCase}}DSModel struct {
+// 	ID          types.String `tfsdk:"id"`
+	// TODO: add attribute definitions
+//}
+
+func (d *{{.NameCamelCase}}DS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			// TODO: add attribute definitions
+		},
+	}
+}
+
+func (d *{{.NameCamelCase}}DS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var {{.NameCamelCase}}Config TF{{.NamePascalCase}}Model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &{{.NameCamelCase}}Config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make get request to resource
+
+	// connV2 := r.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	new{{.NamePascalCase}}Model, diags := NewTF{{.NamePascalCase}}(ctx, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, new{{.NamePascalCase}}Model)...)
+}

--- a/tools/scaffold/template/model.tmpl
+++ b/tools/scaffold/template/model.tmpl
@@ -1,0 +1,36 @@
+package {{.NameLowerNoSpaces}}
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	// "go.mongodb.org/atlas-sdk/v20231115002/admin" use latest version
+)
+
+// TODO: `ctx` parameter and `diags` return value can be removed if tf schema has no complex data types (e.g., schema.ListAttribute, schema.SetAttribute)
+func NewTF{{.NamePascalCase}}(ctx context.Context, apiResp *admin.{{.NamePascalCase}}) (*TF{{.NamePascalCase}}Model, diag.Diagnostics) {
+	// complexAttr, diagnostics := types.ListValueFrom(ctx, InnerObjectType, newTFComplexAttrModel(apiResp.ComplexAttr))
+	// if diagnostics.HasError() {
+	// 	return nil, diagnostics
+	// }
+	return &TF{{.NamePascalCase}}Model{}, nil
+}
+
+{{if eq .GenerationType "resource"}}
+// TODO: If SDK defined different models for create and update separate functions will need to be defined.
+// TODO: `ctx` parameter and `diags` in return value can be removed if tf schema has no complex data types (e.g., schema.ListAttribute, schema.SetAttribute)
+func New{{.NamePascalCase}}Req(ctx context.Context, plan *TF{{.NamePascalCase}}Model) (*admin.{{.NamePascalCase}}, diag.Diagnostics) {
+    // var tfList []complexArgumentData
+	// resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+	// if resp.Diagnostics.HasError() {
+	// 	return nil, diagnostics
+	// }
+	return &admin.{{.NamePascalCase}}{}, nil
+}
+{{end}}
+
+{{if eq .GenerationType "plural-data-source"}}
+func NewTF{{.NamePascalCase}}s(ctx context.Context, paginatedResult *admin.Paginated{{.NamePascalCase}}) (*TF{{.NamePascalCase}}sDSModel, diag.Diagnostics) {
+	return &TF{{.NamePascalCase}}sDSModel{}, nil
+}
+{{end}}

--- a/tools/scaffold/template/model_test.tmpl
+++ b/tools/scaffold/template/model_test.tmpl
@@ -1,0 +1,71 @@
+package {{.NameLowerNoSpaces}}_test
+
+import (
+	"context"
+	"testing"
+
+    "github.com/stretchr/testify/assert"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/{{.NameLowerNoSpaces}}"
+	// "go.mongodb.org/atlas-sdk/v20231115002/admin" use latest version
+)
+
+type sdkToTFModelTestCase struct {
+	SDKResp         *admin.{{.NamePascalCase}}
+	expectedTFModel *{{.NameLowerNoSpaces}}.TF{{.NamePascalCase}}Model
+	name            string
+}
+
+func Test{{.NamePascalCase}}SDKToTFModel(t *testing.T) {
+	testCases := []sdkToTFModelTestCase{ // TODO: consider adding test cases to contemplate all possible API responses
+		{
+			name: "Complete SDK response",
+			SDKResp: &admin.{{.NamePascalCase}}{
+			},
+			expectedTFModel: &{{.NameLowerNoSpaces}}.TF{{.NamePascalCase}}Model{
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resultModel, diags := {{.NameLowerNoSpaces}}.NewTF{{.NamePascalCase}}(context.Background(), tc.SDKResp)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			if !assert.Equal(t, resultModel, tc.expectedTFModel) {
+				t.Errorf("created terraform model did not match expected output")
+			}
+		})
+	}
+}
+
+{{if eq .GenerationType "resource"}}
+type tfToSDKModelTestCase struct {
+	name           string
+	tfModel        *{{.NameLowerNoSpaces}}.TF{{.NamePascalCase}}Model
+	expectedSDKReq *admin.{{.NamePascalCase}}
+}
+
+func Test{{.NamePascalCase}}TFModelToSDK(t *testing.T) {
+	testCases := []tfToSDKModelTestCase{
+		{
+			name: "Complete TF state",
+			tfModel: &{{.NameLowerNoSpaces}}.TF{{.NamePascalCase}}Model{
+			},
+			expectedSDKReq: &admin.{{.NamePascalCase}}{
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		apiReqResult, diags := {{.NameLowerNoSpaces}}.New{{.NamePascalCase}}Req(context.Background(), tc.tfModel)
+		if diags.HasError() {
+			t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+		}
+		if !assert.Equal(t, apiReqResult, tc.expectedSDKReq) {
+			t.Errorf("created sdk model did not match expected output")
+		}
+	}
+}
+{{end}}
+

--- a/tools/scaffold/template/pluraldatasource.tmpl
+++ b/tools/scaffold/template/pluraldatasource.tmpl
@@ -1,0 +1,66 @@
+package {{.NameLowerNoSpaces}}
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
+)
+
+var _ datasource.DataSource = &{{.NameCamelCase}}sDS{}
+var _ datasource.DataSourceWithConfigure = &{{.NameCamelCase}}sDS{}
+
+func DataSource() datasource.DataSource {
+	return &{{.NameCamelCase}}DS{
+		DSCommon: config.DSCommon{
+			DataSourceName: fmt.Sprintf("%ss", {{.NameCamelCase}}Name),
+		},
+	}
+}
+
+type {{.NameCamelCase}}sDS struct {
+	config.DSCommon
+}
+
+type TF{{.NamePascalCase}}sDSModel struct {
+	ID           types.String `tfsdk:"id"`
+	// TODO: add attribute definitions
+	Results      []TF{{.NamePascalCase}}DSModel `tfsdk:"results"`
+	PageNum      types.Int64 `tfsdk:"page_num"`
+	ItemsPerPage types.Int64 `tfsdk:"items_per_page"`
+	TotalCount   types.Int64 `tfsdk:"total_count"`
+}
+
+func (d *{{.NameCamelCase}}sDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dsschema.PaginatedDSSchema(
+		map[string]schema.Attribute{}, // TODO: define arguments of the data source
+		map[string]schema.Attribute{}, // TODO: define attributes of the result elements, schema from singular data source can be reused
+        )
+}
+
+func (d *{{.NameCamelCase}}sDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var {{.NameCamelCase}}sConfig TF{{.NamePascalCase}}sDSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &{{.NameCamelCase}}sConfig)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make get request to obtain list of results
+
+	// connV2 := r.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error fetching results", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	new{{.NamePascalCase}}sModel, diags := NewTF{{.NamePascalCase}}s(ctx, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, new{{.NamePascalCase}}sModel)...)
+}

--- a/tools/scaffold/template/resource.tmpl
+++ b/tools/scaffold/template/resource.tmpl
@@ -1,0 +1,157 @@
+package {{.NameLowerNoSpaces}}
+
+import (
+    "context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+const {{.NameCamelCase}}Name = "{{.NameSnakeCase}}"
+
+var _ resource.ResourceWithConfigure = &{{.NameCamelCase}}RS{}
+var _ resource.ResourceWithImportState = &{{.NameCamelCase}}RS{}
+
+func Resource() resource.Resource {
+	return &{{.NameCamelCase}}RS{
+		RSCommon: config.RSCommon{
+			ResourceName: {{.NameCamelCase}}Name,
+		},
+	}
+}
+
+type {{.NameCamelCase}}RS struct {
+	config.RSCommon
+}
+
+type TF{{.NamePascalCase}}Model struct {
+	ID          types.String   `tfsdk:"id"`
+    // TODO: add attribute definitions
+}
+
+func (r *{{.NameCamelCase}}RS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+            // TODO: add attribute definitions
+        },
+    }
+}
+
+func (r *{{.NameCamelCase}}RS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var {{.NameCamelCase}}Plan TF{{.NamePascalCase}}Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &{{.NameCamelCase}}Plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+    {{.NameCamelCase}}Req, diags := New{{.NamePascalCase}}Req(ctx, &{{.NameCamelCase}}Plan)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	
+	// TODO: make POST request to Atlas API and handle error in response
+
+	// connV2 := r.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error creating resource", err.Error())
+	//	return
+	//}
+	
+    // TODO: process response into new terraform state
+	new{{.NamePascalCase}}Model, diags := NewTF{{.NamePascalCase}}(ctx, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, new{{.NamePascalCase}}Model)...)
+}
+
+func (r *{{.NameCamelCase}}RS) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var {{.NameCamelCase}}State TF{{.NamePascalCase}}Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &{{.NameCamelCase}}State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make get request to resource
+
+	// connV2 := r.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	new{{.NamePascalCase}}Model, diags := NewTF{{.NamePascalCase}}(ctx, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, new{{.NamePascalCase}}Model)...)
+}
+
+func (r *{{.NameCamelCase}}RS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var {{.NameCamelCase}}Plan TF{{.NamePascalCase}}Model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &{{.NameCamelCase}}Plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	{{.NameCamelCase}}Req, diags := New{{.NamePascalCase}}Req(ctx, &{{.NameCamelCase}}Plan)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// TODO: make PATCH request to Atlas API and handle error in response
+	// connV2 := r.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error updating resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+
+	new{{.NamePascalCase}}Model, diags := NewTF{{.NamePascalCase}}(ctx, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, new{{.NamePascalCase}}Model)...)
+}
+
+func (r *{{.NameCamelCase}}RS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var {{.NameCamelCase}}State *TF{{.NamePascalCase}}Model
+	resp.Diagnostics.Append(req.State.Get(ctx, &{{.NameCamelCase}}State)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make Delete request to Atlas API
+
+	// connV2 := r.Client.AtlasV2
+	// if _, _, err := connV2.Api.Delete().Execute(); err != nil {
+	// 	 resp.Diagnostics.AddError("error deleting resource", err.Error())
+	// 	 return
+	// }
+}
+
+func (r *{{.NameCamelCase}}RS) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// TODO: parse req.ID string taking into account documented format. Example:
+	
+	// projectID, other, err := split{{.NamePascalCase}}ImportID(req.ID)
+	// if err != nil {
+	//	resp.Diagnostics.AddError("error splitting import ID", err.Error())
+	//	return
+	//}
+
+	// TODO: define attributes that are required for read operation to work correctly. Example:
+
+	// resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
+}


### PR DESCRIPTION
## Description

Link to any related issue(s): [CLOUDP-214957](https://jira.mongodb.org/browse/CLOUDP-214957)

**Summary**: A new make command was defined to scaffold go files associated to a new resource, singular data source, or plural data source. This will speed up development and ensure consistency in the files and code structure of new implementations.

As part of reviewing I suggest running the command locally to see the files that are generated and the code guidelines that are defined.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
