### PR TITLE
fix: Doesn't disable X.509 in the project when mongodbatlas_x509_authentication_database_user resource is deleted

### DIFF
--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
@@ -176,7 +176,8 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasX509AuthDBUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// We don't do anything because X.509 certificates can not be deleted or disassociated from a user
+	// We don't do anything because X.509 certificates can not be deleted or disassociated from a user.
+	// More info: https://jira.mongodb.org/browse/HELP-53363
 	d.SetId("")
 	return nil
 }

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
@@ -176,21 +176,8 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 }
 
 func resourceMongoDBAtlasX509AuthDBUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
-
-	ids := conversion.DecodeStateID(d.Id())
-	currentCertificate := ids["current_certificate"]
-	projectID := ids["project_id"]
-
-	if currentCertificate == "" {
-		_, err := conn.X509AuthDBUsers.DisableCustomerX509(ctx, projectID)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorCustomerX509AuthDBUsersDelete, projectID, err))
-		}
-	}
-
+	// We don't do anything because X.509 certificates can not be deleted or disassociated from a user
 	d.SetId("")
-
 	return nil
 }
 

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -17,6 +17,8 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
+-> **NOTE:** Before provider version 1.12.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted.
+
 ## Example Usages
 
 ### Example Usage: Generate an Atlas-managed X.509 certificate for a MongoDB user

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
--> **NOTE:** Before provider version 1.14.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted.
+-> **NOTE:** Before provider version 1.14.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted. From that version on, it is not disabled because the other users may want to continue using X.509.
 
 ## Example Usages
 

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
--> **NOTE:** Before provider version 1.14.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted. From that version on, it is not disabled because the other users may want to continue using X.509.
+-> **NOTE:** Before provider version 1.14.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted. Starting from that version onward, it will not be disabled, allowing other users to continue using X.509 within the same project.
 
 ## Example Usages
 

--- a/website/docs/r/x509_authentication_database_user.html.markdown
+++ b/website/docs/r/x509_authentication_database_user.html.markdown
@@ -17,7 +17,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
--> **NOTE:** Before provider version 1.12.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted.
+-> **NOTE:** Before provider version 1.14.0, Self-managed X.509 Authentication was disabled for the project when this resource was deleted.
 
 ## Example Usages
 


### PR DESCRIPTION
## Description

Doesn't disable X.509 in the project when mongodbatlas_x509_authentication_database_user resource is deleted

Link to any related issue(s):  https://jira.mongodb.org/browse/CLOUDP-218316


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
