### PR TITLE
chore: Upgrades x509authentication_database_user resource to auto-generated SDK

### DIFF
--- a/internal/service/x509authenticationdatabaseuser/data_source_x509_authentication_database_user.go
+++ b/internal/service/x509authenticationdatabaseuser/data_source_x509_authentication_database_user.go
@@ -12,7 +12,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasX509AuthDBUserRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -61,7 +61,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user.go
@@ -25,11 +25,11 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasX509AuthDBUserCreate,
-		ReadContext:   resourceMongoDBAtlasX509AuthDBUserRead,
-		DeleteContext: resourceMongoDBAtlasX509AuthDBUserDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasX509AuthDBUserImportState,
+			StateContext: resourceImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -98,7 +98,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	projectID := d.Get("project_id").(string)
@@ -130,10 +130,10 @@ func resourceMongoDBAtlasX509AuthDBUserCreate(ctx context.Context, d *schema.Res
 		"serial_number": serialNumber,
 	}))
 
-	return resourceMongoDBAtlasX509AuthDBUserRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	ids := conversion.DecodeStateID(d.Id())
@@ -175,14 +175,14 @@ func resourceMongoDBAtlasX509AuthDBUserRead(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceMongoDBAtlasX509AuthDBUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// We don't do anything because X.509 certificates can not be deleted or disassociated from a user.
 	// More info: https://jira.mongodb.org/browse/HELP-53363
 	d.SetId("")
 	return nil
 }
 
-func resourceMongoDBAtlasX509AuthDBUserImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	parts := strings.SplitN(d.Id(), "-", 2)
@@ -241,6 +241,5 @@ func flattenCertificates(userCertificates []matlas.UserCertificate) []map[string
 			"subject":    v.Subject,
 		}
 	}
-
 	return certificates
 }

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
@@ -1,0 +1,88 @@
+package x509authenticationdatabaseuser_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationGenericX509AuthDBUser_basic(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
+		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
+		username       = acctest.RandomWithPrefix("test-acc")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			mig.PreCheckBasic(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configBasic(projectName, orgID, username),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "username"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configBasic(projectName, orgID, username),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccMigrationGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
+	var (
+		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
+		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
+		cas            = os.Getenv("CA_CERT")
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { mig.PreCheckCert(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configWithCustomerX509(projectName, orgID, cas),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "customer_x509_cas"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configWithCustomerX509(projectName, orgID, cas),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
@@ -13,11 +13,9 @@ import (
 
 func TestAccMigrationGenericX509AuthDBUser_basic(t *testing.T) {
 	var (
-		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
-		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
-		username       = acctest.RandomWithPrefix("test-acc")
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acctest.RandomWithPrefix("test-acc")
+		username    = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -31,9 +29,9 @@ func TestAccMigrationGenericX509AuthDBUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "username"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "username", username),
 				),
 			},
 			{
@@ -52,11 +50,9 @@ func TestAccMigrationGenericX509AuthDBUser_basic(t *testing.T) {
 
 func TestAccMigrationGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 	var (
-		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
-		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
-		cas            = os.Getenv("CA_CERT")
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acctest.RandomWithPrefix("test-acc")
+		cas         = os.Getenv("CA_CERT")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -14,13 +14,16 @@ import (
 	"github.com/spf13/cast"
 )
 
+const (
+	resourceName   = "mongodbatlas_x509_authentication_database_user.test"
+	dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
+)
+
 func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 	var (
-		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
-		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
-		username       = acctest.RandomWithPrefix("test-acc")
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acctest.RandomWithPrefix("test-acc")
+		username    = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,9 +37,9 @@ func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "username"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "username", username),
 				),
 			},
 		},
@@ -45,7 +48,6 @@ func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 
 func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 	var (
-		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
 		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
 		cas            = os.Getenv("CA_CERT")
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -72,10 +74,9 @@ func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 
 func TestAccGenericX509AuthDBUser_importBasic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_x509_authentication_database_user.test"
-		username     = acctest.RandomWithPrefix("test-acc")
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		username    = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -98,11 +99,10 @@ func TestAccGenericX509AuthDBUser_importBasic(t *testing.T) {
 
 func TestAccGenericX509AuthDBUser_withDatabaseUser(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_x509_authentication_database_user.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		username     = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
-		months       = acctest.RandIntRange(1, 24)
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		username    = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		months      = acctest.RandIntRange(1, 24)
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -126,10 +126,9 @@ func TestAccGenericX509AuthDBUser_withDatabaseUser(t *testing.T) {
 
 func TestAccGenericX509AuthDBUser_importWithCustomerX509(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_x509_authentication_database_user.test"
-		cas          = os.Getenv("CA_CERT")
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		cas         = os.Getenv("CA_CERT")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -193,7 +192,7 @@ func configBasic(projectName, orgID, username string) string {
 
 		resource "mongodbatlas_database_user" "basic_ds" {
 			username           = "%s"
-			project_id         = "${mongodbatlas_project.test.id}"
+			project_id         = mongodbatlas_project.test.id
 			auth_database_name = "$external"
 			x509_type          = "MANAGED"
 
@@ -204,13 +203,14 @@ func configBasic(projectName, orgID, username string) string {
 		}
 
 		resource "mongodbatlas_x509_authentication_database_user" "test" {
-			project_id              = "${mongodbatlas_project.test.id}"
-			username                = "${mongodbatlas_database_user.basic_ds.username}"
+			project_id              = mongodbatlas_project.test.id
+			username                = mongodbatlas_database_user.basic_ds.username
 			months_until_expiration = 5
 		}
 
 		data "mongodbatlas_x509_authentication_database_user" "test" {
-			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
+			project_id = mongodbatlas_x509_authentication_database_user.test.project_id
+			username   = mongodbatlas_x509_authentication_database_user.test.username
 		}
 	`, projectName, orgID, username)
 }
@@ -223,15 +223,15 @@ func configWithCustomerX509(projectName, orgID, cas string) string {
 		}
 
 		resource "mongodbatlas_x509_authentication_database_user" "test" {
-			project_id        = "${mongodbatlas_project.test.id}"
+			project_id        = mongodbatlas_project.test.id
 			customer_x509_cas = <<-EOT
 			%s
 			EOT
 		}
 
 		data "mongodbatlas_x509_authentication_database_user" "test" {
-			project_id = "${mongodbatlas_x509_authentication_database_user.test.project_id}"
-			username   = "${mongodbatlas_x509_authentication_database_user.test.username}"
+			project_id = mongodbatlas_x509_authentication_database_user.test.project_id
+			username   = mongodbatlas_x509_authentication_database_user.test.username
 		}
 	`, projectName, orgID, cas)
 }
@@ -261,9 +261,14 @@ func configWithDatabaseUser(projectName, orgID, username string, months int) str
 		}
 
 		resource "mongodbatlas_x509_authentication_database_user" "test" {
-			project_id              = "${mongodbatlas_database_user.user.project_id}"
-			username                = "${mongodbatlas_database_user.user.username}"
+			project_id              = mongodbatlas_database_user.user.project_id
+			username                = mongodbatlas_database_user.user.username
 			months_until_expiration = %d
+		}
+
+		data "mongodbatlas_x509_authentication_database_user" "test" {
+			project_id = mongodbatlas_x509_authentication_database_user.test.project_id
+			username   = mongodbatlas_x509_authentication_database_user.test.username
 		}
 	`, projectName, orgID, username, months)
 }

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cast"
 )
 
-func TestAccGenericAdvRSX509AuthDBUser_basic(t *testing.T) {
+func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 	var (
 		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
 		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
@@ -28,12 +28,11 @@ func TestAccGenericAdvRSX509AuthDBUser_basic(t *testing.T) {
 			acc.PreCheckBasic(t)
 		},
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username),
+				Config: configBasic(projectName, orgID, username),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "username"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -44,7 +43,7 @@ func TestAccGenericAdvRSX509AuthDBUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccGenericAdvRSX509AuthDBUser_WithCustomerX509(t *testing.T) {
+func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 	var (
 		resourceName   = "mongodbatlas_x509_authentication_database_user.test"
 		dataSourceName = "data.mongodbatlas_x509_authentication_database_user.test"
@@ -56,12 +55,11 @@ func TestAccGenericAdvRSX509AuthDBUser_WithCustomerX509(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas),
+				Config: configWithCustomerX509(projectName, orgID, cas),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -72,7 +70,7 @@ func TestAccGenericAdvRSX509AuthDBUser_WithCustomerX509(t *testing.T) {
 	})
 }
 
-func TestAccGenericAdvRSX509AuthDBUser_importBasic(t *testing.T) {
+func TestAccGenericX509AuthDBUser_importBasic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_x509_authentication_database_user.test"
 		username     = acctest.RandomWithPrefix("test-acc")
@@ -85,21 +83,20 @@ func TestAccGenericAdvRSX509AuthDBUser_importBasic(t *testing.T) {
 			acc.PreCheckBasic(t)
 		},
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username),
+				Config: configBasic(projectName, orgID, username),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportStateIdFunc: importStateIDFuncBasic(resourceName),
 				ImportState:       true,
 			},
 		},
 	})
 }
 
-func TestAccGenericAdvRSX509AuthDBUser_WithDatabaseUser(t *testing.T) {
+func TestAccGenericX509AuthDBUser_withDatabaseUser(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_x509_authentication_database_user.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -111,12 +108,11 @@ func TestAccGenericAdvRSX509AuthDBUser_WithDatabaseUser(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithDatabaseUser(projectName, orgID, username, months),
+				Config: configWithDatabaseUser(projectName, orgID, username, months),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "username"),
 					resource.TestCheckResourceAttrSet(resourceName, "months_until_expiration"),
@@ -128,7 +124,7 @@ func TestAccGenericAdvRSX509AuthDBUser_WithDatabaseUser(t *testing.T) {
 	})
 }
 
-func TestAccGenericAdvRSX509AuthDBUser_importWithCustomerX509(t *testing.T) {
+func TestAccGenericX509AuthDBUser_importWithCustomerX509(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_x509_authentication_database_user.test"
 		cas          = os.Getenv("CA_CERT")
@@ -139,21 +135,20 @@ func TestAccGenericAdvRSX509AuthDBUser_importWithCustomerX509(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasX509AuthDBUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas),
+				Config: configWithCustomerX509(projectName, orgID, cas),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName),
+				ImportStateIdFunc: importStateIDFuncBasic(resourceName),
 				ImportState:       true,
 			},
 		},
 	})
 }
 
-func testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFuncBasic(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -166,7 +161,7 @@ func testAccCheckMongoDBAtlasX509AuthDBUserImportStateIDFuncBasic(resourceName s
 	}
 }
 
-func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -189,27 +184,7 @@ func testAccCheckMongoDBAtlasX509AuthDBUserExists(resourceName string) resource.
 	}
 }
 
-func testAccCheckMongoDBAtlasX509AuthDBUserDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "mongodbatlas_x509_authentication_database_user" {
-			continue
-		}
-		ids := conversion.DecodeStateID(rs.Primary.ID)
-		if ids["current_certificate"] != "" {
-			_, _, err := acc.Conn().X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"], nil)
-			if err == nil {
-				// There is no way to remove one user certificate so until this comes it will keep in this way
-				return nil
-			}
-		}
-		if _, _, err := acc.Conn().X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
-			return nil
-		}
-	}
-	return nil
-}
-
-func testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username string) string {
+func configBasic(projectName, orgID, username string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = "%s"
@@ -240,7 +215,7 @@ func testAccMongoDBAtlasX509AuthDBUserConfig(projectName, orgID, username string
 	`, projectName, orgID, username)
 }
 
-func testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID, cas string) string {
+func configWithCustomerX509(projectName, orgID, cas string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = "%s"
@@ -261,7 +236,7 @@ func testAccMongoDBAtlasX509AuthDBUserConfigWithCustomerX509(projectName, orgID,
 	`, projectName, orgID, cas)
 }
 
-func testAccMongoDBAtlasX509AuthDBUserConfigWithDatabaseUser(projectName, orgID, username string, months int) string {
+func configWithDatabaseUser(projectName, orgID, username string, months int) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = "%s"

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -171,12 +171,12 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		if ids["current_certificate"] != "" {
-			if _, _, err := acc.Conn().X509AuthDBUsers.GetUserCertificates(context.Background(), ids["project_id"], ids["username"], nil); err == nil {
+			if _, _, err := acc.ConnV2().X509AuthenticationApi.ListDatabaseUserCertificates(context.Background(), ids["project_id"], ids["username"]).Execute(); err == nil {
 				return nil
 			}
 			return fmt.Errorf("the X509 Authentication Database User(%s) does not exist in the project(%s)", ids["username"], ids["project_id"])
 		}
-		if _, _, err := acc.Conn().X509AuthDBUsers.GetCurrentX509Conf(context.Background(), ids["project_id"]); err == nil {
+		if _, _, err := acc.ConnV2().LDAPConfigurationApi.GetLDAPConfiguration(context.Background(), ids["project_id"]).Execute(); err == nil {
 			return nil
 		}
 		return fmt.Errorf("the Customer X509 Authentication does not exist in the project(%s)", ids["project_id"])

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -53,7 +53,7 @@ func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheckCert(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
@@ -133,7 +133,7 @@ func TestAccGenericX509AuthDBUser_importWithCustomerX509(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheckCert(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -25,6 +25,16 @@ func PreCheck(tb testing.TB) {
 	}
 }
 
+func PreCheckCert(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
+		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" ||
+		os.Getenv("CA_CERT") == "" {
+		tb.Fatal("`CA_CERT, MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	}
+}
+
 func PreCheckBetaFlag(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_ENABLE_BETA") == "" {

--- a/internal/testutil/mig/pre_check.go
+++ b/internal/testutil/mig/pre_check.go
@@ -22,3 +22,9 @@ func PreCheckBasicOwnerID(tb testing.TB) {
 	tb.Helper()
 	PreCheckBasic(tb)
 }
+
+func PreCheckCert(tb testing.TB) {
+	tb.Helper()
+	checkLastVersion(tb)
+	acc.PreCheckCert(tb)
+}


### PR DESCRIPTION
## Description

Upgrades  x509authentication_database_user resource to auto-generated SDK.

Data source acceptance tests added.

Migration tests created.


Link to any related issue(s): CLOUDP-226094

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
