### PR TITLE
doc: DOCSP-34594 clarify use case for deleting network containers

### DIFF
--- a/website/docs/r/network_container.html.markdown
+++ b/website/docs/r/network_container.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: mongodbatlas_network_container
 
-`mongodbatlas_network_container` provides a Network Peering Container resource. The resource lets you create, edit and delete network peering containers. The resource requires your Project ID.  Each cloud provider requires slightly different attributes so read the argument reference carefully.
+`mongodbatlas_network_container` provides a Network Peering Container resource. The resource lets you create, edit and delete network peering containers. You must delete network peering containers before creating clusters in your project. You can't delete a network peering container if your project contains clusters. The resource requires your Project ID.  Each cloud provider requires slightly different attributes so read the argument reference carefully.
 
  Network peering container is a general term used to describe any cloud providers' VPC/VNet concept.  Containers only need to be created if the peering connection to the cloud provider will be created before the first cluster that requires the container.  If the cluster has been/will be created first Atlas automatically creates the required container per the "containers per cloud provider" information that follows (in this case you can obtain the container id from the cluster resource attribute `container_id`).
 


### PR DESCRIPTION
## Description

The documentation for deleting network containers could use a bit more clarification around when/whether it should be used. The intent is for customer to use this for setting up VPC peering in their project before creating any clusters. However, once clusters have been created in the project, the ability to delete the network container is effectively lost. Either the container can't be deleted because the clusters exist, or it can't be deleted because there are orphaned cloud provider entities left around in the container after deleting a cluster, which are cleaned up asynchronously along with the container itself.

Link to any related issue(s): [DOCSP-34594](https://jira.mongodb.org/browse/DOCSP-34594)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
