### PR TITLE
remove!: Removes `page_num` and `items_per_page` attributes in `mongodbatlas_search_indexes` data source

### DIFF
--- a/internal/service/searchindex/data_source_search_indexes.go
+++ b/internal/service/searchindex/data_source_search_indexes.go
@@ -2,12 +2,10 @@ package searchindex
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115005/admin"
 )
@@ -31,16 +29,6 @@ func PluralDataSource() *schema.Resource {
 			"collection_name": {
 				Type:     schema.TypeString,
 				Required: true,
-			},
-			"page_num": {
-				Type:       schema.TypeInt,
-				Optional:   true,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.15.0"),
-			},
-			"items_per_page": {
-				Type:       schema.TypeInt,
-				Optional:   true,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.15.0"),
 			},
 			"results": {
 				Type:     schema.TypeList,

--- a/website/docs/d/search_indexes.html.markdown
+++ b/website/docs/d/search_indexes.html.markdown
@@ -16,15 +16,11 @@ Describes a Search Indexes.
 ## Example Usage
 
 ```terraform
-data "mongodbatlas_search_index" "test" {
+data "mongodbatlas_search_indexes" "test" {
   project_id = "<PROJECT_ID>"
   cluster_name = "<CLUSTER_NAME>"
   database_name ="<DATABASE_NAME>"
   collection_name = "<COLLECTION_NAME>"
-  
-  page_num = 1
-  items_per_page = 100
-  
 }
 ```
 
@@ -34,8 +30,6 @@ data "mongodbatlas_search_index" "test" {
 * `cluster_name` - (Required) Name of the cluster containing the collection with one or more Atlas Search indexes.
 * `database_name` - (Required) Name of the database containing the collection with one or more Atlas Search indexes.
 * `collection_name` - (Required) Name of the collection with one or more Atlas Search indexes.
-* `page_num` - Page number, starting with one, that Atlas returns of the total number of objects. **WARNING:** this parameter is deprecated and will be removed in version 1.15.0
-* `items_per_page` - Number of items that Atlas returns per page, up to a maximum of 500. **WARNING:** this parameter is deprecated and will be removed in version 1.15.0
 
 ## Attributes Reference
 * `total_count` - Represents the total of the search indexes

--- a/website/docs/guides/1.15.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.15.0-upgrade-guide.html.markdown
@@ -15,9 +15,12 @@ The Terraform MongoDB Atlas Provider version 1.15.0 has a number of new and exci
 
 **Breaking Changes:**
 
-**Deprecations and Removals:**  
+**Deprecations and Removals:**
 
-Format of IdP Id that uniquely identifies the identity provider when importing [`mongodbatlas_federated_settings_identity_provider`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/federated_settings_identity_provider) resource and [`mongodbatlas_federated_settings_identity_provider`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/federated_settings_identity_provider) data source now accepts a different format to align with the Atlas Admin API. Both the current and new IdP Id format are accepted in terraform-provider 1.15.0 version. New features for `mongodbatlas_federated_settings_identity_provider` resource and data source will only be available when using the new Id format.
+- Removal of `page_num` and `items_per_page` attributes in `mongodbatlas_search_indexes` data source.
+- Format of IdP Id that uniquely identifies the identity provider when importing [`mongodbatlas_federated_settings_identity_provider`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/federated_settings_identity_provider) resource and [`mongodbatlas_federated_settings_identity_provider`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/federated_settings_identity_provider) data source now accepts a different format to align with the Atlas Admin API. Details and upgrade guide can be found below: 
+
+Both the current and new IdP Id format are accepted in terraform-provider 1.15.0 version. New features for `mongodbatlas_federated_settings_identity_provider` resource and data source will only be available when using the new Id format.
 
 ***WARNING:*** Old IdP Id format will no longer be accepted starting in terraform-provider 1.16.0 version and onwards. We recommend to update to the new format as soon as possible. A warning will appear if old Id is still being used. Follow the guide below to start using the new Id format.
 


### PR DESCRIPTION
## Description

Link to any related issue(s): [CLOUDP-226421](https://jira.mongodb.org/browse/CLOUDP-226421)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
