### PR TITLE
chore: Upgrades cloud_backup_snapshot resource to auto-generated SDK

### DIFF
--- a/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshot.go
+++ b/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshot.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func DataSource() *schema.Resource {
@@ -102,72 +102,69 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	groupID := d.Get("project_id").(string)
+	clusterName := d.Get("cluster_name").(string)
+	snapshotID := d.Get("snapshot_id").(string)
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		SnapshotID:  d.Get("snapshot_id").(string),
-		GroupID:     d.Get("project_id").(string),
-		ClusterName: d.Get("cluster_name").(string),
-	}
-
-	snapshot, _, err := conn.CloudProviderSnapshots.GetOneCloudProviderSnapshot(ctx, requestParameters)
+	snapshot, _, err := connV2.CloudBackupsApi.GetReplicaSetBackup(ctx, groupID, clusterName, snapshotID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshot Information: %s", err))
 	}
 
-	if err = d.Set("created_at", snapshot.CreatedAt); err != nil {
+	if err = d.Set("created_at", conversion.TimePtrToStringPtr(snapshot.CreatedAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("description", snapshot.Description); err != nil {
+	if err = d.Set("description", snapshot.GetDescription()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `description` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("expires_at", snapshot.ExpiresAt); err != nil {
+	if err = d.Set("expires_at", conversion.TimePtrToStringPtr(snapshot.ExpiresAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("master_key_uuid", snapshot.MasterKeyUUID); err != nil {
+	if err = d.Set("master_key_uuid", snapshot.GetMasterKeyUUID()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `master_key_uuid` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("mongod_version", snapshot.MongodVersion); err != nil {
+	if err = d.Set("mongod_version", snapshot.GetMongodVersion()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `mongod_version` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("snapshot_type", snapshot.SnapshotType); err != nil {
+	if err = d.Set("snapshot_type", snapshot.GetSnapshotType()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `snapshot_type` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("status", snapshot.Status); err != nil {
+	if err = d.Set("status", snapshot.GetStatus()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `status` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("storage_size_bytes", snapshot.StorageSizeBytes); err != nil {
+	if err = d.Set("storage_size_bytes", snapshot.GetStorageSizeBytes()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `storage_size_bytes` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("type", snapshot.Type); err != nil {
+	if err = d.Set("type", snapshot.GetType()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `type` for cloudProviderSnapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("cloud_provider", snapshot.CloudProvider); err != nil {
+	if err = d.Set("cloud_provider", snapshot.GetCloudProvider()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `cloud_provider` for snapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("members", flattenCloudMembers(snapshot.Members)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `members` for snapshot (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("replica_set_name", snapshot.ReplicaSetName); err != nil {
+	if err = d.Set("replica_set_name", snapshot.GetReplicaSetName()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `replica_set_name` for snapshot (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("snapshot_ids", snapshot.SnapshotsIds); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `snapshot_ids` for snapshot (%s): %s", d.Id(), err))
+	sharded, _, _ := connV2.CloudBackupsApi.GetShardedClusterBackup(ctx, groupID, clusterName, snapshotID).Execute()
+	if sharded != nil {
+		if err = d.Set("members", flattenCloudMembers(sharded.GetMembers())); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting `members` for snapshot (%s): %s", d.Id(), err))
+		}
+		if err = d.Set("snapshot_ids", sharded.GetSnapshotIds()); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting `snapshot_ids` for snapshot (%s): %s", d.Id(), err))
+		}
 	}
-
-	d.SetId(snapshot.ID)
-
+	d.SetId(snapshot.GetId())
 	return nil
 }

--- a/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshot.go
+++ b/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshot.go
@@ -12,7 +12,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCloudBackupSnapshotRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"snapshot_id": {
 				Type:     schema.TypeString,
@@ -101,7 +101,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasCloudBackupSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	requestParameters := &matlas.SnapshotReqPathParameters{

--- a/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
+++ b/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
@@ -7,8 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"github.com/mwielbut/pointy"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 func PluralDataSource() *schema.Resource {
@@ -123,28 +125,26 @@ func PluralDataSource() *schema.Resource {
 }
 
 func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		GroupID:     d.Get("project_id").(string),
-		ClusterName: d.Get("cluster_name").(string),
-	}
-	options := &matlas.ListOptions{
-		PageNum:      d.Get("page_num").(int),
-		ItemsPerPage: d.Get("items_per_page").(int),
+	params := &admin.ListReplicaSetBackupsApiParams{
+		GroupId:      d.Get("project_id").(string),
+		ClusterName:  d.Get("cluster_name").(string),
+		PageNum:      pointy.Int(d.Get("page_num").(int)),
+		ItemsPerPage: pointy.Int(d.Get("items_per_page").(int)),
 	}
 
-	cloudProviderSnapshots, _, err := conn.CloudProviderSnapshots.GetAllCloudProviderSnapshots(ctx, requestParameters, options)
+	snapshots, _, err := connV2.CloudBackupsApi.ListReplicaSetBackupsWithParams(ctx, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshots information: %s", err))
 	}
+	shards, _, _ := connV2.CloudBackupsApi.ListShardedClusterBackups(ctx, params.GroupId, params.ClusterName).Execute()
 
-	if err := d.Set("results", flattenCloudBackupSnapshots(cloudProviderSnapshots.Results)); err != nil {
+	if err := d.Set("results", flattenCloudBackupSnapshots(snapshots.GetResults(), shards)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `results`: %s", err))
 	}
 
-	if err := d.Set("total_count", cloudProviderSnapshots.TotalCount); err != nil {
+	if err := d.Set("total_count", snapshots.GetTotalCount()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `total_count`: %s", err))
 	}
 
@@ -153,31 +153,36 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 	return nil
 }
 
-func flattenCloudBackupSnapshots(cloudProviderSnapshots []*matlas.CloudProviderSnapshot) []map[string]any {
-	var results []map[string]any
-
-	if len(cloudProviderSnapshots) > 0 {
-		results = make([]map[string]any, len(cloudProviderSnapshots))
-
-		for k, cloudProviderSnapshot := range cloudProviderSnapshots {
-			results[k] = map[string]any{
-				"id":                 cloudProviderSnapshot.ID,
-				"created_at":         cloudProviderSnapshot.CreatedAt,
-				"description":        cloudProviderSnapshot.Description,
-				"expires_at":         cloudProviderSnapshot.ExpiresAt,
-				"master_key_uuid":    cloudProviderSnapshot.MasterKeyUUID,
-				"mongod_version":     cloudProviderSnapshot.MongodVersion,
-				"snapshot_type":      cloudProviderSnapshot.SnapshotType,
-				"status":             cloudProviderSnapshot.Status,
-				"storage_size_bytes": cloudProviderSnapshot.StorageSizeBytes,
-				"type":               cloudProviderSnapshot.Type,
-				"cloud_provider":     cloudProviderSnapshot.CloudProvider,
-				"members":            flattenCloudMembers(cloudProviderSnapshot.Members),
-				"replica_set_name":   cloudProviderSnapshot.ReplicaSetName,
-				"snapshot_ids":       cloudProviderSnapshot.SnapshotsIds,
+func flattenCloudBackupSnapshots(snapshots []admin.DiskBackupReplicaSet, shards *admin.PaginatedCloudBackupShardedClusterSnapshot) []map[string]any {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	results := make([]map[string]any, len(snapshots))
+	for i := range snapshots {
+		snapshot := &snapshots[i]
+		results[i] = map[string]any{
+			"id":                 snapshot.GetId(),
+			"created_at":         conversion.TimePtrToStringPtr(snapshot.CreatedAt),
+			"expires_at":         conversion.TimePtrToStringPtr(snapshot.ExpiresAt),
+			"description":        snapshot.GetDescription(),
+			"master_key_uuid":    snapshot.GetMasterKeyUUID(),
+			"mongod_version":     snapshot.GetMongodVersion(),
+			"snapshot_type":      snapshot.GetSnapshotType(),
+			"status":             snapshot.GetStatus(),
+			"storage_size_bytes": snapshot.GetStorageSizeBytes(),
+			"type":               snapshot.GetType(),
+			"cloud_provider":     snapshot.GetCloudProvider(),
+			"replica_set_name":   snapshot.GetReplicaSetName(),
+		}
+		if shards != nil {
+			shardResults := shards.GetResults()
+			for j := range shardResults {
+				if shardResults[j].GetId() == snapshot.GetId() {
+					results[i]["members"] = flattenCloudMembers(shardResults[j].GetMembers())
+					results[i]["snapshot_ids"] = shardResults[j].GetSnapshotIds()
+				}
 			}
 		}
 	}
-
 	return results
 }

--- a/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
+++ b/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
@@ -13,7 +13,7 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCloudBackupSnapshotsRead,
+		ReadContext: dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -122,7 +122,7 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasCloudBackupSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 

--- a/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot.go
+++ b/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot.go
@@ -4,21 +4,18 @@ import (
 	"errors"
 	"regexp"
 
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
-func SplitSnapshotImportID(id string) (*matlas.SnapshotReqPathParameters, error) {
+func SplitSnapshotImportID(id string) (*admin.GetReplicaSetBackupApiParams, error) {
 	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-([0-9a-fA-F]{24})$`)
-
 	parts := re.FindStringSubmatch(id)
-
 	if len(parts) != 4 {
 		return nil, errors.New("import format error: to import a snapshot, use the format {project_id}-{cluster_name}-{snapshot_id}")
 	}
-
-	return &matlas.SnapshotReqPathParameters{
-		GroupID:     parts[1],
+	return &admin.GetReplicaSetBackupApiParams{
+		GroupId:     parts[1],
 		ClusterName: parts[2],
-		SnapshotID:  parts[3],
+		SnapshotId:  parts[3],
 	}, nil
 }

--- a/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot.go
+++ b/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot.go
@@ -1,0 +1,24 @@
+package cloudbackupsnapshot
+
+import (
+	"errors"
+	"regexp"
+
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func SplitSnapshotImportID(id string) (*matlas.SnapshotReqPathParameters, error) {
+	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-([0-9a-fA-F]{24})$`)
+
+	parts := re.FindStringSubmatch(id)
+
+	if len(parts) != 4 {
+		return nil, errors.New("import format error: to import a snapshot, use the format {project_id}-{cluster_name}-{snapshot_id}")
+	}
+
+	return &matlas.SnapshotReqPathParameters{
+		GroupID:     parts[1],
+		ClusterName: parts[2],
+		SnapshotID:  parts[3],
+	}, nil
+}

--- a/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cloudbackupsnapshot"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 func TestSplitSnapshotImportID(t *testing.T) {
@@ -14,10 +14,10 @@ func TestSplitSnapshotImportID(t *testing.T) {
 		t.Errorf("splitSnapshotImportID returned error(%s), expected error=nil", err)
 	}
 
-	expected := &matlas.SnapshotReqPathParameters{
-		GroupID:     "5cf5a45a9ccf6400e60981b6",
+	expected := &admin.GetReplicaSetBackupApiParams{
+		GroupId:     "5cf5a45a9ccf6400e60981b6",
 		ClusterName: "projectname-environment-mongo-global-cluster",
-		SnapshotID:  "5cf5a45a9ccf6400e60981b7",
+		SnapshotId:  "5cf5a45a9ccf6400e60981b7",
 	}
 
 	if diff := deep.Equal(expected, got); diff != nil {

--- a/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/model_cloud_backup_snapshot_test.go
@@ -1,0 +1,30 @@
+package cloudbackupsnapshot_test
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cloudbackupsnapshot"
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestSplitSnapshotImportID(t *testing.T) {
+	got, err := cloudbackupsnapshot.SplitSnapshotImportID("5cf5a45a9ccf6400e60981b6-projectname-environment-mongo-global-cluster-5cf5a45a9ccf6400e60981b7")
+	if err != nil {
+		t.Errorf("splitSnapshotImportID returned error(%s), expected error=nil", err)
+	}
+
+	expected := &matlas.SnapshotReqPathParameters{
+		GroupID:     "5cf5a45a9ccf6400e60981b6",
+		ClusterName: "projectname-environment-mongo-global-cluster",
+		SnapshotID:  "5cf5a45a9ccf6400e60981b7",
+	}
+
+	if diff := deep.Equal(expected, got); diff != nil {
+		t.Errorf("Bad splitSnapshotImportID return \n got = %#v\nwant = %#v \ndiff = %#v", expected, *got, diff)
+	}
+
+	if _, err := cloudbackupsnapshot.SplitSnapshotImportID("5cf5a45a9ccf6400e60981b6projectname-environment-mongo-global-cluster5cf5a45a9ccf6400e60981b7"); err == nil {
+		t.Error("splitSnapshotImportID expected to have error")
+	}
+}

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot.go
@@ -140,9 +140,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING"},
 		Target:     []string{"IDLE"},
 		Refresh:    advancedcluster.ResourceClusterRefreshFunc(ctx, d.Get("cluster_name").(string), d.Get("project_id").(string), advancedcluster.ServiceFromClient(conn)),
-		Timeout:    10 * time.Minute,
-		MinTimeout: 10 * time.Second,
-		Delay:      3 * time.Minute,
+		Timeout:    15 * time.Minute,
+		MinTimeout: 30 * time.Second,
 	}
 
 	// Wait, catching any errors

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -1,0 +1,41 @@
+package cloudbackupsnapshot_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestAccMigrationBackupRSCloudBackupSnapshot_basic(t *testing.T) {
+	var (
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName     = acctest.RandomWithPrefix("test-acc")
+		clusterName     = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		description     = "My description in my cluster"
+		retentionInDays = "4"
+		config          = configBasic(orgID, projectName, clusterName, description, retentionInDays)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
@@ -28,7 +29,43 @@ func TestAccMigrationBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "replicaSet"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(resourceName, "replica_set_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}
+
+func TestAccMigrationBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
+	var (
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName     = acctest.RandomWithPrefix("test-acc")
+		description     = "My description in my cluster"
+		retentionInDays = "4"
+		config          = configSharded(orgID, projectName, description, retentionInDays)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acc.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "shardedCluster"),
+					resource.TestCheckResourceAttrWith(resourceName, "members.#", acc.IntGreatThan(0)),
+					resource.TestCheckResourceAttrWith(resourceName, "snapshot_ids.#", acc.IntGreatThan(0)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
 				),

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -1,23 +1,21 @@
 package cloudbackupsnapshot_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestAccMigrationBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 	var (
 		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName     = acctest.RandomWithPrefix("test-acc")
-		clusterName     = fmt.Sprintf("test-acc-%s", acctest.RandString(10))
+		clusterInfo     = acc.GetClusterInfo(orgID, true)
 		description     = "My description in my cluster"
 		retentionInDays = "4"
-		config          = configBasic(orgID, projectName, clusterName, description, retentionInDays)
+		config          = configBasic(&clusterInfo, description, retentionInDays)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +28,7 @@ func TestAccMigrationBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
 				),

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -3,7 +3,6 @@ package cloudbackupsnapshot_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
@@ -73,13 +71,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if ids["snapshot_id"] == "" {
 			return fmt.Errorf("no ID is set")
 		}
-		log.Printf("[DEBUG] cloudBackupSnapshot ID: %s", ids["snapshot_id"])
-		requestParameters := &matlas.SnapshotReqPathParameters{
-			SnapshotID:  ids["snapshot_id"],
-			GroupID:     ids["project_id"],
-			ClusterName: ids["cluster_name"],
-		}
-		_, _, err := acc.Conn().CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
+		_, _, err := acc.ConnV2().CloudBackupsApi.GetReplicaSetBackup(context.Background(), ids["project_id"], ids["cluster_name"], ids["snapshot_id"]).Execute()
 		if err == nil {
 			return nil
 		}
@@ -94,12 +86,7 @@ func checkDestroy(s *terraform.State) error {
 			continue
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		requestParameters := &matlas.SnapshotReqPathParameters{
-			SnapshotID:  ids["snapshot_id"],
-			GroupID:     ids["project_id"],
-			ClusterName: ids["cluster_name"],
-		}
-		res, _, _ := acc.Conn().CloudProviderSnapshots.GetOneCloudProviderSnapshot(context.Background(), requestParameters)
+		res, _, _ := acc.ConnV2().CloudBackupsApi.GetReplicaSetBackup(context.Background(), ids["project_id"], ids["cluster_name"], ids["snapshot_id"]).Execute()
 		if res != nil {
 			return fmt.Errorf("cloudBackupSnapshot (%s) still exists", rs.Primary.Attributes["snapshot_id"])
 		}

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -48,6 +48,8 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "replicaSet"),
+					resource.TestCheckResourceAttr(dataSourceName, "members.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "snapshot_ids.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(dataSourceName, "replica_set_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider", "AWS"),
@@ -92,6 +94,8 @@ func TestAccBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", "shardedCluster"),
+					resource.TestCheckResourceAttrWith(dataSourceName, "members.#", acc.IntGreatThan(0)),
+					resource.TestCheckResourceAttrWith(dataSourceName, "snapshot_ids.#", acc.IntGreatThan(0)),
 					resource.TestCheckResourceAttr(dataSourceName, "description", description)),
 			},
 		},
@@ -212,6 +216,12 @@ func configSharded(orgID, projectName, description, retentionInDays string) stri
 			cluster_name      = mongodbatlas_advanced_cluster.my_cluster.name
 			description       = %[3]q
 			retention_in_days = %[4]q
+		}
+
+		data "mongodbatlas_cloud_backup_snapshot" "test" {
+			snapshot_id  = mongodbatlas_cloud_backup_snapshot.test.snapshot_id
+			project_id        = mongodbatlas_advanced_cluster.my_cluster.project_id
+			cluster_name      = mongodbatlas_advanced_cluster.my_cluster.name
 		}
 
 	`, orgID, projectName, description, retentionInDays)

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -13,12 +14,12 @@ import (
 )
 
 const (
-	resourceName = "mongodbatlas_cloud_backup_snapshot.test"
+	resourceName   = "mongodbatlas_cloud_backup_snapshot.test"
+	dataSourceName = "data.mongodbatlas_cloud_backup_snapshot.test"
 )
 
 func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 	var (
-		dataSourceName                 = "data.mongodbatlas_cloud_backup_snapshot.test"
 		dataSourcePluralSimpleName     = "data.mongodbatlas_cloud_backup_snapshots.test"
 		dataSourcePluralPaginationName = "data.mongodbatlas_cloud_backup_snapshots.pagination"
 		orgID                          = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -37,11 +38,19 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "replicaSet"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(resourceName, "replica_set_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "replicaSet"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(dataSourceName, "replica_set_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(dataSourceName, "description", description),
 					resource.TestCheckResourceAttrSet(dataSourcePluralSimpleName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralPaginationName, "results.#"),
@@ -53,6 +62,37 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"retention_in_days"},
+			},
+		},
+	})
+}
+
+func TestAccBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
+	var (
+		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName     = acctest.RandomWithPrefix("test-acc")
+		description     = "My description in my cluster"
+		retentionInDays = "4"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configSharded(orgID, projectName, description, retentionInDays),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "shardedCluster"),
+					resource.TestCheckResourceAttrWith(resourceName, "members.#", acc.IntGreatThan(0)),
+					resource.TestCheckResourceAttrWith(resourceName, "snapshot_ids.#", acc.IntGreatThan(0)),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "retention_in_days", retentionInDays),
+					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "shardedCluster"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", description)),
 			},
 		},
 	})
@@ -78,6 +118,9 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 }
 
 func checkDestroy(s *terraform.State) error {
+	if os.Getenv("MONGODB_ATLAS_CLUSTER_NAME") != "" {
+		return nil
+	}
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cloud_backup_snapshot" {
 			continue
@@ -129,4 +172,47 @@ func configBasic(info *acc.ClusterInfo, description, retentionInDays string) str
 			items_per_page = 5
 		}
 	`, info.ClusterNameStr, info.ProjectIDStr, description, retentionInDays)
+}
+
+func configSharded(orgID, projectName, description, retentionInDays string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "backup_project" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
+		resource "mongodbatlas_advanced_cluster" "my_cluster" {
+			project_id   = mongodbatlas_project.backup_project.id
+			name           = "ClusterSharded"
+			cluster_type   = "SHARDED"
+			backup_enabled = true
+		
+			replication_specs {
+				num_shards = 3
+		
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_EAST_1"
+				}
+		
+			}
+		}
+
+		resource "mongodbatlas_cloud_backup_snapshot" "test" {
+			project_id        = mongodbatlas_cluster.my_cluster.project_id
+			cluster_name      = mongodbatlas_cluster.my_cluster.name
+			description       = %[3]q
+			retention_in_days = %[4]q
+		}
+
+	`, orgID, projectName, description, retentionInDays)
 }

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -208,8 +208,8 @@ func configSharded(orgID, projectName, description, retentionInDays string) stri
 		}
 
 		resource "mongodbatlas_cloud_backup_snapshot" "test" {
-			project_id        = mongodbatlas_cluster.my_cluster.project_id
-			cluster_name      = mongodbatlas_cluster.my_cluster.name
+			project_id        = mongodbatlas_advanced_cluster.my_cluster.project_id
+			cluster_name      = mongodbatlas_advanced_cluster.my_cluster.name
 			description       = %[3]q
 			retention_in_days = %[4]q
 		}

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -45,7 +45,6 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttr(dataSourceName, "description", description),
-					resource.TestCheckResourceAttr(dataSourceName, "retention_in_days", retentionInDays),
 					resource.TestCheckResourceAttrSet(dataSourcePluralSimpleName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralPaginationName, "results.#"),
 				),

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccSearchIndexRS_basic(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -56,7 +56,7 @@ func TestAccSearchIndexRS_basic(t *testing.T) {
 func TestAccSearchIndexRS_withSearchType(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -96,7 +96,7 @@ func TestAccSearchIndexRS_withSearchType(t *testing.T) {
 func TestAccSearchIndexRS_withMapping(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -141,7 +141,7 @@ func TestAccSearchIndexRS_withMapping(t *testing.T) {
 func TestAccSearchIndexRS_withSynonyms(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -190,7 +190,7 @@ func TestAccSearchIndexRS_withSynonyms(t *testing.T) {
 func TestAccSearchIndexRS_updatedToEmptySynonyms(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -223,7 +223,7 @@ func TestAccSearchIndexRS_updatedToEmptySynonyms(t *testing.T) {
 func TestAccSearchIndexRS_updatedToEmptyAnalyzers(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -253,7 +253,7 @@ func TestAccSearchIndexRS_updatedToEmptyAnalyzers(t *testing.T) {
 func TestAccSearchIndexRS_updatedToEmptyMappingsFields(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -283,7 +283,7 @@ func TestAccSearchIndexRS_updatedToEmptyMappingsFields(t *testing.T) {
 func TestAccSearchIndexRS_importBasic(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -315,7 +315,7 @@ func TestAccSearchIndexRS_importBasic(t *testing.T) {
 func TestAccSearchIndexRS_withVector(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)

--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -53,7 +53,7 @@ func TestAccStreamDSStreamConnection_kafkaSSL(t *testing.T) {
 func TestAccStreamDSStreamConnection_cluster(t *testing.T) {
 	var (
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo    = acc.GetClusterInfo(orgID)
+		clusterInfo    = acc.GetClusterInfo(orgID, false)
 		instanceName   = acctest.RandomWithPrefix("test-acc-name")
 		dataSourceName = "data.mongodbatlas_stream_connection.test"
 	)

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -79,7 +79,7 @@ func TestAccMigrationStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 func TestAccMigrationStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		instanceName = acctest.RandomWithPrefix("test-acc-name")
 		resourceName = "mongodbatlas_stream_connection.test"
 	)

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -77,7 +77,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 func TestAccStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID)
+		clusterInfo  = acc.GetClusterInfo(orgID, false)
 		instanceName = acctest.RandomWithPrefix("test-acc-name")
 		resourceName = "mongodbatlas_stream_connection.test"
 	)

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -40,7 +40,6 @@ func GetClusterInfo(orgID string, cloudBackup bool) ClusterInfo {
 			name         									= %[3]q
 			cloud_backup         					= %[4]t
 			disk_size_gb 									= 10
-			backup_enabled               	= false
 			auto_scaling_disk_gb_enabled	= false
 			provider_name               	= "AWS"
 			provider_instance_size_name 	= "M10"

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -16,7 +16,7 @@ type ClusterInfo struct {
 
 // GetClusterInfo is used to obtain a project and cluster configuration resource.
 // When `MONGODB_ATLAS_CLUSTER_NAME` and `MONGODB_ATLAS_PROJECT_ID` are defined, creation of resources is avoided. This is useful for local execution but not intended for CI executions.
-func GetClusterInfo(orgID string) ClusterInfo {
+func GetClusterInfo(orgID string, cloudBackup bool) ClusterInfo {
 	clusterName := os.Getenv("MONGODB_ATLAS_CLUSTER_NAME")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	if clusterName != "" && projectID != "" {
@@ -38,6 +38,7 @@ func GetClusterInfo(orgID string) ClusterInfo {
 		resource "mongodbatlas_cluster" "test_cluster" {
 			project_id   									= mongodbatlas_project.test.id
 			name         									= %[3]q
+			cloud_backup         					= %[4]t
 			disk_size_gb 									= 10
 			backup_enabled               	= false
 			auto_scaling_disk_gb_enabled	= false
@@ -55,7 +56,7 @@ func GetClusterInfo(orgID string) ClusterInfo {
 				}
 			}
 		}
-	`, orgID, projectName, clusterName)
+	`, orgID, projectName, clusterName, cloudBackup)
 	return ClusterInfo{
 		ProjectIDStr:        "mongodbatlas_project.test.id",
 		ClusterName:         clusterName,


### PR DESCRIPTION
## Description

Upgrades  cloud_backup_snapshot resource to auto-generated SDK.

- Migration tests created.
- Current tests were for replica set clusters, tests added for sharded clusters.
- Add ability to use existing cluster and project in local tests.
- Extracted unit tests to model file.


Link to any related issue(s): CLOUDP-226078

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
