### PR TITLE
chore: Updates the Advanced Cluster and Federation tests to use EU_WEST_1 and EU_WEST_2 regions

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -753,7 +753,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name         = "TENANT"
       backing_provider_name = "AWS"
-      region_name           = "US_EAST_1"
+      region_name           = "EU_WEST_1"
       priority              = 7
     }
   }
@@ -846,7 +846,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 }
@@ -882,7 +882,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
     region_configs {
       electable_specs {
@@ -931,7 +931,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
     region_configs {
       electable_specs {
@@ -971,7 +971,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 }
@@ -1001,7 +1001,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 
@@ -1053,7 +1053,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 
@@ -1101,7 +1101,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 	  }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 
@@ -1141,7 +1141,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 	  }
       provider_name = "AWS"
       priority      = 7
-      region_name   = "US_EAST_1"
+      region_name   = "EU_WEST_1"
     }
   }
 

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -753,7 +753,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
       }
       provider_name         = "TENANT"
       backing_provider_name = "AWS"
-      region_name           = "EU_WEST_1"
+      region_name           = "US_EAST_1"
       priority              = 7
     }
   }

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -145,7 +145,7 @@ func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName
 		provider_name               = "AWS"
 		name                        = "tfCluster0"
 		backing_provider_name       = "AWS"
-		provider_region_name        = "EU_WEST_1"
+		provider_region_name        = "EU_WEST_2"
 		provider_instance_size_name = "M10"
 	  }
 	  
@@ -155,8 +155,8 @@ func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName
 		provider_name               = "AWS"
 		name                        = "tfCluster1"
 		backing_provider_name       = "AWS"
-		provider_region_name        = "EU_WEST_1"
-		provider_instance_size_name = "M20"
+		provider_region_name        = "EU_WEST_2"
+		provider_instance_size_name = "M10"
 	  }
 
 	  resource "mongodbatlas_federated_database_instance" "test" {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -145,7 +145,7 @@ func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName
 		provider_name               = "AWS"
 		name                        = "tfCluster0"
 		backing_provider_name       = "AWS"
-		provider_region_name        = "US_EAST_1"
+		provider_region_name        = "EU_WEST_1"
 		provider_instance_size_name = "M10"
 	  }
 	  
@@ -155,7 +155,7 @@ func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName
 		provider_name               = "AWS"
 		name                        = "tfCluster1"
 		backing_provider_name       = "AWS"
-		provider_region_name        = "US_EAST_1"
+		provider_region_name        = "EU_WEST_1"
 		provider_instance_size_name = "M10"
 	  }
 

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -156,7 +156,7 @@ func testAccMongoDBAtlasFederatedDatabaseInstanceAtlasProviderConfig(projectName
 		name                        = "tfCluster1"
 		backing_provider_name       = "AWS"
 		provider_region_name        = "EU_WEST_1"
-		provider_instance_size_name = "M10"
+		provider_instance_size_name = "M20"
 	  }
 
 	  resource "mongodbatlas_federated_database_instance" "test" {


### PR DESCRIPTION
## Description
Ticket: https://jira.mongodb.org/browse/CLOUDP-221942

This PR updates the Advanced Cluster and Federation tests to use the region `EU_WEST_1` and `EU_WEST_2` to avoid getting [out_of_capacity failures](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/7454874818/job/20284136460) when creating clusters using `US_EAST_1` . 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.

## Further comments
