### PR TITLE
fix: Fixes backup_online_archive test group in older TF versions

### DIFF
--- a/internal/service/onlinearchive/resource_online_archive.go
+++ b/internal/service/onlinearchive/resource_online_archive.go
@@ -67,10 +67,11 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"criteria": {
-			Type:     schema.TypeList,
-			MinItems: 1,
-			MaxItems: 1,
-			Required: true,
+			Type:       schema.TypeList,
+			MinItems:   1,
+			MaxItems:   1,
+			Required:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
@@ -81,20 +82,23 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 					"date_field": {
 						Type:     schema.TypeString,
 						Optional: true,
+						Computed: true,
 					},
 					"date_format": {
 						Type:         schema.TypeString,
 						Optional:     true,
-						Computed:     true, // api will set the default
+						Computed:     true,
 						ValidateFunc: validation.StringInSlice([]string{"ISODATE", "EPOCH_SECONDS", "EPOCH_MILLIS", "EPOCH_NANOSECONDS"}, false),
 					},
 					"expire_after_days": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"query": {
 						Type:     schema.TypeString,
 						Optional: true,
+						Computed: true,
 					},
 				},
 			},
@@ -117,9 +121,9 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 			Type:       schema.TypeList,
 			MinItems:   1,
 			MaxItems:   1,
-			ConfigMode: schema.SchemaConfigModeAttr,
 			Optional:   true,
 			Computed:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"region": {
@@ -136,10 +140,12 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 			},
 		},
 		"schedule": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MinItems: 1,
-			MaxItems: 1,
+			Type:       schema.TypeList,
+			Optional:   true,
+			Computed:   true,
+			MinItems:   1,
+			MaxItems:   1,
+			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
@@ -150,34 +156,41 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 					"end_hour": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"end_minute": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"start_hour": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"start_minute": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"day_of_month": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 					"day_of_week": {
 						Type:     schema.TypeInt,
 						Optional: true,
+						Computed: true,
 					},
 				},
 			},
 		},
 		"partition_fields": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
+			Type:       schema.TypeList,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"field_name": {
@@ -212,7 +225,7 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 		"sync_creation": {
 			Type:     schema.TypeBool,
 			Optional: true,
-			Default:  false,
+			Computed: true,
 		},
 	}
 }

--- a/internal/service/onlinearchive/resource_online_archive.go
+++ b/internal/service/onlinearchive/resource_online_archive.go
@@ -204,6 +204,7 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 					},
 					"field_type": {
 						Type:     schema.TypeString,
+						Optional: true,
 						Computed: true,
 					},
 				},

--- a/internal/service/onlinearchive/resource_online_archive.go
+++ b/internal/service/onlinearchive/resource_online_archive.go
@@ -70,13 +70,15 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 			Type:       schema.TypeList,
 			MinItems:   1,
 			MaxItems:   1,
-			Required:   true,
+			Optional:   true,
+			Computed:   true,
 			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"type": {
 						Type:         schema.TypeString,
-						Required:     true,
+						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.StringInSlice([]string{"DATE", "CUSTOM"}, false),
 					},
 					"date_field": {
@@ -104,15 +106,18 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 			},
 		},
 		"data_expiration_rule": {
-			Type:     schema.TypeList,
-			MinItems: 1,
-			MaxItems: 1,
-			Optional: true,
+			Type:       schema.TypeList,
+			MinItems:   1,
+			MaxItems:   1,
+			Optional:   true,
+			Computed:   true,
+			ConfigMode: schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"expire_after_days": {
 						Type:     schema.TypeInt,
-						Required: true,
+						Optional: true,
+						Computed: true,
 					},
 				},
 			},
@@ -150,7 +155,8 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"type": {
 						Type:         schema.TypeString,
-						Required:     true,
+						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.StringInSlice([]string{"DAILY", "MONTHLY", "WEEKLY"}, false),
 					},
 					"end_hour": {
@@ -195,11 +201,13 @@ func getMongoDBAtlasOnlineArchiveSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"field_name": {
 						Type:     schema.TypeString,
-						Required: true,
+						Optional: true,
+						Computed: true,
 					},
 					"order": {
 						Type:         schema.TypeInt,
-						Required:     true,
+						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntAtLeast(0),
 					},
 					"field_type": {


### PR DESCRIPTION
## Description

Fixes backup_online_archive test group in older TF versions, tested in version 1.0.8.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-217538


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
