### PR TITLE
doc: Clean up doc bug of resource mongodbatlas_access_list_api_key resource name

### DIFF
--- a/website/docs/r/access_list_api_key.html.markdown
+++ b/website/docs/r/access_list_api_key.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Creates the access list entries for the specified Atlas Organization API Key. 
 ---
 
-# Resource: mongodbatlas_project_ip_access_list_key
+# Resource: mongodbatlas_access_list_api_key
 
 `mongodbatlas_access_list_api_key` provides an IP Access List entry resource. The access list grants access from IPs, CIDRs or AWS Security Groups (if VPC Peering is enabled) to clusters within the Project.
 


### PR DESCRIPTION
Clean up doc bug, incorrect name of resource

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.
Clean up doc bug of resource mongodbatlas_access_list_api_key resource name

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
