### PR TITLE
chore: Upgrades `privatelink_endpoint_service_serverless` resource to auto-generated SDK

### DIFF
--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
@@ -13,7 +13,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasPrivateEndpointServiceServerlessLinkRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -62,48 +62,43 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasPrivateEndpointServiceServerlessLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 	endpointID := d.Get("endpoint_id").(string)
 
-	serviceEndpoint, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	serviceEndpoint, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorServiceEndpointRead, endpointID, err))
 	}
 
-	if err := d.Set("error_message", serviceEndpoint.ErrorMessage); err != nil {
+	if err := d.Set("error_message", serviceEndpoint.GetErrorMessage()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "error_message", endpointID, err))
 	}
 
-	if err := d.Set("status", serviceEndpoint.Status); err != nil {
+	if err := d.Set("status", serviceEndpoint.GetStatus()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "status", endpointID, err))
 	}
 
-	if err := d.Set("comment", serviceEndpoint.Comment); err != nil {
+	if err := d.Set("comment", serviceEndpoint.GetComment()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "comment", endpointID, err))
 	}
 
-	if err := d.Set("error_message", serviceEndpoint.ErrorMessage); err != nil {
-		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "error_message", endpointID, err))
-	}
-
-	if err := d.Set("endpoint_service_name", serviceEndpoint.EndpointServiceName); err != nil {
+	if err := d.Set("endpoint_service_name", serviceEndpoint.GetEndpointServiceName()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "endpoint_service_name", endpointID, err))
 	}
 
-	if err := d.Set("cloud_provider_endpoint_id", serviceEndpoint.CloudProviderEndpointID); err != nil {
+	if err := d.Set("cloud_provider_endpoint_id", serviceEndpoint.GetCloudProviderEndpointId()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "cloud_provider_endpoint_id", endpointID, err))
 	}
 
-	if err := d.Set("private_link_service_resource_id", serviceEndpoint.PrivateLinkServiceResourceID); err != nil {
+	if err := d.Set("private_link_service_resource_id", serviceEndpoint.GetPrivateLinkServiceResourceId()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "private_link_service_resource_id", endpointID, err))
 	}
 
-	if err := d.Set("private_endpoint_ip_address", serviceEndpoint.PrivateEndpointIPAddress); err != nil {
+	if err := d.Set("private_endpoint_ip_address", serviceEndpoint.GetPrivateEndpointIpAddress()); err != nil {
 		return diag.FromErr(fmt.Errorf(privatelinkendpointservice.ErrorEndpointSetting, "private_endpoint_ip_address", endpointID, err))
 	}
 

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -24,12 +24,14 @@ func PluralDataSource() *schema.Resource {
 				ForceNew: true,
 			},
 			"page_num": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Deprecated: "mongodbatlas_privatelink_endpoints_service_serverless now returns all existing privatelink endpoints. Pagination is not supported anymore",
+				Type:       schema.TypeInt,
+				Optional:   true,
 			},
 			"items_per_page": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Deprecated: "mongodbatlas_privatelink_endpoints_service_serverless now returns all existing privatelink endpoints. Pagination is not supported anymore",
+				Type:       schema.TypeInt,
+				Optional:   true,
 			},
 			"results": {
 				Type:     schema.TypeList,

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -7,12 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasPrivateLinkEndpointsServiceServerlessRead,
+		ReadContext: dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -76,18 +76,12 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasPrivateLinkEndpointsServiceServerlessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 
-	options := &matlas.ListOptions{
-		PageNum:      d.Get("page_num").(int),
-		ItemsPerPage: d.Get("items_per_page").(int),
-	}
-
-	privateLinkEndpoints, _, err := conn.ServerlessPrivateEndpoints.List(ctx, projectID, instanceName, options)
+	privateLinkEndpoints, _, err := connV2.ServerlessPrivateEndpointsApi.ListServerlessPrivateEndpoints(ctx, projectID, instanceName).Execute()
 	if err != nil {
 		return diag.Errorf("error getting Serverless PrivateLink Endpoints Information: %s", err)
 	}
@@ -101,7 +95,7 @@ func dataSourceMongoDBAtlasPrivateLinkEndpointsServiceServerlessRead(ctx context
 	return nil
 }
 
-func flattenServerlessPrivateLinkEndpoints(privateLinks []matlas.ServerlessPrivateEndpointConnection) []map[string]any {
+func flattenServerlessPrivateLinkEndpoints(privateLinks []admin.ServerlessTenantEndpoint) []map[string]any {
 	var results []map[string]any
 
 	if len(privateLinks) == 0 {
@@ -112,14 +106,14 @@ func flattenServerlessPrivateLinkEndpoints(privateLinks []matlas.ServerlessPriva
 
 	for k := range privateLinks {
 		results[k] = map[string]any{
-			"endpoint_id":                      privateLinks[k].ID,
-			"endpoint_service_name":            privateLinks[k].EndpointServiceName,
-			"cloud_provider_endpoint_id":       privateLinks[k].CloudProviderEndpointID,
-			"private_link_service_resource_id": privateLinks[k].PrivateLinkServiceResourceID,
-			"private_endpoint_ip_address":      privateLinks[k].PrivateEndpointIPAddress,
-			"comment":                          privateLinks[k].Comment,
-			"error_message":                    privateLinks[k].ErrorMessage,
-			"status":                           privateLinks[k].Status,
+			"endpoint_id":                      privateLinks[k].GetId(),
+			"endpoint_service_name":            privateLinks[k].GetEndpointServiceName(),
+			"cloud_provider_endpoint_id":       privateLinks[k].GetCloudProviderEndpointId(),
+			"private_link_service_resource_id": privateLinks[k].GetPrivateLinkServiceResourceId(),
+			"private_endpoint_ip_address":      privateLinks[k].GetPrivateEndpointIpAddress(),
+			"comment":                          privateLinks[k].GetComment(),
+			"error_message":                    privateLinks[k].GetErrorMessage(),
+			"status":                           privateLinks[k].GetStatus(),
 		}
 	}
 

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -96,13 +96,11 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 }
 
 func flattenServerlessPrivateLinkEndpoints(privateLinks []admin.ServerlessTenantEndpoint) []map[string]any {
-	var results []map[string]any
-
 	if len(privateLinks) == 0 {
-		return results
+		return nil
 	}
 
-	results = make([]map[string]any, len(privateLinks))
+	results := make([]map[string]any, len(privateLinks))
 
 	for k := range privateLinks {
 		results[k] = map[string]any{

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -2,10 +2,12 @@ package privatelinkendpointserviceserverless
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
@@ -24,12 +26,12 @@ func PluralDataSource() *schema.Resource {
 				ForceNew: true,
 			},
 			"page_num": {
-				Deprecated: "mongodbatlas_privatelink_endpoints_service_serverless now returns all existing privatelink endpoints. Pagination is not supported anymore",
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.17.0"),
 				Type:       schema.TypeInt,
 				Optional:   true,
 			},
 			"items_per_page": {
-				Deprecated: "mongodbatlas_privatelink_endpoints_service_serverless now returns all existing privatelink endpoints. Pagination is not supported anymore",
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.17.0"),
 				Type:       schema.TypeInt,
 				Optional:   true,
 			},

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 const (
@@ -25,11 +25,11 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate,
-		ReadWithoutTimeout:   resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead,
-		DeleteWithoutTimeout: resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessDelete,
+		CreateWithoutTimeout: resourceCreate,
+		ReadWithoutTimeout:   resourceRead,
+		DeleteWithoutTimeout: resourceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState,
+			StateContext: resourceImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -86,28 +86,25 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	instanceName := d.Get("instance_name").(string)
 	endpointID := d.Get("endpoint_id").(string)
 
-	privateLink, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	_, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
 		return diag.Errorf("error getting Serverless PrivateLink Endpoint Information: %s", err)
 	}
 
-	privateLink.Comment = d.Get("comment").(string)
-	privateLink.CloudProviderEndpointID = d.Get("cloud_provider_endpoint_id").(string)
-	privateLink.ProviderName = d.Get("provider_name").(string)
-	privateLink.PrivateLinkServiceResourceID = ""
-	privateLink.PrivateEndpointIPAddress = d.Get("private_endpoint_ip_address").(string)
-	privateLink.ID = ""
-	privateLink.Status = ""
-	privateLink.EndpointServiceName = ""
+	updateRequest := admin.ServerlessTenantEndpointUpdate{
+		Comment:                  conversion.StringPtr(d.Get("comment").(string)),
+		ProviderName:             d.Get("provider_name").(string),
+		CloudProviderEndpointId:  conversion.StringPtr(d.Get("cloud_provider_endpoint_id").(string)),
+		PrivateEndpointIpAddress: conversion.StringPtr(d.Get("private_endpoint_ip_address").(string)),
+	}
 
-	endPoint, _, err := conn.ServerlessPrivateEndpoints.Update(ctx, projectID, instanceName, endpointID, privateLink)
+	endPoint, _, err := connV2.ServerlessPrivateEndpointsApi.UpdateServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID, &updateRequest).Execute()
 	if err != nil {
 		return diag.Errorf(ErrorServerlessServiceEndpointAdd, endpointID, err)
 	}
@@ -115,12 +112,12 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"RESERVATION_REQUESTED", "INITIATING", "DELETING"},
 		Target:     []string{"RESERVED", "FAILED", "DELETED", "AVAILABLE"},
-		Refresh:    resourceServiceEndpointServerlessRefreshFunc(ctx, conn, projectID, instanceName, endpointID),
+		Refresh:    resourceServiceEndpointServerlessRefreshFunc(ctx, connV2, projectID, instanceName, endpointID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Minute,
 	}
-	// Wait, catching any errors
+
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorServerlessServiceEndpointAdd, endpointID, err))
@@ -129,7 +126,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 	clusterConf := &retry.StateChangeConf{
 		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
-		Refresh:    resourceServerlessInstanceListRefreshFunc(ctx, projectID, conn),
+		Refresh:    resourceServerlessInstanceListRefreshFunc(ctx, projectID, connV2),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Minute,
@@ -143,35 +140,32 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessCreate(ctx context.
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":    projectID,
 		"instance_name": instanceName,
-		"endpoint_id":   endPoint.ID,
+		"endpoint_id":   endPoint.GetId(),
 	}))
 
-	return resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
 	endpointID := ids["endpoint_id"]
 
-	privateLinkResponse, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	privateLinkResponse, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
-		// case 404
-		// deleted in the backend case
+		// case 404: deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil
 		}
-
 		return diag.Errorf("error getting Serverless private link endpoint  information: %s", err)
 	}
 
-	privateLinkResponse.ProviderName = d.Get("provider_name").(string)
+	privateLinkResponse.ProviderName = conversion.StringPtr(d.Get("provider_name").(string))
 
-	if err := d.Set("endpoint_id", privateLinkResponse.ID); err != nil {
+	if err := d.Set("endpoint_id", privateLinkResponse.GetId()); err != nil {
 		return diag.Errorf("error setting `endpoint_id` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
@@ -179,50 +173,47 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessRead(ctx context.Co
 		return diag.Errorf("error setting `instance Name` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("comment", privateLinkResponse.Comment); err != nil {
+	if err := d.Set("comment", privateLinkResponse.GetComment()); err != nil {
 		return diag.Errorf("error setting `comment` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("provider_name", privateLinkResponse.ProviderName); err != nil {
+	if err := d.Set("provider_name", privateLinkResponse.GetProviderName()); err != nil {
 		return diag.Errorf("error setting `provider_name` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("status", privateLinkResponse.Status); err != nil {
+	if err := d.Set("status", privateLinkResponse.GetStatus()); err != nil {
 		return diag.Errorf("error setting `status` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("cloud_provider_endpoint_id", privateLinkResponse.CloudProviderEndpointID); err != nil {
+	if err := d.Set("cloud_provider_endpoint_id", privateLinkResponse.GetCloudProviderEndpointId()); err != nil {
 		return diag.Errorf("error setting `cloud_provider_endpoint_id` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("private_link_service_resource_id", privateLinkResponse.PrivateLinkServiceResourceID); err != nil {
+	if err := d.Set("private_link_service_resource_id", privateLinkResponse.GetPrivateLinkServiceResourceId()); err != nil {
 		return diag.Errorf("error setting `private_link_service_resource_id` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("private_endpoint_ip_address", privateLinkResponse.PrivateEndpointIPAddress); err != nil {
+	if err := d.Set("private_endpoint_ip_address", privateLinkResponse.GetPrivateEndpointIpAddress()); err != nil {
 		return diag.Errorf("error setting `private_endpoint_ip_address` for endpoint_id (%s): %s", d.Id(), err)
 	}
 
 	return nil
 }
 
-func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	instanceName := ids["instance_name"]
 	endpointID := ids["endpoint_id"]
 
-	_, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	_, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
-		// case 404
-		// deleted in the backend case
+		// case 404: deleted in the backend case
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "400") {
 			d.SetId("")
 			return nil
 		}
-
 		return diag.Errorf(errorServerlessServiceEndpointDelete, endpointID, err)
 	}
 
@@ -231,8 +222,8 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessDelete(ctx context.
 	return nil
 }
 
-func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
@@ -243,7 +234,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 	instanceName := parts[1]
 	endpointID := parts[2]
 
-	privateLinkResponse, _, err := conn.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointID)
+	privateLinkResponse, _, err := connV2.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import serverless private link endpoint (%s) in projectID (%s) , error: %s", endpointID, projectID, err)
 	}
@@ -260,7 +251,7 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 		log.Printf("[WARN] Error setting instance_name for (%s): %s", endpointID, err)
 	}
 
-	if privateLinkResponse.PrivateLinkServiceResourceID != "" {
+	if privateLinkResponse.GetPrivateLinkServiceResourceId() != "" {
 		if err := d.Set("provider_name", "AZURE"); err != nil {
 			log.Printf("[WARN] Error setting provider_name for (%s): %s", endpointID, err)
 		}
@@ -279,34 +270,35 @@ func resourceMongoDBAtlasPrivateLinkEndpointServiceServerlessImportState(ctx con
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, client *matlas.Client, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
+func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, client *admin.APIClient, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		i, resp, err := client.ServerlessPrivateEndpoints.Get(ctx, projectID, instanceName, endpointServiceID)
+		serverlessTenantEndpoint, resp, err := client.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointServiceID).Execute()
 		if err != nil {
-			if resp != nil && resp.StatusCode == 404 || resp.Response.StatusCode == 400 {
+			if resp != nil && resp.StatusCode == 404 || resp.StatusCode == 400 {
 				return "", "DELETED", nil
 			}
 
 			return nil, "", err
 		}
 
-		if i.Status != "AVAILABLE" {
-			return "", i.Status, nil
+		if serverlessTenantEndpoint.GetStatus() != "AVAILABLE" {
+			return "", serverlessTenantEndpoint.GetStatus(), nil
 		}
+		resultStatus := serverlessTenantEndpoint.GetStatus()
 
-		return i, i.Status, nil
+		return serverlessTenantEndpoint, resultStatus, nil
 	}
 }
 
-func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID string, client *matlas.Client) retry.StateRefreshFunc {
+func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID string, client *admin.APIClient) retry.StateRefreshFunc {
 	return func() (any, string, error) {
-		c, resp, err := client.ServerlessInstances.List(ctx, projectID, nil)
+		serverlessInstances, resp, err := client.ServerlessInstancesApi.ListServerlessInstances(ctx, projectID).Execute()
 
 		if err != nil && strings.Contains(err.Error(), "reset by peer") {
 			return nil, "REPEATING", nil
 		}
 
-		if err != nil && c == nil && resp == nil {
+		if err != nil && serverlessInstances == nil && resp == nil {
 			return nil, "", err
 		} else if err != nil {
 			if resp.StatusCode == 404 {
@@ -318,12 +310,12 @@ func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID st
 			return nil, "", err
 		}
 
-		for i := range c.Results {
-			if c.Results[i].StateName != "IDLE" {
-				return c.Results[i], "PENDING", nil
+		for i := range serverlessInstances.GetResults() {
+			if serverlessInstances.GetResults()[i].GetStateName() != "IDLE" {
+				return serverlessInstances.GetResults()[i], "PENDING", nil
 			}
 		}
 
-		return c, "IDLE", nil
+		return serverlessInstances, "IDLE", nil
 	}
 }

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
@@ -112,7 +112,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"RESERVATION_REQUESTED", "INITIATING", "DELETING"},
 		Target:     []string{"RESERVED", "FAILED", "DELETED", "AVAILABLE"},
-		Refresh:    resourceServiceEndpointServerlessRefreshFunc(ctx, connV2, projectID, instanceName, endpointID),
+		Refresh:    resourceRefreshFunc(ctx, connV2, projectID, instanceName, endpointID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Minute,
@@ -126,7 +126,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	clusterConf := &retry.StateChangeConf{
 		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
-		Refresh:    resourceServerlessInstanceListRefreshFunc(ctx, projectID, connV2),
+		Refresh:    resourceListRefreshFunc(ctx, projectID, connV2),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 		Delay:      5 * time.Minute,
@@ -270,7 +270,7 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, client *admin.APIClient, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
+func resourceRefreshFunc(ctx context.Context, client *admin.APIClient, projectID, instanceName, endpointServiceID string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		serverlessTenantEndpoint, resp, err := client.ServerlessPrivateEndpointsApi.GetServerlessPrivateEndpoint(ctx, projectID, instanceName, endpointServiceID).Execute()
 		if err != nil {
@@ -290,7 +290,7 @@ func resourceServiceEndpointServerlessRefreshFunc(ctx context.Context, client *a
 	}
 }
 
-func resourceServerlessInstanceListRefreshFunc(ctx context.Context, projectID string, client *admin.APIClient) retry.StateRefreshFunc {
+func resourceListRefreshFunc(ctx context.Context, projectID string, client *admin.APIClient) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		serverlessInstances, resp, err := client.ServerlessInstancesApi.ListServerlessInstances(ctx, projectID).Execute()
 

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
@@ -11,14 +11,13 @@ import (
 
 func TestAccMigrationServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 	var (
-		resourceName            = "mongodbatlas_privatelink_endpoint_service_serverless.test"
-		datasourceName          = "data.mongodbatlas_privatelink_endpoint_service_serverless.test"
-		datasourceEndpointsName = "data.mongodbatlas_privatelink_endpoints_service_serverless.test"
-		orgID                   = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName             = acctest.RandomWithPrefix("test-acc-serverless")
-		instanceName            = acctest.RandomWithPrefix("test-acc-serverless")
-		commentOrigin           = "this is a comment for serverless private link endpoint"
-		config                  = configBasic(orgID, projectName, instanceName, commentOrigin)
+		resourceName   = "mongodbatlas_privatelink_endpoint_service_serverless.test"
+		datasourceName = "data.mongodbatlas_privatelink_endpoint_service_serverless.test"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName   = acctest.RandomWithPrefix("test-acc-serverless")
+		commentOrigin  = "this is a comment for serverless private link endpoint"
+		config         = configBasic(orgID, projectName, instanceName, commentOrigin)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -33,9 +32,6 @@ func TestAccMigrationServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
 					resource.TestCheckResourceAttr(datasourceName, "comment", commentOrigin),
-					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "project_id"),
-					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "results.#"),
-					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "instance_name"),
 				),
 			},
 			mig.TestStep(config),

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
@@ -1,0 +1,45 @@
+package privatelinkendpointserviceserverless_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationServerlessPrivateLinkEndpointService_basic(t *testing.T) {
+	var (
+		resourceName            = "mongodbatlas_privatelink_endpoint_service_serverless.test"
+		datasourceName          = "data.mongodbatlas_privatelink_endpoint_service_serverless.test"
+		datasourceEndpointsName = "data.mongodbatlas_privatelink_endpoints_service_serverless.test"
+		orgID                   = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName             = acctest.RandomWithPrefix("test-acc-serverless")
+		instanceName            = acctest.RandomWithPrefix("test-acc-serverless")
+		commentOrigin           = "this is a comment for serverless private link endpoint"
+		config                  = configBasic(orgID, projectName, instanceName, commentOrigin)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acc.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
+					resource.TestCheckResourceAttr(datasourceName, "comment", commentOrigin),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "project_id"),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "results.#"),
+					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "instance_name"),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
@@ -23,7 +22,7 @@ func TestAccMigrationServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t) },
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
## Description

Upgrades `privatelink_endpoint_service_serverless` resource to auto-generated SDK
Add migration test

Link to any related issue(s): CLOUDP-226089

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
