### PR TITLE
feat: Adds StreamConfig attribute to `mongodbatlas_stream_instance` resource and datasources

### DIFF
--- a/examples/mongodbatlas_stream_instance/main.tf
+++ b/examples/mongodbatlas_stream_instance/main.tf
@@ -10,4 +10,7 @@ resource "mongodbatlas_stream_instance" "example" {
     region         = "VIRGINIA_USA"
     cloud_provider = "AWS"
   }
+  stream_config = {
+    tier = "SP30"
+  }
 }

--- a/internal/service/streaminstance/data_source_stream_instance.go
+++ b/internal/service/streaminstance/data_source_stream_instance.go
@@ -60,6 +60,14 @@ func DSAttributes(withArguments bool) map[string]schema.Attribute {
 			ElementType: types.StringType,
 			Computed:    true,
 		},
+		"stream_config": schema.SingleNestedAttribute{
+			Computed: true,
+			Attributes: map[string]schema.Attribute{
+				"tier": schema.StringAttribute{
+					Computed: true,
+				},
+			},
+		},
 	}
 }
 

--- a/internal/service/streaminstance/data_source_stream_instance_test.go
+++ b/internal/service/streaminstance/data_source_stream_instance_test.go
@@ -24,7 +24,7 @@ func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstanceDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider),
-				Check:  streamInstanceAttributeChecks(dataSourceName, orgID, projectName, instanceName, region, cloudProvider),
+				Check:  streamInstanceAttributeChecks(dataSourceName, instanceName, region, cloudProvider),
 			},
 		},
 	})

--- a/internal/service/streaminstance/data_source_stream_instance_test.go
+++ b/internal/service/streaminstance/data_source_stream_instance_test.go
@@ -24,7 +24,10 @@ func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstanceDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider),
-				Check:  streamInstanceAttributeChecks(dataSourceName, instanceName, region, cloudProvider),
+				Check: resource.ComposeTestCheckFunc(
+					streamInstanceAttributeChecks(dataSourceName, instanceName, region, cloudProvider),
+					resource.TestCheckResourceAttr(dataSourceName, "stream_config.tier", "SP30"),
+				),
 			},
 		},
 	})

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -24,7 +24,7 @@ func NewStreamInstanceCreateReq(ctx context.Context, plan *TFStreamInstanceModel
 			Region:        dataProcessRegion.Region.ValueString(),
 		},
 	}
-	if !plan.StreamConfig.IsNull() {
+	if !plan.StreamConfig.IsNull() && !plan.StreamConfig.IsUnknown() {
 		streamConfig := &TFInstanceStreamConfigSpecModel{}
 		if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
@@ -60,9 +60,10 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 		diags.Append(diagsProcessRegion...)
 	}
 	var streamConfig = types.ObjectNull(StreamConfigObjectType.AttrTypes)
-	if apiResp.StreamConfig != nil && apiResp.StreamConfig.Tier != nil {
+	apiStreamConfig := apiResp.StreamConfig
+	if apiStreamConfig != nil && apiStreamConfig.Tier != nil {
 		returnedStreamConfig, diagsStreamConfig := types.ObjectValueFrom(ctx, StreamConfigObjectType.AttrTypes, TFInstanceStreamConfigSpecModel{
-			Tier: types.StringPointerValue(apiResp.StreamConfig.Tier),
+			Tier: types.StringPointerValue(apiStreamConfig.Tier),
 		})
 		streamConfig = returnedStreamConfig
 		diags.Append(diagsStreamConfig...)

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -16,7 +16,7 @@ func NewStreamInstanceCreateReq(ctx context.Context, plan *TFStreamInstanceModel
 	if diags := plan.DataProcessRegion.As(ctx, dataProcessRegion, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags
 	}
-	streamTenanat := &admin.StreamsTenant{
+	streamTenant := &admin.StreamsTenant{
 		GroupId: plan.ProjectID.ValueStringPointer(),
 		Name:    plan.InstanceName.ValueStringPointer(),
 		DataProcessRegion: &admin.StreamsDataProcessRegion{
@@ -29,11 +29,11 @@ func NewStreamInstanceCreateReq(ctx context.Context, plan *TFStreamInstanceModel
 		if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}
-		streamTenanat.StreamConfig = &admin.StreamConfig{
+		streamTenant.StreamConfig = &admin.StreamConfig{
 			Tier: streamConfig.Tier.ValueStringPointer(),
 		}
 	}
-	return streamTenanat, nil
+	return streamTenant, nil
 }
 
 func NewStreamInstanceUpdateReq(ctx context.Context, plan *TFStreamInstanceModel) (*admin.StreamsDataProcessRegion, diag.Diagnostics) {

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -16,14 +16,24 @@ func NewStreamInstanceCreateReq(ctx context.Context, plan *TFStreamInstanceModel
 	if diags := plan.DataProcessRegion.As(ctx, dataProcessRegion, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags
 	}
-	return &admin.StreamsTenant{
+	streamConfig := &TFInstanceStreamConfigSpecModel{}
+	if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return nil, diags
+	}
+	streamTenanat := &admin.StreamsTenant{
 		GroupId: plan.ProjectID.ValueStringPointer(),
 		Name:    plan.InstanceName.ValueStringPointer(),
 		DataProcessRegion: &admin.StreamsDataProcessRegion{
 			CloudProvider: dataProcessRegion.CloudProvider.ValueString(),
 			Region:        dataProcessRegion.Region.ValueString(),
 		},
-	}, nil
+	}
+	if !streamConfig.Tier.IsNull() {
+		streamTenanat.StreamConfig = &admin.StreamConfig{
+			Tier: streamConfig.Tier.ValueStringPointer(),
+		}
+	}
+	return streamTenanat, nil
 }
 
 func NewStreamInstanceUpdateReq(ctx context.Context, plan *TFStreamInstanceModel) (*admin.StreamsDataProcessRegion, diag.Diagnostics) {
@@ -49,6 +59,14 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 		dataProcessRegion = returnedProcessRegion
 		diags.Append(diagsProcessRegion...)
 	}
+	var streamConfig = types.ObjectNull(StreamConfigObjectType.AttrTypes)
+	if apiResp.StreamConfig != nil {
+		returnedStreamConfig, diagsStreamConfig := types.ObjectValueFrom(ctx, ProcessRegionObjectType.AttrTypes, TFInstanceStreamConfigSpecModel{
+			Tier: types.StringPointerValue(apiResp.StreamConfig.Tier),
+		})
+		streamConfig = returnedStreamConfig
+		diags.Append(diagsStreamConfig...)
+	}
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -58,6 +76,7 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 		InstanceName:      types.StringPointerValue(apiResp.Name),
 		ProjectID:         types.StringPointerValue(apiResp.GroupId),
 		DataProcessRegion: dataProcessRegion,
+		StreamConfig:      streamConfig,
 		Hostnames:         hostnames,
 	}, nil
 }

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -25,7 +25,7 @@ func NewStreamInstanceCreateReq(ctx context.Context, plan *TFStreamInstanceModel
 		},
 	}
 	if !plan.StreamConfig.IsNull() && !plan.StreamConfig.IsUnknown() {
-		streamConfig := &TFInstanceStreamConfigSpecModel{}
+		streamConfig := new(TFInstanceStreamConfigSpecModel)
 		if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}

--- a/internal/service/streaminstance/resource_stream_instance.go
+++ b/internal/service/streaminstance/resource_stream_instance.go
@@ -94,6 +94,7 @@ func (r *streamInstanceRS) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"stream_config": schema.SingleNestedAttribute{
 				Optional: true,
+				Computed: true,
 				Attributes: map[string]schema.Attribute{
 					"tier": schema.StringAttribute{
 						Required: true,

--- a/internal/service/streaminstance/resource_stream_instance.go
+++ b/internal/service/streaminstance/resource_stream_instance.go
@@ -97,7 +97,8 @@ func (r *streamInstanceRS) Schema(ctx context.Context, req resource.SchemaReques
 				Computed: true,
 				Attributes: map[string]schema.Attribute{
 					"tier": schema.StringAttribute{
-						Required: true,
+						Optional: true,
+						Computed: true,
 					},
 				},
 			},

--- a/internal/service/streaminstance/resource_stream_instance.go
+++ b/internal/service/streaminstance/resource_stream_instance.go
@@ -37,6 +37,7 @@ type TFStreamInstanceModel struct {
 	InstanceName      types.String `tfsdk:"instance_name"`
 	ProjectID         types.String `tfsdk:"project_id"`
 	DataProcessRegion types.Object `tfsdk:"data_process_region"`
+	StreamConfig      types.Object `tfsdk:"stream_config"`
 	Hostnames         types.List   `tfsdk:"hostnames"`
 }
 
@@ -45,9 +46,17 @@ type TFInstanceProcessRegionSpecModel struct {
 	Region        types.String `tfsdk:"region"`
 }
 
+type TFInstanceStreamConfigSpecModel struct {
+	Tier types.String `tfsdk:"tier"`
+}
+
 var ProcessRegionObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"cloud_provider": types.StringType,
 	"region":         types.StringType,
+}}
+
+var StreamConfigObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"tier": types.StringType,
 }}
 
 func (r *streamInstanceRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -82,6 +91,14 @@ func (r *streamInstanceRS) Schema(ctx context.Context, req resource.SchemaReques
 			"hostnames": schema.ListAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
+			},
+			"stream_config": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"tier": schema.StringAttribute{
+						Required: true,
+					},
+				},
 			},
 		},
 	}

--- a/internal/service/streaminstance/resource_stream_instance_migration_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_migration_test.go
@@ -27,7 +27,7 @@ func TestAccMigrationStreamRSStreamInstance_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider),
-				Check:             streamInstanceAttributeChecks(resourceName, orgID, projectName, instanceName, region, cloudProvider),
+				Check:             streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -25,7 +25,10 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
-				Check:  streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
+				Check: resource.ComposeTestCheckFunc(
+					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -51,7 +54,10 @@ func TestAccStreamRSStreamInstance_withStreamConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.StreamInstanceWithStreamConfigConfig(orgID, projectName, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
-				Check:  streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
+				Check: resource.ComposeTestCheckFunc(
+					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -72,7 +78,6 @@ func streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProv
 		resource.TestCheckResourceAttr(resourceName, "data_process_region.region", region),
 		resource.TestCheckResourceAttr(resourceName, "data_process_region.cloud_provider", cloudProvider),
 		resource.TestCheckResourceAttr(resourceName, "hostnames.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
 	}
 	return resource.ComposeTestCheckFunc(resourceChecks...)
 }

--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -25,7 +25,7 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
-				Check:  streamInstanceAttributeChecks(resourceName, orgID, projectName, instanceName, region, cloudProvider),
+				Check:  streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 			},
 			{
 				ResourceName:      resourceName,
@@ -37,7 +37,7 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 	})
 }
 
-func streamInstanceAttributeChecks(resourceName, orgID, projectName, instanceName, region, cloudProvider string) resource.TestCheckFunc {
+func streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider string) resource.TestCheckFunc {
 	resourceChecks := []resource.TestCheckFunc{
 		checkSearchInstanceExists(),
 		resource.TestCheckResourceAttrSet(resourceName, "id"),

--- a/internal/testutil/acc/stream_instance.go
+++ b/internal/testutil/acc/stream_instance.go
@@ -25,6 +25,27 @@ func StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvide
 	`, orgID, projectName, instanceName, region, cloudProvider)
 }
 
+func StreamInstanceWithStreamConfigConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "test" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
+		resource "mongodbatlas_stream_instance" "test" {
+			project_id = mongodbatlas_project.test.id
+			instance_name = %[3]q
+			data_process_region = {
+				region = %[4]q
+				cloud_provider = %[5]q
+			}
+			stream_config = {
+				tier = "SP30"
+			}
+		}
+	`, orgID, projectName, instanceName, region, cloudProvider)
+}
+
 func CheckDestroyStreamInstance(state *terraform.State) error {
 	if projectDestroyedErr := CheckDestroyProject(state); projectDestroyedErr != nil {
 		return projectDestroyedErr

--- a/website/docs/d/stream_instance.html.markdown
+++ b/website/docs/d/stream_instance.html.markdown
@@ -30,12 +30,17 @@ data "mongodbatlas_stream_instance" "example" {
 
 * `data_process_region` - Defines the cloud service provider and region where MongoDB Cloud performs stream processing. See [data process region](#data-process-region).
 * `hostnames` - List that contains the hostnames assigned to the stream instance.
+* `stream_config` - Defines the configuration options for an Atlas Stream Processing Instance. See [stream config](#stream-config)
 
 
 ### Data Process Region
 
 * `cloud_provider` - Label that identifies the cloud service provider where MongoDB Cloud performs stream processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
 * `region` - Name of the cloud provider region hosting Atlas Stream Processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
+
+### Stream Config
+
+* `tier` - Selected tier for the Stream Instance. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
 
 To learn more, see: [MongoDB Atlas API - Stream Instance](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/website/docs/d/stream_instances.html.markdown
+++ b/website/docs/d/stream_instances.html.markdown
@@ -41,11 +41,16 @@ In addition to all arguments above, it also exports the following attributes:
 * `instance_name` - Human-readable label that identifies the stream instance.
 * `data_process_region` - Defines the cloud service provider and region where MongoDB Cloud performs stream processing. See [data process region](#data-process-region).
 * `hostnames` - List that contains the hostnames assigned to the stream instance.
+* `stream_config` - Defines the configuration options for an Atlas Stream Processing Instance. See [stream config](#stream-config)
 
 ### Data Process Region
 
 * `cloud_provider` - Label that identifies the cloud service provider where MongoDB Cloud performs stream processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
 * `region` - Name of the cloud provider region hosting Atlas Stream Processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
   
+### Stream Config
+
+* `tier` - Selected tier for the Stream Instance. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
+
 To learn more, see: [MongoDB Atlas API - Stream Instance](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/website/docs/r/stream_instance.html.markdown
+++ b/website/docs/r/stream_instance.html.markdown
@@ -30,11 +30,18 @@ resource "mongodbatlas_stream_instance" "test" {
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - (Required) Human-readable label that identifies the stream instance.
 * `data_process_region` - (Required) Cloud service provider and region where MongoDB Cloud performs stream processing. See [data process region](#data-process-region).
+* `stream_config` - (Optional) Configuration options for an Atlas Stream Processing Instance. See [stream config](#stream-config)
+
 
 ### Data Process Region
 
 * `cloud_provider` - (Required) Label that identifies the cloud service provider where MongoDB Cloud performs stream processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
 * `region` - (Required) Name of the cloud provider region hosting Atlas Stream Processing. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
+
+### Stream Config
+
+* `tier` - (Required) Selected tier for the Stream Instance. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/createStreamInstance) describes the valid values.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Adds StreamConfig attribute to `mongodbatlas_stream_instance` resource and datasources
Attribute is optional and computed.

Link to any related issue(s): CLOUDP-230536

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
