### PR TITLE
test: Fixes tests after updating terraform-plugin-testing from 1.5.1 to 1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/hashicorp/terraform-plugin-testing v1.5.1
+	github.com/hashicorp/terraform-plugin-testing v1.6.0
 	github.com/mongodb-forks/digest v1.0.5
 	github.com/mwielbut/pointy v1.1.0
 	github.com/spf13/cast v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/hashicorp/terraform-plugin-sdk v1.17.2/go.mod h1:wkvldbraEMkz23NxkkAs
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0 h1:Bl3e2ei2j/Z3Hc2HIS15Gal2KMKyLAZ2om1HCEvK6es=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0/go.mod h1:i2C41tszDjiWfziPQDL5R/f3Zp0gahXe5No/MIO9rCE=
 github.com/hashicorp/terraform-plugin-test/v2 v2.2.1/go.mod h1:eZ9JL3O69Cb71Skn6OhHyj17sLmHRb+H6VrDcJjKrYU=
-github.com/hashicorp/terraform-plugin-testing v1.5.1 h1:T4aQh9JAhmWo4+t1A7x+rnxAJHCDIYW9kXyo4sVO92c=
-github.com/hashicorp/terraform-plugin-testing v1.5.1/go.mod h1:dg8clO6K59rZ8w9EshBmDp1CxTIPu3yA4iaDpX1h5u0=
+github.com/hashicorp/terraform-plugin-testing v1.6.0 h1:Wsnfh+7XSVRfwcr2jZYHsnLOnZl7UeaOBvsx6dl/608=
+github.com/hashicorp/terraform-plugin-testing v1.6.0/go.mod h1:cJGG0/8j9XhHaJZRC+0sXFI4uzqQZ9Az4vh6C4GJpFE=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1450,7 +1450,6 @@ func TestAccClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_main
 				Config:                   cfg,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
-						acc.DebugPlan(),
 						plancheck.ExpectEmptyPlan(),
 					},
 				},

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1451,9 +1451,9 @@ func TestAccClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_main
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
 						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
 					},
 				},
-				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/service/customdbrole/resource_custom_db_role_test.go
+++ b/internal/service/customdbrole/resource_custom_db_role_test.go
@@ -447,10 +447,11 @@ func TestAccConfigRSCustomDBRoles_importBasic(t *testing.T) {
 				Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "INSERT", databaseName),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasCustomDBRolesImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testAccCheckMongoDBAtlasCustomDBRolesImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"actions.0.resources.0.cluster"},
 			},
 		},
 	})

--- a/internal/service/customdbrole/resource_custom_db_role_test.go
+++ b/internal/service/customdbrole/resource_custom_db_role_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -452,6 +453,15 @@ func TestAccConfigRSCustomDBRoles_importBasic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"actions.0.resources.0.cluster"},
+			},
+			{
+				Config: testAccMongoDBAtlasCustomDBRolesConfigBasic(orgID, projectName, roleName, "INSERT", databaseName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -54,6 +54,8 @@ func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 				ImportStateIdFunc:        testAccCheckMongoDBAtlasFederatedDatabaseInstanceImportStateIDFunc(resourceName),
 				ImportState:              true,
 				ImportStateVerify:        true,
+				ImportStateVerifyIgnore: []string{"storage_stores.0.allow_insecure", "storage_stores.0.include_tags", "storage_stores.0.read_preference.0.max_staleness_seconds",
+					"storage_stores.1.allow_insecure", "storage_stores.1.include_tags", "storage_stores.1.read_preference.0.max_staleness_seconds"},
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Link to any related issue(s): [CLOUDP-219141](https://jira.mongodb.org/browse/CLOUDP-219141)

This PR uses the [dependabot PR](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1743) as the base branch which is updating `terraform-plugin-testing` from 1.5.1 to 1.6.0.
Due to some changes introduced in this new version some of our tests where impacted (seen in the following [CI execution](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/7274953242/job/19824564091) that was triggered manually):
- (caused by 1) TestAccClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_maintainsBackwardCompatibility
- (caused by 2) TestAccFederatedDatabaseInstance_basic
- (caused by 2) TestAccConfigRSCustomDBRoles_importBasic

The failing test are due to 2 causes.

### 1. Changes in the behaviour of `PlanOnly`

I raised an issue to HashiCorp with the details of the failing test and guidance was provided: https://github.com/hashicorp/terraform-plugin-testing/issues/256.
In summary, the failing case defines a migration test from an old provider version to the latest, and during these version one attribute is removed from the schema. After `terraform-plugin-testing` v1.6.0 when using `PlanOnly` the state is not automatically updated with the current provider schema before the destroy begins, leading to the error.
The suggested way moving forward is to avoid using `PlanOnly: true`, and instead use [plancheck.ExpectEmptyPlan()](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/plancheck#ExpectEmptyPlan). This is only needed when the underlying provider schema changes between TestSteps.

### 2. Changes in the behaviour of `ImportState`

Examples of the failing test:
```
--- FAIL: TestAccConfigRSCustomDBRoles_importBasic (18.63s)
    /Users/agustin.bettati/mongodb/terraform-provider-mongodbatlas/internal/service/customdbrole/resource_custom_db_role_test.go:442: Step 2/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        + 	"actions.0.resources.0.cluster": "false",
          }
```

As seen in the message, after `terraform-plugin-testing` v1.6.0 the `ImportStateVerify: true,` config verifies if there are attributes that are present in the state, but not in the config. Before this version this check only verified missing attributes in the state. I verified that in both cases these additional attributes do not cause a non-empty plan (and also added in test cases), and add these additional attribute in the `ImportStateVerifyIgnore` array.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
