### PR TITLE
chore: Add tfplugindocs & tfplugingen-openapi to the dev tools

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -78,6 +78,7 @@ tools:  ## Install dev tools
 	go install github.com/vektra/mockery/v2@$(MOCKERY_VERSION)
 	go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
 	go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@latest
+	go install github.com/hashicorp/terraform-plugin-codegen-framework/cmd/tfplugingen-framework@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,8 @@ tools:  ## Install dev tools
 	go install github.com/rhysd/actionlint/cmd/actionlint@latest
 	go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
 	go install github.com/vektra/mockery/v2@$(MOCKERY_VERSION)
+	go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
+	go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: check


### PR DESCRIPTION
## Description
Ticket: [CLOUDP-220383](https://jira.mongodb.org/browse/CLOUDP-220383)

This PR adds `tfplugindocs` & `tfplugingen-openapi` to the dev tools makefile command.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
```bash
make tools                                                                    1.6.6  16.18.0
==> Installing dependencies...
go install github.com/icholy/gomajor@latest
go install github.com/client9/misspell/cmd/misspell@latest
go install github.com/terraform-linters/tflint@v0.49.0
go install github.com/rhysd/actionlint/cmd/actionlint@latest
go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
go install github.com/vektra/mockery/v2@v2.38.0
go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
go install github.com/hashicorp/terraform-plugin-codegen-openapi/cmd/tfplugingen-openapi@latest
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /Users/andrea.angiolillo/go/bin v1.55.0
golangci/golangci-lint info checking GitHub for tag 'v1.55.0'
golangci/golangci-lint info found version: 1.55.0 for v1.55.0/darwin/arm64
golangci/golangci-lint info installed /Users/andrea.angiolillo/go/bin/golangci-lint
```