### PR TITLE
fix: Uses `google_cloud_kms_config` correctly in `mongodbatlas_encryption_at_rest` creation

### DIFF
--- a/internal/service/encryptionatrest/resource_encryption_at_rest.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest.go
@@ -221,7 +221,7 @@ func (r *encryptionAtRestRS) Create(ctx context.Context, req resource.CreateRequ
 	if encryptionAtRestPlan.AzureKeyVaultConfig != nil {
 		encryptionAtRestReq.AzureKeyVault = NewAtlasAzureKeyVault(encryptionAtRestPlan.AzureKeyVaultConfig)
 	}
-	if encryptionAtRestPlan.AzureKeyVaultConfig != nil {
+	if encryptionAtRestPlan.GoogleCloudKmsConfig != nil {
 		encryptionAtRestReq.GoogleCloudKms = NewAtlasGcpKms(encryptionAtRestPlan.GoogleCloudKmsConfig)
 	}
 


### PR DESCRIPTION
## Description

Fix `mongodbatlas_encryption_at_rest terraform` resource, when `google_cloud_kms_config` block is defined.
Because of the wrong check-in if statement the request body to MongoDB Atlas was empty if there was no `azure_key_vault_config` block, which resulted in a `MISSING_ENCRYPTION_AT_REST_PROVIDER` error.

## Type of change:

- [ x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
