### PR TITLE
doc: Fixes mongodbatlas_privatelink_endpoint_service_data_federation_online_archives doc

### DIFF
--- a/website/docs/d/privatelink_endpoint_service_data_federation_online_archives.markdown
+++ b/website/docs/d/privatelink_endpoint_service_data_federation_online_archives.markdown
@@ -30,7 +30,7 @@ resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archi
 data "mongodbatlas_privatelink_endpoint_service_data_federation_online_archives" "test_data_source" {
   project_id = mongodbatlas_project.atlas-project.id
 }
-
+```
 
 
 ## Argument Reference


### PR DESCRIPTION
## Description

The page [here](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoint_service_data_federation_online_archives) is missing the closing of the code block. Added the necessary markdown to close the code block. I have verified in VSCode that it resolves the issue.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
