### PR TITLE
fix: Improves error message when improperly setting provider_region_name field

### DIFF
--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -818,10 +818,12 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		cluster.ReplicationSpecs = replicationSpecs
 	}
 
-	err = validateProviderRegionName(d.Get("cluster_type").(string), d.Get("provider_region_name").(string), replicationSpecs)
-	if err != nil {
-		if cluster.ProviderSettings != nil {
-			cluster.ProviderSettings.RegionName = ""
+	if v, ok := d.GetOk("provider_region_name"); ok {
+		err = validateProviderRegionName(d.Get("cluster_type").(string), v.(string), replicationSpecs)
+		if err != nil {
+			if cluster.ProviderSettings != nil {
+				cluster.ProviderSettings.RegionName = ""
+			}
 		}
 	}
 

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -794,53 +794,15 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	// If at least one of the provider settings argument has changed, expand all provider settings
-	// if d.HasChange("provider_disk_iops") ||
-	// 	d.HasChange("backing_provider_name") ||
-	// 	d.HasChange("provider_disk_type_name") ||
-	// 	d.HasChange("provider_instance_size_name") ||
-	// 	d.HasChange("provider_name") ||
-	// 	d.HasChange("provider_region_name") ||
-	// 	d.HasChange("provider_volume_type") ||
-	// 	d.HasChange("provider_auto_scaling_compute_min_instance_size") ||
-	// 	d.HasChange("provider_auto_scaling_compute_max_instance_size") {
-	// 	var err error
-	// 	cluster.ProviderSettings, err = expandProviderSetting(d)
-	// 	if err != nil {
-	// 		return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
-	// 	}
-	// }
-
-	changed := false
-
-	if d.HasChange("provider_disk_iops") {
-		changed = true
-	}
-	if d.HasChange("backing_provider_name") {
-		changed = true
-	}
-	if d.HasChange("provider_disk_type_name") {
-		changed = true
-	}
-	if d.HasChange("provider_instance_size_name") {
-		changed = true
-	}
-	if d.HasChange("provider_name") {
-		changed = true
-	}
-	if d.HasChange("provider_region_name") {
-		changed = true
-	}
-	if d.HasChange("provider_volume_type") {
-		changed = true
-	}
-	if d.HasChange("provider_auto_scaling_compute_min_instance_size") {
-		changed = true
-	}
-	if d.HasChange("provider_auto_scaling_compute_max_instance_size") {
-		changed = true
-	}
-
-	if changed {
+	if d.HasChange("provider_disk_iops") ||
+		d.HasChange("backing_provider_name") ||
+		d.HasChange("provider_disk_type_name") ||
+		d.HasChange("provider_instance_size_name") ||
+		d.HasChange("provider_name") ||
+		d.HasChange("provider_region_name") ||
+		d.HasChange("provider_volume_type") ||
+		d.HasChange("provider_auto_scaling_compute_min_instance_size") ||
+		d.HasChange("provider_auto_scaling_compute_max_instance_size") {
 		var err error
 		cluster.ProviderSettings, err = expandProviderSetting(d)
 		if err != nil {
@@ -860,11 +822,6 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		if cluster.ProviderSettings != nil {
 			cluster.ProviderSettings.RegionName = ""
-			// when converting a single region to a multi-region cluster provider_region_name could be in the state from prior create response so we unset
-			// err = d.Set("provider_region_name", "")
-			// if err != nil {
-			// 	return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
-			// }
 		}
 	}
 

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -986,9 +986,7 @@ func isMultiRegionCluster(repSpecs []matlas.ReplicationSpec) bool {
 	}
 
 	for i := range repSpecs {
-		repSpec := repSpecs[i]
-
-		if len(repSpec.RegionsConfig) > 1 {
+		if len(repSpecs[i].RegionsConfig) > 1 {
 			return true
 		}
 	}

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -794,15 +794,53 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	// If at least one of the provider settings argument has changed, expand all provider settings
-	if d.HasChange("provider_disk_iops") ||
-		d.HasChange("backing_provider_name") ||
-		d.HasChange("provider_disk_type_name") ||
-		d.HasChange("provider_instance_size_name") ||
-		d.HasChange("provider_name") ||
-		d.HasChange("provider_region_name") ||
-		d.HasChange("provider_volume_type") ||
-		d.HasChange("provider_auto_scaling_compute_min_instance_size") ||
-		d.HasChange("provider_auto_scaling_compute_max_instance_size") {
+	// if d.HasChange("provider_disk_iops") ||
+	// 	d.HasChange("backing_provider_name") ||
+	// 	d.HasChange("provider_disk_type_name") ||
+	// 	d.HasChange("provider_instance_size_name") ||
+	// 	d.HasChange("provider_name") ||
+	// 	d.HasChange("provider_region_name") ||
+	// 	d.HasChange("provider_volume_type") ||
+	// 	d.HasChange("provider_auto_scaling_compute_min_instance_size") ||
+	// 	d.HasChange("provider_auto_scaling_compute_max_instance_size") {
+	// 	var err error
+	// 	cluster.ProviderSettings, err = expandProviderSetting(d)
+	// 	if err != nil {
+	// 		return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
+	// 	}
+	// }
+
+	changed := false
+
+	if d.HasChange("provider_disk_iops") {
+		changed = true
+	}
+	if d.HasChange("backing_provider_name") {
+		changed = true
+	}
+	if d.HasChange("provider_disk_type_name") {
+		changed = true
+	}
+	if d.HasChange("provider_instance_size_name") {
+		changed = true
+	}
+	if d.HasChange("provider_name") {
+		changed = true
+	}
+	if d.HasChange("provider_region_name") {
+		changed = true
+	}
+	if d.HasChange("provider_volume_type") {
+		changed = true
+	}
+	if d.HasChange("provider_auto_scaling_compute_min_instance_size") {
+		changed = true
+	}
+	if d.HasChange("provider_auto_scaling_compute_max_instance_size") {
+		changed = true
+	}
+
+	if changed {
 		var err error
 		cluster.ProviderSettings, err = expandProviderSetting(d)
 		if err != nil {
@@ -818,10 +856,15 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		cluster.ReplicationSpecs = replicationSpecs
 	}
 
-	if cluster.ProviderSettings != nil || len(cluster.ReplicationSpecs) > 0 {
-		err := validateProviderRegionName(d.Get("cluster_type").(string), d.Get("provider_region_name").(string), replicationSpecs)
-		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
+	err = validateProviderRegionName(d.Get("cluster_type").(string), d.Get("provider_region_name").(string), replicationSpecs)
+	if err != nil {
+		if cluster.ProviderSettings != nil {
+			cluster.ProviderSettings.RegionName = ""
+			// when converting a single region to a multi-region cluster provider_region_name could be in the state from prior create response so we unset
+			// err = d.Set("provider_region_name", "")
+			// if err != nil {
+			// 	return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
+			// }
 		}
 	}
 

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -818,7 +818,7 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		cluster.ReplicationSpecs = replicationSpecs
 	}
 
-	if cluster.ProviderSettings != nil && len(cluster.ReplicationSpecs) > 0 {
+	if cluster.ProviderSettings != nil || len(cluster.ReplicationSpecs) > 0 {
 		err := validateProviderRegionName(d.Get("cluster_type").(string), d.Get("provider_region_name").(string), replicationSpecs)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -818,8 +818,8 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		cluster.ReplicationSpecs = replicationSpecs
 	}
 
-	if cluster.ProviderSettings != nil || len(cluster.ReplicationSpecs) > 0 {
-		err := validateProviderRegionName(d.Get("cluster_type").(string), cluster.ProviderSettings.RegionName, replicationSpecs)
+	if cluster.ProviderSettings != nil && len(cluster.ReplicationSpecs) > 0 {
+		err := validateProviderRegionName(d.Get("cluster_type").(string), d.Get("provider_region_name").(string), replicationSpecs)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(errorClusterUpdate, clusterName, err))
 		}

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -2560,7 +2560,6 @@ resource "mongodbatlas_cluster" "test" {
 	`, orgID, projectName, name, backupEnabled, paused)
 }
 
-// TestIsMultiRegionCluster tests the isMultiRegionCluster function
 func TestIsMultiRegionCluster(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -2623,7 +2622,6 @@ func TestIsMultiRegionCluster(t *testing.T) {
 	}
 }
 
-// TestValidateProviderRegionName tests the validateProviderRegionName function
 func TestValidateProviderRegionName(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -574,7 +574,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				}`
 	updatedRegionsConfig2 := `regions_config {
 					region_name     = "US_WEST_2"
-					electable_nodes = 3
+					electable_nodes = 1
 					priority        = 6
 					read_only_nodes = 0
 				}

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -574,7 +574,6 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				}`
 	updatedRegionsConfig2 := `regions_config {
 					region_name     = "US_WEST_2"
-					electable_nodes = 1
 					priority        = 6
 					read_only_nodes = 0
 				}

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -574,6 +574,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				}`
 	updatedRegionsConfig2 := `regions_config {
 					region_name     = "US_WEST_2"
+					electable_nodes = 2
 					priority        = 6
 					read_only_nodes = 0
 				}

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
+	clustersvc "github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -2614,8 +2614,7 @@ func TestIsMultiRegionCluster(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			if got := cluster.IsMultiRegionCluster(tt.repSpecs); got != tt.want {
+			if got := clustersvc.IsMultiRegionCluster(tt.repSpecs); got != tt.want {
 				t.Errorf("isMultiRegionCluster() = %v, want %v", got, tt.want)
 			}
 		})
@@ -2680,7 +2679,7 @@ func TestValidateProviderRegionName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := cluster.ValidateProviderRegionName(tt.clusterType, tt.providerRegionName, tt.repSpecs)
+			err := clustersvc.ValidateProviderRegionName(tt.clusterType, tt.providerRegionName, tt.repSpecs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateProviderRegionName() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
## Description

This PR adds validation logic to Create & Update handlers of cluster resource to not set provider_region_name attribute for multi-region clusters.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-215125

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
