### PR TITLE
chore: update the alert notifications regions for Datadog

### DIFF
--- a/internal/service/alertconfiguration/resource_alert_configuration.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration.go
@@ -260,9 +260,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						},
 						"datadog_region": schema.StringAttribute{
 							Optional: true,
-							Validators: []validator.String{
-								stringvalidator.OneOf("US", "EU", "US3", "US5"),
-							},
 						},
 						"delay_min": schema.Int64Attribute{
 							Optional: true,

--- a/internal/service/alertconfiguration/resource_alert_configuration.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration.go
@@ -261,7 +261,7 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"datadog_region": schema.StringAttribute{
 							Optional: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("US", "EU"),
+								stringvalidator.OneOf("US", "EU", "US3", "US5"),
 							},
 						},
 						"delay_min": schema.Int64Attribute{

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -198,7 +198,7 @@ Notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. See the `datadogRegion` field in the `notifications` request parameter of [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createAlertConfiguration) for more details. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. Atlas returns this value if `type_name` is set  to `ORG`, `GROUP`, or `USER`.

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -198,7 +198,7 @@ Notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. Atlas returns this value if `type_name` is set  to `ORG`, `GROUP`, or `USER`.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -142,7 +142,7 @@ Notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. See the `datadogRegion` field in the `notifications` request parameter of [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createAlertConfiguration) for more details. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. Atlas returns this value if `type_name` is set  to `ORG`, `GROUP`, or `USER`.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -142,7 +142,7 @@ Notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. Atlas returns this value if `type_name` is set  to `ORG`, `GROUP`, or `USER`.

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -195,7 +195,7 @@ List of notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. This flag is only valid if `type_name` is set to `ORG`, `GROUP`, or `USER`.

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -195,7 +195,7 @@ List of notifications to send when an alert condition is detected.
 * `api_token` - Slack API token. Required for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.
 * `channel_name` - Slack channel name. Required for the SLACK notifications type.
 * `datadog_api_key` - Datadog API Key. Found in the Datadog dashboard. Required for the DATADOG notifications type.
-* `datadog_region` - Region that indicates which API URL to use. Accepted regions are: `US`, `EU`, `US3`, `US5`. The default Datadog region is US.
+* `datadog_region` - Region that indicates which API URL to use. See the `datadogRegion` field in the `notifications` request parameter of [MongoDB API Alert Configuration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Alert-Configurations/operation/createAlertConfiguration) for more details. The default Datadog region is US.
 * `delay_min` - Number of minutes to wait after an alert condition is detected before sending out the first notification.
 * `email_address` - Email address to which alert notifications are sent. Required for the EMAIL notifications type.
 * `email_enabled` - Flag indicating email notifications should be sent. This flag is only valid if `type_name` is set to `ORG`, `GROUP`, or `USER`.


### PR DESCRIPTION
Since at least the version 2023-01-01 of the MongoDB Atlas REST API (https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/2023-01-01/#tag/Alert-Configurations/operation/createAlertConfiguration), there are more than 2 regions available with Datadog to send alerts.

Added the additional supported regions (US3 and US5) to the list for the `datadog_region` attribute.