### PR TITLE
chore: Reuses project in tests for `cluster` resource

### DIFF
--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -92,7 +92,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, name,
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "EU_CENTRAL_1"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -105,7 +105,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, name,
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
-			provider_region_name        = "EU_CENTRAL_1"
+			provider_region_name        = "US_WEST_2"
 
 			advanced_configuration {
 				minimum_enabled_tls_protocol         = %[4]q

--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_backwardCompatibility(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDGlobal(t)
+		projectID   = mig.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
 		cfg         = configAWS(projectID, clusterName, true, true)
 	)
@@ -40,7 +40,7 @@ func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_back
 
 func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDGlobal(t)
+		projectID   = mig.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
 		cfgPartial  = configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 			MinimumEnabledTLSProtocol: "TLS1_2",

--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -15,11 +15,9 @@ import (
 
 func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_backwardCompatibility(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
-		cfg          = testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true)
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+		cfg         = testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,8 +28,7 @@ func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_back
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            cfg,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 				),
@@ -43,11 +40,9 @@ func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_back
 
 func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.advance_conf"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
-		cfgPartial   = testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+		cfgPartial  = testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 			MinimumEnabledTLSProtocol: "TLS1_2",
 		})
 		cfgPartialUpdated = testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, clusterName, "false", &matlas.ProcessArgs{
@@ -64,7 +59,7 @@ func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            cfgPartial,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 				),
 			},
@@ -83,7 +78,7 @@ func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *
 
 func testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "advance_conf" {
+		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
 			disk_size_gb = 10

--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -17,7 +17,7 @@ func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_back
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
-		cfg         = testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true)
+		cfg         = configAWS(projectID, clusterName, true, true)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,10 +42,10 @@ func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
-		cfgPartial  = testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
+		cfgPartial  = configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 			MinimumEnabledTLSProtocol: "TLS1_2",
 		})
-		cfgPartialUpdated = testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, clusterName, "false", &matlas.ProcessArgs{
+		cfgPartialUpdated = configAdvancedConfPartialUpdated(projectID, clusterName, "false", &matlas.ProcessArgs{
 			MinimumEnabledTLSProtocol: "TLS1_2",
 			SampleSizeBIConnector:     conversion.Pointer[int64](110),
 		})
@@ -76,7 +76,7 @@ func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *
 	})
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfPartialUpdated(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func configAdvancedConfPartialUpdated(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q

--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_backwardCompatibility(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
+		projectID   = acc.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
 		cfg         = configAWS(projectID, clusterName, true, true)
 	)
@@ -40,7 +40,7 @@ func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_back
 
 func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
+		projectID   = acc.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
 		cfgPartial  = configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 			MinimumEnabledTLSProtocol: "TLS1_2",

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -524,7 +524,8 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -560,7 +561,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "true", createRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -576,7 +577,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -599,7 +600,8 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -628,11 +630,11 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(projectID, clusterName, "false", updatedRegionsConfig),
+				Config:      testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				ExpectError: regexp.MustCompile("attribute must be set ONLY for single-region clusters"),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectID, clusterName, "false"),
+				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -648,7 +650,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -664,7 +666,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),
@@ -726,7 +728,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1", []matlas.Label{}),
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "US_WEST_2", []matlas.Label{}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -738,7 +740,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Label{
 						{
 							Key:   "key 4",
@@ -765,7 +767,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Label{
 						{
 							Key:   "key 1",
@@ -808,7 +810,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1", []matlas.Tag{}),
+				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2", []matlas.Tag{}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -821,7 +823,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Tag{
 						{
 							Key:   "key 1",
@@ -851,7 +853,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Tag{
 						{
 							Key:   "key 3",
@@ -1289,7 +1291,8 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1374,7 +1377,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replications),
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replications),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1382,7 +1385,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replicationsUpdate),
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1390,7 +1393,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replicationsShardsUpdate),
+				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1547,7 +1550,7 @@ func testAccMongoDBAtlasClusterConfigAWS(projectID, name string, backupEnabled, 
 			replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "EU_CENTRAL_1"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
 							read_only_nodes = 0
@@ -1588,7 +1591,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEn
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "EU_CENTRAL_1"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -1633,7 +1636,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, nam
 			replication_specs {
 				num_shards = 1
 				regions_config {
-					region_name     = "EU_CENTRAL_1"
+					region_name     = "US_WEST_2"
 					electable_nodes = 3
 					priority        = 7
 					read_only_nodes = 0
@@ -1674,7 +1677,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autosc
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "EU_CENTRAL_1"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -1687,7 +1690,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autosc
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
-			provider_region_name        = "EU_CENTRAL_1"
+			provider_region_name        = "US_WEST_2"
 
 			advanced_configuration {
 				minimum_enabled_tls_protocol         = %[4]q
@@ -1707,7 +1710,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name,
 			replication_specs {
 				num_shards = 1
 				regions_config {
-					region_name     = "EU_CENTRAL_1"
+					region_name     = "US_WEST_2"
 					electable_nodes = 3
 					priority        = 7
 					read_only_nodes = 0
@@ -1720,7 +1723,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name,
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
-			provider_region_name        = "EU_CENTRAL_1"
+			provider_region_name        = "US_WEST_2"
 
 			advanced_configuration {
 				minimum_enabled_tls_protocol = %[4]q
@@ -1743,7 +1746,7 @@ func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled, insta
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_EAST_2"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -1757,7 +1760,7 @@ func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled, insta
 			provider_name               = "AZURE"
 			%[4]s
 			provider_instance_size_name = %[5]q
-			provider_region_name        = "US_EAST_2"
+			provider_region_name        = "US_WEST_2"
 		}
 	`, projectID, name, backupEnabled, diskType, instanceSizeName)
 }
@@ -1773,7 +1776,7 @@ func testAccMongoDBAtlasClusterConfigGCP(projectID, name, backupEnabled string) 
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_EAST_4"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -1801,7 +1804,7 @@ func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, name, backupE
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_EAST_4"
+			     region_name     = "US_WEST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
@@ -1821,14 +1824,18 @@ func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, name, backupE
 	`, projectID, name, backupEnabled, biConnectorEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegion(projectID, name, backupEnabled, regionsConfig string) string {
+func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = %[1]q
-			name                    = %[2]q
+			project_id              = mongodbatlas_project.cluster_project.id
+			name                    = %[3]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[3]s
+			cloud_backup            = %[4]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
@@ -1838,44 +1845,52 @@ func testAccMongoDBAtlasClusterConfigMultiRegion(projectID, name, backupEnabled,
 			replication_specs {
 				num_shards = 1
 
-				%[4]s
+				%[5]s
 			}
 		}
-	`, projectID, name, backupEnabled, regionsConfig)
+	`, orgID, projectName, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(projectID, name, backupEnabled, regionsConfig string) string {
+func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = %[1]q
-			name                    = %[2]q
+			project_id              = mongodbatlas_project.cluster_project.id
+			name                    = %[3]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[3]s
+			cloud_backup            = %[4]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
-			provider_region_name = "US_EAST_1"
+			provider_region_name = "US_WEST_2"
 
 			replication_specs {
 				num_shards = 1
 
-				%[4]s
+				%[5]s
 			}
 		}
-	`, projectID, name, backupEnabled, regionsConfig)
+	`, orgID, projectName, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectID, name, backupEnabled string) string {
+func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, name, backupEnabled string) string {
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = %[1]q
-			name                    = %[2]q
+			project_id              = mongodbatlas_project.cluster_project.id
+			name                    = %[3]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[3]s
+			cloud_backup            = %[4]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
@@ -1894,7 +1909,7 @@ func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectI
 				}
 			}
 		}
-	`, projectID, name, backupEnabled)
+	`, orgID, projectName, name, backupEnabled)
 }
 
 func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskSize, majorDBVersion string) string {
@@ -1905,7 +1920,7 @@ func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskS
 
 			provider_name         = "TENANT"
 			backing_provider_name = "AWS"
-			provider_region_name  = "US_EAST_1"
+			provider_region_name  = "US_WEST_2"
 				//M2 must be 2, M5 must be 5
 				disk_size_gb            = %[3]q
 
@@ -1923,7 +1938,7 @@ func testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, name string) strin
 			name       = %[2]q
 
 			provider_name        = "AWS"
-			provider_region_name = "EU_CENTRAL_1"
+			provider_region_name = "US_WEST_2"
 
 			provider_instance_size_name  = "M10"
 			disk_size_gb                 = 10
@@ -2325,7 +2340,7 @@ func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, name, backupE
 			replication_specs {
 				num_shards = 1
 				regions_config {
-				region_name     = "EU_CENTRAL_1"
+				region_name     = "US_WEST_2"
 				electable_nodes = 3
 				priority        = 7
 				read_only_nodes = 0
@@ -2369,27 +2384,32 @@ func testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, name, regionName s
 	`, projectID, name, regionName)
 }
 
-func testAccMongoDBAtlasClusterConfigRegions(projectID, name, replications string) string {
+func testAccMongoDBAtlasClusterConfigRegions(
+	orgID, projectName, name, replications string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "test" {
-			project_id              = %[1]q
-			name                    = %[2]q
-			disk_size_gb            = 400
-			num_shards              = 3
-			cloud_backup            = true
-			cluster_type            = "GEOSHARDED"
-			// Provider Settings "block"
-			provider_name               = "AWS"
-			provider_disk_iops          = 1200
-			provider_instance_size_name = "M30"
-			%[3]s
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "test" {
+	  project_id              = mongodbatlas_project.cluster_project.id
+	  name                    = "%[3]s"
+	  disk_size_gb            = 400
+	  num_shards              = 3
+	  cloud_backup            = true
+	  cluster_type            = "GEOSHARDED"
+	  // Provider Settings "block"
+	  provider_name               = "AWS"
+	  provider_disk_iops          = 1200
+	  provider_instance_size_name = "M30"
+	  %[4]s
 
-			lifecycle {
-			# avoid cluster has been auto-scaled to different instance size
-			ignore_changes = [provider_instance_size_name, disk_size_gb]
-			}
-		}
-	`, projectID, name, replications)
+		lifecycle {
+		# avoid cluster has been auto-scaled to different instance size
+		ignore_changes = [provider_instance_size_name, disk_size_gb]
+	  }
+	}
+	`, orgID, projectName, name, replications)
 }
 
 func testAccMongoDBAtlasClusterConfigAWSPaused(projectID, name string, backupEnabled, paused bool) string {
@@ -2402,7 +2422,7 @@ resource "mongodbatlas_cluster" "test" {
   replication_specs {
     num_shards = 1
     regions_config {
-      region_name     = "EU_CENTRAL_1"
+      region_name     = "US_WEST_2"
       electable_nodes = 3
       priority        = 7
       read_only_nodes = 0

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -353,7 +353,8 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -363,7 +364,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M30", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -375,7 +376,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "false", "M30", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "false", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -394,7 +395,8 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		clusterName  = acc.RandomClusterName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -403,7 +405,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M60", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -416,7 +418,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M60_NVME", false),
+				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60_NVME", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -436,7 +438,8 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -446,7 +449,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(projectID, clusterName, "true"),
+				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -459,7 +462,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(projectID, clusterName, "false"),
+				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -479,7 +482,8 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -489,7 +493,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, clusterName, "true", false),
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -503,7 +507,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, clusterName, "false", true),
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -525,7 +529,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -601,7 +605,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1172,7 +1176,8 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.tenant"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because tenant
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1184,7 +1189,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, clusterName, "M2", "2", dbMajorVersion),
+				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1195,7 +1200,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, clusterName),
+				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1213,7 +1218,8 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 	var (
 		cluster        matlas.Cluster
 		resourceName   = "mongodbatlas_cluster.tenant"
-		projectID      = acc.ProjectIDExecution(t)
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because tenant
 		clusterName    = acc.RandomClusterName()
 		dbMajorVersion = testAccGetMongoDBAtlasMajorVersion()
 	)
@@ -1224,7 +1230,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, clusterName, "M5", "5", dbMajorVersion),
+				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1241,7 +1247,8 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		clusterName  = acc.RandomClusterName()
 		regionName   = "WESTERN_US"
 	)
@@ -1252,7 +1259,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, clusterName, regionName),
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1266,8 +1273,9 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName  = acc.RandomProjectName()
+		clusterName  = acc.RandomClusterName() // No ProjectIDExecution to avoid cross-region limits because no AWS
 		regionName   = "US_WEST_2"
 	)
 
@@ -1277,7 +1285,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, clusterName, regionName),
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1292,7 +1300,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits
+		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1732,96 +1740,108 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name,
 	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
-func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
+func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
 	var diskType string
 	if includeDiskType {
 		diskType = `provider_disk_type_name     = "P6"`
 	}
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "basic_azure" {
-			project_id   = %[1]q
-			name         = %[2]q
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
 
             cluster_type = "REPLICASET"
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_WEST_2"
+			     region_name     = "US_EAST_2"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
 		       }
 		    }
 
-			cloud_backup                 = %[3]q
+			cloud_backup                 = %[4]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "AZURE"
-			%[4]s
-			provider_instance_size_name = %[5]q
-			provider_region_name        = "US_WEST_2"
+			%[5]s
+			provider_instance_size_name = %[6]q
+			provider_region_name        = "US_EAST_2"
 		}
-	`, projectID, name, backupEnabled, diskType, instanceSizeName)
+	`, orgID, projectName, name, backupEnabled, diskType, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCP(projectID, name, backupEnabled string) string {
+func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled string) string {
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "basic_gcp" {
-			project_id   = %[1]q
-			name         = %[2]q
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
 			disk_size_gb = 40
 
             cluster_type = "REPLICASET"
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_WEST_2"
+			     region_name     = "US_EAST_4"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
 		       }
 		    }
 
-			cloud_backup                 = %[3]q
+			cloud_backup                 = %[4]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "GCP"
 			provider_instance_size_name = "M30"
 		}
-	`, projectID, name, backupEnabled)
+	`, orgID, projectName, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, name, backupEnabled string, biConnectorEnabled bool) string {
+func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, backupEnabled string, biConnectorEnabled bool) string {
 	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			name   = %[2]q
+			org_id = %[1]q
+		}
 		resource "mongodbatlas_cluster" "basic_gcp" {
-			project_id   = %[1]q
-			name         = %[2]q
+			project_id   = mongodbatlas_project.cluster_project.id
+			name         = %[3]q
 			disk_size_gb = 40
 
             cluster_type = "REPLICASET"
 		    replication_specs {
 			  num_shards = 1
 			  regions_config {
-			     region_name     = "US_WEST_2"
+			     region_name     = "US_EAST_4"
 			     electable_nodes = 3
 			     priority        = 7
                  read_only_nodes = 0
 		       }
 		    }
 
-			cloud_backup                 = %[3]q
+			cloud_backup                 = %[4]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "GCP"
 			provider_instance_size_name = "M30"
 			bi_connector_config {
-				enabled = %[4]t
+				enabled = %[5]t
 			}
 		}
-	`, projectID, name, backupEnabled, biConnectorEnabled)
+	`, orgID, projectName, name, backupEnabled, biConnectorEnabled)
 }
 
 func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
@@ -1912,39 +1932,47 @@ func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, p
 	`, orgID, projectName, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskSize, majorDBVersion string) string {
+func testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, instanceSize, diskSize, majorDBVersion string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "tenant" {
-			project_id = %[1]q
-			name       = %[2]q
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "tenant" {
+		project_id = mongodbatlas_project.cluster_project.id
+		name       = %[3]q
 
-			provider_name         = "TENANT"
-			backing_provider_name = "AWS"
-			provider_region_name  = "US_WEST_2"
-				//M2 must be 2, M5 must be 5
-				disk_size_gb            = %[3]q
+		provider_name         = "TENANT"
+		backing_provider_name = "AWS"
+		provider_region_name  = "US_EAST_1"
+	  	//M2 must be 2, M5 must be 5
+	  	disk_size_gb            = %[4]q
 
-			provider_instance_size_name  = %[4]q
-			//These must be the following values
-			mongo_db_major_version = %[5]q
-		}
-	`, projectID, name, diskSize, instanceSize, majorDBVersion)
+		provider_instance_size_name  = %[5]q
+		//These must be the following values
+ 	 	mongo_db_major_version = %[6]q
+	  }
+	`, orgID, projectName, name, diskSize, instanceSize, majorDBVersion)
 }
 
-func testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, name string) string {
+func testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, name string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "tenant" {
-			project_id = %[1]q
-			name       = %[2]q
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "tenant" {
+		project_id = mongodbatlas_project.cluster_project.id
+		name       = %[3]q
 
-			provider_name        = "AWS"
-			provider_region_name = "US_WEST_2"
+		provider_name        = "AWS"
+		provider_region_name = "EU_CENTRAL_1"
 
-			provider_instance_size_name  = "M10"
-			disk_size_gb                 = 10
-			auto_scaling_disk_gb_enabled = true
-			}
-	`, projectID, name)
+		provider_instance_size_name  = "M10"
+		disk_size_gb                 = 10
+		auto_scaling_disk_gb_enabled = true
+	  }
+	`, orgID, projectName, name)
 }
 
 func testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, name, backupEnabled, tier, region string, labels []matlas.Label) string {
@@ -2369,19 +2397,24 @@ func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, name, backupE
 	`, projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, name, regionName string) string {
+func testAccMongoDBAtlasClusterConfigGCPRegionName(
+	orgID, projectName, name, regionName string) string {
 	return fmt.Sprintf(`
-			resource "mongodbatlas_cluster" "test" {
-			project_id                   = %[1]q
-			name                         = %[2]q
-			auto_scaling_disk_gb_enabled = true
-			provider_name                = "GCP"
-			disk_size_gb                 = 10
-			provider_instance_size_name  = "M10"
-			num_shards                   = 1
-			provider_region_name         = %[3]q
-		}
-	`, projectID, name, regionName)
+	resource "mongodbatlas_project" "cluster_project" {
+		name   = %[2]q
+		org_id = %[1]q
+	}
+	resource "mongodbatlas_cluster" "test" {
+  project_id                   = mongodbatlas_project.cluster_project.id
+  name                         = %[3]q
+  auto_scaling_disk_gb_enabled = true
+  provider_name                = "GCP"
+  disk_size_gb                 = 10
+  provider_instance_size_name  = "M10"
+  num_shards                   = 1
+  provider_region_name         = %[4]q
+}
+	`, orgID, projectName, name, regionName)
 }
 
 func testAccMongoDBAtlasClusterConfigRegions(

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -22,8 +22,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -33,7 +32,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, clusterName, true, true),
+				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -56,7 +55,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, clusterName, false, false),
+				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -80,8 +79,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -91,7 +89,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, clusterName, "M40_NVME"),
+				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -102,7 +100,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, clusterName, "M50_NVME"),
+				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -118,13 +116,11 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 
 func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 	var (
-		cluster                matlas.Cluster
-		resourceName           = "mongodbatlas_cluster.advance_conf"
-		dataSourceName         = "data.mongodbatlas_cluster.test"
-		dataSourceClustersName = "data.mongodbatlas_clusters.test"
-		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName            = acc.RandomProjectName()
-		clusterName            = acc.RandomClusterName()
+		cluster        matlas.Cluster
+		resourceName   = "mongodbatlas_cluster.advance_conf"
+		dataSourceName = "data.mongodbatlas_cluster.test"
+		projectID      = acc.ProjectIDExecution(t)
+		clusterName    = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +129,7 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -163,14 +159,10 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
 					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
-					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.version_release_system", "LTS"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -193,8 +185,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.advance_conf"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -204,7 +195,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, clusterName, "false", &matlas.ProcessArgs{
 					DefaultReadConcern:               "available",
 					DefaultWriteConcern:              "1",
 					FailIndexKeyTooLong:              conversion.Pointer(false),
@@ -230,7 +221,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -253,8 +244,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.advance_conf"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -264,12 +254,12 @@ func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -298,8 +288,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.advance_conf"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -309,7 +298,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_2",
@@ -333,7 +322,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, clusterName, "false", &matlas.ProcessArgs{
+				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(false),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -364,8 +353,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -375,7 +363,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M30", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -387,7 +375,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "false", "M30", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "false", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -406,8 +394,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -416,7 +403,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60", true),
+				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M60", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -429,7 +416,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60_NVME", false),
+				Config: testAccMongoDBAtlasClusterConfigAzure(projectID, clusterName, "true", "M60_NVME", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -449,8 +436,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -460,7 +446,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "true"),
+				Config: testAccMongoDBAtlasClusterConfigGCP(projectID, clusterName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -473,7 +459,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "false"),
+				Config: testAccMongoDBAtlasClusterConfigGCP(projectID, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -493,8 +479,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -504,7 +489,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, clusterName, "true", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -518,7 +503,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
+				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, clusterName, "false", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -539,8 +524,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -576,7 +560,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "true", createRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -592,7 +576,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -615,8 +599,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -645,11 +628,11 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config:      testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(projectID, clusterName, "false", updatedRegionsConfig),
 				ExpectError: regexp.MustCompile("attribute must be set ONLY for single-region clusters"),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
+				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectID, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -665,7 +648,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -681,7 +664,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: testAccMongoDBAtlasClusterConfigMultiRegion(projectID, clusterName, "false", updatedRegionsConfig),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),
@@ -698,8 +681,7 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 		cluster        matlas.Cluster
 		resourceSuffix = "global_cluster"
 		resourceName   = fmt.Sprintf("mongodbatlas_cluster.%s", resourceSuffix)
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		clusterName    = acc.RandomClusterName()
 	)
 
@@ -709,7 +691,7 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigClusterGlobal(resourceSuffix, orgID, projectName, clusterName, "false"),
+				Config: acc.ConfigClusterGlobal(resourceSuffix, projectID, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -734,8 +716,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.aws_with_labels"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -745,7 +726,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1", []matlas.Label{}),
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1", []matlas.Label{}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -757,7 +738,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1",
 					[]matlas.Label{
 						{
 							Key:   "key 4",
@@ -784,7 +765,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, clusterName, "false", "M10", "EU_CENTRAL_1",
+				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "EU_CENTRAL_1",
 					[]matlas.Label{
 						{
 							Key:   "key 1",
@@ -817,7 +798,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 		dataSourceName         = "data.mongodbatlas_cluster.test"
 		dataSourceClustersName = "data.mongodbatlas_clusters.test"
 		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName            = acc.RandomProjectName()
+		projectName            = acc.RandomProjectName() // No ProjectIDExecution because this test has plural datasource
 		clusterName            = acc.RandomClusterName()
 	)
 
@@ -1102,13 +1083,11 @@ func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
 
 func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 	var (
-		cluster                matlas.Cluster
-		resourceName           = "mongodbatlas_cluster.test"
-		dataSourceName         = "data.mongodbatlas_cluster.test"
-		dataSourceClustersName = "data.mongodbatlas_clusters.test"
-		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName            = acc.RandomProjectName()
-		clusterName            = acc.RandomClusterName()
+		cluster        matlas.Cluster
+		resourceName   = "mongodbatlas_cluster.test"
+		dataSourceName = "data.mongodbatlas_cluster.test"
+		projectID      = acc.ProjectIDExecution(t)
+		clusterName    = acc.RandomClusterName()
 
 		instanceSize = "M30"
 		minSize      = ""
@@ -1125,7 +1104,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(orgID, projectName, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
+				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1142,15 +1121,10 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "disk_size_gb", "100"),
 					resource.TestCheckResourceAttr(dataSourceName, "version_release_system", "LTS"),
 					resource.TestCheckResourceAttr(dataSourceName, "termination_protection_enabled", "false"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrSet(dataSourceClustersName, "results.0.name"),
-					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.version_release_system", "LTS"),
-					resource.TestCheckResourceAttr(dataSourceClustersName, "results.0.termination_protection_enabled", "false"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(orgID, projectName, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
+				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1169,8 +1143,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 func TestAccClusterRSCluster_importBasic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1180,7 +1153,7 @@ func TestAccClusterRSCluster_importBasic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, clusterName, true, false),
+				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, false),
 			},
 			{
 				ResourceName:            resourceName,
@@ -1197,8 +1170,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.tenant"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1210,7 +1182,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
+				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, clusterName, "M2", "2", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1221,7 +1193,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, clusterName),
+				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1239,8 +1211,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 	var (
 		cluster        matlas.Cluster
 		resourceName   = "mongodbatlas_cluster.tenant"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		clusterName    = acc.RandomClusterName()
 		dbMajorVersion = testAccGetMongoDBAtlasMajorVersion()
 	)
@@ -1251,7 +1222,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
+				Config: testAccMongoDBAtlasClusterConfigTenant(projectID, clusterName, "M5", "5", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1268,8 +1239,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 		regionName   = "WESTERN_US"
 	)
@@ -1280,7 +1250,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1294,8 +1264,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 		regionName   = "US_WEST_2"
 	)
@@ -1306,7 +1275,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1320,8 +1289,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1406,7 +1374,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replications),
+				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replications),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1414,7 +1382,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsUpdate),
+				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replicationsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1422,7 +1390,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
+				Config: testAccMongoDBAtlasClusterConfigRegions(projectID, clusterName, replicationsShardsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1440,8 +1408,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1451,7 +1418,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, clusterName, true, false),
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1465,7 +1432,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, clusterName, false, true),
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1493,8 +1460,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 	var (
 		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 	)
 
@@ -1504,7 +1470,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, clusterName, true, true),
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1518,7 +1484,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, clusterName, false, false),
+				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
 					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
@@ -1571,67 +1537,51 @@ func testAccCheckMongoDBAtlasClusterAttributes(cluster *matlas.Cluster, name str
 	}
 }
 
-func testAccMongoDBAtlasClusterConfigAWS(orgID, projectName, name string, backupEnabled, autoDiskGBEnabled bool) string {
+func testAccMongoDBAtlasClusterConfigAWS(projectID, name string, backupEnabled, autoDiskGBEnabled bool) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "test" {
-			project_id                   = mongodbatlas_project.cluster_project.id
-			name                         = %[3]q
+			project_id                   = %[1]q
+			name                         = %[2]q
 			disk_size_gb                 = 100
-            cluster_type = "REPLICASET"
-		    replication_specs {
+			cluster_type = "REPLICASET"
+			replication_specs {
 			  num_shards = 1
 			  regions_config {
 			     region_name     = "EU_CENTRAL_1"
 			     electable_nodes = 3
 			     priority        = 7
-                 read_only_nodes = 0
+							read_only_nodes = 0
 		       }
 		    }
-			cloud_backup                 = %[4]t
-			pit_enabled                  = %[4]t
+			cloud_backup                 = %[3]t
+			pit_enabled                  = %[3]t
 			retain_backups_enabled       = true
-			auto_scaling_disk_gb_enabled = %[5]t
-			// Provider Settings "block"
-
+			auto_scaling_disk_gb_enabled = %[4]t
 			provider_name               = "AWS"
 			provider_instance_size_name = "M30"
 		}
-	`, orgID, projectName, name, backupEnabled, autoDiskGBEnabled)
+	`, projectID, name, backupEnabled, autoDiskGBEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(orgID, projectName, name, instanceName string) string {
+func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, instanceName string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "test" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
-
+			project_id   = %[1]q
+			name         = %[2]q
 			cloud_backup                 = true
-			// Provider Settings "block"
 			provider_region_name     = "US_EAST_1"
 			provider_name               = "AWS"
-			provider_instance_size_name = %[4]q
+			provider_instance_size_name = %[3]q
 			provider_volume_type        = "PROVISIONED"
 		}
-	`, orgID, projectName, name, instanceName)
+	`, projectID, name, instanceName)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "advance_conf" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			disk_size_gb = 10
 
             cluster_type = "REPLICASET"
@@ -1646,21 +1596,21 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, auto
 		    }
 
 			backup_enabled               = false
-			auto_scaling_disk_gb_enabled =  %[4]s
+			auto_scaling_disk_gb_enabled =  %[3]s
 
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
 
 			advanced_configuration  {
-				fail_index_key_too_long              = %[5]t
-				javascript_enabled                   = %[6]t
-				minimum_enabled_tls_protocol         = %[7]q
-				no_table_scan                        = %[8]t
-				oplog_size_mb                        = %[9]d
-				sample_size_bi_connector			 = %[10]d
-				sample_refresh_interval_bi_connector = %[11]d
-				transaction_lifetime_limit_seconds   = %[12]d
+				fail_index_key_too_long              = %[4]t
+				javascript_enabled                   = %[5]t
+				minimum_enabled_tls_protocol         = %[6]q
+				no_table_scan                        = %[7]t
+				oplog_size_mb                        = %[8]d
+				sample_size_bi_connector			 = %[9]d
+				sample_refresh_interval_bi_connector = %[10]d
+				transaction_lifetime_limit_seconds   = %[11]d
 			}
 		}
 
@@ -1668,69 +1618,56 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(orgID, projectName, name, auto
 			project_id = mongodbatlas_cluster.advance_conf.project_id
 			name 	     = mongodbatlas_cluster.advance_conf.name
 		}
-
-		data "mongodbatlas_clusters" "test" {
-			project_id = mongodbatlas_cluster.advance_conf.project_id
-		}
-
-	`, orgID, projectName, name, autoscalingEnabled,
+	`, projectID, name, autoscalingEnabled,
 		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
 		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, *p.TransactionLifetimeLimitSeconds)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}
-resource "mongodbatlas_cluster" "advance_conf" {
-  project_id   = mongodbatlas_project.cluster_project.id
-  name         = %[3]q
-  disk_size_gb = 10
-  cluster_type = "REPLICASET"
-  replication_specs {
-    num_shards = 1
-    regions_config {
-      region_name     = "EU_CENTRAL_1"
-      electable_nodes = 3
-      priority        = 7
-      read_only_nodes = 0
-    }
-  }
+		resource "mongodbatlas_cluster" "advance_conf" {
+			project_id   = %[1]q
+			name         = %[2]q
+			disk_size_gb = 10
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+					region_name     = "EU_CENTRAL_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
 
-  backup_enabled               = false
-  auto_scaling_disk_gb_enabled =  %[4]s
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled =  %[3]s
 
-  // Provider Settings "block"
-  provider_name               = "AWS"
-  provider_instance_size_name = "M10"
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
 
-  advanced_configuration {
-  default_read_concern                 = %[11]q
-  default_write_concern                = %[12]q
-  javascript_enabled                   = %[5]t
-  minimum_enabled_tls_protocol         = %[6]q
-  no_table_scan                        = %[7]t
-  oplog_size_mb                        = %[8]d
-  sample_size_bi_connector             = %[9]d
-  sample_refresh_interval_bi_connector = %[10]d
-  }
-}
-	`, orgID, projectName, name, autoscalingEnabled,
+			advanced_configuration {
+				javascript_enabled                   = %[4]t
+				minimum_enabled_tls_protocol         = %[5]q
+				no_table_scan                        = %[6]t
+				oplog_size_mb                        = %[7]d
+				sample_size_bi_connector             = %[8]d
+				sample_refresh_interval_bi_connector = %[9]d
+				default_read_concern                 = %[10]q
+				default_write_concern                = %[11]q
+			}
+		}
+	`, projectID, name, autoscalingEnabled,
 		*p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
 		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, p.DefaultReadConcern, p.DefaultWriteConcern)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "advance_conf" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			disk_size_gb = 10
 
             cluster_type = "REPLICASET"
@@ -1745,7 +1682,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, nam
 		    }
 
 			backup_enabled               = false
-			auto_scaling_disk_gb_enabled =  %[4]s
+			auto_scaling_disk_gb_enabled =  %[3]s
 
 			// Provider Settings "block"
 			provider_name               = "AWS"
@@ -1753,62 +1690,54 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(orgID, projectName, nam
 			provider_region_name        = "EU_CENTRAL_1"
 
 			advanced_configuration {
-				minimum_enabled_tls_protocol         = %[5]q
+				minimum_enabled_tls_protocol         = %[4]q
 			}
 		}
-	`, orgID, projectName, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
+	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(orgID, projectName, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}
-resource "mongodbatlas_cluster" "advance_conf" {
-  project_id   = mongodbatlas_project.cluster_project.id
-  name         = %[3]q
-  disk_size_gb = 10
+		resource "mongodbatlas_cluster" "advance_conf" {
+			project_id   = %[1]q
+			name         = %[2]q
+			disk_size_gb = 10
 
-  cluster_type = "REPLICASET"
-  replication_specs {
-    num_shards = 1
-    regions_config {
-      region_name     = "EU_CENTRAL_1"
-      electable_nodes = 3
-      priority        = 7
-      read_only_nodes = 0
-    }
-  }
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+					region_name     = "EU_CENTRAL_1"
+					electable_nodes = 3
+					priority        = 7
+					read_only_nodes = 0
+				}
+			}
 
-  backup_enabled               = false
-  auto_scaling_disk_gb_enabled =  %[4]s
+			backup_enabled               = false
+			auto_scaling_disk_gb_enabled =  %[3]s
 
-  // Provider Settings "block"
-  provider_name               = "AWS"
-  provider_instance_size_name = "M10"
-  provider_region_name        = "EU_CENTRAL_1"
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_instance_size_name = "M10"
+			provider_region_name        = "EU_CENTRAL_1"
 
-  advanced_configuration {
-    minimum_enabled_tls_protocol = %[5]q
-  }
-}
-	`, orgID, projectName, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
+			advanced_configuration {
+				minimum_enabled_tls_protocol = %[4]q
+			}
+		}
+	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
-func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
+func testAccMongoDBAtlasClusterConfigAzure(projectID, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
 	var diskType string
 	if includeDiskType {
 		diskType = `provider_disk_type_name     = "P6"`
 	}
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "basic_azure" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 
             cluster_type = "REPLICASET"
 		    replication_specs {
@@ -1821,27 +1750,23 @@ func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabl
 		       }
 		    }
 
-			cloud_backup                 = %[4]q
+			cloud_backup                 = %[3]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "AZURE"
-			%[5]s
-			provider_instance_size_name = %[6]q
+			%[4]s
+			provider_instance_size_name = %[5]q
 			provider_region_name        = "US_EAST_2"
 		}
-	`, orgID, projectName, name, backupEnabled, diskType, instanceSizeName)
+	`, projectID, name, backupEnabled, diskType, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled string) string {
+func testAccMongoDBAtlasClusterConfigGCP(projectID, name, backupEnabled string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "basic_gcp" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			disk_size_gb = 40
 
             cluster_type = "REPLICASET"
@@ -1855,25 +1780,21 @@ func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled
 		       }
 		    }
 
-			cloud_backup                 = %[4]q
+			cloud_backup                 = %[3]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "GCP"
 			provider_instance_size_name = "M30"
 		}
-	`, orgID, projectName, name, backupEnabled)
+	`, projectID, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, backupEnabled string, biConnectorEnabled bool) string {
+func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(projectID, name, backupEnabled string, biConnectorEnabled bool) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "basic_gcp" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			disk_size_gb = 40
 
             cluster_type = "REPLICASET"
@@ -1887,31 +1808,27 @@ func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name
 		       }
 		    }
 
-			cloud_backup                 = %[4]q
+			cloud_backup                 = %[3]q
 			auto_scaling_disk_gb_enabled = true
 
 			// Provider Settings "block"
 			provider_name               = "GCP"
 			provider_instance_size_name = "M30"
 			bi_connector_config {
-				enabled = %[5]t
+				enabled = %[4]t
 			}
 		}
-	`, orgID, projectName, name, backupEnabled, biConnectorEnabled)
+	`, projectID, name, backupEnabled, biConnectorEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
+func testAccMongoDBAtlasClusterConfigMultiRegion(projectID, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = mongodbatlas_project.cluster_project.id
-			name                    = %[3]q
+			project_id              = %[1]q
+			name                    = %[2]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[4]s
+			cloud_backup            = %[3]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
@@ -1921,24 +1838,20 @@ func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backu
 			replication_specs {
 				num_shards = 1
 
-				%[5]s
+				%[4]s
 			}
 		}
-	`, orgID, projectName, name, backupEnabled, regionsConfig)
+	`, projectID, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, name, backupEnabled, regionsConfig string) string {
+func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(projectID, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = mongodbatlas_project.cluster_project.id
-			name                    = %[3]q
+			project_id              = %[1]q
+			name                    = %[2]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[4]s
+			cloud_backup            = %[3]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
@@ -1949,24 +1862,20 @@ func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(or
 			replication_specs {
 				num_shards = 1
 
-				%[5]s
+				%[4]s
 			}
 		}
-	`, orgID, projectName, name, backupEnabled, regionsConfig)
+	`, projectID, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, name, backupEnabled string) string {
+func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectID, name, backupEnabled string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "multi_region" {
-			project_id              = mongodbatlas_project.cluster_project.id
-			name                    = %[3]q
+			project_id              = %[1]q
+			name                    = %[2]q
 			disk_size_gb            = 100
 			num_shards              = 1
-			cloud_backup            = %[4]s
+			cloud_backup            = %[3]s
 			cluster_type            = "REPLICASET"
 
 			// Provider Settings "block"
@@ -1985,53 +1894,45 @@ func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, p
 				}
 			}
 		}
-	`, orgID, projectName, name, backupEnabled)
+	`, projectID, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, instanceSize, diskSize, majorDBVersion string) string {
+func testAccMongoDBAtlasClusterConfigTenant(projectID, name, instanceSize, diskSize, majorDBVersion string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "tenant" {
-		project_id = mongodbatlas_project.cluster_project.id
-		name       = %[3]q
+		resource "mongodbatlas_cluster" "tenant" {
+			project_id = %[1]q
+			name       = %[2]q
 
-		provider_name         = "TENANT"
-		backing_provider_name = "AWS"
-		provider_region_name  = "US_EAST_1"
-	  	//M2 must be 2, M5 must be 5
-	  	disk_size_gb            = %[4]q
+			provider_name         = "TENANT"
+			backing_provider_name = "AWS"
+			provider_region_name  = "US_EAST_1"
+				//M2 must be 2, M5 must be 5
+				disk_size_gb            = %[3]q
 
-		provider_instance_size_name  = %[5]q
-		//These must be the following values
- 	 	mongo_db_major_version = %[6]q
-	  }
-	`, orgID, projectName, name, diskSize, instanceSize, majorDBVersion)
+			provider_instance_size_name  = %[4]q
+			//These must be the following values
+			mongo_db_major_version = %[5]q
+		}
+	`, projectID, name, diskSize, instanceSize, majorDBVersion)
 }
 
-func testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, name string) string {
+func testAccMongoDBAtlasClusterConfigTenantUpdated(projectID, name string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "tenant" {
-		project_id = mongodbatlas_project.cluster_project.id
-		name       = %[3]q
+		resource "mongodbatlas_cluster" "tenant" {
+			project_id = %[1]q
+			name       = %[2]q
 
-		provider_name        = "AWS"
-		provider_region_name = "EU_CENTRAL_1"
+			provider_name        = "AWS"
+			provider_region_name = "EU_CENTRAL_1"
 
-		provider_instance_size_name  = "M10"
-		disk_size_gb                 = 10
-		auto_scaling_disk_gb_enabled = true
-	  }
-	`, orgID, projectName, name)
+			provider_instance_size_name  = "M10"
+			disk_size_gb                 = 10
+			auto_scaling_disk_gb_enabled = true
+			}
+	`, projectID, name)
 }
 
-func testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, backupEnabled, tier, region string, labels []matlas.Label) string {
+func testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, name, backupEnabled, tier, region string, labels []matlas.Label) string {
 	var labelsConf string
 	for _, label := range labels {
 		labelsConf += fmt.Sprintf(`
@@ -2043,34 +1944,30 @@ func testAccMongoDBAtlasClusterAWSConfigdWithLabels(orgID, projectName, name, ba
 	}
 
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
-			org_id = %[1]q
-		}
 		resource "mongodbatlas_cluster" "aws_with_labels" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			disk_size_gb = 10
   
-			backup_enabled               = %[4]s
+			backup_enabled               = %[3]s
 			auto_scaling_disk_gb_enabled = false
 
 			// Provider Settings "block"
 			provider_name               = "AWS"
-			provider_instance_size_name = %[5]q
+			provider_instance_size_name = %[4]q
 			cluster_type = "REPLICASET"
 			  replication_specs {
 				num_shards = 1
 				regions_config {
-				  region_name     = %[6]q
+				  region_name     = %[5]q
 				  electable_nodes = 3
 				  priority        = 7
 				  read_only_nodes = 0
 				}
 		  	}
-			%[7]s
+			%[6]s
 		}
-	`, orgID, projectName, name, backupEnabled, tier, region, labelsConf)
+	`, projectID, name, backupEnabled, tier, region, labelsConf)
 }
 
 func testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, name, backupEnabled, tier, region string, tags []matlas.Tag) string {
@@ -2086,9 +1983,10 @@ func testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, name, backupEn
 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[2]q
 			org_id = %[1]q
+			name   = %[2]q
 		}
+
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = mongodbatlas_project.cluster_project.id
 			name         = %[3]q
@@ -2416,112 +2314,89 @@ func testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion,
 	`, gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(
-	orgID, projectName, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName string) string {
+func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "test" {
-		project_id                              = mongodbatlas_project.cluster_project.id
-		name                                    = %[3]q
-		disk_size_gb                            = 100
+		resource "mongodbatlas_cluster" "test" {
+			project_id                              = %[1]q
+			name                                    = %[2]q
+			disk_size_gb                            = 100
 
-		cluster_type = "REPLICASET"
-		replication_specs {
-		  num_shards = 1
-		  regions_config {
-			 region_name     = "EU_CENTRAL_1"
-			 electable_nodes = 3
-			 priority        = 7
-			 read_only_nodes = 0
-		   }
+			cluster_type = "REPLICASET"
+			replication_specs {
+				num_shards = 1
+				regions_config {
+				region_name     = "EU_CENTRAL_1"
+				electable_nodes = 3
+				priority        = 7
+				read_only_nodes = 0
+				}
+			}
+			cloud_backup                            = %[3]s
+			auto_scaling_disk_gb_enabled            = %[4]s
+			auto_scaling_compute_enabled            = %[5]s
+			auto_scaling_compute_scale_down_enabled = %[6]s
+
+			//Provider Settings "block"
+			provider_name                                   = "AWS"
+			provider_auto_scaling_compute_min_instance_size = %[7]q
+			provider_auto_scaling_compute_max_instance_size = %[8]q
+			provider_instance_size_name                     = %[9]q
+
+			lifecycle { // To simulate if there a new instance size name to avoid scale cluster down to original value
+				ignore_changes = [provider_instance_size_name]
+			}
 		}
-		cloud_backup                            = %[4]s
-		auto_scaling_disk_gb_enabled            = %[5]s
-		auto_scaling_compute_enabled            = %[6]s
-		auto_scaling_compute_scale_down_enabled = %[7]s
 
-		//Provider Settings "block"
-		provider_name                                   = "AWS"
-		provider_instance_size_name                     = %[9]q
-		provider_auto_scaling_compute_min_instance_size = %[8]q
-		provider_auto_scaling_compute_max_instance_size = %[9]q
-
-		lifecycle { // To simulate if there a new instance size name to avoid scale cluster down to original value
-			ignore_changes = [provider_instance_size_name]
+		data "mongodbatlas_cluster" "test" {
+			project_id = mongodbatlas_cluster.test.project_id
+			name 	     = mongodbatlas_cluster.test.name
 		}
-	}
-
-	data "mongodbatlas_cluster" "test" {
-		project_id = mongodbatlas_cluster.test.project_id
-		name 	     = mongodbatlas_cluster.test.name
-	}
-
-	data "mongodbatlas_clusters" "test" {
-		project_id = mongodbatlas_cluster.test.project_id
-	}
-	`, orgID, projectName, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
+	`, projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPRegionName(
-	orgID, projectName, name, regionName string) string {
+func testAccMongoDBAtlasClusterConfigGCPRegionName(projectID, name, regionName string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "test" {
-  project_id                   = mongodbatlas_project.cluster_project.id
-  name                         = %[3]q
-  auto_scaling_disk_gb_enabled = true
-  provider_name                = "GCP"
-  disk_size_gb                 = 10
-  provider_instance_size_name  = "M10"
-  num_shards                   = 1
-  provider_region_name         = %[4]q
-}
-	`, orgID, projectName, name, regionName)
+			resource "mongodbatlas_cluster" "test" {
+			project_id                   = %[1]q
+			name                         = %[2]q
+			auto_scaling_disk_gb_enabled = true
+			provider_name                = "GCP"
+			disk_size_gb                 = 10
+			provider_instance_size_name  = "M10"
+			num_shards                   = 1
+			provider_region_name         = %[3]q
+		}
+	`, projectID, name, regionName)
 }
 
-func testAccMongoDBAtlasClusterConfigRegions(
-	orgID, projectName, name, replications string) string {
+func testAccMongoDBAtlasClusterConfigRegions(projectID, name, replications string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "test" {
-	  project_id              = mongodbatlas_project.cluster_project.id
-	  name                    = "%[3]s"
-	  disk_size_gb            = 400
-	  num_shards              = 3
-	  cloud_backup            = true
-	  cluster_type            = "GEOSHARDED"
-	  // Provider Settings "block"
-	  provider_name               = "AWS"
-	  provider_disk_iops          = 1200
-	  provider_instance_size_name = "M30"
-	  %[4]s
+		resource "mongodbatlas_cluster" "test" {
+			project_id              = %[1]q
+			name                    = %[2]q
+			disk_size_gb            = 400
+			num_shards              = 3
+			cloud_backup            = true
+			cluster_type            = "GEOSHARDED"
+			// Provider Settings "block"
+			provider_name               = "AWS"
+			provider_disk_iops          = 1200
+			provider_instance_size_name = "M30"
+			%[3]s
 
-		lifecycle {
-		# avoid cluster has been auto-scaled to different instance size
-		ignore_changes = [provider_instance_size_name, disk_size_gb]
-	  }
-	}
-	`, orgID, projectName, name, replications)
+			lifecycle {
+			# avoid cluster has been auto-scaled to different instance size
+			ignore_changes = [provider_instance_size_name, disk_size_gb]
+			}
+		}
+	`, projectID, name, replications)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSPaused(orgID, projectName, name string, backupEnabled, paused bool) string {
+func testAccMongoDBAtlasClusterConfigAWSPaused(projectID, name string, backupEnabled, paused bool) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}
 resource "mongodbatlas_cluster" "test" {
-  project_id                   = mongodbatlas_project.cluster_project.id
-  name                         = %[3]q
+  project_id                   = %[1]q
+  name                         = %[2]q
   disk_size_gb                 = 100
   cluster_type = "REPLICASET"
   replication_specs {
@@ -2533,14 +2408,14 @@ resource "mongodbatlas_cluster" "test" {
       read_only_nodes = 0
     }
   }
-  cloud_backup                 = %[4]t
-  paused                       = %[5]t
+  cloud_backup                 = %[3]t
+  paused                       = %[4]t
   // Provider Settings "block"
 
   provider_name               = "AWS"
   provider_instance_size_name = "M30"
 }
-	`, orgID, projectName, name, backupEnabled, paused)
+	`, projectID, name, backupEnabled, paused)
 }
 
 func TestIsMultiRegionCluster(t *testing.T) {

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -18,12 +18,15 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
+const (
+	resourceName   = "mongodbatlas_cluster.test"
+	dataSourceName = "data.mongodbatlas_cluster.test"
+)
+
 func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,8 +37,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -57,8 +59,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -77,10 +78,8 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 
 func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -91,8 +90,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M40_NVME"),
@@ -102,8 +100,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M50_NVME"),
@@ -116,11 +113,8 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 
 func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 	var (
-		cluster        matlas.Cluster
-		resourceName   = "mongodbatlas_cluster.advance_conf"
-		dataSourceName = "data.mongodbatlas_cluster.test"
-		projectID      = acc.ProjectIDExecution(t)
-		clusterName    = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -140,8 +134,7 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
@@ -166,8 +159,7 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
@@ -183,10 +175,8 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 
 func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.advance_conf"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -208,8 +198,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -225,8 +214,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -243,9 +231,8 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 
 func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cluster.advance_conf"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -286,10 +273,8 @@ func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 
 func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.advance_conf"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -309,8 +294,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
@@ -333,8 +317,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](60),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
@@ -351,7 +334,6 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 
 func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
@@ -366,8 +348,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -378,8 +359,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "false", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -393,7 +373,6 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 
 func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_azure"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
@@ -407,8 +386,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60", true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M60"),
@@ -420,8 +398,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60_NVME", false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M60_NVME"),
@@ -436,7 +413,6 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 
 func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
@@ -451,8 +427,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "true"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
@@ -464,8 +439,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
@@ -480,7 +454,6 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 
 func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.basic_gcp"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
@@ -495,8 +468,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
@@ -509,8 +481,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "40"),
@@ -526,7 +497,6 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 
 func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -567,8 +537,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
@@ -583,8 +552,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
@@ -602,7 +570,6 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 
 func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -640,8 +607,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
@@ -656,8 +622,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
@@ -684,7 +649,6 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 
 func TestAccClusterRSCluster_Global(t *testing.T) {
 	var (
-		cluster        matlas.Cluster
 		resourceSuffix = "global_cluster"
 		resourceName   = fmt.Sprintf("mongodbatlas_cluster.%s", resourceSuffix)
 		projectID      = acc.ProjectIDExecution(t)
@@ -699,8 +663,7 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 			{
 				Config: acc.ConfigClusterGlobal(resourceSuffix, projectID, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
@@ -720,7 +683,6 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 
 func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.aws_with_labels"
 		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
@@ -734,8 +696,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "US_WEST_2", []matlas.Label{}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
@@ -761,8 +722,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
@@ -784,8 +744,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
@@ -799,9 +758,6 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 
 func TestAccClusterRSCluster_WithTags(t *testing.T) {
 	var (
-		cluster                matlas.Cluster
-		resourceName           = "mongodbatlas_cluster.test"
-		dataSourceName         = "data.mongodbatlas_cluster.test"
 		dataSourceClustersName = "data.mongodbatlas_clusters.test"
 		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName            = acc.RandomProjectName() // No ProjectIDExecution because this test has plural datasource
@@ -816,8 +772,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2", []matlas.Tag{}),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -840,8 +795,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -866,8 +820,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -886,7 +839,6 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.with_endpoint_link"
 
 		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
@@ -911,7 +863,7 @@ func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
 				Config: testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 				),
 			},
@@ -922,7 +874,6 @@ func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
 func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.with_azure_peering"
 
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -945,7 +896,7 @@ func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 				),
@@ -957,8 +908,6 @@ func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
 func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		cluster          matlas.Cluster
-		resourceName     = "mongodbatlas_cluster.test"
 		projectID        = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		gcpRegion        = os.Getenv("GCP_REGION_NAME")
 		gcpProjectID     = os.Getenv("GCP_PROJECT_ID")
@@ -976,8 +925,7 @@ func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
@@ -993,7 +941,6 @@ func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
 func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		resourceName      = "mongodbatlas_cluster.test"
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		clusterName       = acc.RandomClusterName()
 		providerName      = "AZURE"
@@ -1024,11 +971,8 @@ func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
 func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		resourceName = "mongodbatlas_cluster.test"
-
 		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		clusterName  = acc.RandomClusterName()
 		providerName = "AWS"
@@ -1057,7 +1001,6 @@ func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
 func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t)
 	var (
-		resourceName     = "mongodbatlas_cluster.test"
 		gcpProjectID     = os.Getenv("GCP_PROJECT_ID")
 		gcpRegion        = os.Getenv("GCP_REGION_NAME")
 		projectID        = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -1089,11 +1032,8 @@ func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
 
 func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 	var (
-		cluster        matlas.Cluster
-		resourceName   = "mongodbatlas_cluster.test"
-		dataSourceName = "data.mongodbatlas_cluster.test"
-		projectID      = acc.ProjectIDExecution(t)
-		clusterName    = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 
 		instanceSize = "M30"
 		minSize      = ""
@@ -1112,8 +1052,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_compute_enabled", "true"),
@@ -1132,8 +1071,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_compute_enabled", "true"),
@@ -1148,9 +1086,8 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 
 func TestAccClusterRSCluster_importBasic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1174,7 +1111,6 @@ func TestAccClusterRSCluster_importBasic(t *testing.T) {
 
 func TestAccClusterRSCluster_tenant(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
 		resourceName = "mongodbatlas_cluster.tenant"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because tenant
@@ -1191,8 +1127,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "2"),
@@ -1202,8 +1137,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
@@ -1216,7 +1150,6 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 
 func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 	var (
-		cluster        matlas.Cluster
 		resourceName   = "mongodbatlas_cluster.tenant"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName    = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because tenant
@@ -1232,8 +1165,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
@@ -1246,11 +1178,10 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 
 func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
-		clusterName  = acc.RandomClusterName()
-		regionName   = "WESTERN_US"
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
+		clusterName = acc.RandomClusterName()
+		regionName  = "WESTERN_US"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1272,11 +1203,10 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 
 func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
-		clusterName  = acc.RandomClusterName() // No ProjectIDExecution to avoid cross-region limits because no AWS
-		regionName   = "US_WEST_2"
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName() // No ProjectIDExecution to avoid cross-region limits because no AWS
+		regionName  = "US_WEST_2"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1298,10 +1228,9 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 
 func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cluster.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName  = acc.RandomClusterName()
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
+		clusterName = acc.RandomClusterName()
 	)
 
 	replications := `replication_specs {
@@ -1417,10 +1346,8 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 
 func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1431,8 +1358,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -1445,8 +1371,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -1469,10 +1394,8 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 
 func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 	var (
-		cluster      matlas.Cluster
-		resourceName = "mongodbatlas_cluster.test"
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1483,8 +1406,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -1497,8 +1419,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 			{
 				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasClusterExists(resourceName, &cluster),
-					testAccCheckMongoDBAtlasClusterAttributes(&cluster, clusterName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "100"),
@@ -1519,7 +1440,7 @@ func testAccGetMongoDBAtlasMajorVersion() string {
 	return majorVersion
 }
 
-func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -1530,21 +1451,10 @@ func testAccCheckMongoDBAtlasClusterExists(resourceName string, cluster *matlas.
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
-		if clusterResp, _, err := acc.Conn().Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
-			*cluster = *clusterResp
+		if _, _, err := acc.Conn().Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"]); err == nil {
 			return nil
 		}
 		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
-	}
-}
-
-func testAccCheckMongoDBAtlasClusterAttributes(cluster *matlas.Cluster, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if cluster.Name != name {
-			return fmt.Errorf("bad name: %s", cluster.Name)
-		}
-
-		return nil
 	}
 }
 
@@ -1590,7 +1500,7 @@ func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, instanceNa
 
 func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "advance_conf" {
+		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
 			disk_size_gb = 10
@@ -1626,8 +1536,8 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEn
 		}
 
 		data "mongodbatlas_cluster" "test" {
-			project_id = mongodbatlas_cluster.advance_conf.project_id
-			name 	     = mongodbatlas_cluster.advance_conf.name
+			project_id = mongodbatlas_cluster.test.project_id
+			name 	     = mongodbatlas_cluster.test.name
 		}
 	`, projectID, name, autoscalingEnabled,
 		*p.FailIndexKeyTooLong, *p.JavascriptEnabled, p.MinimumEnabledTLSProtocol, *p.NoTableScan,
@@ -1636,7 +1546,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEn
 
 func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "advance_conf" {
+		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
 			disk_size_gb = 10
@@ -1676,7 +1586,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, nam
 
 func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "advance_conf" {
+		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
 			disk_size_gb = 10
@@ -1709,7 +1619,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autosc
 
 func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "advance_conf" {
+		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
 			disk_size_gb = 10

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1569,7 +1569,7 @@ func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, instanceNa
 			project_id   = %[1]q
 			name         = %[2]q
 			cloud_backup                 = true
-			provider_region_name     = "US_EAST_1"
+			provider_region_name     = "US_WEST_2"
 			provider_name               = "AWS"
 			provider_instance_size_name = %[3]q
 			provider_volume_type        = "PROVISIONED"
@@ -1881,13 +1881,13 @@ func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(projectI
 			// Provider Settings "block"
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
-			provider_region_name = "US_EAST_1"
+			provider_region_name = "US_WEST_2"
 
 			replication_specs {
 				num_shards = 1
 
 				regions_config {
-					region_name     = "US_EAST_1"
+					region_name     = "US_WEST_2"
 					electable_nodes = 3
 					priority        = 7
 					read_only_nodes = 0

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -35,7 +35,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, true),
+				Config: configAWS(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -57,7 +57,7 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, false, false),
+				Config: configAWS(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -88,7 +88,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
+				Config: configAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -98,7 +98,7 @@ func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
+				Config: configAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -123,7 +123,7 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -155,7 +155,7 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -185,7 +185,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConfDefaultWriteRead(projectID, clusterName, "false", &matlas.ProcessArgs{
 					DefaultReadConcern:               "available",
 					DefaultWriteConcern:              "1",
 					FailIndexKeyTooLong:              conversion.Pointer(false),
@@ -210,7 +210,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConfPartialDefault(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -241,12 +241,12 @@ func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -283,7 +283,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(true),
 					MinimumEnabledTLSProtocol:        "TLS1_2",
@@ -306,7 +306,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
+				Config: configAdvancedConf(projectID, clusterName, "false", &matlas.ProcessArgs{
 					FailIndexKeyTooLong:              conversion.Pointer(false),
 					JavascriptEnabled:                conversion.Pointer(false),
 					MinimumEnabledTLSProtocol:        "TLS1_1",
@@ -346,7 +346,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M30", true),
+				Config: configAzure(orgID, projectName, clusterName, "true", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -357,7 +357,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "false", "M30", true),
+				Config: configAzure(orgID, projectName, clusterName, "false", "M30", true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -384,7 +384,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60", true),
+				Config: configAzure(orgID, projectName, clusterName, "true", "M60", true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -396,7 +396,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, clusterName, "true", "M60_NVME", false),
+				Config: configAzure(orgID, projectName, clusterName, "true", "M60_NVME", false),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -425,7 +425,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "true"),
+				Config: configGCP(orgID, projectName, clusterName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -437,7 +437,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, clusterName, "false"),
+				Config: configGCP(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -466,7 +466,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
+				Config: configGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -479,7 +479,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
+				Config: configGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -535,7 +535,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
+				Config: configMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -550,7 +550,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: configMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -601,11 +601,11 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config:      configMultiRegionWithProviderRegionNameInvalid(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				ExpectError: regexp.MustCompile("attribute must be set ONLY for single-region clusters"),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
+				Config: configSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -620,7 +620,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: configMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -635,7 +635,7 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
+				Config: configMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),
@@ -770,7 +770,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2", []matlas.Tag{}),
+				Config: configWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2", []matlas.Tag{}),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -782,7 +782,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
+				Config: configWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Tag{
 						{
 							Key:   "key 1",
@@ -811,7 +811,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
+				Config: configWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2",
 					[]matlas.Tag{
 						{
 							Key:   "key 3",
@@ -860,7 +860,7 @@ func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(
+				Config: configWithPrivateEndpointLink(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
@@ -894,7 +894,7 @@ func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
+				Config: configAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -923,7 +923,7 @@ func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion),
+				Config: configGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -957,7 +957,7 @@ func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName),
+				Config: configAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -987,7 +987,7 @@ func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, awsRegion, vpcCIDRBlock, awsAccountID),
+				Config: configAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, awsRegion, vpcCIDRBlock, awsAccountID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -1016,7 +1016,7 @@ func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName),
+				Config: configGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1050,7 +1050,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
+				Config: configAWSWithAutoscaling(projectID, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1069,7 +1069,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
+				Config: configAWSWithAutoscaling(projectID, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1096,7 +1096,7 @@ func TestAccClusterRSCluster_importBasic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWS(projectID, clusterName, true, false),
+				Config: configAWS(projectID, clusterName, true, false),
 			},
 			{
 				ResourceName:            resourceName,
@@ -1125,7 +1125,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
+				Config: configTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1135,7 +1135,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, clusterName),
+				Config: configTenantUpdated(orgID, projectName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1163,7 +1163,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
+				Config: configTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1190,7 +1190,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Config: configGCPRegionName(orgID, projectName, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1215,7 +1215,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigGCPRegionName(orgID, projectName, clusterName, regionName),
+				Config: configGCPRegionName(orgID, projectName, clusterName, regionName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1314,7 +1314,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replications),
+				Config: configRegions(orgID, projectName, clusterName, replications),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1322,7 +1322,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsUpdate),
+				Config: configRegions(orgID, projectName, clusterName, replicationsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1330,7 +1330,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
+				Config: configRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1356,7 +1356,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, false),
+				Config: configAWSPaused(projectID, clusterName, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1369,7 +1369,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, true),
+				Config: configAWSPaused(projectID, clusterName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1404,7 +1404,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, true, true),
+				Config: configAWSPaused(projectID, clusterName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1417,7 +1417,7 @@ func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasClusterConfigAWSPaused(projectID, clusterName, false, false),
+				Config: configAWSPaused(projectID, clusterName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -1458,7 +1458,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccMongoDBAtlasClusterConfigAWS(projectID, name string, backupEnabled, autoDiskGBEnabled bool) string {
+func configAWS(projectID, name string, backupEnabled, autoDiskGBEnabled bool) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id                   = %[1]q
@@ -1484,7 +1484,7 @@ func testAccMongoDBAtlasClusterConfigAWS(projectID, name string, backupEnabled, 
 	`, projectID, name, backupEnabled, autoDiskGBEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, instanceName string) string {
+func configAWSNVMEInstance(projectID, name, instanceName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
@@ -1498,7 +1498,7 @@ func testAccMongoDBAtlasClusterConfigAWSNVMEInstance(projectID, name, instanceNa
 	`, projectID, name, instanceName)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func configAdvancedConf(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
@@ -1544,7 +1544,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConf(projectID, name, autoscalingEn
 		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, *p.TransactionLifetimeLimitSeconds)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func configAdvancedConfDefaultWriteRead(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
@@ -1584,7 +1584,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfDefaultWriteRead(projectID, nam
 		*p.OplogSizeMB, *p.SampleSizeBIConnector, *p.SampleRefreshIntervalBIConnector, p.DefaultReadConcern, p.DefaultWriteConcern)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func configAdvancedConfPartial(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
@@ -1617,7 +1617,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartial(projectID, name, autosc
 	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
-func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
+func configAdvancedConfPartialDefault(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = %[1]q
@@ -1650,7 +1650,7 @@ func testAccMongoDBAtlasClusterConfigAdvancedConfPartialDefault(projectID, name,
 	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol)
 }
 
-func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
+func configAzure(orgID, projectName, name, backupEnabled, instanceSizeName string, includeDiskType bool) string {
 	var diskType string
 	if includeDiskType {
 		diskType = `provider_disk_type_name     = "P6"`
@@ -1687,7 +1687,7 @@ func testAccMongoDBAtlasClusterConfigAzure(orgID, projectName, name, backupEnabl
 	`, orgID, projectName, name, backupEnabled, diskType, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled string) string {
+func configGCP(orgID, projectName, name, backupEnabled string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			name   = %[2]q
@@ -1719,7 +1719,7 @@ func testAccMongoDBAtlasClusterConfigGCP(orgID, projectName, name, backupEnabled
 	`, orgID, projectName, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name, backupEnabled string, biConnectorEnabled bool) string {
+func configGCPWithBiConnector(orgID, projectName, name, backupEnabled string, biConnectorEnabled bool) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			name   = %[2]q
@@ -1754,7 +1754,7 @@ func testAccMongoDBAtlasClusterConfigGCPWithBiConnector(orgID, projectName, name
 	`, orgID, projectName, name, backupEnabled, biConnectorEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
+func configMultiRegion(orgID, projectName, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			name   = %[2]q
@@ -1781,7 +1781,7 @@ func testAccMongoDBAtlasClusterConfigMultiRegion(orgID, projectName, name, backu
 	`, orgID, projectName, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(orgID, projectName, name, backupEnabled, regionsConfig string) string {
+func configMultiRegionWithProviderRegionNameInvalid(orgID, projectName, name, backupEnabled, regionsConfig string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			name   = %[2]q
@@ -1809,7 +1809,7 @@ func testAccMongoDBAtlasClusterConfigMultiRegionWithProviderRegionNameInvalid(or
 	`, orgID, projectName, name, backupEnabled, regionsConfig)
 }
 
-func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, projectName, name, backupEnabled string) string {
+func configSingleRegionWithProviderRegionName(orgID, projectName, name, backupEnabled string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			name   = %[2]q
@@ -1842,7 +1842,7 @@ func testAccMongoDBAtlasClusterConfigSingleRegionWithProviderRegionName(orgID, p
 	`, orgID, projectName, name, backupEnabled)
 }
 
-func testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, instanceSize, diskSize, majorDBVersion string) string {
+func configTenant(orgID, projectName, name, instanceSize, diskSize, majorDBVersion string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "cluster_project" {
 		name   = %[2]q
@@ -1865,7 +1865,7 @@ func testAccMongoDBAtlasClusterConfigTenant(orgID, projectName, name, instanceSi
 	`, orgID, projectName, name, diskSize, instanceSize, majorDBVersion)
 }
 
-func testAccMongoDBAtlasClusterConfigTenantUpdated(orgID, projectName, name string) string {
+func configTenantUpdated(orgID, projectName, name string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "cluster_project" {
 		name   = %[2]q
@@ -1923,7 +1923,7 @@ func testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, name, backupEnabl
 	`, projectID, name, backupEnabled, tier, region, labelsConf)
 }
 
-func testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, name, backupEnabled, tier, region string, tags []matlas.Tag) string {
+func configWithTags(orgID, projectName, name, backupEnabled, tier, region string, tags []matlas.Tag) string {
 	var tagsConf string
 	for _, label := range tags {
 		tagsConf += fmt.Sprintf(`
@@ -1976,7 +1976,7 @@ func testAccMongoDBAtlasClusterConfigWithTags(orgID, projectName, name, backupEn
 	`, orgID, projectName, name, backupEnabled, tier, region, tagsConf)
 }
 
-func testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName string) string {
+func configWithPrivateEndpointLink(awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName string) string {
 	return fmt.Sprintf(`
 		provider "aws" {
 			region     = "${lower(replace("%[5]s", "_", "-"))}"
@@ -2020,7 +2020,7 @@ func testAccMongoDBAtlasClusterConfigWithPrivateEndpointLink(awsAccessKey, awsSe
 	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName)
 }
 
-func testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region string) string {
+func configAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_network_container" "test" {
 			project_id       = "%[1]s"
@@ -2067,7 +2067,7 @@ func testAccMongoDBAtlasClusterConfigAzureWithNetworkPeering(projectID, provider
 	`, projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion string) string {
+func configGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion string) string {
 	return fmt.Sprintf(`
 		provider "google" {
 			project     = "%[1]s"
@@ -2124,7 +2124,7 @@ func testAccMongoDBAtlasClusterConfigGCPWithNetworkPeering(gcpProjectID, gcpRegi
 	`, gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion)
 }
 
-func testAccMongoDBAtlasClusterConfigAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName string) string {
+func configAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id   = "%[1]s"
@@ -2161,7 +2161,7 @@ func testAccMongoDBAtlasClusterConfigAzureWithContainerID(projectID, clusterName
 	`, projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, region, vpcCIDRBlock, awsAccountID string) string {
+func configAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, region, vpcCIDRBlock, awsAccountID string) string {
 	return fmt.Sprintf(`
 		provider "aws" {
 			region     = lower(replace("%[6]s", "_", "-"))
@@ -2218,7 +2218,7 @@ func testAccMongoDBAtlasClusterConfigAWSWithContainerID(awsAccessKey, awsSecretK
 	`, awsAccessKey, awsSecretKey, projectID, clusterName, providerName, region, vpcCIDRBlock, awsAccountID)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName string) string {
+func configGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName string) string {
 	return fmt.Sprintf(`
 		provider "google" {
 			project     = "%[1]s"
@@ -2267,7 +2267,7 @@ func testAccMongoDBAtlasClusterConfigGCPWithContainerID(gcpProjectID, gcpRegion,
 	`, gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName string) string {
+func configAWSWithAutoscaling(projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "test" {
 			project_id                              = %[1]q
@@ -2307,7 +2307,7 @@ func testAccMongoDBAtlasClusterConfigAWSWithAutoscaling(projectID, name, backupE
 	`, projectID, name, backupEnabled, autoDiskEnabled, autoScalingEnabled, scaleDownEnabled, minSizeName, maxSizeName, instanceSizeName)
 }
 
-func testAccMongoDBAtlasClusterConfigGCPRegionName(
+func configGCPRegionName(
 	orgID, projectName, name, regionName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "cluster_project" {
@@ -2327,7 +2327,7 @@ func testAccMongoDBAtlasClusterConfigGCPRegionName(
 	`, orgID, projectName, name, regionName)
 }
 
-func testAccMongoDBAtlasClusterConfigRegions(
+func configRegions(
 	orgID, projectName, name, replications string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_project" "cluster_project" {
@@ -2355,7 +2355,7 @@ func testAccMongoDBAtlasClusterConfigRegions(
 	`, orgID, projectName, name, replications)
 }
 
-func testAccMongoDBAtlasClusterConfigAWSPaused(projectID, name string, backupEnabled, paused bool) string {
+func configAWSPaused(projectID, name string, backupEnabled, paused bool) string {
 	return fmt.Sprintf(`
 resource "mongodbatlas_cluster" "test" {
   project_id                   = %[1]q

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -21,16 +21,14 @@ func TestAccNetworkRSPrivateEndpointRegionalMode_conn(t *testing.T) {
 		resourceName           = fmt.Sprintf("mongodbatlas_private_endpoint_regional_mode.%s", resourceSuffix)
 		awsAccessKey           = os.Getenv("AWS_ACCESS_KEY_ID")
 		awsSecretKey           = os.Getenv("AWS_SECRET_ACCESS_KEY")
-		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectID              = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		projectName            = acc.RandomProjectName()
 		providerName           = "AWS"
 		region                 = os.Getenv("AWS_REGION")
+		projectID              = acc.ProjectIDExecution(t)
 		clusterName            = acc.RandomClusterName()
 		clusterResourceName    = "global_cluster"
 	)
 
-	clusterResource := acc.ConfigClusterGlobal(clusterResourceName, orgID, projectName, clusterName, "false")
+	clusterResource := acc.ConfigClusterGlobal(clusterResourceName, projectID, clusterName, "false")
 	clusterDataSource := testAccMongoDBAtlasPrivateEndpointRegionalModeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
 	endpointResources := testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(
 		awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -69,7 +69,7 @@ func ConfigClusterGlobal(resourceName, projectID, name, backupEnabled string) st
 				zone_name  = "Zone 2"
 				num_shards = 2
 				regions_config {
-				region_name     = "US_EAST_2"
+				region_name     = "US_WEST_2"
 				electable_nodes = 3
 				priority        = 7
 				read_only_nodes = 0

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -40,19 +40,14 @@ func CheckDestroyCluster(s *terraform.State) error {
 	return nil
 }
 
-func ConfigClusterGlobal(resourceName, orgID, projectName, name, backupEnabled string) string {
+func ConfigClusterGlobal(resourceName, projectID, name, backupEnabled string) string {
 	return fmt.Sprintf(`
-
-		resource "mongodbatlas_project" "cluster_project" {
-			name   = %[3]q
-			org_id = %[2]q
-		}
 		resource "mongodbatlas_cluster" %[1]q {
-			project_id              = mongodbatlas_project.cluster_project.id
-			name                    = %[4]q
+			project_id              = %[2]q
+			name                    = %[3]q
 			disk_size_gb            = 80
 			num_shards              = 1
-			cloud_backup            = %[5]s
+			cloud_backup            = %[4]s
 			cluster_type            = "GEOSHARDED"
 
 			// Provider Settings "block"
@@ -81,7 +76,7 @@ func ConfigClusterGlobal(resourceName, orgID, projectName, name, backupEnabled s
 				}
 			}
 		}
-	`, resourceName, orgID, projectName, name, backupEnabled)
+	`, resourceName, projectID, name, backupEnabled)
 }
 
 func ImportStateClusterIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -32,8 +32,8 @@ func CheckDestroyCluster(s *terraform.State) error {
 		}
 		projectID := rs.Primary.Attributes["project_id"]
 		clusterName := rs.Primary.Attributes["cluster_name"]
-		_, _, err := ConnV2().ClustersApi.GetCluster(context.Background(), projectID, clusterName).Execute()
-		if err == nil {
+		resp, _, _ := ConnV2().ClustersApi.GetCluster(context.Background(), projectID, clusterName).Execute()
+		if resp.GetId() != "" {
 			return fmt.Errorf("cluster (%s:%s) still exists", clusterName, rs.Primary.ID)
 		}
 	}

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -29,7 +29,7 @@ func deleteProject(id string) {
 	}
 }
 
-func projectID(tb testing.TB, name string) string {
+func ProjectID(tb testing.TB, name string) string {
 	tb.Helper()
 	SkipInUnitTest(tb)
 	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -10,7 +10,7 @@ import (
 const (
 	prefixName        = "test-acc-tf"
 	prefixProject     = prefixName + "-p"
-	prefixProjectKeep = prefixProject + "-keep"
+	PrefixProjectKeep = prefixProject + "-keep"
 	prefixCluster     = prefixName + "-c"
 	prefixIAMRole     = "mongodb-atlas-" + prefixName
 	prefixIAMUser     = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
@@ -48,7 +48,9 @@ func RandomLDAPName() string {
 	return fmt.Sprintf("CN=%s-%s@example.com,OU=users,DC=example,DC=com", prefixName, acctest.RandString(10))
 }
 
+// ProjectIDGlobal returns a common global project.
+// Consider mig.ProjectIDGlobal for mig tests.
 func ProjectIDGlobal(tb testing.TB) string {
 	tb.Helper()
-	return projectID(tb, prefixProjectKeep+"-global")
+	return ProjectID(tb, PrefixProjectKeep+"-global")
 }

--- a/internal/testutil/mig/name.go
+++ b/internal/testutil/mig/name.go
@@ -1,0 +1,14 @@
+package mig
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// ProjectIDGlobal returns a common global project to be used by migration tests.
+// As there is a small number of mig tests this project won't hit limits.
+func ProjectIDGlobal(tb testing.TB) string {
+	tb.Helper()
+	return acc.ProjectID(tb, acc.PrefixProjectKeep+"-global-mig")
+}


### PR DESCRIPTION
## Description

Reuses project in tests for `cluster` resource

Link to any related issue(s): CLOUDP-237988

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
