### PR TITLE
chore: Upgrades roles_org_id resource to auto-generated SDK

### DIFF
--- a/internal/service/rolesorgid/data_source_roles_org_id.go
+++ b/internal/service/rolesorgid/data_source_roles_org_id.go
@@ -13,7 +13,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasOrgIDRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"org_id": {
 				Type:     schema.TypeString,
@@ -23,7 +23,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasOrgIDRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	apiKeyOrgList, _, err := connV2.RootApi.GetSystemStatus(ctx).Execute()
 	if err != nil {

--- a/internal/service/rolesorgid/data_source_roles_org_id.go
+++ b/internal/service/rolesorgid/data_source_roles_org_id.go
@@ -29,13 +29,12 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if err != nil {
 		return diag.Errorf("error getting API Key's org assigned (%s): ", err)
 	}
-	for idx, role := range apiKeyOrgList.ApiKey.GetRoles() {
+	for _, role := range apiKeyOrgList.ApiKey.GetRoles() {
 		if strings.HasPrefix(role.GetRoleName(), "ORG_") {
-			orgID := apiKeyOrgList.ApiKey.GetRoles()[idx].GetOrgId()
-			if err := d.Set("org_id", orgID); err != nil {
+			if err := d.Set("org_id", role.GetOrgId()); err != nil {
 				return diag.Errorf(constant.ErrorSettingAttribute, "org_id", err)
 			}
-			d.SetId(orgID)
+			d.SetId(role.GetOrgId())
 			return nil
 		}
 	}

--- a/internal/service/rolesorgid/data_source_roles_org_id_test.go
+++ b/internal/service/rolesorgid/data_source_roles_org_id_test.go
@@ -1,11 +1,8 @@
 package rolesorgid_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -13,32 +10,20 @@ import (
 func TestAccConfigDSOrgID_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_roles_org_id.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		name           = fmt.Sprintf("test-acc-%s@mongodb.com", acctest.RandString(10))
-		initialRole    = []string{"ORG_OWNER"}
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyOrgInvitation,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasOrgIDConfig(orgID, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
-				),
+				Config: configDS(),
+				Check:  resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
 			},
 		},
 	})
 }
 
-func testAccDataSourceMongoDBAtlasOrgIDConfig(orgID, username string, roles []string) string {
-	return (`
-	data "mongodbatlas_roles_org_id" "test" {
-	}
-	
-	output "org_id" {
-	 value = data.mongodbatlas_roles_org_id.test.org_id
-	}`)
+func configDS() string {
+	return `data "mongodbatlas_roles_org_id" "test" {}`
 }


### PR DESCRIPTION
## Description

Upgrades  roles_org_id resource to auto-generated SDK.

Migration tests not created because it's only a data source.

Link to any related issue(s): CLOUDP-226091

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
