### PR TITLE
feat: Add support for using DEV/QA for mongodbgov

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -486,7 +486,7 @@ func isGovBaseURLConfigured(baseURL string) bool {
 			"MCLI_OPS_MANAGER_URL",
 		}, "").(string)
 	}
-	return baseURL != "" && (baseURL == MongodbGovCloudURL || baseURL == MongodbGovCloudDevURL || baseURL == MongodbGovCloudQAURL)
+	return baseURL == MongodbGovCloudDevURL || baseURL == MongodbGovCloudQAURL
 }
 
 func isGovBaseURLConfiguredForProvider(data *tfMongodbAtlasProviderModel) bool {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -487,7 +486,7 @@ func isGovBaseURLConfigured(baseURL string) bool {
 			"MCLI_OPS_MANAGER_URL",
 		}, "").(string)
 	}
-	return baseURL != "" && (strings.Contains(baseURL, MongodbGovCloudDevURL) || strings.Contains(baseURL, MongodbGovCloudQAURL) || strings.Contains(baseURL, MongodbGovCloudURL))
+	return baseURL != "" && (baseURL == MongodbGovCloudURL || baseURL == MongodbGovCloudDevURL || baseURL == MongodbGovCloudQAURL)
 }
 
 func isGovBaseURLConfiguredForProvider(data *tfMongodbAtlasProviderModel) bool {

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -325,7 +325,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 
 	mongodbgovCloud := conversion.Pointer(d.Get("is_mongodbgov_cloud").(bool))
 	if *mongodbgovCloud {
-		if !isBaseURLConfiguredForSDK2Provider(d) {
+		if !isGovBaseURLConfiguredForSDK2Provider(d) {
 			if err := d.Set("base_url", MongodbGovCloudURL); err != nil {
 				return append(diagnostics, diag.FromErr(err)...)
 			}
@@ -577,6 +577,6 @@ func expandAssumeRole(tfMap map[string]any) *config.AssumeRole {
 	return &assumeRole
 }
 
-func isBaseURLConfiguredForSDK2Provider(d *schema.ResourceData) bool {
-	return isBaseURLConfigured(d.Get("base_url").(string))
+func isGovBaseURLConfiguredForSDK2Provider(d *schema.ResourceData) bool {
+	return isGovBaseURLConfigured(d.Get("base_url").(string))
 }

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/accesslistapikey"
@@ -324,8 +325,10 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 
 	mongodbgovCloud := conversion.Pointer(d.Get("is_mongodbgov_cloud").(bool))
 	if *mongodbgovCloud {
-		if err := d.Set("base_url", MongodbGovCloudURL); err != nil {
-			return append(diagnostics, diag.FromErr(err)...)
+		if !isBaseURLConfiguredForSDK2Provider(d) {
+			if err := d.Set("base_url", MongodbGovCloudURL); err != nil {
+				return append(diagnostics, diag.FromErr(err)...)
+			}
 		}
 	}
 
@@ -572,4 +575,8 @@ func expandAssumeRole(tfMap map[string]any) *config.AssumeRole {
 	}
 
 	return &assumeRole
+}
+
+func isBaseURLConfiguredForSDK2Provider(d *schema.ResourceData) bool {
+	return isBaseURLConfigured(d.Get("base_url").(string))
 }


### PR DESCRIPTION
## Description

Currently if `is_mongodbgov_cloud` flag is set in the provider config, it will always call mongodbgov production, even if `base_url` is set to use dev/QA env of mongodbgov. This PR will let the user/developer specify base_url correctly when `is_mongodbgov_cloud` flag is set.


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
