### PR TITLE
chore: fix examples job by defining beta flag

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,14 +2,16 @@ name: Examples Checks
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     paths:
       - .github/workflows/examples.yml
       - examples/**
+  workflow_dispatch: {}
 
 env:
   AWS_DEFAULT_REGION: us-west-2
+  MONGODB_ATLAS_ENABLE_BETA: ${{ vars.MONGODB_ATLAS_ENABLE_BETA }}
 
 jobs:
   tf-validate:
@@ -17,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: ["1.5.2"]
+        terraform_version: ["${{vars.TF_VERSION_LATEST}}"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: ["1.5.2"]
+        terraform_version: ["${{vars.TF_VERSION_LATEST}}"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

**Context**: TF examples job is currently failing but only runs if examples are modified, error appeared [here](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/7188123383/job/19577127209?pr=1745). The beta flag change was merged with no issue because no examples were modified and therefor this job was not run.

This PR includes:

- Defining beta flag env variable in examples job so that it runs successfully.
- Fix branch name so this job runs on every merged commit to master.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
