### PR TITLE
chore: Upgrades `cluster_outage_simulation` resource to auto-generated SDK

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -483,8 +483,8 @@ jobs:
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
           MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
-          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
-          MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
+          MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
+          MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           TEST_REGEX: "^TestAccMigrationOutageSimulationCluster"
         run: make testacc

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -66,6 +66,7 @@ jobs:
       encryption: ${{ steps.filter.outputs.encryption == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       data_lake: ${{ steps.filter.outputs.data_lake == 'true' || env.mustTrigger == 'true' }}
+      cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd
@@ -132,6 +133,8 @@ jobs:
             - 'internal/service/privatelinkendpointserviceserverless/*.go'
           data_lake:
             - 'internal/service/datalakepipeline/*.go'
+          cluster_outage_simulation:
+            - 'internal/service/clusteroutagesimulation/*.go'
   
   project: 
     needs: [ change-detection, get-provider-version ]
@@ -460,4 +463,27 @@ jobs:
           MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           TEST_REGEX: "^TestAccMigrationcDataLake"
+        run: make testacc
+  cluster_outage_simulation:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || inputs.test_group == 'cluster_outage_simulation' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.terraform_version }}
+          terraform_wrapper: false    
+      - name: Migration Tests
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
+          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
+          MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
+          TEST_REGEX: "^TestAccMigrationOutageSimulationCluster"
         run: make testacc

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -284,12 +284,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -313,12 +313,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -338,12 +338,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -365,12 +365,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -398,12 +398,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -422,12 +422,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -446,12 +446,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    
@@ -470,12 +470,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
         with:
           terraform_version: ${{ env.terraform_version }}
           terraform_wrapper: false    

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -481,8 +481,8 @@ jobs:
           terraform_wrapper: false    
       - name: Migration Tests
         env:
-          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
-          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.MONGODB_ATLAS_PUBLIC_KEY_CLOUD_DEV }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.MONGODB_ATLAS_PRIVATE_KEY_CLOUD_DEV }}
           MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
           MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -485,5 +485,6 @@ jobs:
           MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
           MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
           MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           TEST_REGEX: "^TestAccMigrationOutageSimulationCluster"
         run: make testacc

--- a/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation.go
@@ -12,7 +12,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasClusterOutageSimulationRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -58,7 +58,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasClusterOutageSimulationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	projectID, projectIDOk := d.GetOk("project_id")

--- a/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation.go
@@ -59,7 +59,7 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID, projectIDOk := d.GetOk("project_id")
 	clusterName, clusterNameOk := d.GetOk("cluster_name")
@@ -68,7 +68,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("project_id and cluster_name must be configured")
 	}
 
-	outageSimulation, _, err := conn.ClusterOutageSimulation.GetOutageSimulation(ctx, projectID.(string), clusterName.(string))
+	outageSimulation, _, err := connV2.ClusterOutageSimulationApi.GetOutageSimulation(ctx, projectID.(string), clusterName.(string)).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorClusterOutageSimulationRead, projectID, clusterName, err))
 	}

--- a/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation_test.go
@@ -21,10 +21,10 @@ func TestAccOutageSimulationClusterDS_SingleRegion_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName),
+				Config: dataSourceConfigSingleRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -49,10 +49,10 @@ func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName),
+				Config: dataSourceConfigMultiRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -66,7 +66,7 @@ func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(projectName, orgID, clusterName string) string {
+func dataSourceConfigSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"
@@ -101,7 +101,7 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSSingleRegion(pr
 	`, projectName, orgID, clusterName)
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigDSMultiRegion(projectName, orgID, clusterName string) string {
+func dataSourceConfigMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"

--- a/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/data_source_cluster_outage_simulation_test.go
@@ -69,14 +69,14 @@ func TestAccOutageSimulationClusterDS_MultiRegion_basic(t *testing.T) {
 func dataSourceConfigSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
-		name   = "%s"
-		org_id = "%s"
+		name   = %[1]q
+		org_id = %[2]q
 	}
 
 	resource "mongodbatlas_cluster" "atlas_cluster" {
 		project_id                  = mongodbatlas_project.outage_project.id
    		provider_name               = "AWS"
-   		name                        = "%s"
+   		name                        = %[3]q
    		backing_provider_name       = "AWS"
    		provider_region_name        = "US_EAST_1"
    		provider_instance_size_name = "M10"
@@ -104,13 +104,13 @@ func dataSourceConfigSingleRegion(projectName, orgID, clusterName string) string
 func dataSourceConfigMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
-		name   = "%s"
-		org_id = "%s"
+		name   = %[1]q
+		org_id = %[2]q
 	}
 
 	resource "mongodbatlas_cluster" "atlas_cluster" {
 		project_id   = mongodbatlas_project.outage_project.id
-		name         = "%s"
+		name         = %[3]q
 		cluster_type = "REPLICASET"
 	  
 		provider_name               = "AWS"

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
@@ -217,7 +217,7 @@ func convertOutageSimulationToSchema(outageSimulation *admin.ClusterOutageSimula
 	if err := d.Set("state", outageSimulation.GetState()); err != nil {
 		return fmt.Errorf(errorClusterOutageSimulationSetting, "state", err)
 	}
-	if err := d.Set("start_request_date", conversion.TimeToString(outageSimulation.GetStartRequestDate())); err != nil {
+	if err := d.Set("start_request_date", conversion.TimePtrToStringPtr(outageSimulation.StartRequestDate)); err != nil {
 		return fmt.Errorf(errorClusterOutageSimulationSetting, "start_request_date", err)
 	}
 	if err := d.Set("simulation_id", outageSimulation.GetId()); err != nil {

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
@@ -217,7 +217,7 @@ func convertOutageSimulationToSchema(outageSimulation *admin.ClusterOutageSimula
 	if err := d.Set("state", outageSimulation.GetState()); err != nil {
 		return fmt.Errorf(errorClusterOutageSimulationSetting, "state", err)
 	}
-	if err := d.Set("start_request_date", outageSimulation.GetStartRequestDate()); err != nil {
+	if err := d.Set("start_request_date", conversion.TimeToString(outageSimulation.GetStartRequestDate())); err != nil {
 		return fmt.Errorf(errorClusterOutageSimulationSetting, "start_request_date", err)
 	}
 	if err := d.Set("simulation_id", outageSimulation.GetId()); err != nil {

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
@@ -1,0 +1,70 @@
+package clusteroutagesimulation_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-project")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+		config       = configSingleRegion(projectName, orgID, clusterName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}
+
+func TestAccMigrationOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_cluster_outage_simulation.test_outage"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc-project")
+		clusterName  = acctest.RandomWithPrefix("test-acc-cluster")
+		config       = configMultiRegion(projectName, orgID, clusterName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_request_date"),
+					resource.TestCheckResourceAttrSet(resourceName, "simulation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -24,10 +24,10 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName),
+				Config: configSingleRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -52,10 +52,10 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasClusterOutageSimulationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName),
+				Config: configMultiRegion(projectName, orgID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
@@ -69,7 +69,7 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(projectName, orgID, clusterName string) string {
+func configSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"
@@ -96,7 +96,7 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigSingleRegion(proj
 	`, projectName, orgID, clusterName)
 }
 
-func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(projectName, orgID, clusterName string) string {
+func configMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
 		name   = "%s"
@@ -149,7 +149,7 @@ func testAccDataSourceMongoDBAtlasClusterOutageSimulationConfigMultiRegion(proje
 	`, projectName, orgID, clusterName)
 }
 
-func testAccCheckMongoDBAtlasClusterOutageSimulationDestroy(s *terraform.State) error {
+func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster_outage_simulation" {
 			continue

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -155,7 +155,7 @@ func checkDestroy(s *terraform.State) error {
 			continue
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := acc.Conn().ClusterOutageSimulation.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"])
+		_, _, err := acc.ConnV2().ClusterOutageSimulationApi.GetOutageSimulation(context.Background(), ids["project_id"], ids["cluster_name"]).Execute()
 		if err == nil {
 			return fmt.Errorf("cluster outage simulation for project (%s) and cluster (%s) still exists", ids["project_id"], ids["cluster_name"])
 		}

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -72,14 +72,14 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 func configSingleRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
-		name   = "%s"
-		org_id = "%s"
+		name   = %[1]q
+		org_id = %[2]q
 	}
 
 	resource "mongodbatlas_cluster" "atlas_cluster" {
 		project_id                  = mongodbatlas_project.outage_project.id
    		provider_name               = "AWS"
-   		name                        = "%s"
+   		name                        = %[3]q
    		backing_provider_name       = "AWS"
    		provider_region_name        = "US_EAST_1"
    		provider_instance_size_name = "M10"
@@ -99,13 +99,13 @@ func configSingleRegion(projectName, orgID, clusterName string) string {
 func configMultiRegion(projectName, orgID, clusterName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "outage_project" {
-		name   = "%s"
-		org_id = "%s"
+		name   = %[1]q
+		org_id = %[2]q
 	}
 
 	resource "mongodbatlas_cluster" "atlas_cluster" {
 		project_id   = mongodbatlas_project.outage_project.id
-		name         = "%s"
+		name         = %[3]q
 		cluster_type = "REPLICASET"
 	  
 		provider_name               = "AWS"


### PR DESCRIPTION
## Description

Upgrades `cluster_outage_simulation` resource to auto-generated SDK
Add migration test

Link to any related issue(s): CLOUDP-226079

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
