### PR TITLE
fix: Sets replication_specs IDs when updating them.

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -850,6 +850,10 @@ func expandAdvancedReplicationSpec(tfMap map[string]any) *matlas.AdvancedReplica
 		RegionConfigs: expandRegionConfigs(tfMap["region_configs"].([]any)),
 	}
 
+	if tfMap["id"].(string) != "" {
+		apiObject.ID = tfMap["id"].(string)
+	}
+
 	return apiObject
 }
 

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -606,8 +606,8 @@ func TestAccClusterAdvancedClusterConfig_ReplicationSpecsAndShardUpdating(t *tes
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName      = acctest.RandomWithPrefix("test-acc")
 		rName            = acctest.RandomWithPrefix("test-acc")
-		numShards        = 1
-		numShardsUpdated = 1
+		numShards        = "1"
+		numShardsUpdated = "2"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1181,7 +1181,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 	`, orgID, projectName, name, *p.Compute.Enabled, *p.DiskGBEnabled, p.Compute.MaxInstanceSize)
 }
 
-func testAccMongoDBAtlasAdvancedClusterConfigMultiZoneWithShards(orgID, projectName, name string, numShardsFirstZone, numShardsSecondZone int) string {
+func testAccMongoDBAtlasAdvancedClusterConfigMultiZoneWithShards(orgID, projectName, name, numShardsFirstZone, numShardsSecondZone string) string {
 	return fmt.Sprintf(`
 
 	resource "mongodbatlas_project" "cluster_project" {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1189,7 +1189,7 @@ func testAccMongoDBAtlasAdvancedClusterConfigMultiZoneWithShards(orgID, projectN
 		org_id = %[1]q
 	}
 
-	resource "mongodbatlas_advanced_cluster" "cluster" {
+	resource "mongodbatlas_advanced_cluster" "test" {
 		project_id = mongodbatlas_project.cluster_project.id
 		name = %[3]q
 		backup_enabled = false

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1380,6 +1380,28 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 		}
 	}`
 
+	replicationsShardsUpdate := `replication_specs {
+		num_shards = 2
+		zone_name = "us2"
+		regions_config{
+			region_name     = "US_WEST_2"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	  }
+
+	 replication_specs {
+		num_shards = 1
+		zone_name = "us1"
+		regions_config{
+			region_name     = "US_WEST_1"
+			electable_nodes = 3
+			priority        = 7
+			read_only_nodes = 0
+		}
+	}`
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -1399,6 +1421,14 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "2"),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "2"),
 				),
 			},
 		},

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1428,7 +1428,12 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "2"),
+					// Note: replication_specs is a set for the cluster resource, therefore the order does not
+					// necessarily match the one used to insert the configuration in the .tf file.
+					// In fact, the num_shards field is used in the custom hash algorithm hence it affects the ordering.
+					// https://github.com/mongodb/terraform-provider-mongodbatlas/blob/059cd565e7aafd59eb8be30bbc9372b56ce2ffa4/internal/service/cluster/resource_cluster.go#L274
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_specs.1.num_shards", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Passes the replicationSpec item id to the PATCH request during updates. This fixes the error:

```
400 (request "INVALID_CLUSTER_CONFIGURATION") The specified cluster configuration is not valid: Updating id of existing replication spec.
```

Link to any related issue(s): [CLOUDP-227483](https://jira.mongodb.org/browse/CLOUDP-227483)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
