### PR TITLE
chore: Upgrades `privatelink_endpoint_serverless` resource to auto-generated SDK

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -113,6 +113,7 @@ jobs:
             - 'internal/service/privateendpointregionalmode/*.go'
             - 'internal/service/privatelinkendpoint/*.go'
             - 'internal/service/privatelinkendpointservice/*.go'
+            - 'internal/service/privatelinkendpointseerverless/*.go'
             - 'internal/service/privatelinkendpointservicedatafederationonlinearchive/*.go'
   
   project: 

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -113,6 +113,7 @@ jobs:
             - 'internal/service/privateendpointregionalmode/*.go'
             - 'internal/service/privatelinkendpoint/*.go'
             - 'internal/service/privatelinkendpointservice/*.go'
+            - 'internal/service/privatelinkendpointserverless/*.go'
             - 'internal/service/privatelinkendpointservicedatafederationonlinearchive/*.go'
   
   project: 

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -113,7 +113,6 @@ jobs:
             - 'internal/service/privateendpointregionalmode/*.go'
             - 'internal/service/privatelinkendpoint/*.go'
             - 'internal/service/privatelinkendpointservice/*.go'
-            - 'internal/service/privatelinkendpointserverless/*.go'
             - 'internal/service/privatelinkendpointservicedatafederationonlinearchive/*.go'
   
   project: 

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -113,7 +113,7 @@ jobs:
             - 'internal/service/privateendpointregionalmode/*.go'
             - 'internal/service/privatelinkendpoint/*.go'
             - 'internal/service/privatelinkendpointservice/*.go'
-            - 'internal/service/privatelinkendpointseerverless/*.go'
+            - 'internal/service/privatelinkendpointserverless/*.go'
             - 'internal/service/privatelinkendpointservicedatafederationonlinearchive/*.go'
   
   project: 

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -251,10 +251,12 @@ func resourceRefreshFunc(ctx context.Context, client *admin.APIClient, projectID
 			return nil, "REJECTED", err
 		}
 
-		if p.GetStatus() != "WAITING_FOR_USER" {
-			return "", p.GetStatus(), nil
+		status := p.GetStatus()
+
+		if status != "WAITING_FOR_USER" {
+			return "", status, nil
 		}
 
-		return p, p.GetStatus(), nil
+		return p, status, nil
 	}
 }

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -120,6 +120,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 
 	privateLinkResponse, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
+		// case 404/400: deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil
@@ -160,6 +161,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	_, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
+		// case 404/400: deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115005/admin"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -75,56 +75,51 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 
-	privateLinkRequest := &matlas.ServerlessPrivateEndpointConnection{
-		Comment: "create",
+	serverlessTenantCreateRequest := &admin.ServerlessTenantCreateRequest{
+		Comment: conversion.StringPtr("create"),
 	}
 
-	endPoint, _, err := conn.ServerlessPrivateEndpoints.Create(ctx, projectID, instanceName, privateLinkRequest)
+	endPoint, _, err := connV2.ServerlessPrivateEndpointsApi.CreateServerlessPrivateEndpoint(ctx, projectID, instanceName, serverlessTenantCreateRequest).Execute()
 	if err != nil {
-		return diag.Errorf(privatelinkendpointserviceserverless.ErrorServerlessServiceEndpointAdd, privateLinkRequest.CloudProviderEndpointID, err)
+		return diag.Errorf(privatelinkendpointserviceserverless.ErrorServerlessServiceEndpointAdd, endPoint.GetCloudProviderEndpointId(), err)
 	}
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"RESERVATION_REQUESTED", "INITIATING", "DELETING"},
 		Target:     []string{"RESERVED", "FAILED", "DELETED", "AVAILABLE"},
-		Refresh:    resourceRefreshFunc(ctx, conn, projectID, instanceName, endPoint.ID),
+		Refresh:    resourceRefreshFunc(ctx, connV2, projectID, instanceName, endPoint.GetId()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Second,
 	}
-	// RESERVATION_REQUESTED, RESERVED, INITIATING, AVAILABLE, FAILED, DELETING.
-	// Wait, catching any errors
+
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorServerlessEndpointAdd, err, endPoint.ID))
+		return diag.FromErr(fmt.Errorf(errorServerlessEndpointAdd, err, endPoint.GetId()))
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":    projectID,
 		"instance_name": instanceName,
-		"endpoint_id":   endPoint.ID,
+		"endpoint_id":   endPoint.GetId(),
 	}))
 
 	return resourceRead(ctx, d, meta)
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
 	endpointID := ids["endpoint_id"]
 
-	privateLinkResponse, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	privateLinkResponse, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
-		// case 404/ 400
-		// deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil
@@ -133,7 +128,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("error getting Serverless private link endpoint  information: %s", err)
 	}
 
-	if err := d.Set("endpoint_id", privateLinkResponse.ID); err != nil {
+	if err := d.Set("endpoint_id", privateLinkResponse.GetId()); err != nil {
 		return diag.Errorf("error setting `endpoint_id` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
@@ -141,15 +136,15 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("error setting `instance Name` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("endpoint_service_name", privateLinkResponse.EndpointServiceName); err != nil {
+	if err := d.Set("endpoint_service_name", privateLinkResponse.GetEndpointServiceName()); err != nil {
 		return diag.Errorf("error setting `endpoint_service_name Name` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("private_link_service_resource_id", privateLinkResponse.PrivateLinkServiceResourceID); err != nil {
+	if err := d.Set("private_link_service_resource_id", privateLinkResponse.GetPrivateLinkServiceResourceId()); err != nil {
 		return diag.Errorf("error setting `private_link_service_resource_id Name` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("status", privateLinkResponse.Status); err != nil {
+	if err := d.Set("status", privateLinkResponse.GetStatus()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpoint.ErrorPrivateLinkEndpointsSetting, "status", d.Id(), err))
 	}
 
@@ -157,17 +152,14 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
 	endpointID := ids["endpoint_id"]
 
-	_, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	_, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
-		// case 404
-		// deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil
@@ -176,7 +168,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("error getting Serverless private link endpoint  information: %s", err)
 	}
 
-	_, err = conn.ServerlessPrivateEndpoints.Delete(ctx, projectID, instanceName, endpointID)
+	_, _, err = connV2.ServerlessPrivateEndpointsApi.DeleteServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
 		return diag.Errorf("error deleting serverless private link endpoint(%s): %s", endpointID, err)
 	}
@@ -184,7 +176,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"DELETING"},
 		Target:     []string{"DELETED", "FAILED"},
-		Refresh:    resourceRefreshFunc(ctx, conn, projectID, instanceName, endpointID),
+		Refresh:    resourceRefreshFunc(ctx, connV2, projectID, instanceName, endpointID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Second,
@@ -199,7 +191,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
@@ -210,7 +202,7 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	instanceName := parts[1]
 	endpointID := parts[2]
 
-	privateLinkResponse, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	privateLinkResponse, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import serverless private link endpoint (%s) in projectID (%s) , error: %s", endpointID, projectID, err)
 	}
@@ -226,11 +218,11 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 		log.Printf("[WARN] Error setting instance_name for (%s): %s", endpointID, err)
 	}
 
-	if err := d.Set("endpoint_service_name", privateLinkResponse.EndpointServiceName); err != nil {
+	if err := d.Set("endpoint_service_name", privateLinkResponse.GetEndpointServiceName()); err != nil {
 		log.Printf("[WARN] Error setting endpoint_service_name for (%s): %s", endpointID, err)
 	}
 
-	if privateLinkResponse.PrivateLinkServiceResourceID != "" {
+	if privateLinkResponse.GetPrivateLinkServiceResourceId() != "" {
 		if err := d.Set("provider_name", "AZURE"); err != nil {
 			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
 		}
@@ -249,21 +241,20 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceRefreshFunc(ctx context.Context, client *matlas.Client, projectID, instanceName, privateLinkID string) retry.StateRefreshFunc {
+func resourceRefreshFunc(ctx context.Context, client *admin.APIClient, projectID, instanceName, privateLinkID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		p, resp, err := client.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, privateLinkID)
+		p, resp, err := client.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, privateLinkID).Execute()
 		if err != nil {
-			if resp.Response.StatusCode == 404 || resp.Response.StatusCode == 400 {
+			if resp.StatusCode == 404 || resp.StatusCode == 400 {
 				return "", "DELETED", nil
 			}
-
 			return nil, "REJECTED", err
 		}
 
-		if p.Status != "WAITING_FOR_USER" {
-			return "", p.Status, nil
+		if p.GetStatus() != "WAITING_FOR_USER" {
+			return "", p.GetStatus(), nil
 		}
 
-		return p, p.Status, nil
+		return p, p.GetStatus(), nil
 	}
 }

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestAccMigrationNetworkServerlessPrivateLinkEndpoint_basic(t *testing.T) {
+func TestAccMigrationServerlessPrivateLinkEndpoint_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_privatelink_endpoint_serverless.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestAccMigrationServerlessPrivateLinkEndpoint_basic(t *testing.T) {
+func TestAccMigrationNetworkServerlessPrivateLinkEndpoint_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_privatelink_endpoint_serverless.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_migration_test.go
@@ -1,0 +1,46 @@
+package privatelinkendpointserverless_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationServerlessPrivateLinkEndpoint_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_privatelink_endpoint_serverless.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName = "serverlessplink"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configBasic(orgID, projectName, instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configBasic(orgID, projectName, instanceName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
@@ -24,12 +24,12 @@ func TestAccServerlessPrivateLinkEndpoint_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, true),
+				Config: configBasic(orgID, projectName, instanceName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
 				),
 			},
@@ -47,18 +47,18 @@ func TestAccServerlessPrivateLinkEndpoint_importBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, true),
+				Config: configBasic(orgID, projectName, instanceName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
 				),
 			},
 			{
-				Config:                  testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName, false),
+				Config:                  configBasic(orgID, projectName, instanceName, false),
 				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessImportStateIDFunc(resourceName),
+				ImportStateIdFunc:       importStateIDFuncBasic(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"connection_strings_private_endpoint_srv"},
@@ -67,7 +67,7 @@ func TestAccServerlessPrivateLinkEndpoint_importBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy(state *terraform.State) error {
+func checkDestroy(state *terraform.State) error {
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type != "mongodbatlas_privatelink_endpoint_serverless" {
 			continue
@@ -81,7 +81,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessDestroy(state *terrafo
 	return nil
 }
 
-func testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, instanceName string, ignoreConnectionStrings bool) string {
+func configBasic(orgID, projectName, instanceName string, ignoreConnectionStrings bool) string {
 	return fmt.Sprintf(`
 
 	resource "mongodbatlas_privatelink_endpoint_serverless" "test" {
@@ -94,7 +94,7 @@ func testAccMongoDBAtlasPrivateLinkEndpointServerlessConfig(orgID, projectName, 
 	`, acc.ConfigServerlessInstanceBasic(orgID, projectName, instanceName, ignoreConnectionStrings))
 }
 
-func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName string) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -112,7 +112,7 @@ func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessExists(resourceName st
 	}
 }
 
-func testAccCheckMongoDBAtlasPrivateLinkEndpointServerlessImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFuncBasic(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
@@ -73,7 +73,7 @@ func checkDestroy(state *terraform.State) error {
 			continue
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		privateLink, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		privateLink, _, err := acc.ConnV2().ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"]).Execute()
 		if err == nil && privateLink != nil {
 			return fmt.Errorf("endpoint_id (%s) still exists", ids["endpoint_id"])
 		}
@@ -104,7 +104,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := acc.Conn().ServerlessPrivateEndpoints.Get(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"])
+		_, _, err := acc.ConnV2().ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(context.Background(), ids["project_id"], ids["instance_name"], ids["endpoint_id"]).Execute()
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
## Description

Upgrades privatelink_endpoint_serverless resource to auto-generated SDK

Migration tests created.

Link to any related issue(s): CLOUDP-226087

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
