### PR TITLE
chore: Upgrades `global_cluster_config` resource to auto-generated SDK

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -125,16 +125,16 @@ jobs:
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
       cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
-      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      stream: false
       generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
-      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      backup: false
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
       config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
       assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
       event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
-      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
+      search_index: false
       federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
       data_lake: ${{ steps.filter.outputs.data_lake == 'true' || env.mustTrigger == 'true' }}
       ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -125,16 +125,16 @@ jobs:
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
       cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
-      stream: false
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
       generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}
-      backup: false
+      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
       config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
       assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
       event_trigger: ${{ steps.filter.outputs.event_trigger == 'true' || env.mustTrigger == 'true' }}
-      search_index: false
+      search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
       data_lake: ${{ steps.filter.outputs.data_lake == 'true' || env.mustTrigger == 'true' }}
       ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -57,8 +57,8 @@ jobs:
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
       config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      backup: false
-      stream: false
+      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
+      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
       federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
       generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -67,6 +67,7 @@ jobs:
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       data_lake: ${{ steps.filter.outputs.data_lake == 'true' || env.mustTrigger == 'true' }}
       cluster_outage_simulation: ${{ steps.filter.outputs.cluster_outage_simulation == 'true' || env.mustTrigger == 'true' }}
+      cluster: ${{ steps.filter.outputs.cluster == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd
@@ -135,6 +136,9 @@ jobs:
             - 'internal/service/datalakepipeline/*.go'
           cluster_outage_simulation:
             - 'internal/service/clusteroutagesimulation/*.go'
+          cluster:
+            - 'internal/service/cluster/*.go'
+            - 'internal/service/globalclusterconfig/*.go'
   
   project: 
     needs: [ change-detection, get-provider-version ]
@@ -488,3 +492,28 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           TEST_REGEX: "^TestAccMigrationOutageSimulationCluster"
         run: make testacc
+  cluster:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.cluster == 'true' || inputs.test_group == 'cluster' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: ${{ env.terraform_version }}
+          terraform_wrapper: false    
+      - name: Migration Tests
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.MONGODB_ATLAS_PUBLIC_KEY_CLOUD_DEV }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.MONGODB_ATLAS_PRIVATE_KEY_CLOUD_DEV }}
+          MONGODB_ATLAS_ORG_ID: ${{ vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
+          MONGODB_ATLAS_BASE_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          TEST_REGEX: "^TestAccMigrationClusterRS"
+        run: make testacc
+    

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -57,8 +57,8 @@ jobs:
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
       config: ${{ steps.filter.outputs.config == 'true' || env.mustTrigger == 'true' }}
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
-      stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      backup: false
+      stream: false
       federated: ${{ steps.filter.outputs.federated == 'true' || env.mustTrigger == 'true' }}
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
       generic: ${{ steps.filter.outputs.generic == 'true' || env.mustTrigger == 'true' }}

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -12,8 +12,7 @@ import (
 
 func TestAccMigrationBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 	var (
-		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo     = acc.GetClusterInfo(orgID, true)
+		clusterInfo     = acc.GetClusterInfo(&acc.ClusterRequest{CloudBackup: true})
 		description     = "My description in my cluster"
 		retentionInDays = "4"
 		config          = configBasic(&clusterInfo, description, retentionInDays)

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -22,8 +22,7 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 	var (
 		dataSourcePluralSimpleName     = "data.mongodbatlas_cloud_backup_snapshots.test"
 		dataSourcePluralPaginationName = "data.mongodbatlas_cloud_backup_snapshots.pagination"
-		orgID                          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo                    = acc.GetClusterInfo(orgID, true)
+		clusterInfo                    = acc.GetClusterInfo(&acc.ClusterRequest{CloudBackup: true})
 		description                    = "My description in my cluster"
 		retentionInDays                = "4"
 	)

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config.go
@@ -12,7 +12,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasGlobalClusterRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -61,8 +61,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config.go
@@ -62,11 +62,11 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	globalCluster, resp, err := conn.GlobalClusters.Get(ctx, projectID, clusterName)
+	globalCluster, resp, err := connV2.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil
@@ -75,11 +75,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
-	if err := d.Set("managed_namespaces", flattenManagedNamespaces(globalCluster.ManagedNamespaces)); err != nil {
+	if err := d.Set("managed_namespaces", flattenManagedNamespaces(globalCluster.GetManagedNamespaces())); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
-	if err := d.Set("custom_zone_mapping", globalCluster.CustomZoneMapping); err != nil {
+	if err := d.Set("custom_zone_mapping", globalCluster.GetCustomZoneMapping()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
@@ -22,10 +22,10 @@ func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDSMongoDBAtlasGlobalClusterConfig(orgID, projectName, name),
+				Config: configGlobalCluster(orgID, projectName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
@@ -35,9 +35,8 @@ func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
 	})
 }
 
-func testAccDSMongoDBAtlasGlobalClusterConfig(orgID, projectName, name string) string {
+func configGlobalCluster(orgID, projectName, name string) string {
 	return fmt.Sprintf(`
-
 	resource "mongodbatlas_project" "project" {
 		org_id = %[1]q
 		name   = %[2]q

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
@@ -1,22 +1,15 @@
 package globalclusterconfig_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
 func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
-	acc.SkipTestForCI(t) // needs to be fixed: 404 (request "GROUP_NOT_FOUND") No group with ID
 	var (
-		dataSourceName = "data.mongodbatlas_global_cluster_config.config"
-		name           = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acctest.RandomWithPrefix("test-acc")
+		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -25,7 +18,7 @@ func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configGlobalCluster(orgID, projectName, name),
+				Config: configBasic(&clusterInfo, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
@@ -33,68 +26,4 @@ func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func configGlobalCluster(orgID, projectName, name string) string {
-	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "project" {
-		org_id = %[1]q
-		name   = %[2]q
-	}
-
-	resource "mongodbatlas_cluster" "test" {
-		project_id              = mongodbatlas_project.project.id
-		name                    = %[3]q
-		disk_size_gb            = 80
-		cloud_backup            = false
-		cluster_type            = "GEOSHARDED"
-
-		// Provider Settings "block"
-		provider_name               = "AWS"
-		provider_instance_size_name = "M30"
-
-		replication_specs {
-			zone_name  = "Zone 1"
-			num_shards = 2
-			regions_config {
-			region_name     = "US_EAST_1"
-			electable_nodes = 3
-			priority        = 7
-			read_only_nodes = 0
-			}
-		}
-
-		replication_specs {
-			zone_name  = "Zone 2"
-			num_shards = 2
-			regions_config {
-			region_name     = "US_EAST_2"
-			electable_nodes = 3
-			priority        = 7
-			read_only_nodes = 0
-			}
-		}
-	}
-
-	resource "mongodbatlas_global_cluster_config" "config" {
-		project_id = mongodbatlas_cluster.test.project_id
-		cluster_name = mongodbatlas_cluster.test.name
-
-		managed_namespaces {
-			db 				 = "mydata"
-			collection 		 = "publishers"
-			custom_shard_key = "city"
-		}
-
-		custom_zone_mappings {
-			location ="CA"
-			zone =  "Zone 1"
-		}
-	}
-
-	data "mongodbatlas_global_cluster_config" "config" {
-		project_id = mongodbatlas_global_cluster_config.config.project_id
-		cluster_name = mongodbatlas_global_cluster_config.config.cluster_name
-	}
-	`, orgID, projectName, name)
 }

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -13,8 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/mwielbut/pointy"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 const (
@@ -102,7 +101,7 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -110,33 +109,31 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		for _, m := range v.(*schema.Set).List() {
 			mn := m.(map[string]any)
 
-			addManagedNamespace := &matlas.ManagedNamespace{
-				Collection:     mn["collection"].(string),
-				Db:             mn["db"].(string),
-				CustomShardKey: mn["custom_shard_key"].(string),
+			addManagedNamespace := &admin.ManagedNamespace{
+				Collection:     conversion.StringPtr(mn["collection"].(string)),
+				Db:             conversion.StringPtr(mn["db"].(string)),
+				CustomShardKey: conversion.StringPtr(mn["custom_shard_key"].(string)),
 			}
 
 			if isCustomShardKeyHashed, okCustomShard := mn["is_custom_shard_key_hashed"]; okCustomShard {
-				addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
+				addManagedNamespace.IsCustomShardKeyHashed = conversion.Pointer[bool](isCustomShardKeyHashed.(bool))
 			}
 
 			if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
-				addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
+				addManagedNamespace.IsShardKeyUnique = conversion.Pointer[bool](isShardKeyUnique.(bool))
 			}
 
 			err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-				_, _, err := conn.GlobalClusters.AddManagedNamespace(ctx, projectID, clusterName, addManagedNamespace)
+				_, _, err := connV2.GlobalClustersApi.CreateManagedNamespace(ctx, projectID, clusterName, addManagedNamespace).Execute()
 				if err != nil {
-					var target *matlas.ErrorResponse
-					if errors.As(err, &target) && target.ErrorCode == "DUPLICATE_MANAGED_NAMESPACE" {
-						if err := removeManagedNamespaces(ctx, conn, v.(*schema.Set).List(), projectID, clusterName); err != nil {
+					if admin.IsErrorCode(err, "DUPLICATE_MANAGED_NAMESPACE") {
+						if err := removeManagedNamespaces(ctx, connV2, v.(*schema.Set).List(), projectID, clusterName); err != nil {
 							return retry.NonRetryableError(fmt.Errorf(errorGlobalClusterCreate, err))
 						}
 						return retry.RetryableError(err)
 					}
 					return retry.NonRetryableError(fmt.Errorf(errorGlobalClusterCreate, err))
 				}
-
 				return nil
 			})
 			if err != nil {
@@ -146,13 +143,13 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if v, ok := d.GetOk("custom_zone_mappings"); ok {
-		_, _, err := conn.GlobalClusters.AddCustomZoneMappings(ctx, projectID, clusterName, &matlas.CustomZoneMappingsRequest{
+		_, _, err := connV2.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin.CustomZoneMappings{
 			CustomZoneMappings: newCustomZoneMappings(v.(*schema.Set).List()),
-		})
+		}).Execute()
 
 		if err != nil {
 			if v2, ok2 := d.GetOk("managed_namespaces"); ok2 {
-				if err := removeManagedNamespaces(ctx, conn, v2.(*schema.Set).List(), projectID, clusterName); err != nil {
+				if err := removeManagedNamespaces(ctx, connV2, v2.(*schema.Set).List(), projectID, clusterName); err != nil {
 					return diag.FromErr(fmt.Errorf(errorGlobalClusterCreate, err))
 				}
 			}
@@ -169,12 +166,12 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	globalCluster, resp, err := conn.GlobalClusters.Get(ctx, projectID, clusterName)
+	globalCluster, resp, err := connV2.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -184,11 +181,11 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
-	if err := d.Set("managed_namespaces", flattenManagedNamespaces(globalCluster.ManagedNamespaces)); err != nil {
+	if err := d.Set("managed_namespaces", flattenManagedNamespaces(globalCluster.GetManagedNamespaces())); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
-	if err := d.Set("custom_zone_mapping", globalCluster.CustomZoneMapping); err != nil {
+	if err := d.Set("custom_zone_mapping", globalCluster.GetCustomZoneMapping()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
@@ -196,7 +193,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -210,13 +207,13 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		add := newSet.Difference(oldSet).List()
 
 		if len(remove) > 0 {
-			if err := removeManagedNamespaces(ctx, conn, remove, projectID, clusterName); err != nil {
+			if err := removeManagedNamespaces(ctx, connV2, remove, projectID, clusterName); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 		}
 
 		if len(add) > 0 {
-			if err := addManagedNamespaces(ctx, conn, add, projectID, clusterName); err != nil {
+			if err := addManagedNamespaces(ctx, connV2, add, projectID, clusterName); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 		}
@@ -231,22 +228,22 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		add := newSet.Difference(oldSet).List()
 
 		if len(remove) > 0 {
-			if _, _, err := conn.GlobalClusters.DeleteCustomZoneMappings(ctx, projectID, clusterName); err != nil {
+			if _, _, err := connV2.GlobalClustersApi.DeleteAllCustomZoneMappings(ctx, projectID, clusterName).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 			if v, ok := d.GetOk("custom_zone_mappings"); ok {
-				if _, _, err := conn.GlobalClusters.AddCustomZoneMappings(ctx, projectID, clusterName, &matlas.CustomZoneMappingsRequest{
+				if _, _, err := connV2.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin.CustomZoneMappings{
 					CustomZoneMappings: newCustomZoneMappings(v.(*schema.Set).List()),
-				}); err != nil {
+				}).Execute(); err != nil {
 					return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 				}
 			}
 		}
 
 		if len(add) > 0 {
-			if _, _, err := conn.GlobalClusters.AddCustomZoneMappings(ctx, projectID, clusterName, &matlas.CustomZoneMappingsRequest{
+			if _, _, err := connV2.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin.CustomZoneMappings{
 				CustomZoneMappings: newCustomZoneMappings(add),
-			}); err != nil {
+			}).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
 			}
 		}
@@ -256,20 +253,20 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
 	if v, ok := d.GetOk("managed_namespaces"); ok {
-		if err := removeManagedNamespaces(ctx, conn, v.(*schema.Set).List(), projectID, clusterName); err != nil {
+		if err := removeManagedNamespaces(ctx, connV2, v.(*schema.Set).List(), projectID, clusterName); err != nil {
 			return diag.FromErr(fmt.Errorf(errorGlobalClusterDelete, clusterName, err))
 		}
 	}
 
 	if v, ok := d.GetOk("custom_zone_mappings"); ok {
 		if v.(*schema.Set).Len() > 0 {
-			if _, _, err := conn.GlobalClusters.DeleteCustomZoneMappings(ctx, projectID, clusterName); err != nil {
+			if _, _, err := connV2.GlobalClustersApi.DeleteAllCustomZoneMappings(ctx, projectID, clusterName).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterDelete, clusterName, err))
 			}
 		}
@@ -278,7 +275,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	return nil
 }
 
-func flattenManagedNamespaces(managedNamespaces []matlas.ManagedNamespace) []map[string]any {
+func flattenManagedNamespaces(managedNamespaces []admin.ManagedNamespaces) []map[string]any {
 	var results []map[string]any
 
 	if len(managedNamespaces) > 0 {
@@ -286,15 +283,14 @@ func flattenManagedNamespaces(managedNamespaces []matlas.ManagedNamespace) []map
 
 		for k, managedNamespace := range managedNamespaces {
 			results[k] = map[string]any{
-				"db":                         managedNamespace.Db,
-				"collection":                 managedNamespace.Collection,
-				"custom_shard_key":           managedNamespace.CustomShardKey,
-				"is_custom_shard_key_hashed": *managedNamespace.IsCustomShardKeyHashed,
-				"is_shard_key_unique":        *managedNamespace.IsShardKeyUnique,
+				"db":                         managedNamespace.GetDb(),
+				"collection":                 managedNamespace.GetCollection(),
+				"custom_shard_key":           managedNamespace.GetCustomShardKey(),
+				"is_custom_shard_key_hashed": managedNamespace.GetIsCustomShardKeyHashed(),
+				"is_shard_key_unique":        managedNamespace.GetIsShardKeyUnique(),
 			}
 		}
 	}
-
 	return results
 }
 
@@ -323,65 +319,57 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	return []*schema.ResourceData{d}, nil
 }
 
-func removeManagedNamespaces(ctx context.Context, conn *matlas.Client, remove []any, projectID, clusterName string) error {
+func removeManagedNamespaces(ctx context.Context, connV2 *admin.APIClient, remove []any, projectID, clusterName string) error {
 	for _, m := range remove {
 		mn := m.(map[string]any)
-		addManagedNamespace := &matlas.ManagedNamespace{
-			Collection:     mn["collection"].(string),
-			Db:             mn["db"].(string),
-			CustomShardKey: mn["custom_shard_key"].(string),
+		managedNamespace := &admin.DeleteManagedNamespaceApiParams{
+			Collection:  conversion.StringPtr(mn["collection"].(string)),
+			Db:          conversion.StringPtr(mn["db"].(string)),
+			ClusterName: clusterName,
+			GroupId:     projectID,
 		}
 
-		if isCustomShardKeyHashed, okCustomShard := mn["is_custom_shard_key_hashed"]; okCustomShard {
-			addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
-		}
-
-		if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
-			addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
-		}
-		_, _, err := conn.GlobalClusters.DeleteManagedNamespace(ctx, projectID, clusterName, addManagedNamespace)
+		_, _, err := connV2.GlobalClustersApi.DeleteManagedNamespaceWithParams(ctx, managedNamespace).Execute()
 
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func addManagedNamespaces(ctx context.Context, conn *matlas.Client, add []any, projectID, clusterName string) error {
+func addManagedNamespaces(ctx context.Context, connV2 *admin.APIClient, add []any, projectID, clusterName string) error {
 	for _, m := range add {
 		mn := m.(map[string]any)
 
-		addManagedNamespace := &matlas.ManagedNamespace{
-			Collection:     mn["collection"].(string),
-			Db:             mn["db"].(string),
-			CustomShardKey: mn["custom_shard_key"].(string),
+		addManagedNamespace := &admin.ManagedNamespace{
+			Collection:     conversion.StringPtr(mn["collection"].(string)),
+			Db:             conversion.StringPtr(mn["db"].(string)),
+			CustomShardKey: conversion.StringPtr(mn["custom_shard_key"].(string)),
 		}
 
 		if isCustomShardKeyHashed, okCustomShard := mn["is_custom_shard_key_hashed"]; okCustomShard {
-			addManagedNamespace.IsCustomShardKeyHashed = pointy.Bool(isCustomShardKeyHashed.(bool))
+			addManagedNamespace.IsCustomShardKeyHashed = conversion.Pointer[bool](isCustomShardKeyHashed.(bool))
 		}
 
 		if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
-			addManagedNamespace.IsShardKeyUnique = pointy.Bool(isShardKeyUnique.(bool))
+			addManagedNamespace.IsShardKeyUnique = conversion.Pointer[bool](isShardKeyUnique.(bool))
 		}
-		_, _, err := conn.GlobalClusters.AddManagedNamespace(ctx, projectID, clusterName, addManagedNamespace)
+		_, _, err := connV2.GlobalClustersApi.CreateManagedNamespace(ctx, projectID, clusterName, addManagedNamespace).Execute()
 
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func newCustomZoneMapping(tfMap map[string]any) *matlas.CustomZoneMapping {
+func newCustomZoneMapping(tfMap map[string]any) *admin.ZoneMapping {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &matlas.CustomZoneMapping{
+	apiObject := &admin.ZoneMapping{
 		Location: tfMap["location"].(string),
 		Zone:     tfMap["zone"].(string),
 	}
@@ -389,12 +377,12 @@ func newCustomZoneMapping(tfMap map[string]any) *matlas.CustomZoneMapping {
 	return apiObject
 }
 
-func newCustomZoneMappings(tfList []any) []matlas.CustomZoneMapping {
+func newCustomZoneMappings(tfList []any) *[]admin.ZoneMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	apiObjects := make([]matlas.CustomZoneMapping, len(tfList))
+	apiObjects := make([]admin.ZoneMapping, len(tfList))
 	if len(tfList) > 0 {
 		for i, tfMapRaw := range tfList {
 			if tfMap, ok := tfMapRaw.(map[string]any); ok {
@@ -407,5 +395,5 @@ func newCustomZoneMappings(tfList []any) []matlas.CustomZoneMapping {
 		}
 	}
 
-	return apiObjects
+	return &apiObjects
 }

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -26,12 +26,12 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasGlobalClusterCreate,
-		ReadContext:   resourceMongoDBAtlasGlobalClusterRead,
-		UpdateContext: resourceMongoDBAtlasGlobalClusterUpdate,
-		DeleteContext: resourceMongoDBAtlasGlobalClusterDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasGlobalClusterImportState,
+			StateContext: resourceImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -101,8 +101,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
@@ -166,11 +165,10 @@ func resourceMongoDBAtlasGlobalClusterCreate(ctx context.Context, d *schema.Reso
 		"cluster_name": clusterName,
 	}))
 
-	return resourceMongoDBAtlasGlobalClusterRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -197,8 +195,7 @@ func resourceMongoDBAtlasGlobalClusterRead(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -255,11 +252,10 @@ func resourceMongoDBAtlasGlobalClusterUpdate(ctx context.Context, d *schema.Reso
 		}
 	}
 
-	return resourceMongoDBAtlasGlobalClusterRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -302,7 +298,7 @@ func flattenManagedNamespaces(managedNamespaces []matlas.ManagedNamespace) []map
 	return results
 }
 
-func resourceMongoDBAtlasGlobalClusterImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "-", 2)
 	if len(parts) != 2 {
 		return nil, errors.New("import format error: to import a global cluster, use the format {project_id}-{cluster-name}")

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
@@ -1,0 +1,48 @@
+package globalclusterconfig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+	"go.mongodb.org/atlas-sdk/v20231115006/admin"
+)
+
+func TestAccMigrationClusterRSGlobalCluster_basic(t *testing.T) {
+	acc.SkipTestForCI(t) // needs to be fixed: "cloud_backup": conflicts with backup_enabled
+	var (
+		globalConfig admin.GeoSharding
+		resourceName = "mongodbatlas_global_cluster_config.config"
+		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acctest.RandomWithPrefix("test-acc")
+		config       = configBasic(orgID, projectName, name, "false", "false", "false")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            config,
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName, &globalConfig),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
+				),
+			},
+			mig.TestStep(config),
+		},
+	})
+}

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
@@ -6,14 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
-	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 func TestAccMigrationClusterRSGlobalCluster_basic(t *testing.T) {
 	var (
-		globalConfig admin.GeoSharding
-		clusterInfo  = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
-		config       = configBasic(&clusterInfo, false, false)
+		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
+		config      = configBasic(&clusterInfo, false, false)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,7 +22,7 @@ func TestAccMigrationClusterRSGlobalCluster_basic(t *testing.T) {
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
@@ -1,11 +1,8 @@
 package globalclusterconfig_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
@@ -13,14 +10,10 @@ import (
 )
 
 func TestAccMigrationClusterRSGlobalCluster_basic(t *testing.T) {
-	acc.SkipTestForCI(t) // needs to be fixed: "cloud_backup": conflicts with backup_enabled
 	var (
 		globalConfig admin.GeoSharding
-		resourceName = "mongodbatlas_global_cluster_config.config"
-		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
-		config       = configBasic(orgID, projectName, name, "false", "false", "false")
+		clusterInfo  = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
+		config       = configBasic(&clusterInfo, false, false)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,12 +25,12 @@ func TestAccMigrationClusterRSGlobalCluster_basic(t *testing.T) {
 				Config:            config,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName, &globalConfig),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
 				),

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	"go.mongodb.org/atlas-sdk/v20231115006/admin"
 )
 
 const (
@@ -21,8 +20,7 @@ const (
 
 func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 	var (
-		globalConfig admin.GeoSharding
-		clusterInfo  = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
+		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -33,7 +31,7 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 			{
 				Config: configBasic(&clusterInfo, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
@@ -47,7 +45,7 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 			{
 				Config: configBasic(&clusterInfo, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "true"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
@@ -56,7 +54,7 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 			{
 				Config: configBasic(&clusterInfo, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "true"),
@@ -69,10 +67,9 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 func TestAccClusterRSGlobalCluster_WithAWSCluster(t *testing.T) {
 	acc.SkipTestForCI(t) // needs to be fixed: 404 (request "GROUP_NOT_FOUND") No group with ID
 	var (
-		globalConfig admin.GeoSharding
-		name         = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acctest.RandomWithPrefix("test-acc")
+		name        = fmt.Sprintf("test-acc-global-%s", acctest.RandString(10))
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acctest.RandomWithPrefix("test-acc")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -83,14 +80,13 @@ func TestAccClusterRSGlobalCluster_WithAWSCluster(t *testing.T) {
 			{
 				Config: configWithAWSCluster(orgID, projectName, name, "true"),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					checkManagedNamepacesLenght(&globalConfig, 1),
 				),
 			},
 		},
@@ -127,7 +123,6 @@ func TestAccClusterRSGlobalCluster_importBasic(t *testing.T) {
 func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	acc.SkipTestForCI(t) // needs to be fixed: 404 (request "GROUP_NOT_FOUND") No group with ID, next steps should use the first project
 	var (
-		globalConfig admin.GeoSharding
 		resourceName = "mongodbatlas_global_cluster_config.test"
 		name         = acctest.RandomWithPrefix("test-acc-global")
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -173,8 +168,8 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 			{
 				Config: configWithDBConfig(orgID, projectName, name, "false", customZone),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.US"),
@@ -182,14 +177,13 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.DE"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					checkManagedNamepacesLenght(&globalConfig, 5),
 				),
 			},
 			{
 				Config: configWithDBConfig(orgID, projectName, name, "false", customZoneUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &globalConfig),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.US"),
@@ -198,7 +192,6 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.JP"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					checkManagedNamepacesLenght(&globalConfig, 5),
 				),
 			},
 			{
@@ -212,7 +205,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	})
 }
 
-func checkExists(resourceName string, globalConfig *admin.GeoSharding) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -222,10 +215,9 @@ func checkExists(resourceName string, globalConfig *admin.GeoSharding) resource.
 			return fmt.Errorf("no ID is set")
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		globalConfigResp, _, err := acc.ConnV2().GlobalClustersApi.GetManagedNamespace(context.Background(), ids["project_id"], ids["cluster_name"]).Execute()
+		config, _, err := acc.ConnV2().GlobalClustersApi.GetManagedNamespace(context.Background(), ids["project_id"], ids["cluster_name"]).Execute()
 		if err == nil {
-			globalConfig = globalConfigResp
-			if len(globalConfig.GetCustomZoneMapping()) > 0 || len(globalConfig.GetManagedNamespaces()) > 0 {
+			if len(config.GetCustomZoneMapping()) > 0 || len(config.GetManagedNamespaces()) > 0 {
 				return nil
 			}
 		}
@@ -241,15 +233,6 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		return fmt.Sprintf("%s-%s", ids["project_id"], ids["cluster_name"]), nil
-	}
-}
-
-func checkManagedNamepacesLenght(globalCluster *admin.GeoSharding, managedNamespacesCount int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if len(globalCluster.GetManagedNamespaces()) != managedNamespacesCount {
-			return fmt.Errorf("bad managed namespaces: %v", globalCluster.GetManagedNamespaces())
-		}
-		return nil
 	}
 }
 

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -28,12 +28,12 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, "false", "false", "false"),
+				Config: configBasic(orgID, projectName, name, "false", "false", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
@@ -42,25 +42,25 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+					checkManagedNamepacesLenght(&globalConfig, 1),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, "false", "true", "false"),
+				Config: configBasic(orgID, projectName, name, "false", "true", "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "true"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+					checkManagedNamepacesLenght(&globalConfig, 1),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, "false", "false", "true"),
+				Config: configBasic(orgID, projectName, name, "false", "false", "true"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "true"),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+					checkManagedNamepacesLenght(&globalConfig, 1),
 				),
 			},
 		},
@@ -80,19 +80,19 @@ func TestAccClusterRSGlobalCluster_WithAWSCluster(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(orgID, projectName, name, "true"),
+				Config: configWithAWSCluster(orgID, projectName, name, "true"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.CA"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 1),
+					checkManagedNamepacesLenght(&globalConfig, 1),
 				),
 			},
 		},
@@ -111,14 +111,14 @@ func TestAccClusterRSGlobalCluster_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, "false", "false", "false"),
+				Config: configBasic(orgID, projectName, name, "false", "false", "false"),
 			},
 			{
 				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName),
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"custom_zone_mappings"},
@@ -171,12 +171,12 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasGlobalClusterDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasGlobalClusterWithDBConfig(orgID, projectName, name, "false", customZone),
+				Config: configWithDBConfig(orgID, projectName, name, "false", customZone),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
@@ -185,13 +185,13 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.DE"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 5),
+					checkManagedNamepacesLenght(&globalConfig, 5),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasGlobalClusterWithDBConfig(orgID, projectName, name, "false", customZoneUpdated),
+				Config: configWithDBConfig(orgID, projectName, name, "false", customZoneUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasGlobalClusterExists(resourceName, &globalConfig),
+					checkExists(resourceName, &globalConfig),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_namespaces.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
@@ -201,12 +201,12 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.JP"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", name),
-					testAccCheckMongoDBAtlasGlobalClusterAttributes(&globalConfig, 5),
+					checkManagedNamepacesLenght(&globalConfig, 5),
 				),
 			},
 			{
 				ResourceName:            resourceName,
-				ImportStateIdFunc:       testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName),
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"custom_zone_mappings"},
@@ -215,7 +215,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	})
 }
 
-func testAccCheckMongoDBAtlasGlobalClusterExists(resourceName string, globalConfig *matlas.GlobalCluster) resource.TestCheckFunc {
+func checkExists(resourceName string, globalConfig *matlas.GlobalCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -236,7 +236,7 @@ func testAccCheckMongoDBAtlasGlobalClusterExists(resourceName string, globalConf
 	}
 }
 
-func testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -247,7 +247,7 @@ func testAccCheckMongoDBAtlasGlobalClusterImportStateIDFunc(resourceName string)
 	}
 }
 
-func testAccCheckMongoDBAtlasGlobalClusterAttributes(globalCluster *matlas.GlobalCluster, managedNamespacesCount int) resource.TestCheckFunc {
+func checkManagedNamepacesLenght(globalCluster *matlas.GlobalCluster, managedNamespacesCount int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(globalCluster.ManagedNamespaces) != managedNamespacesCount {
 			return fmt.Errorf("bad managed namespaces: %v", globalCluster.ManagedNamespaces)
@@ -256,13 +256,12 @@ func testAccCheckMongoDBAtlasGlobalClusterAttributes(globalCluster *matlas.Globa
 	}
 }
 
-func testAccCheckMongoDBAtlasGlobalClusterDestroy(s *terraform.State) error {
+func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_global_cluster_config" {
 			continue
 		}
 
-		// Try to find the cluster
 		globalConfig, _, err := acc.Conn().GlobalClusters.Get(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
 		if err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf("No cluster named %s exists in group %s", rs.Primary.Attributes["cluster_name"], rs.Primary.Attributes["project_id"])) {
@@ -278,7 +277,7 @@ func testAccCheckMongoDBAtlasGlobalClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, backupEnabled, isCustomShard, isShardKeyUnique string) string {
+func configBasic(orgID, projectName, name, backupEnabled, isCustomShard, isShardKeyUnique string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "project" {
 			org_id = %[1]q
@@ -340,7 +339,7 @@ func testAccMongoDBAtlasGlobalClusterConfig(orgID, projectName, name, backupEnab
 	`, orgID, projectName, name, backupEnabled, isCustomShard, isShardKeyUnique)
 }
 
-func testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(orgID, projectName, name, backupEnabled string) string {
+func configWithAWSCluster(orgID, projectName, name, backupEnabled string) string {
 	return fmt.Sprintf(`
 
 		resource "mongodbatlas_project" "project" {
@@ -389,7 +388,7 @@ func testAccMongoDBAtlasGlobalClusterWithAWSClusterConfig(orgID, projectName, na
 	`, orgID, projectName, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasGlobalClusterWithDBConfig(orgID, projectName, name, backupEnabled, zones string) string {
+func configWithDBConfig(orgID, projectName, name, backupEnabled, zones string) string {
 	return fmt.Sprintf(`
 
 resource "mongodbatlas_project" "project" {

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -233,7 +233,7 @@ func checkDestroy(s *terraform.State) error {
 
 		globalConfig, _, err := acc.ConnV2().GlobalClustersApi.GetManagedNamespace(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"]).Execute()
 		if err != nil {
-			if strings.Contains(err.Error(), fmt.Sprintf("No cluster named %s exists in group %s", rs.Primary.Attributes["cluster_name"], rs.Primary.Attributes["project_id"])) {
+			if strings.Contains(err.Error(), "GROUP_NOT_FOUND") {
 				return nil
 			}
 			return err

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-const (
-	resourceName   = "mongodbatlas_global_cluster_config.config"
-	dataSourceName = "data.mongodbatlas_global_cluster_config.config"
-)
-
 func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 	var (
 		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
@@ -115,39 +110,8 @@ func TestAccClusterRSGlobalCluster_importBasic(t *testing.T) {
 
 func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	var (
-		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true})
+		clusterInfo = acc.GetClusterInfo(&acc.ClusterRequest{Geosharded: true, ExtraConfig: zonesStr})
 	)
-
-	customZone := `
-  custom_zone_mappings {
-    location = "US"
-    zone     = "US"
-  }
-  custom_zone_mappings {
-    location = "IE"
-    zone     = "EU"
-  }
-  custom_zone_mappings {
-    location = "DE"
-    zone     = "DE"
-  }`
-	customZoneUpdated := `
-  custom_zone_mappings {
-    location = "US"
-    zone     = "US"
-  }
-  custom_zone_mappings {
-    location = "IE"
-    zone     = "EU"
-  }
-  custom_zone_mappings {
-    location = "DE"
-    zone     = "DE"
-  }
-  custom_zone_mappings {
-    location = "JP"
-    zone     = "JP"
-  }`
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -308,3 +272,84 @@ func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
 		}
 	`, info.ClusterNameStr, info.ProjectIDStr, zones)
 }
+
+const (
+	resourceName   = "mongodbatlas_global_cluster_config.config"
+	dataSourceName = "data.mongodbatlas_global_cluster_config.config"
+
+	customZone = `
+		custom_zone_mappings {
+			location = "US"
+			zone     = "US"
+		}
+		custom_zone_mappings {
+			location = "IE"
+			zone     = "EU"
+		}
+		custom_zone_mappings {
+			location = "DE"
+			zone     = "DE"
+		}
+	`
+	customZoneUpdated = `
+		custom_zone_mappings {
+			location = "US"
+			zone     = "US"
+		}
+		custom_zone_mappings {
+			location = "IE"
+			zone     = "EU"
+		}
+		custom_zone_mappings {
+			location = "DE"
+			zone     = "DE"
+		}
+		custom_zone_mappings {
+			location = "JP"
+			zone     = "JP"
+		}
+	`
+
+	zonesStr = `
+		replication_specs {
+			zone_name  = "US"
+			num_shards = 1
+			regions_config {
+				region_name     = "US_EAST_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+			}
+		}
+		replication_specs {
+			zone_name  = "EU"
+			num_shards = 1
+			regions_config {
+				region_name     = "EU_WEST_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+			}
+		}
+		replication_specs {
+			zone_name  = "DE"
+			num_shards = 1
+			regions_config {
+				region_name     = "EU_NORTH_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+			}
+		}
+		replication_specs {
+			zone_name  = "JP"
+			num_shards = 1
+			regions_config {
+				region_name     = "AP_NORTHEAST_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+			}
+		}
+	`
+)

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	resourceName = "mongodbatlas_global_cluster_config.config"
+	resourceName   = "mongodbatlas_global_cluster_config.config"
+	dataSourceName = "data.mongodbatlas_global_cluster_config.config"
 )
 
 func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
@@ -264,6 +265,11 @@ func configBasic(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool) st
 				zone     = "Zone 1"
 			}
 		}
+
+		data "mongodbatlas_global_cluster_config" "config" {
+			cluster_name     = %[1]s
+			project_id       = %[2]s
+		}	
 	`, info.ClusterNameStr, info.ProjectIDStr, isCustomShard, isShardKeyUnique)
 }
 

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -3,7 +3,6 @@ package searchindex_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -15,8 +14,7 @@ import (
 
 func TestAccSearchIndexRS_basic(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -55,8 +53,7 @@ func TestAccSearchIndexRS_basic(t *testing.T) {
 
 func TestAccSearchIndexRS_withSearchType(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -95,8 +92,7 @@ func TestAccSearchIndexRS_withSearchType(t *testing.T) {
 
 func TestAccSearchIndexRS_withMapping(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -140,8 +136,7 @@ func TestAccSearchIndexRS_withMapping(t *testing.T) {
 
 func TestAccSearchIndexRS_withSynonyms(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -189,8 +184,7 @@ func TestAccSearchIndexRS_withSynonyms(t *testing.T) {
 
 func TestAccSearchIndexRS_updatedToEmptySynonyms(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -222,8 +216,7 @@ func TestAccSearchIndexRS_updatedToEmptySynonyms(t *testing.T) {
 
 func TestAccSearchIndexRS_updatedToEmptyAnalyzers(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -252,8 +245,7 @@ func TestAccSearchIndexRS_updatedToEmptyAnalyzers(t *testing.T) {
 
 func TestAccSearchIndexRS_updatedToEmptyMappingsFields(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -282,8 +274,7 @@ func TestAccSearchIndexRS_updatedToEmptyMappingsFields(t *testing.T) {
 
 func TestAccSearchIndexRS_importBasic(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)
@@ -314,8 +305,7 @@ func TestAccSearchIndexRS_importBasic(t *testing.T) {
 
 func TestAccSearchIndexRS_withVector(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		indexName    = acctest.RandomWithPrefix("test-acc-index")
 		databaseName = acctest.RandomWithPrefix("test-acc-db")
 	)

--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -52,8 +52,7 @@ func TestAccStreamDSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccStreamDSStreamConnection_cluster(t *testing.T) {
 	var (
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo    = acc.GetClusterInfo(orgID, false)
+		clusterInfo    = acc.GetClusterInfo(nil)
 		instanceName   = acctest.RandomWithPrefix("test-acc-name")
 		dataSourceName = "data.mongodbatlas_stream_connection.test"
 	)

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -78,8 +78,7 @@ func TestAccMigrationStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccMigrationStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		instanceName = acctest.RandomWithPrefix("test-acc-name")
 		resourceName = "mongodbatlas_stream_connection.test"
 	)

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -76,8 +76,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		clusterInfo  = acc.GetClusterInfo(orgID, false)
+		clusterInfo  = acc.GetClusterInfo(nil)
 		instanceName = acctest.RandomWithPrefix("test-acc-name")
 		resourceName = "mongodbatlas_stream_connection.test"
 	)

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -7,6 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
+type ClusterRequest struct {
+	OrgID       string
+	CloudBackup bool
+}
+
 type ClusterInfo struct {
 	ProjectIDStr        string
 	ClusterName         string
@@ -16,7 +21,13 @@ type ClusterInfo struct {
 
 // GetClusterInfo is used to obtain a project and cluster configuration resource.
 // When `MONGODB_ATLAS_CLUSTER_NAME` and `MONGODB_ATLAS_PROJECT_ID` are defined, creation of resources is avoided. This is useful for local execution but not intended for CI executions.
-func GetClusterInfo(orgID string, cloudBackup bool) ClusterInfo {
+func GetClusterInfo(req *ClusterRequest) ClusterInfo {
+	if req == nil {
+		req = new(ClusterRequest)
+	}
+	if req.OrgID == "" {
+		req.OrgID = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	}
 	clusterName := os.Getenv("MONGODB_ATLAS_CLUSTER_NAME")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	if clusterName != "" && projectID != "" {
@@ -55,7 +66,7 @@ func GetClusterInfo(orgID string, cloudBackup bool) ClusterInfo {
 				}
 			}
 		}
-	`, orgID, projectName, clusterName, cloudBackup)
+	`, req.OrgID, projectName, clusterName, req.CloudBackup)
 	return ClusterInfo{
 		ProjectIDStr:        "mongodbatlas_project.test.id",
 		ClusterName:         clusterName,

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -9,6 +9,7 @@ import (
 
 type ClusterRequest struct {
 	OrgID       string
+	ExtraConfig string
 	CloudBackup bool
 	Geosharded  bool
 }
@@ -71,8 +72,10 @@ func GetClusterInfo(req *ClusterRequest) ClusterInfo {
 					read_only_nodes = 0
 				}
 			}
+
+			%[6]s
 		}
-	`, req.OrgID, projectName, clusterName, req.CloudBackup, clusterTypeStr)
+	`, req.OrgID, projectName, clusterName, req.CloudBackup, clusterTypeStr, req.ExtraConfig)
 	return ClusterInfo{
 		ProjectIDStr:        "mongodbatlas_project.test.id",
 		ClusterName:         clusterName,


### PR DESCRIPTION
## Description

Upgrades `global_cluster_config` resource to auto-generated SDK

- Add migration tests
- All tests were skipped and now run in CI
- Add ability to use existing cluster and project in local tests

Link to any related issue(s): CLOUDP-226083

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
