### PR TITLE
fix: Update attributes `copy_protection_enabled`, `pit_enabled` and `encryption_at_rest_enabled` in the  resource `backup_compliance_policy` to be Optional

### DIFF
--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
@@ -52,12 +52,10 @@ func Resource() *schema.Resource {
 				Required: true,
 			},
 			"copy_protection_enabled": {
-				Type:     schema.TypeBool,
-				Required: true,
+				Type: schema.TypeBool,
 			},
 			"encryption_at_rest_enabled": {
-				Type:     schema.TypeBool,
-				Required: true,
+				Type: schema.TypeBool,
 			},
 			"restore_window_days": {
 				Type:     schema.TypeInt,
@@ -94,8 +92,7 @@ func Resource() *schema.Resource {
 				},
 			},
 			"pit_enabled": {
-				Type:     schema.TypeBool,
-				Required: true,
+				Type: schema.TypeBool,
 			},
 			"state": {
 				Type:     schema.TypeString,

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
@@ -52,10 +52,14 @@ func Resource() *schema.Resource {
 				Required: true,
 			},
 			"copy_protection_enabled": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"encryption_at_rest_enabled": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"restore_window_days": {
 				Type:     schema.TypeInt,
@@ -92,7 +96,9 @@ func Resource() *schema.Resource {
 				},
 			},
 			"pit_enabled": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"state": {
 				Type:     schema.TypeString,
@@ -411,7 +417,7 @@ func resourceMongoDBAtlasBackupCompliancePolicyUpdate(ctx context.Context, d *sc
 
 	backupCompliancePolicyUpdate.AuthorizedEmail = d.Get("authorized_email").(string)
 
-	backupCompliancePolicyUpdate.AuthorizedUserFirstName = d.Get("authorized_user_fist_name").(string)
+	backupCompliancePolicyUpdate.AuthorizedUserFirstName = d.Get("authorized_user_first_name").(string)
 
 	backupCompliancePolicyUpdate.AuthorizedUserLastName = d.Get("authorized_user_last_name").(string)
 

--- a/website/docs/r/backup_compliance_policy.html.markdown
+++ b/website/docs/r/backup_compliance_policy.html.markdown
@@ -145,9 +145,9 @@ resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
-* `authorized_email` - Email address of a security or legal representative for the Backup Compliance Policy who is authorized to update the Backup Compliance Policy settings.
-* `authorized_user_first_name` - First name of the user who authorized to update the Backup Compliance Policy settings.
-* `authorized_user_last_name` - Last name of the user who authorized to update the Backup Compliance Policy settings.
+* `authorized_email` - (Required) Email address of a security or legal representative for the Backup Compliance Policy who is authorized to update the Backup Compliance Policy settings.
+* `authorized_user_first_name` - (Required) First name of the user who authorized to update the Backup Compliance Policy settings.
+* `authorized_user_last_name` - (Required) Last name of the user who authorized to update the Backup Compliance Policy settings.
 * `copy_protection_enabled` - Flag that indicates whether to enable additional backup copies for the cluster. If unspecified, this value defaults to false.
 * `pit_enabled` - Flag that indicates whether the cluster uses Continuous Cloud Backups with a Backup Compliance Policy. If unspecified, this value defaults to false.
 * `encryption_at_rest_enabled` - Flag that indicates whether Encryption at Rest using Customer Key Management is required for all clusters with a Backup Compliance Policy. If unspecified, this value defaults to false.


### PR DESCRIPTION
## Description
Ticket: https://jira.mongodb.org/browse/CLOUDP-220487

`mongodbatlas_backup_compliance_policy` defines the `copy_protection_enabled`, `pit_enabled` and `encryption_at_rest_enabled` as required attributes when both the [API documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Cloud-Backups/operation/updateDataProtectionSettings) and the [resource documentation](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/backup_compliance_policy) say the opposite.

Link to any related issue(s): #1800 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Testing

### I defined a new Acceptance tests
```hcl
Running tool: /Users/andrea.angiolillo/.asdf/shims/go test -timeout 300000s -run ^TestAccGenericBackupRSBackupCompliancePolicy_withoutOptionals$ github.com/mongodb/terraform-provider-mongodbatlas/internal/service/backupcompliancepolicy

ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/backupcompliancepolicy	15.761s
```

### Local test

- I installed the provider version 1.14.0
- I used the following TF conf
```hcl
resource "mongodbatlas_project" "atlas-project" {
  name   = "test-andrea"
  org_id = "XXXXXXXXXXX"
}

resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
  project_id                 = mongodbatlas_project.atlas-project.id
  authorized_email           = "user@email.com"
  authorized_user_first_name = "ssss"
  authorized_user_last_name  = "sss"
  copy_protection_enabled    = false
  pit_enabled                = false
  encryption_at_rest_enabled = false

  restore_window_days = 7

  on_demand_policy_item {
    frequency_interval = 1
    retention_unit     = "days"
    retention_value    = 3
  }

  policy_item_hourly {
    frequency_interval = 1
    retention_unit     = "days"
    retention_value    = 7
  }

  policy_item_daily {
    frequency_interval = 1
    retention_unit     = "days"
    retention_value    = 7
  }

  policy_item_weekly {
    frequency_interval = 1
    retention_unit     = "weeks"
    retention_value    = 4
  }

  policy_item_monthly {
    frequency_interval = 1
    retention_unit     = "months"
    retention_value    = 12
  }
}
```

- Run `terraform apply`
```hcl
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
- I upgraded the provider to the local changes
- I removed the optional fields from the tf conf
- I run `terraform apply`
```hcl
No changes. Your infrastructure matches the configuration.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```