### PR TITLE
chore: Reuses project in tests for `x509_authentication_database_user` resource

### DIFF
--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
@@ -12,9 +12,8 @@ import (
 
 func TestMigGenericX509AuthDBUser_basic(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		username    = acc.RandomName()
+		projectID = mig.ProjectIDGlobal(t)
+		username  = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,7 +23,7 @@ func TestMigGenericX509AuthDBUser_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            configBasic(projectName, orgID, username),
+				Config:            configBasic(projectID, username),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -35,7 +34,7 @@ func TestMigGenericX509AuthDBUser_basic(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configBasic(projectName, orgID, username),
+				Config:                   configBasic(projectID, username),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),
@@ -49,9 +48,8 @@ func TestMigGenericX509AuthDBUser_basic(t *testing.T) {
 
 func TestMigGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 	var (
-		cas         = os.Getenv("CA_CERT")
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
+		projectID = mig.ProjectIDGlobal(t)
+		cas       = os.Getenv("CA_CERT")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,7 +57,7 @@ func TestMigGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            configWithCustomerX509(projectName, orgID, cas),
+				Config:            configWithCustomerX509(projectID, cas),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -70,7 +68,7 @@ func TestMigGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configWithCustomerX509(projectName, orgID, cas),
+				Config:                   configWithCustomerX509(projectID, cas),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -29,7 +29,7 @@ func deleteProject(id string) {
 	}
 }
 
-func projectID(tb testing.TB, name string) string {
+func ProjectID(tb testing.TB, name string) string {
 	tb.Helper()
 	SkipInUnitTest(tb)
 	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -10,7 +10,7 @@ import (
 const (
 	prefixName        = "test-acc-tf"
 	prefixProject     = prefixName + "-p"
-	prefixProjectKeep = prefixProject + "-keep"
+	PrefixProjectKeep = prefixProject + "-keep"
 	prefixCluster     = prefixName + "-c"
 	prefixIAMRole     = "mongodb-atlas-" + prefixName
 	prefixIAMUser     = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
@@ -48,7 +48,9 @@ func RandomLDAPName() string {
 	return fmt.Sprintf("CN=%s-%s@example.com,OU=users,DC=example,DC=com", prefixName, acctest.RandString(10))
 }
 
+// ProjectIDGlobal returns a common global project.
+// Consider mig.ProjectIDGlobal for mig tests.
 func ProjectIDGlobal(tb testing.TB) string {
 	tb.Helper()
-	return projectID(tb, prefixProjectKeep+"-global")
+	return ProjectID(tb, PrefixProjectKeep+"-global")
 }

--- a/internal/testutil/mig/name.go
+++ b/internal/testutil/mig/name.go
@@ -1,0 +1,14 @@
+package mig
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// ProjectIDGlobal returns a common global project to be used by migration tests.
+// As there is a small number of mig tests this project won't hit limits.
+func ProjectIDGlobal(tb testing.TB) string {
+	tb.Helper()
+	return acc.ProjectID(tb, acc.PrefixProjectKeep+"-global-mig")
+}


### PR DESCRIPTION
## Description

Reuses project in tests for `x509_authentication_database_user` resource

Link to any related issue(s): CLOUDP-237993

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
