### PR TITLE
chore: Creates project for test execution

### DIFF
--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -15,7 +15,7 @@ var (
 
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchiveDS_basic(t *testing.T) {
 	var (
-		projectID               = acc.ProjectIDGlobal(t)
+		projectID               = acc.ProjectIDExecution(t)
 		endpointID              = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 		customerEndpointDNSName = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_DNS_NAME")
 	)

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archives_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archives_test.go
@@ -15,7 +15,7 @@ var (
 
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchivesDSPlural_basic(t *testing.T) {
 	var (
-		projectID  = acc.ProjectIDGlobal(t)
+		projectID  = acc.ProjectIDExecution(t)
 		endpointID = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 	)
 

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_migration_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_migration_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccMigrationNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t *testing.T) {
 	var (
-		projectID  = acc.ProjectIDGlobal(t)
+		projectID  = acc.ProjectIDExecution(t)
 		endpointID = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 		config     = resourceConfigBasic(projectID, endpointID, comment)
 	)

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -18,9 +18,13 @@ var (
 	atlasRegion  = "US_EAST_1"
 )
 
+func TestMain(m *testing.M) {
+	acc.TestMainExecution(m)
+}
+
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t *testing.T) {
 	var (
-		projectID  = acc.ProjectIDGlobal(t)
+		projectID  = acc.ProjectIDExecution(t)
 		endpointID = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 	)
 
@@ -51,7 +55,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t
 }
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_updateComment(t *testing.T) {
 	var (
-		projectID      = acc.ProjectIDGlobal(t)
+		projectID      = acc.ProjectIDExecution(t)
 		endpointID     = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 		commentUpdated = "Terraform Acceptance Test Updated"
 	)
@@ -98,7 +102,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_updateC
 
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basicWithRegionDnsName(t *testing.T) {
 	var (
-		projectID               = acc.ProjectIDGlobal(t)
+		projectID               = acc.ProjectIDExecution(t)
 		endpointID              = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_ID")
 		customerEndpointDNSName = os.Getenv("MONGODB_ATLAS_PRIVATE_ENDPOINT_DNS_NAME")
 	)

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -19,7 +19,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	acc.TestMainExecution(m)
+	acc.SetupSharedResources()
+	exitCode := m.Run()
+	acc.CleanupSharedResources()
+	os.Exit(exitCode)
 }
 
 func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t *testing.T) {

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -4,88 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
-	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
-
-// TestMainExecution must be called from TestMain in the test package if ProjectIDExecution is going to be used.
-func TestMainExecution(m *testing.M) {
-	atlasInfo.init = true
-	atlasInfo.resourceName = resourceName()
-
-	exitCode := m.Run()
-
-	if atlasInfo.needsDeletion {
-		fmt.Printf("Deleting execution project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
-		deleteProject(atlasInfo.projectID)
-	}
-
-	os.Exit(exitCode)
-}
-
-// ProjectIDExecution returns a project id created for the execution of the resource tests.
-func ProjectIDExecution(tb testing.TB) string {
-	tb.Helper()
-	SkipInUnitTest(tb)
-	require.True(tb, atlasInfo.init, "TestMainExecution must called to be able to use ProjectIDExecution")
-
-	atlasInfo.mu.Lock()
-	defer atlasInfo.mu.Unlock()
-
-	// lazy creation so it's only done if really needed
-	if atlasInfo.projectName == "" {
-		var globalName, globalID string
-		if atlasInfo.resourceName != "" {
-			globalName = (prefixProjectKeep + "-" + atlasInfo.resourceName)[:projectNameMaxLen]
-			globalID = projectID(globalName)
-		}
-
-		if globalID == "" {
-			atlasInfo.projectName = RandomProjectName()
-			tb.Logf("Creating execution project: %s, resource: %s, global project (not found): %s\n", atlasInfo.projectName, atlasInfo.resourceName, globalName)
-			atlasInfo.projectID = createProject(tb, atlasInfo.projectName)
-			atlasInfo.needsDeletion = true
-		} else {
-			atlasInfo.projectName = globalName
-			tb.Logf("Reusing global project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
-			atlasInfo.projectID = globalID
-		}
-	}
-
-	return atlasInfo.projectID
-}
-
-var atlasInfo = struct {
-	projectID     string
-	projectName   string
-	resourceName  string
-	mu            sync.Mutex
-	init          bool
-	needsDeletion bool
-}{}
-
-const (
-	projectNameMaxLen = 64
-)
-
-func resourceName() string {
-	pc, _, _, ok := runtime.Caller(2)
-	if !ok {
-		return ""
-	}
-	pattern := `([^/]+)_test\.TestMain$`
-	re := regexp.MustCompile(pattern)
-	matches := re.FindStringSubmatch(runtime.FuncForPC(pc).Name())
-	if len(matches) <= 1 {
-		return ""
-	}
-	return matches[1]
-}
 
 func createProject(tb testing.TB, name string) string {
 	tb.Helper()
@@ -106,7 +29,11 @@ func deleteProject(id string) {
 	}
 }
 
-func projectID(name string) string {
+func projectID(tb testing.TB, name string) string {
+	tb.Helper()
+	SkipInUnitTest(tb)
 	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()
-	return resp.GetId()
+	id := resp.GetId()
+	require.NotEmpty(tb, id, "Project name not found: %s", name)
+	return id
 }

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -1,0 +1,116 @@
+package acc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20231115007/admin"
+)
+
+// TestMainExecution must be called from TestMain in the test package if ProjectIDExecution is going to be used.
+func TestMainExecution(m *testing.M) {
+	if !InUnitTest() {
+		atlasInfo.init = true
+		atlasInfo.resourceName = resourceName()
+	}
+
+	exitCode := m.Run()
+
+	if !InUnitTest() && atlasInfo.needsDeletion {
+		fmt.Printf("Deleting execution project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
+		deleteProject(atlasInfo.projectID)
+		atlasInfo.projectID = ""
+		atlasInfo.projectName = ""
+	}
+
+	os.Exit(exitCode)
+}
+
+// ProjectIDExecution returns a project id created for the execution of the resource tests.
+func ProjectIDExecution(tb testing.TB) string {
+	tb.Helper()
+	SkipInUnitTest(tb)
+	require.True(tb, atlasInfo.init, "TestMainExecution must called to be able to use ProjectIDExecution")
+
+	atlasInfo.mu.Lock()
+	defer atlasInfo.mu.Unlock()
+
+	// lazy creation so it's only done if really needed
+	if atlasInfo.projectName == "" {
+		var globalName, globalID string
+		if atlasInfo.resourceName != "" {
+			globalName = (prefixProjectKeep + "-" + atlasInfo.resourceName)[:projectNameMaxLen]
+			globalID = projectID(globalName)
+		}
+
+		if globalID == "" {
+			atlasInfo.projectName = RandomProjectName()
+			tb.Logf("Creating execution project: %s, resource: %s, global project (not found): %s\n", atlasInfo.projectName, atlasInfo.resourceName, globalName)
+			atlasInfo.projectID = createProject(tb, atlasInfo.projectName)
+			atlasInfo.needsDeletion = true
+		} else {
+			atlasInfo.projectName = globalName
+			tb.Logf("Reusing global project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
+			atlasInfo.projectID = globalID
+		}
+	}
+
+	return atlasInfo.projectID
+}
+
+var atlasInfo = struct {
+	projectID     string
+	projectName   string
+	resourceName  string
+	mu            sync.Mutex
+	init          bool
+	needsDeletion bool
+}{}
+
+const (
+	projectNameMaxLen = 64
+)
+
+func resourceName() string {
+	pc, _, _, ok := runtime.Caller(2)
+	if !ok {
+		return ""
+	}
+	pattern := `([^/]+)_test\.TestMain$`
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(runtime.FuncForPC(pc).Name())
+	if len(matches) <= 1 {
+		return ""
+	}
+	return matches[1]
+}
+
+func createProject(tb testing.TB, name string) string {
+	tb.Helper()
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	require.NotNil(tb, "Project creation failed: %s, org not set", name)
+	params := &admin.Group{Name: name, OrgId: orgID}
+	resp, _, err := ConnV2().ProjectsApi.CreateProject(context.Background(), params).Execute()
+	require.NoError(tb, err, "Project creation failed: %s, err: %s", name, err)
+	id := resp.GetId()
+	require.NotEmpty(tb, id, "Project creation failed: %s", name)
+	return id
+}
+
+func deleteProject(id string) {
+	_, _, err := ConnV2().ProjectsApi.DeleteProject(context.Background(), id).Execute()
+	if err != nil {
+		fmt.Printf("Project deletion failed: %s, error: %s", id, err)
+	}
+}
+
+func projectID(name string) string {
+	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()
+	return resp.GetId()
+}

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -15,14 +15,12 @@ import (
 
 // TestMainExecution must be called from TestMain in the test package if ProjectIDExecution is going to be used.
 func TestMainExecution(m *testing.M) {
-	if !InUnitTest() {
-		atlasInfo.init = true
-		atlasInfo.resourceName = resourceName()
-	}
+	atlasInfo.init = true
+	atlasInfo.resourceName = resourceName()
 
 	exitCode := m.Run()
 
-	if !InUnitTest() && atlasInfo.needsDeletion {
+	if atlasInfo.needsDeletion {
 		fmt.Printf("Deleting execution project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
 		deleteProject(atlasInfo.projectID)
 	}

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -25,8 +25,6 @@ func TestMainExecution(m *testing.M) {
 	if !InUnitTest() && atlasInfo.needsDeletion {
 		fmt.Printf("Deleting execution project: %s, resource: %s\n", atlasInfo.projectName, atlasInfo.resourceName)
 		deleteProject(atlasInfo.projectID)
-		atlasInfo.projectID = ""
-		atlasInfo.projectName = ""
 	}
 
 	os.Exit(exitCode)

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -1,12 +1,9 @@
 package acc
 
 import (
-	"context"
 	"fmt"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -39,18 +36,4 @@ func RandomIP(a, b, c byte) string {
 
 func RandomEmail() string {
 	return fmt.Sprintf("%s-%s@mongodb.com", prefixName, acctest.RandString(10))
-}
-
-func ProjectIDGlobal(tb testing.TB) string {
-	tb.Helper()
-	return projectID(tb, prefixProjectKeep+"-global")
-}
-
-func projectID(tb testing.TB, name string) string {
-	tb.Helper()
-	SkipInUnitTest(tb)
-	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()
-	id := resp.GetId()
-	require.NotEmpty(tb, id, "Project name not found: %s", name)
-	return id
 }

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -2,6 +2,7 @@ package acc
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
@@ -36,4 +37,9 @@ func RandomIP(a, b, c byte) string {
 
 func RandomEmail() string {
 	return fmt.Sprintf("%s-%s@mongodb.com", prefixName, acctest.RandString(10))
+}
+
+func ProjectIDGlobal(tb testing.TB) string {
+	tb.Helper()
+	return projectID(tb, prefixProjectKeep+"-global")
 }

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -22,6 +22,7 @@ func CleanupSharedResources() {
 }
 
 // ProjectIDExecution returns a project id created for the execution of the tests in the resource package.
+// Even if a GH test group is run, every resource/package will create its own project, not a shared project for all the test group.
 func ProjectIDExecution(tb testing.TB) string {
 	tb.Helper()
 	SkipInUnitTest(tb)

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -1,0 +1,46 @@
+package acc
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func SetupSharedResources() {
+	sharedInfo.init = true
+}
+
+func CleanupSharedResources() {
+	if sharedInfo.projectID != "" {
+		fmt.Printf("Deleting execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
+		deleteProject(sharedInfo.projectID)
+	}
+}
+
+// ProjectIDExecution returns a project id created for the execution of the tests in the resource package.
+func ProjectIDExecution(tb testing.TB) string {
+	tb.Helper()
+	SkipInUnitTest(tb)
+	require.True(tb, sharedInfo.init, "SetupSharedResources must called from TestMain test package")
+
+	sharedInfo.mu.Lock()
+	defer sharedInfo.mu.Unlock()
+
+	// lazy creation so it's only done if really needed
+	if sharedInfo.projectID == "" {
+		sharedInfo.projectName = RandomProjectName()
+		tb.Logf("Creating execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
+		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
+	}
+
+	return sharedInfo.projectID
+}
+
+var sharedInfo = struct {
+	projectID   string
+	projectName string
+	mu          sync.Mutex
+	init        bool
+}{}

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
 func SetupSharedResources() {
 	sharedInfo.init = true
 }
 
+// CleanupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
 func CleanupSharedResources() {
 	if sharedInfo.projectID != "" {
 		fmt.Printf("Deleting execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
@@ -31,7 +33,7 @@ func ProjectIDExecution(tb testing.TB) string {
 	// lazy creation so it's only done if really needed
 	if sharedInfo.projectID == "" {
 		sharedInfo.projectName = RandomProjectName()
-		tb.Logf("Creating execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
+		tb.Logf("Creating execution project: %s\n", sharedInfo.projectName)
 		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
 	}
 

--- a/internal/testutil/acc/skip.go
+++ b/internal/testutil/acc/skip.go
@@ -18,7 +18,11 @@ func SkipTestForCI(tb testing.TB) {
 // This can be useful for acceptance tests that define logic prior to resource.Test/resource.ParallelTest functions as this code would always be run.
 func SkipInUnitTest(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("TF_ACC") == "" {
+	if InUnitTest() {
 		tb.Skip()
 	}
+}
+
+func InUnitTest() bool {
+	return os.Getenv("TF_ACC") == ""
 }


### PR DESCRIPTION
## Description

Creates project for test execution. As an example it's used for `privatelink_endpoint_service_data_federation_online_archive` resource tests.

Link to any related issue(s): CLOUDP-237263


This creates a project for each resource test execution (if needed), example log:

```
Creating execution project: test-acc-tf-p-430893557017739723, resource: privatelinkendpointservicedatafederationonlinearchive, global project (not found): test-acc-tf-p-keep-privatelinkendpointservicedatafederationonlin
--- PASS: TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic (11.40s)
=== RUN   TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basicWithRegionDnsName
--- PASS: TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basicWithRegionDnsName (8.42s)
PASS
Deleting execution project: test-acc-tf-p-430893557017739723, resource: privatelinkendpointservicedatafederationonlinearchive
```

Optionally it can use an existing project for that resource if it exists, example log:

```
Reusing global project: test-acc-tf-p-keep-privatelinkendpointservicedatafederationonlin, resource: privatelinkendpointservicedatafederationonlinearchive
```



## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
