### PR TITLE
chore: Skips Stream test group when running in QA

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -16,6 +16,10 @@ on:
         description: 'The branch, tag or SHA where tests will run, e.g. v1.14.0, empty for default branch'
         type: string
         required: false
+      atlas_cloud_env:
+        description: 'Atlas cloud environment used, can be either `dev` or `qa`, empty for `dev`'     
+        type: string
+        required: false  
       
       mongodb_atlas_org_id:
         type: string
@@ -268,7 +272,7 @@ jobs:
 
   stream:
     needs: [ change-detection ]
-    if: ${{ needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream' }}
+    if: ${{ inputs.atlas_cloud_env != 'qa' && (needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -53,6 +53,7 @@ jobs:
       terraform_version: ${{ inputs.terraform_version || vars.TF_VERSION_LATEST }}
       ref: ${{ inputs.ref }}
       test_group: ${{ inputs.test_group }}
+      atlas_cloud_env: ${{ inputs.atlas_cloud_env }}
       mongodb_atlas_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA || vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
       mongodb_atlas_org_id_network: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA || vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV_NETWORK }}
       mongodb_atlas_project_id_network: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_ID_CLOUD_QA || vars.MONGODB_ATLAS_PROJECT_ID_CLOUD_DEV_NETWORK }}


### PR DESCRIPTION
## Description

Temporarily removing stream test group from acceptance test when running with QA.

Example run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/7412811442

This change will be reverted on the 31 of Jan when streams feature passes to Public Preview.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
