### PR TITLE
chore: Unifies SDK connection getting in tests

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
-	sdkv2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
@@ -451,28 +450,17 @@ func NewFrameworkProvider() provider.Provider {
 }
 
 func MuxedProviderFactory() func() tfprotov6.ProviderServer {
-	return muxedProviderFactoryFn(NewSdkV2Provider())
-}
-
-// muxedProviderFactoryFn creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
-// Used in testing where existing sdk v2 provider has to be used.
-func muxedProviderFactoryFn(sdkV2Provider *sdkv2schema.Provider) func() tfprotov6.ProviderServer {
-	fwProvider := NewFrameworkProvider()
-
+	v2Provider := NewSdkV2Provider()
+	newProvider := NewFrameworkProvider()
 	ctx := context.Background()
-	upgradedSdkProvider, err := tf5to6server.UpgradeServer(ctx, sdkV2Provider.GRPCProvider)
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(ctx, v2Provider.GRPCProvider)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkProvider
-		},
-		providerserver.NewProtocol6(fwProvider),
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	muxServer, err := tf6muxserver.NewMuxServer(ctx,
+		func() tfprotov6.ProviderServer { return upgradedSdkProvider },
+		providerserver.NewProtocol6(newProvider),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -451,12 +451,12 @@ func NewFrameworkProvider() provider.Provider {
 }
 
 func MuxedProviderFactory() func() tfprotov6.ProviderServer {
-	return MuxedProviderFactoryFn(NewSdkV2Provider())
+	return muxedProviderFactoryFn(NewSdkV2Provider())
 }
 
-// MuxedProviderFactoryFn creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
+// muxedProviderFactoryFn creates mux provider using existing sdk v2 provider passed as parameter and creating new instance of framework provider.
 // Used in testing where existing sdk v2 provider has to be used.
-func MuxedProviderFactoryFn(sdkV2Provider *sdkv2schema.Provider) func() tfprotov6.ProviderServer {
+func muxedProviderFactoryFn(sdkV2Provider *sdkv2schema.Provider) func() tfprotov6.ProviderServer {
 	fwProvider := NewFrameworkProvider()
 
 	ctx := context.Background()

--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -116,20 +115,15 @@ func TestAccProjectRSAccessListAPIKey_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.AccessListAPIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"], ids["entry"])
+		_, _, err := acc.Conn().AccessListAPIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"], ids["entry"])
 		if err != nil {
 			return fmt.Errorf("access list API Key (%s) does not exist", ids["api_key_id"])
 		}
@@ -139,16 +133,12 @@ func testAccCheckMongoDBAtlasAccessListAPIKeyExists(resourceName string) resourc
 }
 
 func testAccCheckMongoDBAtlasAccessListAPIKeyDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_access_list_api_key" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.AccessListAPIKeys.Get(context.Background(), ids["project_id"], ids["api_key_id"], ids["entry"])
+		_, _, err := acc.Conn().AccessListAPIKeys.Get(context.Background(), ids["project_id"], ids["api_key_id"], ids["entry"])
 		if err == nil {
 			return fmt.Errorf("access list API Key (%s) still exists", ids["api_key_id"])
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -681,26 +680,19 @@ func TestAccClusterAdvancedCluster_WithTags(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAdvancedClusterExists(resourceName string, cluster *matlas.AdvancedCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
-
-		if clusterResp, _, err := conn.AdvancedClusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
+		if clusterResp, _, err := acc.Conn().AdvancedClusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
 			*cluster = *clusterResp
 			return nil
 		}
-
 		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
 	}
 }

--- a/internal/service/alertconfiguration/data_source_alert_configurations_test.go
+++ b/internal/service/alertconfiguration/data_source_alert_configurations_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -153,21 +152,17 @@ func configTotalCount(orgID, projectName string) string {
 
 func checkCount(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		projectID := ids["project_id"]
 
-		alertResp, _, err := conn.AlertConfigurations.List(context.Background(), projectID, &matlas.ListOptions{
+		alertResp, _, err := acc.Conn().AlertConfigurations.List(context.Background(), projectID, &matlas.ListOptions{
 			PageNum:      0,
 			ItemsPerPage: 100,
 			IncludeCount: true,

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -310,7 +310,7 @@ func TestAccConfigRSAlertConfiguration_importBasic(t *testing.T) {
 				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id"},
+				ImportStateVerifyIgnore: []string{"project_id", "updated"},
 			},
 		},
 	})
@@ -361,7 +361,7 @@ func TestAccConfigRSAlertConfiguration_importConfigNotifications(t *testing.T) {
 				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id"},
+				ImportStateVerifyIgnore: []string{"project_id", "updated"},
 			},
 		},
 	})
@@ -398,7 +398,7 @@ func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
 				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"notification.0.service_key"}, // service key is not returned by api in import operation
+				ImportStateVerifyIgnore: []string{"updated", "notification.0.service_key"}, // service key is not returned by api in import operation
 			},
 		},
 	})

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/alertconfiguration"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
@@ -544,46 +543,34 @@ func TestAccConfigRSAlertConfiguration_withVictorOps(t *testing.T) {
 
 func checkExists(resourceName string, alert *admin.GroupAlertsConfig) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		alertResp, _, err := connV2.AlertConfigurationsApi.GetAlertConfiguration(context.Background(), ids[alertconfiguration.EncodedIDKeyProjectID], ids[alertconfiguration.EncodedIDKeyAlertID]).Execute()
+		alertResp, _, err := acc.ConnV2().AlertConfigurationsApi.GetAlertConfiguration(context.Background(), ids[alertconfiguration.EncodedIDKeyProjectID], ids[alertconfiguration.EncodedIDKeyAlertID]).Execute()
 		if err != nil {
 			return fmt.Errorf("the Alert Configuration(%s) does not exist", ids[alertconfiguration.EncodedIDKeyAlertID])
 		}
-
 		alert = alertResp
-
 		return nil
 	}
 }
 
 func checkDestroy(s *terraform.State) error {
-	conn := acc.TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_alert_configuration" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		alert, _, err := conn.AlertConfigurations.GetAnAlertConfig(context.Background(), ids[alertconfiguration.EncodedIDKeyProjectID], ids[alertconfiguration.EncodedIDKeyAlertID])
+		alert, _, err := acc.Conn().AlertConfigurations.GetAnAlertConfig(context.Background(), ids[alertconfiguration.EncodedIDKeyProjectID], ids[alertconfiguration.EncodedIDKeyAlertID])
 		if alert != nil {
 			return fmt.Errorf("the Project Alert Configuration(%s) still exists %s", ids[alertconfiguration.EncodedIDKeyAlertID], err)
 		}
 	}
-
 	return nil
 }
 
@@ -593,7 +580,6 @@ func importStateProjectIDFunc(resourceName string) resource.ImportStateIdFunc {
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["alert_configuration_id"]), nil
 	}
 }

--- a/internal/service/apikey/resource_api_key_test.go
+++ b/internal/service/apikey/resource_api_key_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -81,44 +80,33 @@ func TestAccConfigRSAPIKey_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAPIKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.APIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"])
+		_, _, err := acc.Conn().APIKeys.Get(context.Background(), ids["org_id"], ids["api_key_id"])
 		if err != nil {
 			return fmt.Errorf("API Key (%s) does not exist", ids["api_key_id"])
 		}
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasAPIKeyDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_api_key" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.APIKeys.Get(context.Background(), ids["org_id"], ids["role_name"])
+		_, _, err := acc.Conn().APIKeys.Get(context.Background(), ids["org_id"], ids["role_name"])
 		if err == nil {
 			return fmt.Errorf("API Key (%s) still exists", ids["role_name"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/atlasuser/data_source_atlas_user_test.go
+++ b/internal/service/atlasuser/data_source_atlas_user_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
 )
@@ -89,8 +88,7 @@ func TestAccConfigDSAtlasUser_InvalidAttrCombination(t *testing.T) {
 
 func fetchUser(t *testing.T, userID string) *admin.CloudAppUser {
 	t.Helper()
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-	userResp, _, err := connV2.MongoDBCloudUsersApi.GetUser(context.Background(), userID).Execute()
+	userResp, _, err := acc.ConnV2().MongoDBCloudUsersApi.GetUser(context.Background(), userID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas User (%s) could not be fetched: %v", userID, err)
 	}
@@ -99,9 +97,7 @@ func fetchUser(t *testing.T, userID string) *admin.CloudAppUser {
 
 func fetchUserByUsername(t *testing.T, username string) *admin.CloudAppUser {
 	t.Helper()
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
-	userResp, _, err := connV2.MongoDBCloudUsersApi.GetUserByUsername(context.Background(), username).Execute()
+	userResp, _, err := acc.ConnV2().MongoDBCloudUsersApi.GetUserByUsername(context.Background(), username).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas User (%s) could not be fetched: %v", username, err)
 	}

--- a/internal/service/atlasuser/data_source_atlas_users_test.go
+++ b/internal/service/atlasuser/data_source_atlas_users_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/atlasuser"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
@@ -204,8 +203,7 @@ func TestAccConfigDSAtlasUsers_InvalidAttrCombinations(t *testing.T) {
 
 func fetchOrgUsers(t *testing.T, orgID string) *admin.PaginatedAppUser {
 	t.Helper()
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-	users, _, err := connV2.OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
+	users, _, err := acc.ConnV2().OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas Users for Org(%s) could not be fetched: %v", orgID, err)
 	}
@@ -286,8 +284,6 @@ func testAccDSMongoDBAtlasUsersByTeamWithPagination(orgID, teamName, username st
 
 func testAccCheckMongoDBAtlasOrgWithUsersExists(dataSourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[dataSourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", dataSourceName)
@@ -298,7 +294,7 @@ func testAccCheckMongoDBAtlasOrgWithUsersExists(dataSourceName string) resource.
 			return fmt.Errorf("org_id not defined in data source: %s", dataSourceName)
 		}
 
-		apiResp, _, err := connV2.OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
+		apiResp, _, err := acc.ConnV2().OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
 
 		if err != nil {
 			return fmt.Errorf("unable to determine if users exist in org: %s", orgID)

--- a/internal/service/auditing/resource_auditing_test.go
+++ b/internal/service/auditing/resource_auditing_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -106,42 +105,32 @@ func TestAccAdvRSAuditing_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasAuditingExists(resourceName string, auditing *matlas.Auditing) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		auditingRes, _, err := conn.Auditing.Get(context.Background(), rs.Primary.ID)
+		auditingRes, _, err := acc.Conn().Auditing.Get(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("auditing (%s) does not exist", rs.Primary.ID)
 		}
-
 		auditing = auditingRes
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasAuditingDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_auditing" {
 			continue
 		}
-
-		_, _, err := conn.Auditing.Get(context.Background(), rs.Primary.ID)
+		_, _, err := acc.Conn().Auditing.Get(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("auditing (%s) does not exist", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -169,50 +168,38 @@ func TestAccGenericBackupRSBackupCompliancePolicy_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupCompliancePolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		projectID := ids["project_id"]
-
-		schedule, _, err := conn.BackupCompliancePolicy.Get(context.Background(), projectID)
+		schedule, _, err := acc.Conn().BackupCompliancePolicy.Get(context.Background(), projectID)
 		if err != nil || schedule == nil {
 			return fmt.Errorf("backup compliance policy (%s) does not exist: %s", rs.Primary.ID, err)
 		}
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasBackupCompliancePolicyDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_backup_compliance_policy" {
 			continue
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		projectID := ids["project_id"]
-
-		compliancePolicy, _, err := conn.BackupCompliancePolicy.Get(context.Background(), projectID)
+		compliancePolicy, _, err := acc.Conn().BackupCompliancePolicy.Get(context.Background(), projectID)
 		if compliancePolicy != nil || err == nil {
 			return fmt.Errorf("Backup Compliance Policy (%s) still exists", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }
 
@@ -222,9 +209,7 @@ func testAccCheckMongoDBAtlasBackupCompliancePolicyImportStateIDFunc(resourceNam
 		if !ok {
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		return ids["project_id"], nil
 	}
 }

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mwielbut/pointy"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -396,47 +395,36 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCloudBackupScheduleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		projectID := ids["project_id"]
 		clusterName := ids["cluster_name"]
-
-		schedule, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
+		schedule, _, err := acc.Conn().CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
 		if err != nil || schedule == nil {
 			return fmt.Errorf("cloud Provider Snapshot Schedule (%s) does not exist: %s", rs.Primary.ID, err)
 		}
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasCloudBackupScheduleDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_schedule" {
 			continue
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		projectID := ids["project_id"]
 		clusterName := ids["cluster_name"]
-
-		schedule, _, err := conn.CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
+		schedule, _, err := acc.Conn().CloudProviderSnapshotBackupPolicies.Get(context.Background(), projectID, clusterName)
 		if schedule != nil || err == nil {
 			return fmt.Errorf("cloud Provider Snapshot Schedule (%s) still exists", rs.Primary.ID)
 		}

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -70,20 +69,15 @@ func TestAccBackupRSBackupSnapshotExportBucket_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName string, snapshotExportBucket *matlas.CloudProviderSnapshotExportBucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		response, _, err := conn.CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
+		response, _, err := acc.Conn().CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
 		if err == nil {
 			*snapshotExportBucket = *response
 			return nil
@@ -94,21 +88,16 @@ func testAccCheckMongoDBAtlasBackupSnapshotExportBucketExists(resourceName strin
 }
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy(state *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_bucket" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		snapshotExportBucket, _, err := conn.CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
+		snapshotExportBucket, _, err := acc.Conn().CloudProviderSnapshotExportBuckets.Get(context.Background(), ids["project_id"], ids["id"])
 		if err == nil && snapshotExportBucket != nil {
 			return fmt.Errorf("snapshot export bucket (%s) still exists", ids["id"])
 		}
 	}
-
 	return nil
 }
 
@@ -118,9 +107,7 @@ func testAccCheckMongoDBAtlasBackupSnapshotExportBucketImportStateIDFunc(resourc
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		return fmt.Sprintf("%s-%s", ids["project_id"], ids["id"]), nil
 	}
 }

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -70,45 +69,34 @@ func TestAccBackupRSBackupSnapshotExportJob_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportJobExists(resourceName string, snapshotExportJob *matlas.CloudProviderSnapshotExportJob) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		response, _, err := conn.CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
+		response, _, err := acc.Conn().CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
 		if err == nil {
 			*snapshotExportJob = *response
 			return nil
 		}
-
 		return fmt.Errorf("snapshot export job (%s) does not exist", ids["export_job_id"])
 	}
 }
 
 func testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy(state *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot_export_job" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		snapshotExportBucket, _, err := conn.CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
+		snapshotExportBucket, _, err := acc.Conn().CloudProviderSnapshotExportJobs.Get(context.Background(), ids["project_id"], ids["cluster_name"], ids["export_job_id"])
 		if err == nil && snapshotExportBucket != nil {
 			return fmt.Errorf("snapshot export job (%s) still exists", ids["export_job_id"])
 		}
 	}
-
 	return nil
 }
 
@@ -118,9 +106,7 @@ func testAccCheckMongoDBAtlasBackupSnapshotExportJobImportStateIDFunc(resourceNa
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		return fmt.Sprintf("%s-%s-%s", ids["project_id"], ids["cluster_name"], ids["export_job_id"]), nil
 	}
 }

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cloudprovideraccess"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -155,26 +154,20 @@ func testAccMongoDBAtlasCloudProviderAccessAuthorizationAzure(orgID, projectName
 }
 
 func testAccCheckMongoDBAtlasProviderAccessDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_provider_access" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		roles, _, err := conn.CloudProviderAccess.ListRoles(context.Background(), ids["project_id"])
-
+		roles, _, err := acc.Conn().CloudProviderAccess.ListRoles(context.Background(), ids["project_id"])
 		if err != nil {
 			return fmt.Errorf(cloudprovideraccess.ErrorCloudProviderGetRead, err)
 		}
-
 		var targetRole matlas.CloudProviderAccessRole
 
 		// searching in roles
 		for i := range roles.AWSIAMRoles {
 			role := &(roles.AWSIAMRoles[i])
-
 			if role.RoleID == ids["id"] && role.ProviderName == ids["provider_name"] {
 				targetRole = *role
 			}
@@ -185,6 +178,5 @@ func testAccCheckMongoDBAtlasProviderAccessDestroy(s *terraform.State) error {
 			return fmt.Errorf("error cloud Provider Access Role (%s) still exists", ids["id"])
 		}
 	}
-
 	return nil
 }

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	clustersvc "github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mwielbut/pointy"
@@ -1552,26 +1551,19 @@ func testAccGetMongoDBAtlasMajorVersion() string {
 
 func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
-
-		if clusterResp, _, err := conn.Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
+		if clusterResp, _, err := acc.Conn().Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
 			*cluster = *clusterResp
 			return nil
 		}
-
 		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
 	}
 }

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -151,19 +150,15 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(proje
 }
 
 func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster_outage_simulation" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
+		_, _, err := acc.Conn().ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
 		if err == nil {
 			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["cluster_name"])
 		}
 	}
-
 	return nil
 }

--- a/internal/service/customdbrole/resource_custom_db_role_test.go
+++ b/internal/service/customdbrole/resource_custom_db_role_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mwielbut/pointy"
 	"github.com/spf13/cast"
@@ -601,44 +600,33 @@ func TestAccConfigRSCustomDBRoles_UpdatedInheritRoles(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCustomDBRolesExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
+		_, _, err := acc.Conn().CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
 		if err != nil {
 			return fmt.Errorf("custom DB Role (%s) does not exist", ids["role_name"])
 		}
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasCustomDBRolesDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_custom_db_role" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
+		_, _, err := acc.Conn().CustomDBRoles.Get(context.Background(), ids["project_id"], ids["role_name"])
 		if err == nil {
 			return fmt.Errorf("custom DB Role (%s) still exists", ids["role_name"])
 		}
 	}
-
 	return nil
 }
 
@@ -648,7 +636,6 @@ func testAccCheckMongoDBAtlasCustomDBRolesImportStateIDFunc(resourceName string)
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["role_name"]), nil
 	}
 }

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -84,40 +83,32 @@ func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		_, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		_, _, err := acc.Conn().CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
 		if err == nil {
 			return nil
 		}
-
 		return fmt.Errorf("custom dns configuration cluster(%s) does not exist", rs.Primary.ID)
 	}
 }
 func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_custom_dns_configuration_cluster_aws" {
 			continue
 		}
 
 		// Try to find the Custom DNS Configuration for Atlas Clusters on AWS
-		resp, _, err := conn.CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		resp, _, err := acc.Conn().CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
 		if err != nil && resp != nil && resp.Enabled {
 			return fmt.Errorf("custom dns configuration cluster aws (%s) still enabled", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }
 
@@ -127,7 +118,6 @@ func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName s
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		return rs.Primary.ID, nil
 	}
 }

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline_test.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -42,8 +41,6 @@ func TestAccDataSourceClusterRSDataLakePipeline_basic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasDataLakePipelineDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_data_lake_pipeline" {
 			continue
@@ -51,12 +48,11 @@ func testAccCheckMongoDBAtlasDataLakePipelineDestroy(s *terraform.State) error {
 
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		// Try to find the data lake pipeline
-		_, _, err := conn.DataLakePipeline.Get(context.Background(), ids["project_id"], ids["name"])
+		_, _, err := acc.Conn().DataLakePipeline.Get(context.Background(), ids["project_id"], ids["name"])
 		if err == nil {
 			return fmt.Errorf("datalake (%s) still exists", ids["project_id"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/datalakepipeline/resource_data_lake_pipeline_test.go
+++ b/internal/service/datalakepipeline/resource_data_lake_pipeline_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -62,25 +61,19 @@ func testAccCheckMongoDBAtlasDataLakePipelineImportStateIDFunc(resourceName stri
 
 func testAccCheckMongoDBAtlasDataLakePipelineExists(resourceName string, pipeline *matlas.DataLakePipeline) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		response, _, err := conn.DataLakePipeline.Get(context.Background(), ids["project_id"], ids["name"])
+		response, _, err := acc.Conn().DataLakePipeline.Get(context.Background(), ids["project_id"], ids["name"])
 		if err == nil {
 			*pipeline = *response
 			return nil
 		}
-
 		return fmt.Errorf("DataLake pipeline (%s) does not exist", ids["name"])
 	}
 }

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mocksvc"
@@ -569,35 +568,26 @@ func TestResourceMongoDBAtlasEncryptionAtRestCreateRefreshFunc(t *testing.T) {
 
 func testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		if _, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), rs.Primary.ID).Execute(); err == nil {
+		if _, _, err := acc.ConnV2().EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), rs.Primary.ID).Execute(); err == nil {
 			return nil
 		}
-
 		return fmt.Errorf("encryptionAtRest (%s) does not exist", rs.Primary.ID)
 	}
 }
 
 func testAccCheckMongoDBAtlasEncryptionAtRestDestroy(s *terraform.State) error {
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_encryption_at_rest" {
 			continue
 		}
-
-		res, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), rs.Primary.ID).Execute()
-
+		res, _, err := acc.ConnV2().EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), rs.Primary.ID).Execute()
 		if err != nil ||
 			(*res.AwsKms.Enabled != false &&
 				*res.AzureKeyVault.Enabled != false &&

--- a/internal/service/eventtrigger/resource_event_trigger_test.go
+++ b/internal/service/eventtrigger/resource_event_trigger_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mwielbut/pointy"
 	"go.mongodb.org/realm/realm"
@@ -432,7 +431,7 @@ func TestEventTriggerFunction_basic(t *testing.T) {
 func testAccCheckMongoDBAtlasEventTriggerExists(resourceName string, eventTrigger *realm.EventTrigger) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := context.Background()
-		conn, err := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).GetRealmClient(ctx)
+		conn, err := acc.MongoDBClient.GetRealmClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -462,7 +461,7 @@ func testAccCheckMongoDBAtlasEventTriggerExists(resourceName string, eventTrigge
 
 func testAccCheckMongoDBAtlasEventTriggerDestroy(s *terraform.State) error {
 	ctx := context.Background()
-	conn, err := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).GetRealmClient(ctx)
+	conn, err := acc.MongoDBClient.GetRealmClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
 )
@@ -81,23 +80,18 @@ func TestAccFederatedDatabaseInstanceDS_s3Bucket(t *testing.T) {
 
 func checkExists(resourceName string, dataFederatedInstance *admin.DataLakeTenant) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.Attributes["project_id"] == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		if dataLakeResp, _, err := connV2.DataFederationApi.GetFederatedDatabase(context.Background(), ids["project_id"], ids["name"]).Execute(); err == nil {
+		if dataLakeResp, _, err := acc.ConnV2().DataFederationApi.GetFederatedDatabase(context.Background(), ids["project_id"], ids["name"]).Execute(); err == nil {
 			*dataFederatedInstance = *dataLakeResp
 			return nil
 		}
-
 		return fmt.Errorf("federated database instance (%s) does not exist", ids["project_id"])
 	}
 }

--- a/internal/service/federatedquerylimit/data_source_federated_query_limit_test.go
+++ b/internal/service/federatedquerylimit/data_source_federated_query_limit_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -198,24 +197,18 @@ resource "mongodbatlas_federated_query_limit" "test" {
 
 func testAccCheckMongoDBAtlasFederatedDatabaseDataSourceQueryLimitExists(resourceName string, queryLimit *matlas.DataFederationQueryLimit) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.Attributes["project_id"] == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		if queryLimitResp, _, err := conn.DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"]); err == nil {
+		if queryLimitResp, _, err := acc.Conn().DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"]); err == nil {
 			*queryLimit = *queryLimitResp
 			return nil
 		}
-
 		return fmt.Errorf("federated database query limit for project (%s), tenant (%s) and limit (%s) does not exist", ids["project_id"], ids["tenant_name"], ids["limit_name"])
 	}
 }
@@ -226,7 +219,6 @@ func testAccCheckMongoDBAtlasFederatedDabaseQueryLimitAttributes(queryLimit *mat
 		if queryLimit.Name != limitName {
 			return fmt.Errorf("bad data federated query limit name: %s", queryLimit.Name)
 		}
-
 		return nil
 	}
 }

--- a/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
+++ b/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -204,19 +203,15 @@ func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitImportStateIDFunc(resour
 }
 
 func testAccCheckMongoDBAtlasFederatedDatabaseQueryLimitDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_federated_query_limit" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"])
+		_, _, err := acc.Conn().DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"])
 		if err == nil {
 			return fmt.Errorf("federated database query limit (%s) for project (%s) and tenant (%s)still exists", ids["project_id"], ids["tenant_name"], ids["limit_name"])
 		}
 	}
-
 	return nil
 }

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers_test.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -50,22 +49,17 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsIdentityProvidersConfig(feder
 
 func testAccCheckMongoDBAtlasFederatedSettingsIdentityProvidersExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		_, _, err := connV2.FederatedAuthenticationApi.ListIdentityProviders(context.Background(), rs.Primary.Attributes["federation_settings_id"]).Execute()
+		_, _, err := acc.ConnV2().FederatedAuthenticationApi.ListIdentityProviders(context.Background(), rs.Primary.Attributes["federation_settings_id"]).Execute()
 		if err != nil {
 			return fmt.Errorf("FederatedSettingsIdentityProviders (%s) does not exist", rs.Primary.ID)
 		}
-
 		return nil
 	}
 }

--- a/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
+++ b/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
 )
@@ -80,25 +79,20 @@ func TestAccFedRSFederatedSettingsIdentityProvider_importBasic(t *testing.T) {
 func testAccCheckMongoDBAtlasFederatedSettingsIdentityProviderExists(resourceName string,
 	federatedSettingsIdentityProvider *admin.FederationIdentityProvider, idpID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		response, _, err := connV2.FederatedAuthenticationApi.GetIdentityProvider(context.Background(),
+		response, _, err := acc.ConnV2().FederatedAuthenticationApi.GetIdentityProvider(context.Background(),
 			rs.Primary.Attributes["federation_settings_id"],
 			idpID).Execute()
 		if err == nil {
 			*federatedSettingsIdentityProvider = *response
 			return nil
 		}
-
 		return fmt.Errorf("identity provider (%s) does not exist", idpID)
 	}
 }

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_org_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -51,22 +50,17 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigConfig(fede
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		_, _, err := conn.FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
+		_, _, err := acc.Conn().FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
 		if err != nil {
 			return fmt.Errorf("FederatedSettingsConnectedOrganization (%s) does not exist", rs.Primary.ID)
 		}
-
 		return nil
 	}
 }

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -50,22 +49,17 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationConfigsConfig(fed
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigsExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		_, _, err := conn.FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
+		_, _, err := acc.Conn().FederatedSettings.ListConnectedOrgs(context.Background(), rs.Primary.Attributes["federation_settings_id"], nil)
 		if err != nil {
 			return fmt.Errorf("FederatedSettingsConnectedOrganization (%s) does not exist", rs.Primary.ID)
 		}
-
 		return nil
 	}
 }

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -50,24 +49,18 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsConfig(orgID string) string {
 
 func testAccCheckMongoDBAtlasFederatedSettingsExists(resourceName string, federatedSettings *matlas.FederatedSettings) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		federatedSettingsRes, _, err := conn.FederatedSettings.Get(context.Background(), rs.Primary.Attributes["org_id"])
+		federatedSettingsRes, _, err := acc.Conn().FederatedSettings.Get(context.Background(), rs.Primary.Attributes["org_id"])
 		if err != nil {
 			return fmt.Errorf("FederatedSettings (%s) does not exist", rs.Primary.ID)
 		}
-
 		federatedSettings = federatedSettingsRes
-
 		return nil
 	}
 }

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -78,25 +77,20 @@ func TestAccFedRSFederatedSettingsOrganizationConfig_importBasic(t *testing.T) {
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationConfigRExists(resourceName string,
 	federatedSettingsIdentityProvider *matlas.FederatedSettingsConnectedOrganization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		response, _, err := conn.FederatedSettings.GetConnectedOrg(context.Background(),
+		response, _, err := acc.Conn().FederatedSettings.GetConnectedOrg(context.Background(),
 			rs.Primary.Attributes["federation_settings_id"],
 			rs.Primary.Attributes["org_id"])
 		if err == nil {
 			*federatedSettingsIdentityProvider = *response
 			return nil
 		}
-
 		return fmt.Errorf("connected org  (%s) does not exist", rs.Primary.Attributes["org_id"])
 	}
 }

--- a/internal/service/federatedsettingsorgrolemapping/data_source_federated_settings_org_role_mappings_test.go
+++ b/internal/service/federatedsettingsorgrolemapping/data_source_federated_settings_org_role_mappings_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -51,22 +50,17 @@ func testAccMongoDBAtlasDataSourceFederatedSettingsOrganizationRoleMappingsConfi
 
 func testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingsExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		_, _, err := conn.FederatedSettings.ListRoleMappings(context.Background(), rs.Primary.Attributes["federation_settings_id"], rs.Primary.Attributes["org_id"], nil)
+		_, _, err := acc.Conn().FederatedSettings.ListRoleMappings(context.Background(), rs.Primary.Attributes["federation_settings_id"], rs.Primary.Attributes["org_id"], nil)
 		if err != nil {
 			return fmt.Errorf("FederatedSettingsOrganizationRoleMappings (%s) does not exist", rs.Primary.ID)
 		}
-
 		return nil
 	}
 }

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -144,24 +143,18 @@ func TestAccAdvRSLDAPConfiguration_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasLDAPConfigurationExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		ldapConfRes, _, err := conn.LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
+		ldapConfRes, _, err := acc.Conn().LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("ldapConfiguration (%s) does not exist", rs.Primary.ID)
 		}
-
 		ldapConf = ldapConfRes
-
 		return nil
 	}
 }

--- a/internal/service/ldapverify/resource_ldap_verify_test.go
+++ b/internal/service/ldapverify/resource_ldap_verify_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/spf13/cast"
 
@@ -139,42 +138,33 @@ func TestAccAdvRSLDAPVerify_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasLDAPVerifyExists(resourceName string, ldapConf *matlas.LDAPConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		ldapConfRes, _, err := conn.LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
+		ldapConfRes, _, err := acc.Conn().LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
 		if err != nil {
 			return fmt.Errorf("ldapVerify (%s) does not exist", rs.Primary.ID)
 		}
-
 		ldapConf = ldapConfRes
-
 		return nil
 	}
 }
 
 func testAccCheckMongoDBAtlasLDAPVerifyDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_ldap_verify" {
 			continue
 		}
 
-		_, _, err := conn.LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
+		_, _, err := acc.Conn().LDAPConfigurations.GetStatus(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"])
 		if err == nil {
 			return fmt.Errorf("ldapVerify (%s) still exists", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }
 
@@ -184,7 +174,6 @@ func testAccCheckMongoDBAtlasLDAPVerifyImportStateIDFunc(resourceName string) re
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["request_id"]), nil
 	}
 }

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/spf13/cast"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -149,26 +148,19 @@ func testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectNa
 
 func testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName string, maintenance *matlas.MaintenanceWindow) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		log.Printf("[DEBUG] projectID: %s", rs.Primary.ID)
-
-		maintenanceWindow, _, err := conn.MaintenanceWindows.Get(context.Background(), rs.Primary.ID)
+		maintenanceWindow, _, err := acc.Conn().MaintenanceWindows.Get(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("maintenance Window (%s) does not exist", rs.Primary.ID)
 		}
-
 		*maintenance = *maintenanceWindow
-
 		return nil
 	}
 }

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -228,27 +227,20 @@ func testAccCheckMongoDBAtlasNetworkPeeringImportStateIDFunc(resourceName string
 
 func testAccCheckMongoDBAtlasNetworkPeeringExists(resourceName string, peer *matlas.Peer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		log.Printf("[DEBUG] projectID: %s", ids["project_id"])
-
-		if peerResp, _, err := conn.Peers.Get(context.Background(), ids["project_id"], ids["peer_id"]); err == nil {
+		if peerResp, _, err := acc.Conn().Peers.Get(context.Background(), ids["project_id"], ids["peer_id"]); err == nil {
 			*peer = *peerResp
 			peer.ProviderName = ids["provider_name"]
-
 			return nil
 		}
-
 		return fmt.Errorf("peer(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["peer_id"])
 	}
 }

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -236,7 +236,7 @@ func getTestClientWithNewOrgCreds(rs *terraform.ResourceState) (*admin.APIClient
 	cfg := config.Config{
 		PublicKey:  rs.Primary.Attributes["public_key"],
 		PrivateKey: rs.Primary.Attributes["private_key"],
-		BaseURL:    acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Config.BaseURL,
+		BaseURL:    acc.MongoDBClient.Config.BaseURL,
 	}
 
 	ctx := context.Background()

--- a/internal/service/orginvitation/resource_org_invitation_test.go
+++ b/internal/service/orginvitation/resource_org_invitation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -96,33 +95,25 @@ func TestAccConfigRSOrgInvitation_importBasic(t *testing.T) {
 func testAccCheckMongoDBAtlasOrgInvitationExists(t *testing.T, resourceName string, invitation *matlas.Invitation) resource.TestCheckFunc {
 	t.Helper()
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		orgID := ids["org_id"]
 		username := ids["username"]
 		invitationID := ids["invitation_id"]
-
 		if orgID == "" && username == "" && invitationID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		t.Logf("orgID: %s", orgID)
 		t.Logf("username: %s", username)
 		t.Logf("invitationID: %s", invitationID)
-
-		invitationResp, _, err := conn.Organizations.Invitation(context.Background(), orgID, invitationID)
+		invitationResp, _, err := acc.Conn().Organizations.Invitation(context.Background(), orgID, invitationID)
 		if err == nil {
 			*invitation = *invitationResp
 			return nil
 		}
-
 		return fmt.Errorf("invitation(%s) does not exist", invitationID)
 	}
 }

--- a/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -34,14 +33,10 @@ func TestAccNetworkDSPrivateEndpointRegionalMode_basic(t *testing.T) {
 
 func testAccMongoDBAtlasPrivateEndpointRegionalModeUnmanagedResource(resourceName, projectID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
-		setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
-
+		setting, _, err := acc.Conn().PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
 		if err != nil || setting == nil {
 			return fmt.Errorf("Could not get regionalized private endpoint setting for project_id (%s)", projectID)
 		}
-
 		return resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(setting.Enabled))(s)
 	}
 }

--- a/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
+++ b/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -191,42 +190,32 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointImportStateIDFunc(resourceName s
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		if _, _, err := conn.PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"]); err == nil {
+		if _, _, err := acc.Conn().PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"]); err == nil {
 			return nil
 		}
-
 		return fmt.Errorf("the MongoDB Private Endpoint(%s) for the project(%s) does not exist", rs.Primary.Attributes["private_link_id"], rs.Primary.Attributes["project_id"])
 	}
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"])
+		_, _, err := acc.Conn().PrivateEndpoints.Get(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"])
 		if err == nil {
 			return fmt.Errorf("the MongoDB Private Endpoint(%s) still exists", ids["private_link_id"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -69,21 +68,16 @@ func TestAccServerlessPrivateLinkEndpoint_importBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy(state *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_serverless" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		privateLink, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		privateLink, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
 		if err == nil && privateLink != nil {
 			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
 		}
 	}
-
 	return nil
 }
 
@@ -102,24 +96,18 @@ func testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, 
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		_, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
 		if err == nil {
 			return nil
 		}
-
 		return fmt.Errorf("endpoint_id (%s) does not exist", ids["endpoint_id"])
 	}
 }
@@ -130,9 +118,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessImportStateIDFunc(reso
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["instance_name"], ids["endpoint_id"]), nil
 	}
 }

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -111,20 +110,15 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourc
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
+		_, _, err := acc.Conn().PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
 		if err == nil {
 			return nil
 		}
@@ -134,20 +128,16 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName strin
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy(s *terraform.State) error {
-	conn := acc.TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
+		_, _, err := acc.Conn().PrivateEndpoints.GetOnePrivateEndpoint(context.Background(), ids["project_id"], ids["provider_name"], ids["private_link_id"], ids["endpoint_service_id"])
 		if err == nil {
 			return fmt.Errorf("the MongoDB Private Endpoint(%s) still exists", ids["endpoint_service_id"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -61,46 +60,33 @@ func testAccCheckMongoDBAtlasPrivatelinkEndpointServiceDataFederationOnlineArchi
 }
 
 func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveDestroy(s *terraform.State) error {
-	client := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
-
+		_, _, err := acc.Conn().DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
 		if err == nil {
 			return fmt.Errorf("Private endpoint service data federation online archive still exists")
 		}
 	}
-
 	return nil
 }
 
 func testAccCheckMongoDBAtlasPrivateEndpointServiceDataFederationOnlineArchiveExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
-
 		if !ok {
 			return fmt.Errorf("Private endpoint service data federation online archive not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("Private endpoint service data federation online archive ID not set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := client.DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
-
+		_, _, err := acc.Conn().DataLakes.GetPrivateLinkEndpoint(context.Background(), ids["project_id"], ids["endpoint_id"])
 		if err != nil {
 			return err
 		}
-
 		return nil
 	}
 }

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -78,21 +77,16 @@ func TestAccServerlessPrivateLinkEndpointService_importBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessDestroy(state *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_service_serverless" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		privateLink, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		privateLink, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
 		if err == nil && privateLink != nil {
 			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
 		}
 	}
-
 	return nil
 }
 
@@ -153,24 +147,18 @@ func testAccMongoDBAtlasPrivateLinkEndpointServiceServerlessConfig(orgID, projec
 
 func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := conn.ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		_, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
 		if err == nil {
 			return nil
 		}
-
 		return fmt.Errorf("endpoint_id (%s) does not exist", ids["endpoint_id"])
 	}
 }
@@ -181,9 +169,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServiceServerlessImportStateIDFu
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		return fmt.Sprintf("%s--%s--%s", ids["project_id"], ids["instance_name"], ids["endpoint_id"]), nil
 	}
 }

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -303,14 +302,13 @@ func TestAccConfigRSProjectAPIKey_DeleteProjectAndAssignment(t *testing.T) {
 }
 
 func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-	list, _, err := conn.APIKeys.List(context.Background(), orgID, &matlas.ListOptions{})
+	list, _, err := acc.Conn().APIKeys.List(context.Background(), orgID, &matlas.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, key := range list {
 		if strings.HasPrefix(key.Desc, descriptionPrefix) {
-			if _, err := conn.APIKeys.Delete(context.Background(), orgID, key.ID); err != nil {
+			if _, err := acc.Conn().APIKeys.Delete(context.Background(), orgID, key.ID); err != nil {
 				return err
 			}
 		}
@@ -319,27 +317,21 @@ func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
 }
 
 func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project_api_key" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		projectAPIKeys, _, err := conn.ProjectAPIKeys.List(context.Background(), ids["project_id"], nil)
+		projectAPIKeys, _, err := acc.Conn().ProjectAPIKeys.List(context.Background(), ids["project_id"], nil)
 		if err != nil {
 			return nil
 		}
-
 		for _, val := range projectAPIKeys {
 			if val.ID == ids["api_key_id"] {
 				return fmt.Errorf("Project API Key (%s) still exists", ids["role_name"])
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/internal/service/searchdeployment/resource_search_deployment_test.go
+++ b/internal/service/searchdeployment/resource_search_deployment_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -126,8 +125,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
 
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-		_, _, err := connV2.AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
+		_, _, err := acc.ConnV2().AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
 		if err != nil {
 			return fmt.Errorf("search deployment (%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
 		}
@@ -142,10 +140,9 @@ func checkDestroy(state *terraform.State) error {
 	if clusterDestroyedErr := acc.CheckDestroyTeamAdvancedCluster(state); clusterDestroyedErr != nil {
 		return clusterDestroyedErr
 	}
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type == "mongodbatlas_search_deployment" {
-			_, _, err := connV2.AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
+			_, _, err := acc.ConnV2().AtlasSearchApi.GetAtlasSearchDeployment(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
 			if err == nil {
 				return fmt.Errorf("search deployment (%s:%s) still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
 			}

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -361,14 +360,11 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		connV2 := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).AtlasV2
-		_, _, err := connV2.AtlasSearchApi.GetAtlasSearchIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"]).Execute()
+		_, _, err := acc.ConnV2().AtlasSearchApi.GetAtlasSearchIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"]).Execute()
 		if err != nil {
 			return fmt.Errorf("index (%s) does not exist", ids["index_id"])
 		}

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -211,7 +210,6 @@ func checkStreamConnectionImportStateIDFunc(resourceName string) resource.Import
 
 func checkStreamConnectionExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "mongodbatlas_stream_connection" {
 				continue
@@ -219,7 +217,7 @@ func checkStreamConnectionExists() resource.TestCheckFunc {
 			projectID := rs.Primary.Attributes["project_id"]
 			instanceName := rs.Primary.Attributes["instance_name"]
 			connectionName := rs.Primary.Attributes["connection_name"]
-			_, _, err := connV2.StreamsApi.GetStreamConnection(context.Background(), projectID, instanceName, connectionName).Execute()
+			_, _, err := acc.ConnV2().StreamsApi.GetStreamConnection(context.Background(), projectID, instanceName, connectionName).Execute()
 			if err != nil {
 				return fmt.Errorf("stream connection (%s:%s:%s) does not exist", projectID, instanceName, connectionName)
 			}
@@ -232,7 +230,6 @@ func CheckDestroyStreamConnection(state *terraform.State) error {
 	if instanceDestroyedErr := acc.CheckDestroyStreamInstance(state); instanceDestroyedErr != nil {
 		return instanceDestroyedErr
 	}
-	connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_stream_connection" {
 			continue
@@ -240,7 +237,7 @@ func CheckDestroyStreamConnection(state *terraform.State) error {
 		projectID := rs.Primary.Attributes["project_id"]
 		instanceName := rs.Primary.Attributes["instance_name"]
 		connectionName := rs.Primary.Attributes["connection_name"]
-		_, _, err := connV2.StreamsApi.GetStreamConnection(context.Background(), projectID, instanceName, connectionName).Execute()
+		_, _, err := acc.ConnV2().StreamsApi.GetStreamConnection(context.Background(), projectID, instanceName, connectionName).Execute()
 		if err == nil {
 			return fmt.Errorf("stream connection (%s:%s:%s) still exists", projectID, instanceName, connectionName)
 		}

--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -64,10 +63,9 @@ func checkStreamInstanceImportStateIDFunc(resourceName string) resource.ImportSt
 
 func checkSearchInstanceExists() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := acc.TestMongoDBClient.(*config.MongoDBClient).AtlasV2
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type == "mongodbatlas_stream_instance" {
-				_, _, err := connV2.StreamsApi.GetStreamInstance(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"]).Execute()
+				_, _, err := acc.ConnV2().StreamsApi.GetStreamInstance(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"]).Execute()
 				if err != nil {
 					return fmt.Errorf("stream instance (%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"])
 				}

--- a/internal/service/teams/resource_teams_test.go
+++ b/internal/service/teams/resource_teams_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -116,31 +115,23 @@ func TestAccConfigRSTeam_importBasic(t *testing.T) {
 
 func testAccCheckMongoDBAtlasTeamExists(resourceName string, team *matlas.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		orgID := ids["org_id"]
 		id := ids["id"]
-
 		if orgID == "" && id == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		log.Printf("[DEBUG] orgID: %s", orgID)
 		log.Printf("[DEBUG] teamID: %s", id)
-
-		teamResp, _, err := conn.Teams.Get(context.Background(), orgID, id)
+		teamResp, _, err := acc.Conn().Teams.Get(context.Background(), orgID, id)
 		if err == nil {
 			*team = *teamResp
 			return nil
 		}
-
 		return fmt.Errorf("team(%s) does not exist", id)
 	}
 }
@@ -150,7 +141,6 @@ func testAccCheckMongoDBAtlasTeamAttributes(team *matlas.Team, name string) reso
 		if team.Name != name {
 			return fmt.Errorf("bad name: %s", team.Name)
 		}
-
 		return nil
 	}
 }
@@ -161,7 +151,6 @@ func testAccCheckMongoDBAtlasTeamStateIDFunc(resourceName string) resource.Impor
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["org_id"], rs.Primary.Attributes["team_id"]), nil
 	}
 }

--- a/internal/service/thirdpartyintegration/data_source_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/data_source_third_party_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -249,24 +248,18 @@ func testGenString(length int, charSet string) string {
 
 func testAccCheckThirdPartyIntegrationExists(resourceName string, integration *matlas.ThirdPartyIntegration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.Attributes["project_id"] == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		if integrationResponse, _, err := conn.Integrations.Get(context.Background(), ids["project_id"], ids["type"]); err == nil {
+		if integrationResponse, _, err := acc.Conn().Integrations.Get(context.Background(), ids["project_id"], ids["type"]); err == nil {
 			*integration = *integrationResponse
 			return nil
 		}
-
 		return fmt.Errorf("third party integration (%s) does not exist", ids["project_id"])
 	}
 }

--- a/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
@@ -157,20 +156,16 @@ func TestAccConfigRSThirdPartyIntegration_updateBasic(t *testing.T) {
 }
 
 func testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy(s *terraform.State) error {
-	conn := acc.TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_third_party_integration" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.Integrations.Get(context.Background(), ids["project_id"], ids["type"])
-
+		_, _, err := acc.Conn().Integrations.Get(context.Background(), ids["project_id"], ids["type"])
 		if err == nil {
 			return fmt.Errorf("third party integration service (%s) still exists", ids["type"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 var (
@@ -27,34 +26,28 @@ var (
 )
 
 func CheckClusterDestroy(s *terraform.State) error {
-	conn := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster" {
 			continue
 		}
 
 		// Try to find the cluster
-		_, _, err := conn.Clusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
-
+		_, _, err := Conn().Clusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
 		if err == nil {
 			return fmt.Errorf("cluster (%s:%s) still exists", rs.Primary.Attributes["cluster_name"], rs.Primary.ID)
 		}
 	}
-
 	return nil
 }
 
 func CheckDestroyTeamAdvancedCluster(s *terraform.State) error {
-	conn := TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_advanced_cluster" {
 			continue
 		}
 
 		// Try to find the cluster
-		_, _, err := conn.AdvancedClusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
+		_, _, err := Conn().AdvancedClusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
 
 		if err == nil {
 			return fmt.Errorf("cluster (%s:%s) still exists", rs.Primary.Attributes["cluster_name"], rs.Primary.ID)

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -37,7 +37,6 @@ func init() {
 			return provider.MuxedProviderFactory()(), nil
 		},
 	}
-
 	cfg := config.Config{
 		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"os"
 
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
+	"go.mongodb.org/atlas-sdk/v20231115004/admin"
 )
 
 const (
@@ -21,8 +24,16 @@ var TestAccProviderV6Factories map[string]func() (tfprotov6.ProviderServer, erro
 // this provider instance has to be passed into mux server factory for its configure method to be invoked
 var TestAccProviderSdkV2 *schema.Provider
 
-// TestMongoDBClient is used to configure client required for Framework-based acceptance tests
-var TestMongoDBClient any
+// testMongoDBClient is used to configure client required for Framework-based acceptance tests
+var testMongoDBClient any
+
+func Conn() *matlas.Client {
+	return testMongoDBClient.(*config.MongoDBClient).Atlas
+}
+
+func ConnV2() *admin.APIClient {
+	return testMongoDBClient.(*config.MongoDBClient).AtlasV2
+}
 
 func init() {
 	TestAccProviderSdkV2 = provider.NewSdkV2Provider()
@@ -39,5 +50,5 @@ func init() {
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
 	}
-	TestMongoDBClient, _ = cfg.NewClient(context.Background())
+	testMongoDBClient, _ = cfg.NewClient(context.Background())
 }

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -7,7 +7,6 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
@@ -18,29 +17,24 @@ const (
 	ProviderNameMongoDBAtlas = "mongodbatlas"
 )
 
+// TestAccProviderV6Factories is used in all tests for ProtoV6ProviderFactories.
 var TestAccProviderV6Factories map[string]func() (tfprotov6.ProviderServer, error)
 
-// TestAccProviderSdkV2 is only being used in tests obtaining client: .Meta().(*MongoDBClient)
-// this provider instance has to be passed into mux server factory for its configure method to be invoked
-var TestAccProviderSdkV2 *schema.Provider
-
-// testMongoDBClient is used to configure client required for Framework-based acceptance tests
-var testMongoDBClient any
+// MongoDBClient is used to configure client required for Framework-based acceptance tests.
+var MongoDBClient *config.MongoDBClient
 
 func Conn() *matlas.Client {
-	return testMongoDBClient.(*config.MongoDBClient).Atlas
+	return MongoDBClient.Atlas
 }
 
 func ConnV2() *admin.APIClient {
-	return testMongoDBClient.(*config.MongoDBClient).AtlasV2
+	return MongoDBClient.AtlasV2
 }
 
 func init() {
-	TestAccProviderSdkV2 = provider.NewSdkV2Provider()
-
 	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
-			return provider.MuxedProviderFactoryFn(TestAccProviderSdkV2)(), nil
+			return provider.MuxedProviderFactory()(), nil
 		},
 	}
 
@@ -50,5 +44,6 @@ func init() {
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
 	}
-	testMongoDBClient, _ = cfg.NewClient(context.Background())
+	client, _ := cfg.NewClient(context.Background())
+	MongoDBClient = client.(*config.MongoDBClient)
 }

--- a/internal/testutil/acc/federated.go
+++ b/internal/testutil/acc/federated.go
@@ -6,23 +6,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroyFederatedDatabaseInstance(s *terraform.State) error {
-	connV2 := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).AtlasV2
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_federated_database_instance" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := connV2.DataFederationApi.GetFederatedDatabase(context.Background(), ids["project_id"], ids["name"]).Execute()
+		_, _, err := ConnV2().DataFederationApi.GetFederatedDatabase(context.Background(), ids["project_id"], ids["name"]).Execute()
 		if err == nil {
 			return fmt.Errorf("federated database instance (%s) still exists", ids["project_id"])
 		}
 	}
-
 	return nil
 }

--- a/internal/testutil/acc/ldap.go
+++ b/internal/testutil/acc/ldap.go
@@ -5,22 +5,17 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroyLDAPConfiguration(s *terraform.State) error {
-	conn := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_ldap_configuration" {
 			continue
 		}
-
-		_, _, err := conn.LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
+		_, _, err := Conn().LDAPConfigurations.Get(context.Background(), rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("ldapConfiguration (%s) still exists", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }

--- a/internal/testutil/acc/network_peering.go
+++ b/internal/testutil/acc/network_peering.go
@@ -6,24 +6,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroyNetworkPeering(s *terraform.State) error {
-	conn := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_network_peering" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := conn.Peers.Get(context.Background(), ids["project_id"], ids["peer_id"])
-
+		_, _, err := Conn().Peers.Get(context.Background(), ids["project_id"], ids["peer_id"])
 		if err == nil {
 			return fmt.Errorf("peer (%s) still exists", ids["peer_id"])
 		}
 	}
-
 	return nil
 }

--- a/internal/testutil/acc/org.go
+++ b/internal/testutil/acc/org.go
@@ -6,28 +6,22 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroyOrgInvitation(s *terraform.State) error {
-	conn := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_invitations" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		orgID := ids["org_id"]
 		invitationID := ids["invitation_id"]
 
 		// Try to find the invitation
-		_, _, err := conn.Organizations.Invitation(context.Background(), orgID, invitationID)
+		_, _, err := Conn().Organizations.Invitation(context.Background(), orgID, invitationID)
 		if err == nil {
 			return fmt.Errorf("invitation (%s) still exists", invitationID)
 		}
 	}
-
 	return nil
 }

--- a/internal/testutil/acc/project_ip_acces_list.go
+++ b/internal/testutil/acc/project_ip_acces_list.go
@@ -7,49 +7,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckProjectIPAccessListExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		connV2 := TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("not found: %s", resourceName)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := connV2.ProjectIPAccessListApi.GetProjectIpList(context.Background(), ids["project_id"], ids["entry"]).Execute()
+		_, _, err := ConnV2().ProjectIPAccessListApi.GetProjectIpList(context.Background(), ids["project_id"], ids["entry"]).Execute()
 		if err != nil {
 			return fmt.Errorf("project ip access list entry (%s) does not exist", ids["entry"])
 		}
-
 		return nil
 	}
 }
 
 func CheckDestroyProjectIPAccessList(s *terraform.State) error {
-	connV2 := TestMongoDBClient.(*config.MongoDBClient).AtlasV2
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project_ip_access_list" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		_, _, err := connV2.ProjectIPAccessListApi.GetProjectIpList(context.Background(), ids["project_id"], ids["entry"]).Execute()
+		_, _, err := ConnV2().ProjectIPAccessListApi.GetProjectIpList(context.Background(), ids["project_id"], ids["entry"]).Execute()
 		if err == nil {
 			return fmt.Errorf("project ip access list entry (%s) still exists", ids["entry"])
 		}
 	}
-
 	return nil
 }
 

--- a/internal/testutil/acc/search_index.go
+++ b/internal/testutil/acc/search_index.go
@@ -7,27 +7,21 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroySearchIndex(state *terraform.State) error {
 	if os.Getenv("MONGODB_ATLAS_CLUSTER_NAME") != "" {
 		return nil
 	}
-	conn := TestAccProviderSdkV2.Meta().(*config.MongoDBClient).Atlas
-
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_search_index" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
-		searchIndex, _, err := conn.Search.GetIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"])
+		searchIndex, _, err := Conn().Search.GetIndex(context.Background(), ids["project_id"], ids["cluster_name"], ids["index_id"])
 		if err == nil && searchIndex != nil {
 			return fmt.Errorf("index id (%s) still exists", ids["index_id"])
 		}
 	}
-
 	return nil
 }

--- a/internal/testutil/acc/stream_instance.go
+++ b/internal/testutil/acc/stream_instance.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
@@ -30,10 +29,9 @@ func CheckDestroyStreamInstance(state *terraform.State) error {
 	if projectDestroyedErr := CheckDestroyProject(state); projectDestroyedErr != nil {
 		return projectDestroyedErr
 	}
-	connV2 := TestMongoDBClient.(*config.MongoDBClient).AtlasV2
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type == "mongodbatlas_stream_instance" {
-			_, _, err := connV2.StreamsApi.GetStreamInstance(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"]).Execute()
+			_, _, err := ConnV2().StreamsApi.GetStreamInstance(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"]).Execute()
 			if err == nil {
 				return fmt.Errorf("stream instance (%s:%s) still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["instance_name"])
 			}

--- a/internal/testutil/acc/team.go
+++ b/internal/testutil/acc/team.go
@@ -6,24 +6,19 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 func CheckDestroyTeam(s *terraform.State) error {
-	conn := TestMongoDBClient.(*config.MongoDBClient).Atlas
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_teams" {
 			continue
 		}
-
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-
 		orgID := ids["org_id"]
 		id := ids["id"]
 
 		// Try to find the team
-		_, _, err := conn.Teams.Get(context.Background(), orgID, id)
+		_, _, err := Conn().Teams.Get(context.Background(), orgID, id)
 		if err == nil {
 			return fmt.Errorf("team (%s) still exists", id)
 		}

--- a/main.go
+++ b/main.go
@@ -10,12 +10,10 @@ import (
 
 func main() {
 	var debugMode bool
-
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
 	var serveOpts []tf6server.ServeOpt
-
 	if debugMode {
 		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}


### PR DESCRIPTION
## Description

Unifies SDK connection getting in tests.

Before this PR, SDK connection in tests is got in different ways, not all of them work for migration tests. Here we get the connection in the same way independently of the test type.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-224848

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
