### PR TITLE
chore: Fixes `search_deployment` template to fix doc structure

### DIFF
--- a/templates/data-source.md.tmpl
+++ b/templates/data-source.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: {{ if .Name }}"MongoDB Atlas: {{.Name}}"{{ end }}
-subcategory: {{ if .Type }}"docs_{{ .Name }}_{{.Type | lower}}"{{ end }}
+sidebar_current: {{ if .Type }}"docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ range $element := $arr }}{{ $element | lower}}{{ end }}{{ $name := slice (split .Name "_") 1 }}{{ range $element := $name }}-{{ $element | lower}}{{end}}"{{ end }}
 description: |-
    {{ if ne .Name "" }}"Provides a {{ .Name }} data source."{{ end }}
 ---

--- a/templates/data-sources/search_deployment.md.tmpl
+++ b/templates/data-sources/search_deployment.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: {{.Name}}"
-subcategory: "docs_{{ .Name }}_{{.Type | lower}}"
+sidebar_current: "docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ index $arr 0 | lower }}{{ index $arr 1 | lower }}-{{ $name := split .Name "_" }}{{ index $name 1 }}-{{ index $name 2 }}"
 description: |-
     "Provides a Search Deployment data source."
 ---

--- a/templates/data-sources/search_deployment.md.tmpl
+++ b/templates/data-sources/search_deployment.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: {{.Name}}"
-sidebar_current: "docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ index $arr 0 | lower }}{{ index $arr 1 | lower }}-{{ $name := split .Name "_" }}{{ index $name 1 }}-{{ index $name 2 }}"
+sidebar_current: "docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ range $element := $arr }}{{ $element | lower}}{{ end }}{{ $name := slice (split .Name "_") 1 }}{{ range $element := $name }}-{{ $element | lower}}{{end}}"
 description: |-
     "Provides a Search Deployment data source."
 ---

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: {{ if .Name }}"MongoDB Atlas: {{.Name}}{{ end }}"
-subcategory: {{ if .Type }}"docs_{{ .Name }}_{{.Type | lower}}"{{ end }}
+sidebar_current: {{ if .Type }}"docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ range $element := $arr }}{{ $element | lower}}{{ end }}{{ $name := slice (split .Name "_") 1 }}{{ range $element := $name }}-{{ $element | lower}}{{end}}"{{ end }}
 description: |-
     {{ if .Name }}"Provides a {{ .Name }} resource."{{ end }}
 ---

--- a/templates/resources/search_deployment.md.tmpl
+++ b/templates/resources/search_deployment.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: {{.Name}}"
-subcategory: "docs_{{ .Name }}_{{.Type | lower}}"
+sidebar_current: "docs-{{ .ProviderShortName }}-{{ .Type | lower }}-{{ $name := split .Name "_" }}{{ index $name 1 }}-{{ index $name 2 }}"
 description: |-
     "Provides a Search Deployment resource."
 ---

--- a/templates/resources/search_deployment.md.tmpl
+++ b/templates/resources/search_deployment.md.tmpl
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: {{.Name}}"
-sidebar_current: "docs-{{ .ProviderShortName }}-{{ .Type | lower }}-{{ $name := split .Name "_" }}{{ index $name 1 }}-{{ index $name 2 }}"
+sidebar_current: "docs-{{ .ProviderShortName }}-{{ $arr := split .Type " "}}{{ range $element := $arr }}{{ $element | lower}}{{ end }}{{ $name := slice (split .Name "_") 1 }}{{ range $element := $name }}-{{ $element | lower}}{{end}}"
 description: |-
     "Provides a Search Deployment resource."
 ---

--- a/website/docs/d/search_deployment.html.markdown
+++ b/website/docs/d/search_deployment.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: mongodbatlas_search_deployment"
-subcategory: "docs_mongodbatlas_search_deployment_data source"
+sidebar_current: "docs-mongodbatlas-datasource-search-deployment"
 description: |-
     "Provides a Search Deployment data source."
 ---

--- a/website/docs/r/search_deployment.html.markdown
+++ b/website/docs/r/search_deployment.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "mongodbatlas"
 page_title: "MongoDB Atlas: mongodbatlas_search_deployment"
-subcategory: "docs_mongodbatlas_search_deployment_resource"
+sidebar_current: "docs-mongodbatlas-resource-search-deployment"
 description: |-
     "Provides a Search Deployment resource."
 ---


### PR DESCRIPTION
## Description

[Terraform registry docs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs) for mongodbatlas are displayed with a wrong structure since v1.15.0 was released. The issue can be seen in the following image:

<img width="367" alt="Screenshot 2024-02-14 at 12 16 42" src="https://github.com/mongodb/terraform-provider-mongodbatlas/assets/55513886/2f314ae5-4504-4a57-a923-24337163f2a8">


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
