### PR TITLE
fix: Provider produces inconsistent result after importing `mongodbatlas_encryption_at_rest`

### DIFF
--- a/internal/service/encryptionatrest/resource_encryption_at_rest.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest.go
@@ -297,7 +297,7 @@ func (r *encryptionAtRestRS) Read(ctx context.Context, req resource.ReadRequest,
 
 	encryptionAtRestStateNew := NewTfEncryptionAtRestRSModel(ctx, projectID, encryptionResp)
 	if isImport {
-		setEmpyArrayForEmptyBlocksReturnedFromImport(encryptionAtRestStateNew)
+		setEmptyArrayForEmptyBlocksReturnedFromImport(encryptionAtRestStateNew)
 	} else {
 		resetDefaultsFromConfigOrState(ctx, &encryptionAtRestState, encryptionAtRestStateNew, nil)
 	}
@@ -478,13 +478,13 @@ func HandleAzureKeyVaultConfigDefaults(ctx context.Context, earRSCurrent, earRSN
 	}
 }
 
-// setEmpyArrayForEmptyBlocksReturnedFromImport sets the blocks AwsKmsConfig, GoogleCloudKmsConfig, TfAzureKeyVaultConfigModel
+// setEmptyArrayForEmptyBlocksReturnedFromImport sets the blocks AwsKmsConfig, GoogleCloudKmsConfig, TfAzureKeyVaultConfigModel
 // to an empty array to avoid unnecessary change detection during plan after migration to Plugin Framework.
 // Why:
 // - the API returns the block AwsKmsConfig{enable=false} when the user does not provide the AWS KMS.
 // - the API returns the block GoogleCloudKmsConfig{enable=false} if the user does not provider Google KMS
 // - the API returns the block TfAzureKeyVaultConfigModel{enable=false} if the user does not provider AZURE KMS
-func setEmpyArrayForEmptyBlocksReturnedFromImport(newStateFromImport *TfEncryptionAtRestRSModel) {
+func setEmptyArrayForEmptyBlocksReturnedFromImport(newStateFromImport *TfEncryptionAtRestRSModel) {
 	if len(newStateFromImport.AwsKmsConfig) == 1 && !newStateFromImport.AwsKmsConfig[0].Enabled.ValueBool() {
 		newStateFromImport.AwsKmsConfig = []TfAwsKmsConfigModel{}
 	}

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"go.mongodb.org/atlas-sdk/v20231115002/admin"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -13,6 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/mwielbut/pointy"
+	"go.mongodb.org/atlas-sdk/v20231115002/admin"
 )
 
 func TestAccMigrationAdvRS_EncryptionAtRest_basicAWS(t *testing.T) {


### PR DESCRIPTION
## Description
Ticket: https://jira.mongodb.org/browse/CLOUDP-220654
Ticket: 

This PR fixes a bug in the `mongodbatlas_encryption_at_rest` resource where the IMPORT and READ logics were different causing tf plan to find differences when the resource was imported. 

Link to any related issue(s): #1805

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Testing
### Local test
I tested my changes locally by importing the resource and verifying that the plan did not find any changes
```hcl
terraform import mongodbatlas_encryption_at_rest.kms_encryption 6597de4d840fe16aadbbc713

2024-01-05T11:48:22.089Z [DEBUG] provider: plugin process exited: path=../bin/terraform-provider-mongodbatlas pid=7001
2024-01-05T11:48:22.090Z [DEBUG] provider: plugin exited
2024-01-05T11:48:22.090Z [INFO]  Writing state output to:

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

```hcl
terraform plan


2024-01-05T11:48:46.390Z [INFO]  backend/local: plan operation completed

No changes. Your infrastructure matches the configuration.
```

### Acceptance tests

- I have updated the acceptance tests to test that the state file does not change on imports.
- I ran the acceptance tests locally and tested that the resource import verify was successful

```hcl
Running tool: /Users/andrea.angiolillo/.asdf/shims/go test -timeout 300000s -run ^TestAccAdvRSEncryptionAtRest_basicAWS$ github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest

ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest	13.032s
```

