### PR TITLE
doc: Clarifies lack of support for import statement in organization resource

### DIFF
--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -20,7 +20,7 @@ func Resource() *schema.Resource {
 		ReadContext:   resourceMongoDBAtlasOrganizationRead,
 		UpdateContext: resourceMongoDBAtlasOrganizationUpdate,
 		DeleteContext: resourceMongoDBAtlasOrganizationDelete,
-		Importer:      nil,
+		Importer:      nil, // import is not supported. See CLOUDP-215155
 		Schema: map[string]*schema.Schema{
 			"org_owner_id": {
 				Type:     schema.TypeString,

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -20,9 +20,7 @@ func Resource() *schema.Resource {
 		ReadContext:   resourceMongoDBAtlasOrganizationRead,
 		UpdateContext: resourceMongoDBAtlasOrganizationUpdate,
 		DeleteContext: resourceMongoDBAtlasOrganizationDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasOrganizationImportState,
-		},
+		Importer:      nil,
 		Schema: map[string]*schema.Schema{
 			"org_owner_id": {
 				Type:     schema.TypeString,
@@ -166,30 +164,6 @@ func resourceMongoDBAtlasOrganizationDelete(ctx context.Context, d *schema.Resou
 		return diag.FromErr(fmt.Errorf("error Organization: %s", err))
 	}
 	return nil
-}
-
-func resourceMongoDBAtlasOrganizationImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
-	orgID := d.Id()
-
-	r, _, err := conn.Organizations.Get(ctx, orgID)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't import organization %s , error: %s", orgID, err)
-	}
-
-	if err := d.Set("name", r.Name); err != nil {
-		return nil, fmt.Errorf("error setting `name`: %s", err)
-	}
-
-	if err := d.Set("org_id", r.ID); err != nil {
-		return nil, fmt.Errorf("error setting `org_id`: %s", err)
-	}
-
-	d.SetId(conversion.EncodeStateID(map[string]string{
-		"org_id": orgID,
-	}))
-
-	return []*schema.ResourceData{d}, nil
 }
 
 func newCreateOrganizationRequest(d *schema.ResourceData) *matlas.CreateOrganizationRequest {

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -43,34 +43,6 @@ func TestAccConfigRSOrganization_Basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSOrganization_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceName = "mongodbatlas_organization.test"
-		orgOwnerID   = os.Getenv("MONGODB_ATLAS_ORG_OWNER_ID")
-		name         = fmt.Sprintf("test-acc-import-organization-%s", acctest.RandString(5))
-		description  = "test Key for Acceptance tests"
-		roleName     = "ORG_OWNER"
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasOrganizationImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: false,
-			},
-		},
-	})
-}
-
 func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
@@ -124,17 +96,6 @@ func testAccCheckMongoDBAtlasOrganizationDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckMongoDBAtlasOrganizationImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("not found: %s", resourceName)
-		}
-
-		return rs.Primary.Attributes["org_id"], nil
-	}
 }
 
 func testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleNames string) string {

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -28,14 +28,13 @@ resource "mongodbatlas_organization" "test" {
 
 * `name` - (Required) The name of the organization you want to create. (Cannot be changed via this Provider after creation.)
 * `org_owner_id` - (Required) Unique 24-hexadecimal digit string that identifies the Atlas user that you want to assign the Organization Owner role. This user must be a member of the same organization as the calling API key.  This is only required when authenticating with Programmatic API Keys. [MongoDB Atlas Admin API - Get User By Username](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/MongoDB-Cloud-Users/operation/getUserByUsername)
-* `description` - Programmatic API Key description
+* `description` - (Required) Programmatic API Key description
 
 ~> **NOTE:** Creating an organization will return a new API Key pair that can be used to authenticate and manage the new organization  with MongoDB Atlas Terraform modules/blueprints.  You cannot use the newly created API key pair to manage the newly created organization in the same Terraform module/blueprint that the organization is created in.
 
-
 * `role_names` - (Required) List of Organization roles that the Programmatic API key needs to have. Ensure that you provide at least one role and ensure all roles are valid for the Organization.  You must specify an array even if you are only associating a single role with the Programmatic API key. The [MongoDB Documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/#organization-roles) describes the roles that you can assign to a Programmatic API key.
- 
-  
+* `federation_settings_id` - (Optional) Unique 24-hexadecimal digit string that identifies the federation to link the newly created organization to. If specified, the proposed Organization Owner of the new organization must have the Organization Owner role in an organization associated with the federation.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -43,9 +42,6 @@ In addition to all arguments above, the following attributes are exported:
 * `org_id` - The organization id.
 * `public_key` - Public API key value set for the specified organization API key.
 * `private_key` - Redacted private key returned for this organization API key. This key displays unredacted when first created and is saved within the Terraform state file.
-* `isDeleted` - (computed) Flag that indicates whether this organization has been deleted.
-* `federation_settings_id` - (Optional) Unique 24-hexadecimal digit string that identifies the federation to link the newly created organization to. If specified, the proposed Organization Owner of the new organization must have the Organization Owner role in an organization associated with the federation.
-
 
 ## Import
 

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -12,6 +12,7 @@ description: |-
 
 ~> **IMPORTANT NOTE:**  When you establish an Atlas organization using this resource, it automatically generates a set of initial public and private Programmatic API Keys. These key values are vital to store because you'll need to use them to grant access to the newly created Atlas organization.
 
+~> **NOTE** Import command is currently not supported for this resource.
 
 ## Example Usage
 
@@ -43,11 +44,5 @@ In addition to all arguments above, the following attributes are exported:
 * `public_key` - Public API key value set for the specified organization API key.
 * `private_key` - Redacted private key returned for this organization API key. This key displays unredacted when first created and is saved within the Terraform state file.
 
-## Import
 
-Organization must be imported using organization ID, e.g.
-
-```
-$ terraform import mongodbatlas_organization.my_org 5d09d6a59ccf6445652a444a
-```
 For more information see: [MongoDB Atlas Admin API Organization](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Organizations/operation/createOrganization)  Documentation for more information.


### PR DESCRIPTION
## Description

Related ticket: [CLOUDP-215155](https://jira.mongodb.org/browse/CLOUDP-215155)

As described in Jira ticket import statement of organization is not working. Ticket will still remain in progress until we verify if there is an option of supporting the command with existing API endpoints, or we need to wait for changes from IAM side.

This PR is simply to clarify the currently state in the documentation, and return a more clear message:
**Before**: Error: error reading organization information: GET https://cloud-dev.mongodb.com/api/atlas/v1.0/orgs/64b6bf4c1f89ae5ca0f0d849: 401 (request "") You are not authorized for this resource.
**Now**: Error: resource mongodbatlas_organization doesn't support import

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
