### PR TITLE
fix: Ensure required field RegionName is set when updating network conatiner

### DIFF
--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -57,6 +57,41 @@ func TestAccNetworkContainerRS_basicAWS(t *testing.T) {
 	})
 }
 
+func TestAccNetworkContainerRS_updateCidrWithoutChangingRegions(t *testing.T) {
+	var (
+		randIntUpdated   = acctest.RandIntRange(0, 255)
+		cidrBlockUpdated = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
+		projectName      = acc.RandomProjectName()
+		region           = "US_EAST_1"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configAWS(projectName, orgID, cidrBlock, constant.AWS, region),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+			{
+				Config: configAWS(projectName, orgID, cidrBlockUpdated, constant.AWS, region),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkContainerRS_basicAzure(t *testing.T) {
 	var (
 		randIntUpdated   = acctest.RandIntRange(0, 255)


### PR DESCRIPTION
## Description

The `regionName` field is required when updating a network container: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Network-Peering/operation/updatePeeringContainer

However the current code only sets it if there is a change to the region name. This has the effect of making any change that only affects the cidr fail:
```
2024-03-13T21:07:31.906Z [INFO]  plugin.terraform-provider-mongodbatlas_v1.11.1: 2024/03/13 21:07:31 [DEBUG] MongoDB Atlas API Request Details:
---[ REQUEST ]---------------------------------------
PATCH /api/atlas/v1.0/groups/5e84b906246b5a0e3926c1f4/containers/65b8318cda738f151bd9d8b1 HTTP/1.1Host: cloud.mongodb.comUser-Agent: terraform-provider-mongodbatlas/1.11.1 go-mongodbatlas/0.33.0 (linux;amd64)Content-Length: 57Accept: application/jsonContent-Type: application/jsonAccept-Encoding: gzip{
 "atlasCidrBlock": "10.248.86.0/23",
 "providerName": "AWS"
}-----------------------------------------------------: timestamp=2024-03-13T21:07:31.906Z
---[ RESPONSE ]--------------------------------------
HTTP/2.0 500 Internal Server ErrorContent-Length: 122Content-Type: application/jsonDate: Wed, 13 Mar 2024 21:07:31 GMTReferrer-Policy: strict-origin-when-cross-originServer: mdbwsStrict-Transport-Security: max-age=31536000; includeSubdomains;X-Content-Type-Options: nosniffX-Envoy-Upstream-Service-Time: 46X-Frame-Options: DENYX-Mongodb-Service-Version: gitHash=2a321c7a1e0c84ef86357fa877294b946492ec03; versionString=v20240306X-Permitted-Cross-Domain-Policies: none{
 "detail": "Unexpected error.",
 "error": 500,
 "errorCode": "UNEXPECTED_ERROR",
 "parameters": [],
 "reason": "Internal Server Error"
}
-----------------------------------------------------: timestamp=2024-03-13T21:07:31.983Z 
```

This PR adds a test case that attempts to change the cidr without changing the region, and updates the code to always set the `regionName` field.

Link to any related issue(s): https://jira.mongodb.org/browse/HELP-56981

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
