### PR TITLE
chore: Upgrades maintenance_window resource to auto-generated SDK

### DIFF
--- a/internal/service/maintenancewindow/data_source_maintenance_window.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window.go
@@ -11,7 +11,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasMaintenanceWindowRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -41,7 +41,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)

--- a/internal/service/maintenancewindow/data_source_maintenance_window.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/spf13/cast"
 )
 
 func DataSource() *schema.Resource {
@@ -42,32 +41,31 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	maintenance, _, err := conn.MaintenanceWindows.Get(ctx, projectID)
+	maintenance, _, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("day_of_week", maintenance.DayOfWeek); err != nil {
+	if err := d.Set("day_of_week", maintenance.GetDayOfWeek()); err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("hour_of_day", maintenance.HourOfDay); err != nil {
+	if err := d.Set("hour_of_day", maintenance.GetHourOfDay()); err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("number_of_deferrals", maintenance.NumberOfDeferrals); err != nil {
+	if err := d.Set("number_of_deferrals", maintenance.GetNumberOfDeferrals()); err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("start_asap", cast.ToBool(maintenance.StartASAP)); err != nil {
+	if err := d.Set("start_asap", maintenance.GetStartASAP()); err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("auto_defer_once_enabled", cast.ToBool(maintenance.AutoDeferOnceEnabled)); err != nil {
+	if err := d.Set("auto_defer_once_enabled", maintenance.GetAutoDeferOnceEnabled()); err != nil {
 		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 

--- a/internal/service/maintenancewindow/data_source_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window_test.go
@@ -11,13 +11,16 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
-	var maintenance matlas.MaintenanceWindow
+const dataSourceName = "mongodbatlas_maintenance_window.test"
 
-	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
-	projectName := acctest.RandomWithPrefix("test-acc")
-	dayOfWeek := 7
-	hourOfDay := 3
+func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
+	var (
+		maintenance matlas.MaintenanceWindow
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek   = 7
+		hourOfDay   = 3
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -26,11 +29,11 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 			{
 				Config: configDS(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists("mongodbatlas_maintenance_window.test", &maintenance),
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "project_id"),
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "day_of_week"),
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "hour_of_day"),
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "auto_defer_once_enabled"),
+					checkExists(dataSourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "hour_of_day"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "auto_defer_once_enabled"),
 				),
 			},
 		},

--- a/internal/service/maintenancewindow/data_source_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window_test.go
@@ -24,9 +24,9 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Config: configDS(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasMaintenanceWindowExists("mongodbatlas_maintenance_window.test", &maintenance),
+					checkExists("mongodbatlas_maintenance_window.test", &maintenance),
 					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "project_id"),
 					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "day_of_week"),
 					resource.TestCheckResourceAttrSet("data.mongodbatlas_maintenance_window.test", "hour_of_day"),
@@ -37,7 +37,7 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 	})
 }
 
-func testAccMongoDBAtlasDataSourceMaintenanceWindowConfig(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+func configDS(orgID, projectName string, dayOfWeek, hourOfDay int) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = %[2]q

--- a/internal/service/maintenancewindow/data_source_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/spf13/cast"
 )
 
 const dataSourceName = "mongodbatlas_maintenance_window.test"
@@ -29,9 +30,9 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "hour_of_day"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "auto_defer_once_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(dataSourceName, "hour_of_day", cast.ToString(hourOfDay)),
+					resource.TestCheckResourceAttr(dataSourceName, "auto_defer_once_enabled", "true"),
 				),
 			},
 		},

--- a/internal/service/maintenancewindow/data_source_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const dataSourceName = "mongodbatlas_maintenance_window.test"
 
 func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 	var (
-		maintenance matlas.MaintenanceWindow
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acctest.RandomWithPrefix("test-acc")
 		dayOfWeek   = 7
@@ -29,7 +27,7 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 			{
 				Config: configDS(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(dataSourceName, &maintenance),
+					checkExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "hour_of_day"),

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -132,39 +132,40 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	projectID := d.Id()
 
-	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(context.Background(), d.Id()).Execute()
+	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(context.Background(), projectID).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}
 
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	if err := d.Set("day_of_week", maintenanceWindow.GetDayOfWeek()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	if err := d.Set("hour_of_day", maintenanceWindow.GetHourOfDay()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	if err := d.Set("number_of_deferrals", maintenanceWindow.GetNumberOfDeferrals()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	if err := d.Set("start_asap", maintenanceWindow.GetStartASAP()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	if err := d.Set("auto_defer_once_enabled", maintenanceWindow.GetAutoDeferOnceEnabled()); err != nil {
-		return diag.Errorf(errorMaintenanceRead, d.Id(), err)
+		return diag.Errorf(errorMaintenanceRead, projectID, err)
 	}
 
-	if err := d.Set("project_id", d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, d.Id(), err))
+	if err := d.Set("project_id", projectID); err != nil {
+		return diag.FromErr(fmt.Errorf(errorMaintenanceRead, projectID, err))
 	}
 
 	return nil
@@ -172,11 +173,12 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	projectID := d.Id()
 
 	if d.HasChange("defer") {
-		_, err := connV2.MaintenanceWindowsApi.DeferMaintenanceWindow(ctx, d.Id()).Execute()
+		_, err := connV2.MaintenanceWindowsApi.DeferMaintenanceWindow(ctx, projectID).Execute()
 		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorMaintenanceDefer, d.Id(), err))
+			return diag.FromErr(fmt.Errorf(errorMaintenanceDefer, projectID, err))
 		}
 	}
 
@@ -194,15 +196,15 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		params.AutoDeferOnceEnabled = pointy.Bool(d.Get("auto_defer_once_enabled").(bool))
 	}
 
-	_, _, err := connV2.MaintenanceWindowsApi.UpdateMaintenanceWindow(ctx, d.Id(), params).Execute()
+	_, _, err := connV2.MaintenanceWindowsApi.UpdateMaintenanceWindow(ctx, projectID, params).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceUpdate, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceUpdate, projectID, err))
 	}
 
 	if d.HasChange("auto_defer") {
-		_, err := connV2.MaintenanceWindowsApi.ToggleMaintenanceAutoDefer(ctx, d.Id()).Execute()
+		_, err := connV2.MaintenanceWindowsApi.ToggleMaintenanceAutoDefer(ctx, projectID).Execute()
 		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorMaintenanceAutoDefer, d.Id(), err))
+			return diag.FromErr(fmt.Errorf(errorMaintenanceAutoDefer, projectID, err))
 		}
 	}
 
@@ -211,9 +213,11 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
-	_, err := connV2.MaintenanceWindowsApi.ResetMaintenanceWindow(ctx, d.Id()).Execute()
+	projectID := d.Id()
+
+	_, err := connV2.MaintenanceWindowsApi.ResetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorMaintenanceDelete, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorMaintenanceDelete, projectID, err))
 	}
 	return nil
 }

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -38,8 +38,7 @@ func Resource() *schema.Resource {
 			},
 			"day_of_week": {
 				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 					v := val.(int)
 					if v < 1 || v > 7 {
@@ -63,11 +62,11 @@ func Resource() *schema.Resource {
 			},
 			"start_asap": {
 				Type:     schema.TypeBool,
+				Optional: true,
 				Computed: true,
 			},
 			"number_of_deferrals": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"defer": {
@@ -110,10 +109,6 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if hourOfDay, ok := d.GetOk("hour_of_day"); ok {
 		maintenanceWindowReq.HourOfDay = pointy.Int(cast.ToInt(hourOfDay))
-	}
-
-	if numberOfDeferrals, ok := d.GetOk("number_of_deferrals"); ok {
-		maintenanceWindowReq.NumberOfDeferrals = cast.ToInt(numberOfDeferrals)
 	}
 
 	if autoDeferOnceEnabled, ok := d.GetOk("auto_defer_once_enabled"); ok {
@@ -201,10 +196,6 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if d.HasChange("hour_of_day") {
 		maintenanceWindowReq.HourOfDay = pointy.Int(cast.ToInt(d.Get("hour_of_day")))
-	}
-
-	if d.HasChange("number_of_deferrals") {
-		maintenanceWindowReq.NumberOfDeferrals = cast.ToInt(d.Get("number_of_deferrals"))
 	}
 
 	if d.HasChange("auto_defer_once_enabled") {

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -213,13 +213,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get the client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
-
-	_, err := conn.MaintenanceWindows.Reset(ctx, d.Id())
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	_, err := connV2.MaintenanceWindowsApi.ResetMaintenanceWindow(ctx, d.Id()).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorMaintenanceDelete, d.Id(), err))
 	}
-
 	return nil
 }

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -24,10 +24,10 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasMaintenanceWindowCreate,
-		ReadContext:   resourceMongoDBAtlasMaintenanceWindowRead,
-		UpdateContext: resourceMongoDBAtlasMaintenanceWindowUpdate,
-		DeleteContext: resourceMongoDBAtlasMaintenanceWindowDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -89,7 +89,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasMaintenanceWindowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 
@@ -134,10 +134,10 @@ func resourceMongoDBAtlasMaintenanceWindowCreate(ctx context.Context, d *schema.
 
 	d.SetId(projectID)
 
-	return resourceMongoDBAtlasMaintenanceWindowRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 
@@ -182,7 +182,7 @@ func resourceMongoDBAtlasMaintenanceWindowRead(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func resourceMongoDBAtlasMaintenanceWindowUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 
@@ -226,7 +226,7 @@ func resourceMongoDBAtlasMaintenanceWindowUpdate(ctx context.Context, d *schema.
 	return nil
 }
 
-func resourceMongoDBAtlasMaintenanceWindowDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get the client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -28,8 +28,6 @@ func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/spf13/cast"
 )
@@ -18,6 +16,7 @@ func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 		projectName = acctest.RandomWithPrefix("test-acc")
 		dayOfWeek   = 7
 		hourOfDay   = 3
+		config      = configBasic(orgID, projectName, dayOfWeek, hourOfDay)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,7 +24,7 @@ func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            configBasic(orgID, projectName, dayOfWeek, hourOfDay),
+				Config:            config,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -36,16 +35,7 @@ func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configBasic(orgID, projectName, dayOfWeek, hourOfDay),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStep(config),
 		},
 	})
 }

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -10,12 +10,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/spf13/cast"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 	var (
-		maintenance matlas.MaintenanceWindow
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acctest.RandomWithPrefix("test-acc")
 		dayOfWeek   = 7
@@ -29,14 +27,13 @@ func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configBasic(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &maintenance),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-					checkAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
 				),
 			},
 			{

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -1,0 +1,54 @@
+package maintenancewindow_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+	"github.com/spf13/cast"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestAccMigrationConfigMaintenanceWindow_basic(t *testing.T) {
+	var (
+		maintenance matlas.MaintenanceWindow
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek   = 7
+		hourOfDay   = 3
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { mig.PreCheckBasic(t) },
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configBasic(orgID, projectName, dayOfWeek, hourOfDay),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName, &maintenance),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
+					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
+					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
+					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+					checkAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configBasic(orgID, projectName, dayOfWeek, hourOfDay),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -16,10 +16,11 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
+const resourceName = "mongodbatlas_maintenance_window.test"
+
 func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 	var (
 		maintenance      matlas.MaintenanceWindow
-		resourceName     = "mongodbatlas_maintenance_window.test"
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName      = acctest.RandomWithPrefix("test-acc")
 		dayOfWeek        = 7
@@ -64,12 +65,11 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 
 func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
 	var (
-		maintenance  matlas.MaintenanceWindow
-		resourceName = "mongodbatlas_maintenance_window.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
-		dayOfWeek    = 1
-		hourOfDay    = 3
+		maintenance matlas.MaintenanceWindow
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek   = 1
+		hourOfDay   = 3
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -102,12 +102,11 @@ func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
 
 func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
 	var (
-		maintenance  matlas.MaintenanceWindow
-		resourceName = "mongodbatlas_maintenance_window.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
-		dayOfWeek    = 7
-		hourOfDay    = 3
+		maintenance matlas.MaintenanceWindow
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		dayOfWeek   = 7
+		hourOfDay   = 3
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -35,8 +35,6 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
@@ -47,8 +45,6 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeekUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDayUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
@@ -75,8 +71,6 @@ func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
@@ -110,8 +104,6 @@ func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
-					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -33,29 +33,29 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					checkExists(resourceName, &maintenance),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+					checkAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeekUpdated, hourOfDayUpdated),
+				Config: configBasic(orgID, projectName, dayOfWeekUpdated, hourOfDayUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					checkExists(resourceName, &maintenance),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeekUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDayUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeekUpdated, &maintenance.DayOfWeek),
+					checkAttributes("day_of_week", dayOfWeekUpdated, &maintenance.DayOfWeek),
 				),
 			},
 		},
@@ -77,9 +77,9 @@ func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName, dayOfWeek, hourOfDay),
+				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					checkExists(resourceName, &maintenance),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
@@ -87,12 +87,12 @@ func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
 					resource.TestCheckResourceAttr(resourceName, "start_asap", "false"),
-					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+					checkAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
 				),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasMaintenanceWindowImportStateIDFunc(resourceName),
+				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -115,9 +115,9 @@ func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectName, dayOfWeek, hourOfDay),
+				Config: configWithAutoDeferEnabled(orgID, projectName, dayOfWeek, hourOfDay),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName, &maintenance),
+					checkExists(resourceName, &maintenance),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "day_of_week"),
 					resource.TestCheckResourceAttrSet(resourceName, "hour_of_day"),
@@ -125,28 +125,14 @@ func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_defer_once_enabled", "true"),
-					testAccCheckMongoDBAtlasMaintenanceWindowAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
+					checkAttributes("day_of_week", dayOfWeek, &maintenance.DayOfWeek),
 				),
 			},
 		},
 	})
 }
 
-func testAccMongoDBAtlasMaintenanceWindowConfigAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay int) string {
-	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
-		resource "mongodbatlas_maintenance_window" "test" {
-			project_id  = mongodbatlas_project.test.id
-			day_of_week = %[3]d
-			hour_of_day = %[4]d
-			auto_defer_once_enabled = true
-		}`, orgID, projectName, dayOfWeek, hourOfDay)
-}
-
-func testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName string, maintenance *matlas.MaintenanceWindow) resource.TestCheckFunc {
+func checkExists(resourceName string, maintenance *matlas.MaintenanceWindow) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -165,7 +151,7 @@ func testAccCheckMongoDBAtlasMaintenanceWindowExists(resourceName string, mainte
 	}
 }
 
-func testAccCheckMongoDBAtlasMaintenanceWindowAttributes(attr string, expected int, got *int) resource.TestCheckFunc {
+func checkAttributes(attr string, expected int, got *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if diff := deep.Equal(expected, *got); diff != nil {
 			return fmt.Errorf("bad %s \n got = %#v\nwant = %#v \ndiff = %#v", attr, expected, *got, diff)
@@ -175,7 +161,7 @@ func testAccCheckMongoDBAtlasMaintenanceWindowAttributes(attr string, expected i
 	}
 }
 
-func testAccCheckMongoDBAtlasMaintenanceWindowImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -186,7 +172,7 @@ func testAccCheckMongoDBAtlasMaintenanceWindowImportStateIDFunc(resourceName str
 	}
 }
 
-func testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+func configBasic(orgID, projectName string, dayOfWeek, hourOfDay int) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = %[2]q
@@ -196,5 +182,19 @@ func testAccMongoDBAtlasMaintenanceWindowConfig(orgID, projectName string, dayOf
 			project_id  = mongodbatlas_project.test.id
 			day_of_week = %[3]d
 			hour_of_day = %[4]d
+		}`, orgID, projectName, dayOfWeek, hourOfDay)
+}
+
+func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay int) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
+		resource "mongodbatlas_maintenance_window" "test" {
+			project_id  = mongodbatlas_project.test.id
+			day_of_week = %[3]d
+			hour_of_day = %[4]d
+			auto_defer_once_enabled = true
 		}`, orgID, projectName, dayOfWeek, hourOfDay)
 }

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -47,7 +47,7 @@ data "mongodbatlas_maintenance_window" "test" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
+* `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -50,6 +50,6 @@ In addition to all arguments above, the following attributes are exported:
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
-* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, you can set a maximum of 2 deferrals.
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, it can be a maximum of 2 deferrals.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/maintenance-windows/)

--- a/website/docs/d/maintenance_window.html.markdown
+++ b/website/docs/d/maintenance_window.html.markdown
@@ -50,6 +50,6 @@ In addition to all arguments above, the following attributes are exported:
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
-* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, it can be a maximum of 2 deferrals.
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/maintenance-windows/)

--- a/website/docs/r/maintenance_window.html.markdown
+++ b/website/docs/r/maintenance_window.html.markdown
@@ -54,7 +54,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 In addition to all arguments above, the following attributes are exported:
 
-* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, it can be a maximum of 2 deferrals.
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 
 ## Import
 

--- a/website/docs/r/maintenance_window.html.markdown
+++ b/website/docs/r/maintenance_window.html.markdown
@@ -41,15 +41,20 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 ## Argument Reference
 
 * `project_id` - The unique identifier of the project for the Maintenance Window.
-* `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: S=1, M=2, T=3, W=4, T=5, F=6, S=7.
+* `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12 (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
-* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, you can set a maximum of 2 deferrals.
 * `defer` - Defer the next scheduled maintenance for the given project for one week.
 * `auto_defer` - Defer any scheduled maintenance for the given project for one week.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
 
 -> **NOTE:** The `start_asap` attribute can't be used because of breaks the Terraform flow, but you can enable via API.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, it can be a maximum of 2 deferrals.
 
 ## Import
 


### PR DESCRIPTION
## Description

Upgrades  maintenance_window resource to auto-generated SDK.

- Migration tests created.
- `day_of_week` attribute fixed to be mandatory. It's not a breaking change because a resource without this attribute would fail to be created.
- `number_of_deferrals` attribute fixed to be computed.  It's not a breaking change because a resource with this attribute would fail to be created.

Link to any related issue(s): CLOUDP-226084

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
