### PR TITLE
chore: Reuses project in tests for `project_api_key` resource

### DIFF
--- a/internal/service/projectapikey/resource_project_api_key_migration_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_migration_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDGlobal(t)
+		projectID   = mig.ProjectIDGlobal(t)
 		description = acc.RandomName()
 	)
 

--- a/internal/service/projectapikey/resource_project_api_key_migration_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_migration_test.go
@@ -9,19 +9,17 @@ import (
 
 func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		projectID    = acc.ProjectIDExecution(t)
-		description  = acc.RandomName()
-		roleName     = "GROUP_OWNER"
+		projectID   = acc.ProjectIDExecution(t)
+		description = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acc.PreCheckBasic(t) },
-		CheckDestroy: testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders("1.13.1"), // fixed version as this is the last version where root project id was required.
-				Config:            testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
+				Config:            configBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -31,7 +29,7 @@ func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
+				Config:                   configBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -41,7 +39,7 @@ func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
+				Config:                   configBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),

--- a/internal/service/projectapikey/resource_project_api_key_migration_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_migration_test.go
@@ -1,7 +1,6 @@
 package projectapikey_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,8 +10,7 @@ import (
 func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		description  = acc.RandomName()
 		roleName     = "GROUP_OWNER"
 	)
@@ -23,7 +21,7 @@ func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders("1.13.1"), // fixed version as this is the last version where root project id was required.
-				Config:            testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, true),
+				Config:            testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -33,7 +31,7 @@ func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, true),
+				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -43,7 +41,7 @@ func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config:                   testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),

--- a/internal/service/projectapikey/resource_project_api_key_migration_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_migration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMigConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
+		projectID   = acc.ProjectIDGlobal(t)
 		description = acc.RandomName()
 	)
 

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -15,21 +15,24 @@ import (
 	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
+const (
+	resourceName = "mongodbatlas_project_api_key.test"
+	roleName     = "GROUP_OWNER"
+)
+
+func TestAccConfigRSProjectAPIKey_basic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		projectID    = acc.ProjectIDExecution(t)
-		description  = acc.RandomName()
-		roleName     = "GROUP_OWNER"
+		projectID   = acc.ProjectIDExecution(t)
+		description = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
+				Config: configBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -40,21 +43,19 @@ func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_BasicWithLegacyRootProjectID(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_basicWithLegacyRootProjectID(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		projectID    = acc.ProjectIDExecution(t)
-		description  = acc.RandomName()
-		roleName     = "GROUP_OWNER"
+		projectID   = acc.ProjectIDExecution(t)
+		description = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
+				Config: configBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -66,9 +67,8 @@ func TestAccConfigRSProjectAPIKey_BasicWithLegacyRootProjectID(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_ChangingSingleProject(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_changingSingleProject(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectID1   = acc.ProjectIDExecution(t)
 		projectName2 = acc.RandomProjectName()
@@ -78,10 +78,10 @@ func TestAccConfigRSProjectAPIKey_ChangingSingleProject(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyChangingProject(orgID, projectName2, description, fmt.Sprintf("%q", projectID1)),
+				Config: configChangingProject(orgID, projectName2, description, fmt.Sprintf("%q", projectID1)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -89,7 +89,7 @@ func TestAccConfigRSProjectAPIKey_ChangingSingleProject(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyChangingProject(orgID, projectName2, description, "mongodbatlas_project.proj2.id"),
+				Config: configChangingProject(orgID, projectName2, description, "mongodbatlas_project.proj2.id"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -100,21 +100,19 @@ func TestAccConfigRSProjectAPIKey_ChangingSingleProject(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_removingOptionalRootProjectID(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		projectID    = acc.ProjectIDExecution(t)
-		description  = acc.RandomName()
-		roleName     = "GROUP_OWNER"
+		projectID   = acc.ProjectIDExecution(t)
+		description = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
+				Config: configBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -123,7 +121,7 @@ func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
+				Config: configBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -134,23 +132,21 @@ func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_Multiple(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_multiple(t *testing.T) {
 	var (
-		resourceName    = "mongodbatlas_project_api_key.test"
 		dataSourceName  = "data.mongodbatlas_project_api_key.test"
 		dataSourcesName = "data.mongodbatlas_project_api_keys.test"
 		projectID       = acc.ProjectIDExecution(t)
 		description     = acc.RandomName()
-		roleName        = "GROUP_OWNER"
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigMultiple(projectID, description, roleName),
+				Config: configMultiple(projectID, description, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -168,29 +164,27 @@ func TestAccConfigRSProjectAPIKey_Multiple(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_updateDescription(t *testing.T) {
 	var (
-		resourceName       = "mongodbatlas_project_api_key.test"
 		projectID          = acc.ProjectIDExecution(t)
 		description        = acc.RandomName()
 		updatedDescription = acc.RandomName()
-		roleName           = "GROUP_OWNER"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
+				Config: configBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, updatedDescription, roleName, false),
+				Config: configBasic(projectID, updatedDescription, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
@@ -202,23 +196,21 @@ func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
 
 func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
-		projectID    = acc.ProjectIDExecution(t)
-		description  = acc.RandomName()
-		roleName     = "GROUP_OWNER"
+		projectID   = acc.ProjectIDExecution(t)
+		description = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
+				Config: configBasic(projectID, description, roleName, false),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName),
+				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: false,
 			},
@@ -226,22 +218,20 @@ func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 	var (
-		resourceName      = "mongodbatlas_project_api_key.test"
 		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectID         = acc.ProjectIDExecution(t)
 		descriptionPrefix = acc.RandomName()
 		description       = descriptionPrefix + "-" + acc.RandomName()
-		roleName          = "GROUP_OWNER"
 	)
 
-	projectAPIKeyConfig := testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false)
+	projectAPIKeyConfig := configBasic(projectID, description, roleName, false)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: projectAPIKeyConfig,
@@ -263,9 +253,8 @@ func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSProjectAPIKey_DeleteProjectAndAssignment(t *testing.T) {
+func TestAccConfigRSProjectAPIKey_deleteProjectAndAssignment(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_project_api_key.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectID1   = acc.ProjectIDExecution(t)
 		projectName2 = acc.RandomProjectName()
@@ -275,20 +264,40 @@ func TestAccConfigRSProjectAPIKey_DeleteProjectAndAssignment(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, true),
+				Config: configDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.1.project_id"),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, false),
+				Config: configDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccConfigRSProjectAPIKey_invalidRole(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		description = fmt.Sprintf("desc-%s", projectID)
+		roleName    = "INVALID_ROLE"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      configBasic(projectID, description, roleName, false),
+				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
 			},
 		},
 	})
@@ -309,7 +318,7 @@ func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
 	return nil
 }
 
-func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
+func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_project_api_key" {
 			continue
@@ -328,27 +337,7 @@ func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccConfigRSProjectAPIKey_Invalid_Role(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		description = fmt.Sprintf("desc-%s", projectID)
-		roleName    = "INVALID_ROLE"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
-				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
-			},
-		},
-	})
-}
-
-func testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -361,7 +350,7 @@ func testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName string)
 	}
 }
 
-func testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleNames string, includeRootProjID bool) string {
+func configBasic(projectID, description, roleNames string, includeRootProjID bool) string {
 	var rootProjectID string
 	if includeRootProjID {
 		rootProjectID = fmt.Sprintf("project_id = %q", projectID)
@@ -378,7 +367,7 @@ func testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleNam
 	`, projectID, description, roleNames, rootProjectID)
 }
 
-func testAccMongoDBAtlasProjectAPIKeyChangingProject(orgID, projectName2, description, assignedProject string) string {
+func configChangingProject(orgID, projectName2, description, assignedProject string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "proj2" {
 			org_id = %[1]q
@@ -395,7 +384,7 @@ func testAccMongoDBAtlasProjectAPIKeyChangingProject(orgID, projectName2, descri
 	`, orgID, projectName2, description, assignedProject)
 }
 
-func testAccMongoDBAtlasProjectAPIKeyConfigMultiple(projectID, description, roleNames string) string {
+func configMultiple(projectID, description, roleNames string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project_api_key" "test" {
 			description  = %[2]q
@@ -415,7 +404,7 @@ func testAccMongoDBAtlasProjectAPIKeyConfigMultiple(projectID, description, role
 	`, projectID, description, roleNames)
 }
 
-func testAccMongoDBAtlasProjectAPIKeyConfigDeletedProjectAndAssignment(orgID, projectID1, projectName2, description string, includeSecondProject bool) string {
+func configDeletedProjectAndAssignment(orgID, projectID1, projectName2, description string, includeSecondProject bool) string {
 	var secondProject, secondProjectAssignment string
 	if includeSecondProject {
 		secondProject = fmt.Sprintf(`

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -18,8 +18,7 @@ import (
 func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		description  = acc.RandomName()
 		roleName     = "GROUP_OWNER"
 	)
@@ -30,7 +29,7 @@ func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -44,8 +43,7 @@ func TestAccConfigRSProjectAPIKey_Basic(t *testing.T) {
 func TestAccConfigRSProjectAPIKey_BasicWithLegacyRootProjectID(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		description  = acc.RandomName()
 		roleName     = "GROUP_OWNER"
 	)
@@ -56,7 +54,7 @@ func TestAccConfigRSProjectAPIKey_BasicWithLegacyRootProjectID(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, true),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -105,8 +103,7 @@ func TestAccConfigRSProjectAPIKey_ChangingSingleProject(t *testing.T) {
 func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		description  = acc.RandomName()
 		roleName     = "GROUP_OWNER"
 	)
@@ -117,7 +114,7 @@ func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, true),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -126,7 +123,7 @@ func TestAccConfigRSProjectAPIKey_RemovingOptionalRootProjectID(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
@@ -175,8 +172,7 @@ func TestAccConfigRSProjectAPIKey_Multiple(t *testing.T) {
 func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
 	var (
 		resourceName       = "mongodbatlas_project_api_key.test"
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName()
+		projectID          = acc.ProjectIDExecution(t)
 		description        = acc.RandomName()
 		updatedDescription = acc.RandomName()
 		roleName           = "GROUP_OWNER"
@@ -188,14 +184,14 @@ func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, updatedDescription, roleName, false),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, updatedDescription, roleName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
@@ -208,8 +204,7 @@ func TestAccConfigRSProjectAPIKey_UpdateDescription(t *testing.T) {
 func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_project_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		description  = acc.RandomName()
 		roleName     = "GROUP_OWNER"
 	)
@@ -220,7 +215,7 @@ func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config: testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 			},
 			{
 				ResourceName:      resourceName,
@@ -236,13 +231,13 @@ func TestAccConfigRSProjectAPIKey_RecreateWhenDeletedExternally(t *testing.T) {
 	var (
 		resourceName      = "mongodbatlas_project_api_key.test"
 		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName       = acc.RandomProjectName()
-		descriptionPrefix = "test-acc-delete-api-key-"
-		description       = descriptionPrefix + acc.RandomName()
+		projectID         = acc.ProjectIDExecution(t)
+		descriptionPrefix = acc.RandomName()
+		description       = descriptionPrefix + "-" + acc.RandomName()
 		roleName          = "GROUP_OWNER"
 	)
 
-	projectAPIKeyConfig := testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false)
+	projectAPIKeyConfig := testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -336,9 +331,8 @@ func testAccCheckMongoDBAtlasProjectAPIKeyDestroy(s *terraform.State) error {
 
 func TestAccConfigRSProjectAPIKey_Invalid_Role(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		description = projectName
+		projectID   = acc.ProjectIDExecution(t)
+		description = fmt.Sprintf("desc-%s", projectID)
 		roleName    = "INVALID_ROLE"
 	)
 
@@ -348,7 +342,7 @@ func TestAccConfigRSProjectAPIKey_Invalid_Role(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasProjectAPIKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleName, false),
+				Config:      testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleName, false),
 				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
 			},
 		},
@@ -368,25 +362,21 @@ func testAccCheckMongoDBAtlasProjectAPIKeyImportStateIDFunc(resourceName string)
 	}
 }
 
-func testAccMongoDBAtlasProjectAPIKeyConfigBasic(orgID, projectName, description, roleNames string, includeRootProjID bool) string {
+func testAccMongoDBAtlasProjectAPIKeyConfigBasic(projectID, description, roleNames string, includeRootProjID bool) string {
 	var rootProjectID string
 	if includeRootProjID {
-		rootProjectID = "project_id = mongodbatlas_project.test.id"
+		rootProjectID = fmt.Sprintf("project_id = %q", projectID)
 	}
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
 		resource "mongodbatlas_project_api_key" "test" {
-			%[3]s
-			description  = %[4]q
+			description  = %[2]q
 			project_assignment  {
-				project_id = mongodbatlas_project.test.id
-				role_names = [%[5]q]
+				project_id = %[1]q
+				role_names = [%[3]q]
 			}
+			%[4]s
 		}
-	`, orgID, projectName, rootProjectID, description, roleNames)
+	`, projectID, description, roleNames, rootProjectID)
 }
 
 func testAccMongoDBAtlasProjectAPIKeyChangingProject(orgID, projectName1, projectName2, description, assignedProject string) string {

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -29,7 +29,7 @@ func deleteProject(id string) {
 	}
 }
 
-func projectID(tb testing.TB, name string) string {
+func ProjectID(tb testing.TB, name string) string {
 	tb.Helper()
 	SkipInUnitTest(tb)
 	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -10,7 +10,7 @@ import (
 const (
 	prefixName        = "test-acc-tf"
 	prefixProject     = prefixName + "-p"
-	prefixProjectKeep = prefixProject + "-keep"
+	PrefixProjectKeep = prefixProject + "-keep"
 	prefixCluster     = prefixName + "-c"
 	prefixIAMRole     = "mongodb-atlas-" + prefixName
 	prefixIAMUser     = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
@@ -48,7 +48,9 @@ func RandomLDAPName() string {
 	return fmt.Sprintf("CN=%s-%s@example.com,OU=users,DC=example,DC=com", prefixName, acctest.RandString(10))
 }
 
+// ProjectIDGlobal returns a common global project.
+// Consider mig.ProjectIDGlobal for mig tests.
 func ProjectIDGlobal(tb testing.TB) string {
 	tb.Helper()
-	return projectID(tb, prefixProjectKeep+"-global")
+	return ProjectID(tb, PrefixProjectKeep+"-global")
 }

--- a/internal/testutil/mig/name.go
+++ b/internal/testutil/mig/name.go
@@ -1,0 +1,14 @@
+package mig
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// ProjectIDGlobal returns a common global project to be used by migration tests.
+// As there is a small number of mig tests this project won't hit limits.
+func ProjectIDGlobal(tb testing.TB) string {
+	tb.Helper()
+	return acc.ProjectID(tb, acc.PrefixProjectKeep+"-global-mig")
+}


### PR DESCRIPTION
## Description

Reuses project in tests for `project_api_key` resource

Link to any related issue(s): CLOUDP-237992

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
