### PR TITLE
fix: Removes escape logic on IP address in mongodbatlas_access_list_api_key

### DIFF
--- a/internal/service/accesslistapikey/resource_access_list_api_key.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key.go
@@ -8,14 +8,12 @@ import (
 	"net/http"
 	"strings"
 
-	"go.mongodb.org/atlas-sdk/v20231115007/admin"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
 
 func Resource() *schema.Resource {

--- a/internal/service/accesslistapikey/resource_access_list_api_key.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"strings"
 
+	"go.mongodb.org/atlas-sdk/v20231115007/admin"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
 
 func Resource() *schema.Resource {
@@ -125,8 +127,8 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	ids := conversion.DecodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
+	ipAddress := ids["entry"]
 
-	ipAddress := strings.ReplaceAll(ids["entry"], "/", "%2F")
 	apiKey, resp, err := connV2.ProgrammaticAPIKeysApi.GetApiKeyAccessList(ctx, orgID, ipAddress, apiKeyID).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
@@ -151,7 +153,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"org_id":     orgID,
 		"api_key_id": apiKeyID,
-		"entry":      ids["entry"],
+		"entry":      ipAddress,
 	}))
 
 	return nil
@@ -166,7 +168,8 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ids := conversion.DecodeStateID(d.Id())
 	orgID := ids["org_id"]
 	apiKeyID := ids["api_key_id"]
-	ipAddress := strings.ReplaceAll(ids["entry"], "/", "%2F")
+	ipAddress := ids["entry"]
+
 	_, _, err := connV2.ProgrammaticAPIKeysApi.DeleteApiKeyAccessListEntry(ctx, orgID, apiKeyID, ipAddress).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error deleting API Key: %s", err))
@@ -184,9 +187,8 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 
 	orgID := parts[0]
 	apiKeyID := parts[1]
-	entry := parts[2]
+	ipAddress := parts[2]
 
-	ipAddress := strings.ReplaceAll(entry, "/", "%2F")
 	r, _, err := connV2.ProgrammaticAPIKeysApi.GetApiKeyAccessList(ctx, orgID, ipAddress, apiKeyID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import api key %s in project %s, error: %s", orgID, apiKeyID, err)
@@ -207,7 +209,7 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"org_id":     orgID,
 		"api_key_id": apiKeyID,
-		"entry":      entry,
+		"entry":      ipAddress,
 	}))
 
 	return []*schema.ResourceData{d}, nil

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -57,6 +58,59 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
+			{
+				ExternalProviders: acc.ExternalProviders("1.14.0"), // testing provider version before this resource was migrated to Atlas SDK
+				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+				),
+			},
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configWithCIDRBlock(orgID, description, cidrBlock),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_16(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_access_list_api_key.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		cidrBlock    = acc.RandomIP(179, 154, 226) + "/16"
+		description  = acc.RandomName()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: acc.ExternalProviders("1.14.0"),
+				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+				),
+			},
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -38,7 +38,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 }
 
 func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.14.0")
+	mig.SkipIfVersionBelow(t, "1.14.0") // 1.14.0 is the version when this resource was migrated to the new Atlas SDK
 
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
@@ -52,7 +52,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: acc.ExternalProviders("1.14.0"), // testing provider version before this resource was migrated to Atlas SDK
+				ExternalProviders: acc.ExternalProviders("1.14.0"),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
@@ -76,7 +76,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 }
 
 func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigration(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.14.0")
+	mig.SkipIfVersionBelow(t, "1.14.0") // 1.14.0 is the version when this resource was migrated to the new Atlas SDK
 
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
@@ -90,7 +90,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigrat
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: acc.ExternalProviders("1.14.0"), // testing provider version before this resource was migrated to Atlas SDK
+				ExternalProviders: acc.ExternalProviders("1.14.0"),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -104,7 +104,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR(t *testin
 		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: acc.ExternalProviders("1.14.0"),
+				ExternalProviders: acc.ExternalProviders("1.14.0"), // testing provider version before this resource was migrated to Atlas SDK
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -91,7 +90,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
+func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigration(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -111,16 +110,6 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR(t *testin
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
 				),
-			},
-			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -31,21 +32,14 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configWithIPAddress(orgID, description, ipAddress),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(configWithIPAddress(orgID, description, ipAddress)),
 		},
 	})
 }
 
 func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.14.0")
+
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -76,21 +70,14 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 					},
 				},
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configWithCIDRBlock(orgID, description, cidrBlock),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(configWithCIDRBlock(orgID, description, cidrBlock)),
 		},
 	})
 }
 
 func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigration(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.14.0")
+
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -111,16 +98,7 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigrat
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configWithCIDRBlock(orgID, description, cidrBlock),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(configWithCIDRBlock(orgID, description, cidrBlock)),
 		},
 	})
 }

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -70,11 +70,12 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
-					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
-				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -90,11 +91,11 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_16(t *testing.T) {
+func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_access_list_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		cidrBlock    = acc.RandomIP(179, 154, 226) + "/16"
+		cidrBlock    = "100.10.0.0/16"
 		description  = acc.RandomName()
 	)
 
@@ -114,11 +115,12 @@ func TestAccMigrationProjectAccesslistAPIKey_SettingCIDRBlock_16(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
-					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
-				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -81,7 +81,7 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
 	})
 }
 
-func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_16(t *testing.T) {
+func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
 	var (
 		resourceName     = "mongodbatlas_access_list_api_key.test"
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -53,6 +54,40 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
 		cidrBlock        = acc.RandomIP(179, 154, 226) + "/32"
 		description      = acc.RandomName()
 		updatedCIDRBlock = acc.RandomIP(179, 154, 228) + "/32"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithCIDRBlock(orgID, description, cidrBlock),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
+				),
+			},
+			{
+				Config: configWithCIDRBlock(orgID, description, updatedCIDRBlock),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_16(t *testing.T) {
+	var (
+		resourceName     = "mongodbatlas_access_list_api_key.test"
+		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		cidrBlock        = "100.10.0.0/16"
+		description      = acc.RandomName()
+		updatedCIDRBlock = "172.10.0.0/16"
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )


### PR DESCRIPTION
## Description

Removes escape logic on IP address in `mongodbatlas_access_list_api_key` since the new Atlas SDK escapes characters by default.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-235189
Resolves https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1984 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
