### PR TITLE
fix: Fixes cluster_outage_simulation test group in older TF versions

### DIFF
--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -144,7 +144,7 @@ func Resource() *schema.Resource {
 			"cloud_backup": {
 				Type:          schema.TypeBool,
 				Optional:      true,
-				Default:       false,
+				Computed:      true,
 				ConflictsWith: []string{"backup_enabled"},
 			},
 			"provider_instance_size_name": {
@@ -213,9 +213,10 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"replication_specs": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -228,9 +229,10 @@ func Resource() *schema.Resource {
 							Required: true,
 						},
 						"regions_config": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
+							Type:       schema.TypeSet,
+							Optional:   true,
+							Computed:   true,
+							ConfigMode: schema.SchemaConfigModeAttr,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"region_name": {

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -237,7 +237,8 @@ func Resource() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"region_name": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
+										Computed: true,
 									},
 									"electable_nodes": {
 										Type:     schema.TypeInt,
@@ -252,12 +253,12 @@ func Resource() *schema.Resource {
 									"read_only_nodes": {
 										Type:     schema.TypeInt,
 										Optional: true,
-										Default:  0,
+										Computed: true,
 									},
 									"analytics_nodes": {
 										Type:     schema.TypeInt,
 										Optional: true,
-										Default:  0,
+										Computed: true,
 									},
 								},
 							},


### PR DESCRIPTION
## Description

Fixes cluster_outage_simulation test group in older TF versions, tested in version 1.0.8.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-217534


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
