### PR TITLE
fix: Fixes cluster update when adding replication specs

### DIFF
--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -1220,7 +1220,8 @@ func expandReplicationSpecs(d *schema.ResourceData) ([]matlas.ReplicationSpec, e
 						break
 					}
 				}
-				if id == "" && oldSpecs != nil {
+				// If there was an item before and after then use the same id assuming it's the same replication spec
+				if id == "" && oldSpecs != nil && len(vRSpecs.(*schema.Set).List()) == 1 && len(original.(*schema.Set).List()) == 1 {
 					id = oldSpecs["id"].(string)
 				}
 			}


### PR DESCRIPTION
## Description

Fixes cluster update when adding replication specs.

Fixes: https://jira.mongodb.org/browse/HELP-53360

Also keeps patch done in: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/607


Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-217772


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
