### PR TITLE
chore: Upgrades custom_dns_configuration_cluster_aws resource to auto-generated SDK

### DIFF
--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_migration_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_migration_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
@@ -20,7 +19,7 @@ func TestAccMigrationGenericBackupRSBackupCompliancePolicy_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t) },
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
@@ -34,11 +34,11 @@ func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(ctx context.Context, d 
 
 	customDNSSetting, _, err := conn.CustomAWSDNS.Get(ctx, projectID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationRead, err))
+		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
 
 	if err := d.Set("enabled", customDNSSetting.Enabled); err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationSetting, "enabled", projectID, err))
+		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", projectID, err))
 	}
 
 	d.SetId(projectID)

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
@@ -29,12 +29,12 @@ func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(ctx context.Context, d 
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	customDNSSetting, _, err := connV2.AWSClustersDNSApi.GetAWSCustomDNS(ctx, projectID).Execute()
+	dnsResp, _, err := connV2.AWSClustersDNSApi.GetAWSCustomDNS(ctx, projectID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
 
-	if err := d.Set("enabled", customDNSSetting.GetEnabled()); err != nil {
+	if err := d.Set("enabled", dnsResp.GetEnabled()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", projectID, err))
 	}
 	d.SetId(projectID)

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
@@ -11,7 +11,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -25,15 +25,13 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
-
 	dnsResp, _, err := connV2.AWSClustersDNSApi.GetAWSCustomDNS(ctx, projectID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
-
 	if err := d.Set("enabled", dnsResp.GetEnabled()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", projectID, err))
 	}

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws.go
@@ -16,7 +16,6 @@ func DataSource() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -27,21 +26,17 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasCustomDNSConfigurationAWSRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
-
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	customDNSSetting, _, err := conn.CustomAWSDNS.Get(ctx, projectID)
+	customDNSSetting, _, err := connV2.AWSClustersDNSApi.GetAWSCustomDNS(ctx, projectID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
 
-	if err := d.Set("enabled", customDNSSetting.Enabled); err != nil {
+	if err := d.Set("enabled", customDNSSetting.GetEnabled()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", projectID, err))
 	}
-
 	d.SetId(projectID)
-
 	return nil
 }

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
+const dataSourceName = "data.mongodbatlas_custom_dns_configuration_cluster_aws.test"
+
 func TestAccConfigDSCustomDNSConfigurationAWS_basic(t *testing.T) {
-	resourceName := "data.mongodbatlas_custom_dns_configuration_cluster_aws.test"
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	projectName := acctest.RandomWithPrefix("test-acc")
 
@@ -20,18 +21,18 @@ func TestAccConfigDSCustomDNSConfigurationAWS_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(orgID, projectName, true),
+				Config: configDS(orgID, projectName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
+					checkExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccMongoDBAtlasCustomDNSConfigurationAWSDataSourceConfig(orgID, projectName string, enabled bool) string {
+func configDS(orgID, projectName string, enabled bool) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = %[2]q

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
@@ -62,26 +62,21 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
-
-	dnsResp, resp, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	dnsResp, resp, err := connV2.AWSClustersDNSApi.GetAWSCustomDNS(context.Background(), d.Id()).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}
-
 		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
-
-	if err = d.Set("enabled", dnsResp.Enabled); err != nil {
+	if err = d.Set("enabled", dnsResp.GetEnabled()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", d.Id(), err))
 	}
-
 	if err = d.Set("project_id", d.Id()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorSetting, "project_id", d.Id(), err))
 	}
-
 	return nil
 }
 

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
@@ -13,19 +13,19 @@ import (
 )
 
 const (
-	errorCustomDNSConfigurationCreate  = "error creating custom dns configuration cluster aws information: %s"
-	errorCustomDNSConfigurationRead    = "error getting custom dns configuration cluster aws information: %s"
-	errorCustomDNSConfigurationUpdate  = "error updating custom dns configuration cluster aws information: %s"
-	errorCustomDNSConfigurationDelete  = "error deleting custom dns configuration cluster aws (%s): %s"
-	errorCustomDNSConfigurationSetting = "error setting `%s` for custom dns configuration cluster aws (%s): %s"
+	errorCreate  = "error creating custom dns configuration cluster aws information: %s"
+	errorRead    = "error getting custom dns configuration cluster aws information: %s"
+	errorUpdate  = "error updating custom dns configuration cluster aws information: %s"
+	errorDelete  = "error deleting custom dns configuration cluster aws (%s): %s"
+	errorSetting = "error setting `%s` for custom dns configuration cluster aws (%s): %s"
 )
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasCustomDNSConfigurationCreate,
-		ReadContext:   resourceMongoDBAtlasCustomDNSConfigurationRead,
-		UpdateContext: resourceMongoDBAtlasCustomDNSConfigurationUpdate,
-		DeleteContext: resourceMongoDBAtlasCustomDNSConfigurationDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -43,7 +43,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasCustomDNSConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	orgID := d.Get("project_id").(string)
 
@@ -53,15 +53,15 @@ func resourceMongoDBAtlasCustomDNSConfigurationCreate(ctx context.Context, d *sc
 			Enabled: d.Get("enabled").(bool),
 		})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationCreate, err))
+		return diag.FromErr(fmt.Errorf(errorCreate, err))
 	}
 
 	d.SetId(orgID)
 
-	return resourceMongoDBAtlasCustomDNSConfigurationRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasCustomDNSConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	dnsResp, resp, err := conn.CustomAWSDNS.Get(context.Background(), d.Id())
@@ -71,21 +71,21 @@ func resourceMongoDBAtlasCustomDNSConfigurationRead(ctx context.Context, d *sche
 			return nil
 		}
 
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationRead, err))
+		return diag.FromErr(fmt.Errorf(errorRead, err))
 	}
 
 	if err = d.Set("enabled", dnsResp.Enabled); err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationSetting, "enabled", d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorSetting, "enabled", d.Id(), err))
 	}
 
 	if err = d.Set("project_id", d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationSetting, "project_id", d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorSetting, "project_id", d.Id(), err))
 	}
 
 	return nil
 }
 
-func resourceMongoDBAtlasCustomDNSConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	if d.HasChange("enabled") {
@@ -93,21 +93,21 @@ func resourceMongoDBAtlasCustomDNSConfigurationUpdate(ctx context.Context, d *sc
 			Enabled: d.Get("enabled").(bool),
 		})
 		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationUpdate, err))
+			return diag.FromErr(fmt.Errorf(errorUpdate, err))
 		}
 	}
 
-	return resourceMongoDBAtlasCustomDNSConfigurationRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasCustomDNSConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	_, _, err := conn.CustomAWSDNS.Update(ctx, d.Id(), &matlas.AWSCustomDNSSetting{
 		Enabled: false,
 	})
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorCustomDNSConfigurationDelete, d.Id(), err))
+		return diag.FromErr(fmt.Errorf(errorDelete, d.Id(), err))
 	}
 
 	d.SetId("")

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
@@ -1,0 +1,36 @@
+package customdnsconfigurationclusteraws_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
+		config      = configBasic(orgID, projectName, true)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acc.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
@@ -18,7 +17,7 @@ func TestAccMigrationConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t) },
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
@@ -12,38 +12,39 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
+const resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
+
 func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Config: configBasic(orgID, projectName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, false),
+				Config: configBasic(orgID, projectName, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Config: configBasic(orgID, projectName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
@@ -54,18 +55,17 @@ func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 
 func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_custom_dns_configuration_cluster_aws.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName, true),
+				Config: configBasic(orgID, projectName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
@@ -73,7 +73,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName),
+				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -81,7 +81,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -97,7 +97,8 @@ func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSExists(resourceName string
 		return fmt.Errorf("custom dns configuration cluster(%s) does not exist", rs.Primary.ID)
 	}
 }
-func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State) error {
+
+func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_custom_dns_configuration_cluster_aws" {
 			continue
@@ -112,7 +113,7 @@ func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSDestroy(s *terraform.State
 	return nil
 }
 
-func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -122,7 +123,7 @@ func testAccCheckMongoDBAtlasCustomDNSConfigurationAWSStateIDFunc(resourceName s
 	}
 }
 
-func testAccMongoDBAtlasCustomDNSConfigurationAWSConfig(orgID, projectName string, enabled bool) string {
+func configBasic(orgID, projectName string, enabled bool) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			name   = %[2]q

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
@@ -90,7 +90,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-		_, _, err := acc.Conn().CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		_, _, err := acc.ConnV2().AWSClustersDNSApi.GetAWSCustomDNS(context.Background(), rs.Primary.ID).Execute()
 		if err == nil {
 			return nil
 		}
@@ -104,8 +104,7 @@ func checkDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Try to find the Custom DNS Configuration for Atlas Clusters on AWS
-		resp, _, err := acc.Conn().CustomAWSDNS.Get(context.Background(), rs.Primary.ID)
+		resp, _, err := acc.ConnV2().AWSClustersDNSApi.GetAWSCustomDNS(context.Background(), rs.Primary.ID).Execute()
 		if err != nil && resp != nil && resp.Enabled {
 			return fmt.Errorf("custom dns configuration cluster aws (%s) still enabled", rs.Primary.ID)
 		}


### PR DESCRIPTION
## Description

Upgrades  custom_dns_configuration_cluster_aws resource to auto-generated SDK.

Migration tests created.

Link to any related issue(s): CLOUDP-226081

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
