### PR TITLE
refactor: Removes conversion.IntPtr() and changes usages to Pointer[int]

### DIFF
--- a/internal/common/conversion/pointer.go
+++ b/internal/common/conversion/pointer.go
@@ -4,13 +4,6 @@ func Pointer[T any](x T) *T {
 	return &x
 }
 
-func IntPtr(v int) *int {
-	if v != 0 {
-		return &v
-	}
-	return nil
-}
-
 func StringPtr(v string) *string {
 	if v != "" {
 		return &v

--- a/internal/service/accesslistapikey/data_source_accesslist_api_keys.go
+++ b/internal/service/accesslistapikey/data_source_accesslist_api_keys.go
@@ -74,8 +74,8 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 	orgID := d.Get("org_id").(string)
 	apiKeyID := d.Get("api_key_id").(string)
 	params := &admin.ListApiKeyAccessListsEntriesApiParams{
-		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
-		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+		PageNum:      conversion.Pointer[int](d.Get("page_num").(int)),
+		ItemsPerPage: conversion.Pointer[int](d.Get("items_per_page").(int)),
 		OrgId:        orgID,
 		ApiUserId:    apiKeyID,
 	}

--- a/internal/service/apikey/data_source_api_keys.go
+++ b/internal/service/apikey/data_source_api_keys.go
@@ -63,8 +63,8 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	orgID := d.Get("org_id").(string)
 	params := &admin.ListApiKeysApiParams{
-		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
-		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+		PageNum:      conversion.Pointer[int](d.Get("page_num").(int)),
+		ItemsPerPage: conversion.Pointer[int](d.Get("items_per_page").(int)),
 		OrgId:        orgID,
 	}
 

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -617,7 +617,7 @@ func newReadPreference(storeFromConfMap map[string]any) *admin.DataLakeAtlasStor
 	readPreferenceFromConfMap := readPreferenceFromConf[0].(map[string]any)
 	return &admin.DataLakeAtlasStoreReadPreference{
 		Mode:                conversion.StringPtr(readPreferenceFromConfMap["mode"].(string)),
-		MaxStalenessSeconds: conversion.IntPtr(readPreferenceFromConfMap["max_staleness_seconds"].(int)),
+		MaxStalenessSeconds: conversion.Pointer[int](readPreferenceFromConfMap["max_staleness_seconds"].(int)),
 		TagSets:             newTagSets(readPreferenceFromConfMap),
 	}
 }
@@ -654,7 +654,7 @@ func newDataFederationDatabase(d *schema.ResourceData) *[]admin.DataLakeDatabase
 		storageDBFromConfMap := storageDBFromConf.(map[string]any)
 		dbs[i] = admin.DataLakeDatabaseInstance{
 			Name:                   conversion.StringPtr(storageDBFromConfMap["name"].(string)),
-			MaxWildcardCollections: conversion.IntPtr(storageDBFromConfMap["max_wildcard_collections"].(int)),
+			MaxWildcardCollections: conversion.Pointer[int](storageDBFromConfMap["max_wildcard_collections"].(int)),
 			Collections:            newDataFederationCollections(storageDBFromConfMap),
 		}
 	}

--- a/internal/service/project/data_source_projects.go
+++ b/internal/service/project/data_source_projects.go
@@ -177,8 +177,8 @@ func (d *ProjectsDS) Read(ctx context.Context, req datasource.ReadRequest, resp 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &stateModel)...)
 
 	projectParams := &admin.ListProjectsApiParams{
-		PageNum:      conversion.IntPtr(int(stateModel.PageNum.ValueInt64())),
-		ItemsPerPage: conversion.IntPtr(int(stateModel.ItemsPerPage.ValueInt64())),
+		PageNum:      conversion.Pointer[int](int(stateModel.PageNum.ValueInt64())),
+		ItemsPerPage: conversion.Pointer[int](int(stateModel.ItemsPerPage.ValueInt64())),
 	}
 	projectsRes, _, err := connV2.ProjectsApi.ListProjectsWithParams(ctx, projectParams).Execute()
 	if err != nil {

--- a/internal/service/project/model_project_test.go
+++ b/internal/service/project/model_project_test.go
@@ -146,14 +146,14 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 		{
 			name: "TeamRole",
 			paginatedTeamRole: &admin.PaginatedTeamRole{
-				TotalCount: conversion.IntPtr(0),
+				TotalCount: conversion.Pointer[int](0),
 			}, // not setting explicitly expected result because we expect it to be nil
 		},
 		{
 			name: "Complete TeamRole",
 			paginatedTeamRole: &admin.PaginatedTeamRole{
 				Results:    &teamRolesSDK,
-				TotalCount: conversion.IntPtr(1),
+				TotalCount: conversion.Pointer[int](1),
 			},
 			expectedTFModel: teamsDSTF,
 		},
@@ -201,7 +201,7 @@ func TestProjectDataSourceSDKToDataSourceTFModel(t *testing.T) {
 			projectProps: project.AdditionalProperties{
 				Teams: &admin.PaginatedTeamRole{
 					Results:    &teamRolesSDK,
-					TotalCount: conversion.IntPtr(1),
+					TotalCount: conversion.Pointer[int](1),
 				},
 				Settings:    &projectSettingsSDK,
 				IPAddresses: &IPAddressesSDK,
@@ -252,7 +252,7 @@ func TestProjectDataSourceSDKToResourceTFModel(t *testing.T) {
 			projectProps: project.AdditionalProperties{
 				Teams: &admin.PaginatedTeamRole{
 					Results:    &teamRolesSDK,
-					TotalCount: conversion.IntPtr(1),
+					TotalCount: conversion.Pointer[int](1),
 				},
 				Settings:    &projectSettingsSDK,
 				IPAddresses: &IPAddressesSDK,

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -446,7 +446,7 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 			name: "Successful API call",
 			mockResponses: AdvancedClusterDescriptionResponse{
 				AdvancedClusterDescription: &admin.PaginatedAdvancedClusterDescription{
-					TotalCount: conversion.IntPtr(2),
+					TotalCount: conversion.Pointer[int](2),
 					Results: &[]admin.AdvancedClusterDescription{
 						{StateName: conversion.StringPtr("IDLE")},
 						{StateName: conversion.StringPtr("DELETING")},

--- a/internal/service/searchdeployment/state_transition_search_deployment_test.go
+++ b/internal/service/searchdeployment/state_transition_search_deployment_test.go
@@ -19,9 +19,9 @@ var (
 	updating = "UPDATING"
 	idle     = "IDLE"
 	unknown  = ""
-	sc400    = conversion.IntPtr(400)
-	sc500    = conversion.IntPtr(500)
-	sc503    = conversion.IntPtr(503)
+	sc400    = conversion.Pointer[int](400)
+	sc500    = conversion.Pointer[int](500)
+	sc503    = conversion.Pointer[int](503)
 )
 
 type testCase struct {

--- a/internal/service/serverlessinstance/data_source_serverless_instances.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instances.go
@@ -38,7 +38,7 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return diag.Errorf("project_id must be configured")
 	}
 	options := &admin.ListServerlessInstancesApiParams{
-		ItemsPerPage: conversion.IntPtr(500),
+		ItemsPerPage: conversion.Pointer[int](500),
 		IncludeCount: conversion.Pointer(true),
 		GroupId:      projectID.(string),
 	}
@@ -59,7 +59,7 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 func getServerlessList(ctx context.Context, connV2 *admin.APIClient, options *admin.ListServerlessInstancesApiParams, obtainedItemsCount int) ([]admin.ServerlessInstanceDescription, error) {
 	if options.PageNum == nil {
-		options.PageNum = conversion.IntPtr(1)
+		options.PageNum = conversion.Pointer[int](1)
 	} else {
 		*options.PageNum++
 	}


### PR DESCRIPTION
## Description

Removes conversion.IntPtr() and changes usages to Pointer[int].
`IntPtr()` method was misleading and might lead to unexpected behaviour because if value passed to the method is 0 the method returned nil instead of a pointer to 0 value

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
