### PR TITLE
refactor: Remove redundant parameter in checkExists for trigger tests

### DIFF
--- a/internal/service/eventtrigger/data_source_event_trigger_test.go
+++ b/internal/service/eventtrigger/data_source_event_trigger_test.go
@@ -18,7 +18,6 @@ func TestAccEventTriggerDS_basic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -43,7 +42,7 @@ func TestAccEventTriggerDS_basic(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasDataSourceEventTriggerConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 				),
 			},
 		},

--- a/internal/service/eventtrigger/data_source_event_triggers_test.go
+++ b/internal/service/eventtrigger/data_source_event_triggers_test.go
@@ -17,7 +17,6 @@ func TestAccEventTriggerDSPlural_basic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -44,7 +43,7 @@ func TestAccEventTriggerDSPlural_basic(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 				),
 			},
 		},

--- a/internal/service/eventtrigger/resource_event_trigger_test.go
+++ b/internal/service/eventtrigger/resource_event_trigger_test.go
@@ -20,7 +20,6 @@ func TestAccEventTrigger_basic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -56,14 +55,14 @@ func TestAccEventTrigger_basic(t *testing.T) {
 			{
 				Config: configDatabaseTrigger(projectID, appID, `"INSERT", "UPDATE"`, &event, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configDatabaseTrigger(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, &eventUpdated, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -83,7 +82,6 @@ func TestAccEventTrigger_databaseNoCollection(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -107,7 +105,7 @@ func TestAccEventTrigger_databaseNoCollection(t *testing.T) {
 			{
 				Config: configDatabaseNoCollectionTrigger(projectID, appID, `"INSERT", "UPDATE"`, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "config_database", event.Config.Database),
 					resource.TestCheckResourceAttr(resourceName, "config_collection", ""),
@@ -131,7 +129,6 @@ func TestAccEventTrigger_databaseEventProccesor(t *testing.T) {
 		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
 		eventBridgeAwsRegion    = conversion.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -168,14 +165,14 @@ func TestAccEventTrigger_databaseEventProccesor(t *testing.T) {
 			{
 				Config: configDatabaseEPTrigger(projectID, appID, `"INSERT", "UPDATE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configDatabaseEPTrigger(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -195,7 +192,6 @@ func TestAccEventTrigger_authBasic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -227,14 +223,14 @@ func TestAccEventTrigger_authBasic(t *testing.T) {
 			{
 				Config: configAuthenticationTrigger(projectID, appID, `"anon-user", "local-userpass"`, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configAuthenticationTrigger(projectID, appID, `"anon-user", "local-userpass", "api-key"`, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -256,7 +252,6 @@ func TestAccEventTrigger_authEventProcessor(t *testing.T) {
 		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
 		eventBridgeAwsRegion    = conversion.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -288,14 +283,14 @@ func TestAccEventTrigger_authEventProcessor(t *testing.T) {
 			{
 				Config: configAuthenticationEPTrigger(projectID, appID, `"anon-user", "local-userpass"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configAuthenticationEPTrigger(projectID, appID, `"anon-user", "local-userpass", "api-key"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -315,7 +310,6 @@ func TestAccEventTrigger_scheduleBasic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -344,14 +338,14 @@ func TestAccEventTrigger_scheduleBasic(t *testing.T) {
 			{
 				Config: configScheduleTrigger(projectID, appID, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleTrigger(projectID, appID, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -373,7 +367,6 @@ func TestAccEventTrigger_scheduleEventProcessor(t *testing.T) {
 		eventBridgeAwsAccountID = os.Getenv("AWS_EVENTBRIDGE_ACCOUNT_ID")
 		eventBridgeAwsRegion    = conversion.MongoDBRegionToAWSRegion(os.Getenv("AWS_REGION"))
 		appID                   = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp               = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -402,14 +395,14 @@ func TestAccEventTrigger_scheduleEventProcessor(t *testing.T) {
 			{
 				Config: configScheduleEPTrigger(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleEPTrigger(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -429,7 +422,6 @@ func TestAccEventTrigger_functionBasic(t *testing.T) {
 		resourceName = "mongodbatlas_event_trigger.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		appID        = os.Getenv("MONGODB_REALM_APP_ID")
-		eventResp    = realm.EventTrigger{}
 	)
 	event := realm.EventTriggerRequest{
 		Name:       acc.RandomName(),
@@ -458,14 +450,14 @@ func TestAccEventTrigger_functionBasic(t *testing.T) {
 			{
 				Config: configScheduleTrigger(projectID, appID, &event),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleTrigger(projectID, appID, &eventUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &eventResp),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
@@ -479,7 +471,7 @@ func TestAccEventTrigger_functionBasic(t *testing.T) {
 	})
 }
 
-func checkExists(resourceName string, eventTrigger *realm.EventTrigger) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := context.Background()
 		conn, err := acc.MongoDBClient.GetRealmClient(ctx)
@@ -500,9 +492,8 @@ func checkExists(resourceName string, eventTrigger *realm.EventTrigger) resource
 
 		log.Printf("[DEBUG] trigger_id ID: %s", ids["trigger_id"])
 
-		res, _, err := conn.EventTriggers.Get(ctx, ids["project_id"], ids["app_id"], ids["trigger_id"])
+		_, _, err = conn.EventTriggers.Get(ctx, ids["project_id"], ids["app_id"], ids["trigger_id"])
 		if err == nil {
-			*eventTrigger = *res
 			return nil
 		}
 


### PR DESCRIPTION
## Description

Short clean up as a follow up to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1968

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
