### PR TITLE
feat: Updates mongodbatlas_stream_connection resource & data sources to support dbRoleToExecute attribute

### DIFF
--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -13,6 +13,10 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
   connection_name = "ClusterConnection"
   type            = "Cluster"
   cluster_name    = var.cluster_name
+  db_role_to_execute = {
+		role = "atlasAdmin"
+		type = "BUILT_IN"
+	}
 }
 
 resource "mongodbatlas_stream_connection" "example-kafka-plaintext" {

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -14,9 +14,9 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
   type            = "Cluster"
   cluster_name    = var.cluster_name
   db_role_to_execute = {
-		role = "atlasAdmin"
-		type = "BUILT_IN"
-	}
+    role = "atlasAdmin"
+    type = "BUILT_IN"
+  }
 }
 
 resource "mongodbatlas_stream_connection" "example-kafka-plaintext" {

--- a/internal/service/streamconnection/data_source_stream_connection.go
+++ b/internal/service/streamconnection/data_source_stream_connection.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 

--- a/internal/service/streamconnection/data_source_stream_connection.go
+++ b/internal/service/streamconnection/data_source_stream_connection.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -56,6 +57,17 @@ func DSAttributes(withArguments bool) map[string]schema.Attribute {
 		// cluster type specific
 		"cluster_name": schema.StringAttribute{
 			Computed: true,
+		},
+		"db_role_to_execute": schema.SingleNestedAttribute{
+			Computed: true,
+			Attributes: map[string]schema.Attribute{
+				"role": schema.StringAttribute{
+					Computed: true,
+				},
+				"type": schema.StringAttribute{
+					Computed: true,
+				},
+			},
 		},
 
 		// kafka type specific

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"go.mongodb.org/atlas-sdk/v20231115007/admin"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
 
 func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) (*admin.StreamsConnection, diag.Diagnostics) {

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
-	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas-sdk/v20231115007/admin"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
 )
 
 const (
@@ -21,6 +23,8 @@ const (
 	authUsername     = "user1"
 	securityProtocol = "SSL"
 	bootstrapServers = "localhost:9092,another.host:9092"
+	dbRole           = "customRole"
+	dbRoleType       = "CUSTOM"
 )
 
 var configMap = map[string]string{
@@ -46,19 +50,24 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Name:        admin.PtrString(connectionName),
 				Type:        admin.PtrString("Cluster"),
 				ClusterName: admin.PtrString(clusterName),
+				DbRoleToExecute: &admin.DBRoleToExecute{
+					Role: admin.PtrString(dbRole),
+					Type: admin.PtrString(dbRoleType),
+				},
 			},
 			providedProjID:       dummyProjectID,
 			providedInstanceName: instanceName,
 			providedAuthConfig:   nil,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
-				ProjectID:      types.StringValue(dummyProjectID),
-				InstanceName:   types.StringValue(instanceName),
-				ConnectionName: types.StringValue(connectionName),
-				Type:           types.StringValue("Cluster"),
-				ClusterName:    types.StringValue(clusterName),
-				Authentication: types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
-				Config:         types.MapNull(types.StringType),
-				Security:       types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+				ProjectID:       types.StringValue(dummyProjectID),
+				InstanceName:    types.StringValue(instanceName),
+				ConnectionName:  types.StringValue(connectionName),
+				Type:            types.StringValue("Cluster"),
+				ClusterName:     types.StringValue(clusterName),
+				Authentication:  types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+				Config:          types.MapNull(types.StringType),
+				Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+				DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 			},
 		},
 		{
@@ -89,6 +98,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				BootstrapServers: types.StringValue(bootstrapServers),
 				Config:           tfConfigMap(t, configMap),
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
+				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 			},
 		},
 		{
@@ -101,13 +111,14 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 			providedInstanceName: instanceName,
 			providedAuthConfig:   nil,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
-				ProjectID:      types.StringValue(dummyProjectID),
-				InstanceName:   types.StringValue(instanceName),
-				ConnectionName: types.StringValue(connectionName),
-				Type:           types.StringValue("Kafka"),
-				Authentication: types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
-				Config:         types.MapNull(types.StringType),
-				Security:       types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+				ProjectID:       types.StringValue(dummyProjectID),
+				InstanceName:    types.StringValue(instanceName),
+				ConnectionName:  types.StringValue(connectionName),
+				Type:            types.StringValue("Kafka"),
+				Authentication:  types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+				Config:          types.MapNull(types.StringType),
+				Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 			},
 		},
 		{
@@ -138,6 +149,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				BootstrapServers: types.StringValue(bootstrapServers),
 				Config:           tfConfigMap(t, configMap),
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
+				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 			},
 		},
 	}
@@ -187,6 +199,10 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Name:        admin.PtrString(connectionName),
 						Type:        admin.PtrString("Cluster"),
 						ClusterName: admin.PtrString(clusterName),
+						DbRoleToExecute: &admin.DBRoleToExecute{
+							Role: admin.PtrString(dbRole),
+							Type: admin.PtrString(dbRoleType),
+						},
 					},
 				},
 				TotalCount: admin.PtrInt(2),
@@ -214,17 +230,19 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						BootstrapServers: types.StringValue(bootstrapServers),
 						Config:           tfConfigMap(t, configMap),
 						Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
+						DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 					},
 					{
-						ID:             types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
-						ProjectID:      types.StringValue(dummyProjectID),
-						InstanceName:   types.StringValue(instanceName),
-						ConnectionName: types.StringValue(connectionName),
-						Type:           types.StringValue("Cluster"),
-						ClusterName:    types.StringValue(clusterName),
-						Authentication: types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
-						Config:         types.MapNull(types.StringType),
-						Security:       types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
+						ProjectID:       types.StringValue(dummyProjectID),
+						InstanceName:    types.StringValue(instanceName),
+						ConnectionName:  types.StringValue(connectionName),
+						Type:            types.StringValue("Cluster"),
+						ClusterName:     types.StringValue(clusterName),
+						Authentication:  types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+						Config:          types.MapNull(types.StringType),
+						Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+						DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 					},
 				},
 			},
@@ -275,16 +293,21 @@ func TestStreamInstanceTFToSDKCreateModel(t *testing.T) {
 		{
 			name: "Cluster type complete TF state",
 			tfModel: &streamconnection.TFStreamConnectionModel{
-				ProjectID:      types.StringValue(dummyProjectID),
-				InstanceName:   types.StringValue(instanceName),
-				ConnectionName: types.StringValue(connectionName),
-				Type:           types.StringValue("Cluster"),
-				ClusterName:    types.StringValue(clusterName),
+				ProjectID:       types.StringValue(dummyProjectID),
+				InstanceName:    types.StringValue(instanceName),
+				ConnectionName:  types.StringValue(connectionName),
+				Type:            types.StringValue("Cluster"),
+				ClusterName:     types.StringValue(clusterName),
+				DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 			},
 			expectedSDKReq: &admin.StreamsConnection{
 				Name:        admin.PtrString(connectionName),
 				Type:        admin.PtrString("Cluster"),
 				ClusterName: admin.PtrString(clusterName),
+				DbRoleToExecute: &admin.DBRoleToExecute{
+					Role: admin.PtrString(dbRole),
+					Type: admin.PtrString(dbRoleType),
+				},
 			},
 		},
 		{
@@ -387,4 +410,16 @@ func tfConfigMap(t *testing.T, config map[string]string) types.Map {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
 	}
 	return mapValue
+}
+
+func tfDBRoleToExecuteObject(t *testing.T, role, roleType string) types.Object {
+	t.Helper()
+	auth, diags := types.ObjectValueFrom(context.Background(), streamconnection.DBRoleToExecuteObjectType.AttrTypes, streamconnection.TFDbRoleToExecuteModel{
+		Role: types.StringValue(role),
+		Type: types.StringValue(roleType),
+	})
+	if diags.HasError() {
+		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
+	}
+	return auth
 }

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"go.mongodb.org/atlas-sdk/v20231115007/admin"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
 
 const (

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -5,13 +5,16 @@ import (
 	"errors"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -43,6 +46,7 @@ type TFStreamConnectionModel struct {
 	BootstrapServers types.String `tfsdk:"bootstrap_servers"`
 	Config           types.Map    `tfsdk:"config"`
 	Security         types.Object `tfsdk:"security"`
+	DBRoleToExecute  types.Object `tfsdk:"db_role_to_execute"`
 }
 
 type TFConnectionAuthenticationModel struct {
@@ -65,6 +69,16 @@ type TFConnectionSecurityModel struct {
 var ConnectionSecurityObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"broker_public_certificate": types.StringType,
 	"protocol":                  types.StringType,
+}}
+
+type TFDbRoleToExecuteModel struct {
+	Role types.String `tfsdk:"role"`
+	Type types.String `tfsdk:"type"`
+}
+
+var DBRoleToExecuteObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"role": types.StringType,
+	"type": types.StringType,
 }}
 
 func (r *streamConnectionRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -101,6 +115,20 @@ func (r *streamConnectionRS) Schema(ctx context.Context, req resource.SchemaRequ
 			// cluster type specific
 			"cluster_name": schema.StringAttribute{
 				Optional: true,
+			},
+			"db_role_to_execute": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"role": schema.StringAttribute{
+						Required: true,
+					},
+					"type": schema.StringAttribute{
+						Required: true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("BUILT_IN", "CUSTOM"),
+						},
+					},
+				},
 			},
 
 			// kafka type specific

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -81,7 +82,7 @@ func TestAccMigrationStreamRSStreamConnection_cluster(t *testing.T) {
 		clusterInfo  = acc.GetClusterInfo(nil)
 		instanceName = acc.RandomName()
 	)
-	mig.SkipIfVersionBelow(t, "1.14.0")
+	mig.SkipIfVersionBelow(t, "1.15.2")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acc.PreCheckBetaFlag(t); acc.PreCheckBasic(t) },

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -197,8 +197,8 @@ func clusterStreamConnectionAttributeChecks(resourceName, clusterName string) re
 		resource.TestCheckResourceAttrSet(resourceName, "connection_name"),
 		resource.TestCheckResourceAttr(resourceName, "type", "Cluster"),
 		resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.0.role", "atlasAdmin"),
-		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.0.type", "BUILT_IN"),
+		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.role", "atlasAdmin"),
+		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.type", "BUILT_IN"),
 	}
 	return resource.ComposeTestCheckFunc(resourceChecks...)
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -180,6 +181,10 @@ func clusterStreamConnectionConfig(projectIDStr, instanceName, clusterNameStr, c
 		 	connection_name = "ConnectionNameKafka"
 		 	type = "Cluster"
 		 	cluster_name = %[3]s
+			db_role_to_execute = {
+				role = "atlasAdmin"
+				type = "BUILT_IN"
+			}
 		}
 	`, projectIDStr, instanceName, clusterNameStr)
 }
@@ -192,6 +197,8 @@ func clusterStreamConnectionAttributeChecks(resourceName, clusterName string) re
 		resource.TestCheckResourceAttrSet(resourceName, "connection_name"),
 		resource.TestCheckResourceAttr(resourceName, "type", "Cluster"),
 		resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.0.role", "atlasAdmin"),
+		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.0.type", "BUILT_IN"),
 	}
 	return resource.ComposeTestCheckFunc(resourceChecks...)
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 

--- a/website/docs/d/stream_connection.html.markdown
+++ b/website/docs/d/stream_connection.html.markdown
@@ -34,6 +34,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
+* `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).
@@ -52,6 +53,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `broker_public_certificate` - A trusted, public x509 certificate for connecting to Kafka over SSL. String value of the certificate must be defined in the attribute.
 * `protocol` - Describes the transport type. Can be either `PLAINTEXT` or `SSL`.
 
+### DBRoleToExecute
+
+* `role` - The name of the role to use. Can be a built in role or a custom role.
+* `type` - Type of the DB role. Can be either BUILT_IN or CUSTOM.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/getStreamConnection) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/website/docs/d/stream_connections.html.markdown
+++ b/website/docs/d/stream_connections.html.markdown
@@ -46,6 +46,7 @@ In addition to all arguments above, it also exports the following attributes:
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
+* `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).
@@ -64,6 +65,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `broker_public_certificate` - A trusted, public x509 certificate for connecting to Kafka over SSL. String value of the certificate must be defined in the attribute.
 * `protocol` - Describes the transport type. Can be either `PLAINTEXT` or `SSL`.
 
+### DBRoleToExecute
+
+* `role` - The name of the role to use. Can be a built in role or a custom role.
+* `type` - Type of the DB role. Can be either BUILT_IN or CUSTOM.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/listStreamConnections) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/website/docs/r/stream_connection.html.markdown
+++ b/website/docs/r/stream_connection.html.markdown
@@ -85,6 +85,7 @@ resource "mongodbatlas_stream_connection" "test" {
 
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
+* `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
 
 If `type` is of value `Kafka` the following additional arguments are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).
@@ -102,6 +103,11 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 
 * `broker_public_certificate` - A trusted, public x509 certificate for connecting to Kafka over SSL. String value of the certificate must be defined in the attribute.
 * `protocol` - Describes the transport type. Can be either `PLAINTEXT` or `SSL`.
+
+### DBRoleToExecute
+
+* `role` - The name of the role to use. Can be a built in role or a custom role.
+* `type` - Type of the DB role. Can be either BUILT_IN or CUSTOM.
 
 ## Import
 


### PR DESCRIPTION
## Description

Updates mongodbatlas_stream_connection resource & data sources to support dbRoleToExecute attribute for `Cluster` connection type.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-230542

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
