### PR TITLE
chore: Fixes example on privatelink_endpoint_service.

### DIFF
--- a/examples/mongodbatlas_privatelink_endpoint/gcp/main.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/gcp/main.tf
@@ -52,10 +52,10 @@ resource "mongodbatlas_privatelink_endpoint_service" "test" {
   gcp_project_id      = var.gcp_project_id
 
   dynamic "endpoints" {
-    for_each = mongodbatlas_privatelink_endpoint.test.service_attachment_names
+    for_each = google_compute_address.default
 
     content {
-      ip_address    = google_compute_address.default[endpoints.key].address
+      ip_address    = endpoints.value["address"]
       endpoint_name = google_compute_forwarding_rule.default[endpoints.key].name
     }
   }

--- a/website/docs/r/privatelink_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_endpoint_service.html.markdown
@@ -132,10 +132,10 @@ resource "mongodbatlas_privatelink_endpoint_service" "test" {
   gcp_project_id      = var.gcp_project
 
   dynamic "endpoints" {
-    for_each = mongodbatlas_privatelink_endpoint.test.service_attachment_names
+    for_each = google_compute_address.default
 
     content {
-      ip_address    = google_compute_address.default[endpoints.key].address
+      ip_address    = endpoints.value["address"]
       endpoint_name = google_compute_forwarding_rule.default[endpoints.key].name
     }
   }


### PR DESCRIPTION
## Description

Current example, when used, fails with an error like:
```
[...] produced an invalid new value for .endpoints: new element 1 has appeared.
[...]
```

After some investigation, we saw that the issue is related to the way the `dynamic` block is declared.

Link to any related issue(s): CLOUDP-227737

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
