### PR TITLE
feat: Permits database watch against creation

### DIFF
--- a/internal/service/eventtrigger/resource_event_trigger.go
+++ b/internal/service/eventtrigger/resource_event_trigger.go
@@ -241,7 +241,7 @@ func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.Reso
 
 	if typeTrigger == "DATABASE" {
 		if !okCots || !okD || !okSI {
-			return diag.FromErr(fmt.Errorf("`config_operation_types`, `config_database`,`config_collection`,`config_service_id` must be provided if type is DATABASE"))
+			return diag.FromErr(fmt.Errorf("`config_operation_types`, `config_database`,`config_service_id` must be provided if type is DATABASE"))
 		}
 	}
 	if typeTrigger == "AUTHENTICATION" {

--- a/internal/service/eventtrigger/resource_event_trigger.go
+++ b/internal/service/eventtrigger/resource_event_trigger.go
@@ -240,7 +240,7 @@ func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.Reso
 	sche, oksch := d.GetOk("config_schedule")
 
 	if typeTrigger == "DATABASE" {
-		if !okCots || !okD || !okC || !okSI {
+		if !okCots || !okD || !okSI {
 			return diag.FromErr(fmt.Errorf("`config_operation_types`, `config_database`,`config_collection`,`config_service_id` must be provided if type is DATABASE"))
 		}
 	}


### PR DESCRIPTION
## Description

In order to accept database watch against creation, config_collection should be empty string (config_collection = "").
Removing "d.GetOk("config_collection")" check for typeTrigger == "DATABASE" permit to create database watch mode.

Link to any related issue(s):
- https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1956

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
