### PR TITLE
chore: Reuses project in tests for `advanced_cluster` resource

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -2,7 +2,6 @@ package advancedcluster_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -69,33 +68,37 @@ func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 
 func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		rName       = acc.RandomClusterName()
-		processArgs = `advanced_configuration  {
-			fail_index_key_too_long              = false
-			javascript_enabled                   = true
-			minimum_enabled_tls_protocol         = "TLS1_1"
-			no_table_scan                        = false
-		  }`
-		biConnector = `bi_connector_config {
-			enabled = true
-		  }`
-		processArgsUpdated = `advanced_configuration  {
-			fail_index_key_too_long              = false
-			javascript_enabled                   = true
-			minimum_enabled_tls_protocol         = "TLS1_1"
-			no_table_scan                        = false
-			default_read_concern                 = "available"
-			sample_size_bi_connector			 = 110
-            sample_refresh_interval_bi_connector = 310
-		  }`
-		biConnectorUpdated = `bi_connector_config {
-			enabled = false
-			read_preference = "secondary"
-		  }`
-		config        = configPartialAdvancedConfig(orgID, projectName, rName, processArgs, biConnector)
-		configUpdated = configPartialAdvancedConfig(orgID, projectName, rName, processArgsUpdated, biConnectorUpdated)
+		projectID   = mig.ProjectIDGlobal(t)
+		clusterName = acc.RandomClusterName()
+		extraArgs   = `
+			advanced_configuration  {
+				fail_index_key_too_long              = false
+				javascript_enabled                   = true
+				minimum_enabled_tls_protocol         = "TLS1_1"
+				no_table_scan                        = false
+			}
+
+			bi_connector_config {
+				enabled = true
+			}`
+
+		extraArgsUpdated = `
+			advanced_configuration  {
+				fail_index_key_too_long              = false
+				javascript_enabled                   = true
+				minimum_enabled_tls_protocol         = "TLS1_1"
+				no_table_scan                        = false
+				default_read_concern                 = "available"
+				sample_size_bi_connector			 = 110
+					sample_refresh_interval_bi_connector = 310
+				}
+				
+				bi_connector_config {
+					enabled = false
+					read_preference = "secondary"
+			}`
+		config        = configPartialAdvancedConfig(projectID, clusterName, extraArgs)
+		configUpdated = configPartialAdvancedConfig(projectID, clusterName, extraArgsUpdated)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -116,8 +119,8 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			},
 			mig.TestStepCheckEmptyPlan(config),
 			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configUpdated,
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
@@ -130,42 +133,34 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bi_connector_config.0.read_preference", "secondary"),
 				),
 			},
+			mig.TestStepCheckEmptyPlan(configUpdated),
 		},
 	})
 }
 
-func configPartialAdvancedConfig(orgID, projectName, name, processArgs, biConnector string) string {
+func configPartialAdvancedConfig(projectID, clusterName, extraArgs string) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}	
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id             = mongodbatlas_project.cluster_project.id
-  name                   = %[3]q
-  cluster_type           = "REPLICASET"
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id             = %[1]q
+			name                   = %[2]q
+			cluster_type           = "REPLICASET"
 
-  %[5]s
-
-   replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
-
-  %[4]s
-    
-}
-
-	`, orgID, projectName, name, processArgs, biConnector)
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "EU_WEST_1"
+				}
+			}
+			%[3]s
+		}
+	`, projectID, clusterName, extraArgs)
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -13,10 +13,9 @@ import (
 
 func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
+		projectID   = mig.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
-		config      = configSingleProvider(orgID, projectName, clusterName)
+		config      = configSingleProvider(projectID, clusterName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,10 +41,9 @@ func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 
 func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
+		projectID   = mig.ProjectIDGlobal(t)
 		clusterName = acc.RandomClusterName()
-		config      = configMultiCloud(orgID, projectName, clusterName)
+		config      = configMultiCloud(projectID, clusterName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -2,6 +2,7 @@ package advancedcluster_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -40,9 +41,10 @@ func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 
 func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 	var (
-		projectID   = mig.ProjectIDGlobal(t)
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName = acc.RandomClusterName()
-		config      = configMultiCloud(projectID, clusterName)
+		config      = configMultiCloud(orgID, projectName, clusterName)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -156,7 +158,7 @@ func configPartialAdvancedConfig(projectID, clusterName, extraArgs string) strin
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "EU_WEST_1"
+					region_name   = "US_WEST_2"
 				}
 			}
 			%[3]s

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -119,8 +119,8 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			},
 			mig.TestStepCheckEmptyPlan(config),
 			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            configUpdated,
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configUpdated,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
@@ -133,7 +133,6 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bi_connector_config.0.read_preference", "secondary"),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(configUpdated),
 		},
 	})
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
@@ -26,7 +26,7 @@ func TestMigAdvancedCluster_empty_advancedConfig(t *testing.T) {
 							},
 						},
 						"provider_name": "AWS",
-						"region_name":   "US_EAST_1",
+						"region_name":   "US_WEST_2",
 						"priority":      7,
 					},
 				},
@@ -77,7 +77,7 @@ func TestMigAdvancedCluster_v0StateUpgrade_ReplicationSpecs(t *testing.T) {
 					map[string]any{
 						"priority":      7,
 						"provider_name": "AWS",
-						"region_name":   "US_EAST_1",
+						"region_name":   "US_WEST_2",
 						"electable_specs": []any{
 							map[string]any{
 								"instance_size": "M30",

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -775,7 +775,7 @@ func configSingleProvider(projectID, name string) string {
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "EU_WEST_1"
+					region_name   = "US_WEST_2"
 				}
 			}
 		}
@@ -807,7 +807,7 @@ func configMultiCloud(projectID, name string) string {
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "EU_WEST_1"
+					region_name   = "US_WEST_2"
 				}
 				region_configs {
 					electable_specs {
@@ -852,7 +852,7 @@ func configMultiCloudSharded(projectID, name string) string {
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "EU_WEST_1"
+					region_name   = "US_WEST_2"
 				}
 				region_configs {
 					electable_specs {
@@ -888,7 +888,7 @@ func configSingleProviderPaused(projectID, clusterName string, paused bool, inst
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "US_WEST_2"
+					region_name   = "US_EAST_1"
 				}
 			}
 		}
@@ -1005,7 +1005,7 @@ func configReplicationSpecsAutoScaling(projectID, clusterName string, p *admin.A
 				}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "US_WEST_2"
+					region_name   = "US_EAST_1"
 				}
 			}
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -685,7 +685,7 @@ func configTenant(projectID, name string) string {
 					}
 					provider_name         = "TENANT"
 					backing_provider_name = "AWS"
-					region_name           = "US_WEST_2"
+					region_name           = "US_EAST_1"
 					priority              = 7
 				}
 			}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -3,7 +3,6 @@ package advancedcluster_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -221,8 +220,7 @@ func TestAccClusterAdvancedCluster_multicloudSharded(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 	var (
-		orgID               = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName         = acc.RandomProjectName()
+		projectID           = acc.ProjectIDExecution(t)
 		clusterName         = acc.RandomClusterName()
 		instanceSize        = "M10"
 		anotherInstanceSize = "M20"
@@ -234,7 +232,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configSingleProviderPaused(orgID, projectName, clusterName, false, instanceSize),
+				Config: configSingleProviderPaused(projectID, clusterName, false, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -245,7 +243,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 				),
 			},
 			{
-				Config: configSingleProviderPaused(orgID, projectName, clusterName, true, instanceSize),
+				Config: configSingleProviderPaused(projectID, clusterName, true, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -256,7 +254,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 				),
 			},
 			{
-				Config:      configSingleProviderPaused(orgID, projectName, clusterName, true, anotherInstanceSize),
+				Config:      configSingleProviderPaused(projectID, clusterName, true, anotherInstanceSize),
 				ExpectError: regexp.MustCompile("CANNOT_UPDATE_PAUSED_CLUSTER"),
 			},
 			{
@@ -272,8 +270,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
 		instanceSize = "M10"
 	)
@@ -284,7 +281,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configSingleProviderPaused(orgID, projectName, clusterName, true, instanceSize),
+				Config: configSingleProviderPaused(projectID, clusterName, true, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -295,7 +292,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 				),
 			},
 			{
-				Config: configSingleProviderPaused(orgID, projectName, clusterName, false, instanceSize),
+				Config: configSingleProviderPaused(projectID, clusterName, false, instanceSize),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -306,11 +303,11 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 				),
 			},
 			{
-				Config:      configSingleProviderPaused(orgID, projectName, clusterName, true, instanceSize),
+				Config:      configSingleProviderPaused(projectID, clusterName, true, instanceSize),
 				ExpectError: regexp.MustCompile("CANNOT_PAUSE_RECENTLY_RESUMED_CLUSTER"),
 			},
 			{
-				Config: configSingleProviderPaused(orgID, projectName, clusterName, false, instanceSize),
+				Config: configSingleProviderPaused(projectID, clusterName, false, instanceSize),
 			},
 			{
 				ResourceName:            resourceName,
@@ -325,8 +322,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName()
+		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
 		clusterNameUpdated = acc.RandomClusterName()
 		processArgs        = &admin.ClusterDescriptionProcessArgs{
@@ -361,7 +357,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configAdvanced(orgID, projectName, clusterName, processArgs),
+				Config: configAdvanced(projectID, clusterName, processArgs),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -380,7 +376,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: configAdvanced(orgID, projectName, clusterNameUpdated, processArgsUpdated),
+				Config: configAdvanced(projectID, clusterNameUpdated, processArgsUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -404,8 +400,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName()
+		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
 		clusterNameUpdated = acc.RandomClusterName()
 		processArgs        = &admin.ClusterDescriptionProcessArgs{
@@ -437,7 +432,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configAdvancedDefaultWrite(orgID, projectName, clusterName, processArgs),
+				Config: configAdvancedDefaultWrite(projectID, clusterName, processArgs),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -453,7 +448,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 				),
 			},
 			{
-				Config: configAdvancedDefaultWrite(orgID, projectName, clusterNameUpdated, processArgsUpdated),
+				Config: configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -474,8 +469,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.T) {
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName()
+		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
 		clusterNameUpdated = acc.RandomClusterName()
 		autoScaling        = &admin.AdvancedAutoScalingSettings{
@@ -494,7 +488,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicationSpecsAutoScaling(orgID, projectName, clusterName, autoScaling),
+				Config: configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -503,7 +497,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 				),
 			},
 			{
-				Config: configReplicationSpecsAutoScaling(orgID, projectName, clusterNameUpdated, autoScalingUpdated),
+				Config: configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -517,8 +511,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t *testing.T) {
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName()
+		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
 		clusterNameUpdated = acc.RandomClusterName()
 		autoScaling        = &admin.AdvancedAutoScalingSettings{
@@ -537,7 +530,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicationSpecsAnalyticsAutoScaling(orgID, projectName, clusterName, autoScaling),
+				Config: configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -546,7 +539,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 				),
 			},
 			{
-				Config: configReplicationSpecsAnalyticsAutoScaling(orgID, projectName, clusterNameUpdated, autoScalingUpdated),
+				Config: configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -560,8 +553,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *testing.T) {
 	var (
-		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName      = acc.RandomProjectName()
+		projectID        = acc.ProjectIDExecution(t)
 		clusterName      = acc.RandomClusterName()
 		numShards        = "1"
 		numShardsUpdated = "2"
@@ -573,7 +565,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configMultiZoneWithShards(orgID, projectName, clusterName, numShards, numShards),
+				Config: configMultiZoneWithShards(projectID, clusterName, numShards, numShards),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -582,7 +574,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *tes
 				),
 			},
 			{
-				Config: configMultiZoneWithShards(orgID, projectName, clusterName, numShardsUpdated, numShards),
+				Config: configMultiZoneWithShards(projectID, clusterName, numShardsUpdated, numShards),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -876,259 +868,227 @@ func configMultiCloudSharded(projectID, name string) string {
 	`, projectID, name)
 }
 
-func configSingleProviderPaused(orgID, projectName, name string, paused bool, instanceSize string) string {
+func configSingleProviderPaused(projectID, clusterName string, paused bool, instanceSize string) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id   = mongodbatlas_project.cluster_project.id
-  name         = %[3]q
-  cluster_type = "REPLICASET"
-  paused       = %[4]t
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id   = %[1]q
+			name         = %[2]q
+			paused       = %[3]t
+			cluster_type = "REPLICASET"
 
-  replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = %[5]q
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
-}
-	`, orgID, projectName, name, paused, instanceSize)
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = %[4]q
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_WEST_2"
+				}
+			}
+		}
+	`, projectID, clusterName, paused, instanceSize)
 }
 
-func configAdvanced(orgID, projectName, name string, p *admin.ClusterDescriptionProcessArgs) string {
+func configAdvanced(projectID, clusterName string, p *admin.ClusterDescriptionProcessArgs) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}	
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id             = mongodbatlas_project.cluster_project.id
-  name                   = %[3]q
-  cluster_type           = "REPLICASET"
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id             = %[1]q
+			name                   = %[2]q
+			cluster_type           = "REPLICASET"
 
-   replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "EU_WEST_1"
+				}
+			}
 
-  advanced_configuration  {
-    fail_index_key_too_long              = %[4]t
-    javascript_enabled                   = %[5]t
-    minimum_enabled_tls_protocol         = %[6]q
-    no_table_scan                        = %[7]t
-    oplog_size_mb                        = %[8]d
-    sample_size_bi_connector			 = %[9]d
-    sample_refresh_interval_bi_connector = %[10]d
-	transaction_lifetime_limit_seconds   = %[11]d
-  }
-}
-data "mongodbatlas_advanced_cluster" "test" {
-	project_id = mongodbatlas_advanced_cluster.test.project_id
-	name 	     = mongodbatlas_advanced_cluster.test.name
-}
+			advanced_configuration  {
+				fail_index_key_too_long              = %[3]t
+				javascript_enabled                   = %[4]t
+				minimum_enabled_tls_protocol         = %[5]q
+				no_table_scan                        = %[6]t
+				oplog_size_mb                        = %[7]d
+				sample_size_bi_connector			 = %[8]d
+				sample_refresh_interval_bi_connector = %[9]d
+			transaction_lifetime_limit_seconds   = %[10]d
+			}
+		}
 
-data "mongodbatlas_advanced_clusters" "test" {
-	project_id = mongodbatlas_advanced_cluster.test.project_id
-}
+		data "mongodbatlas_advanced_cluster" "test" {
+			project_id = mongodbatlas_advanced_cluster.test.project_id
+			name 	     = mongodbatlas_advanced_cluster.test.name
+		}
 
-	`, orgID, projectName, name,
+		data "mongodbatlas_advanced_clusters" "test" {
+			project_id = mongodbatlas_advanced_cluster.test.project_id
+		}
+	`, projectID, clusterName,
 		p.GetFailIndexKeyTooLong(), p.GetJavascriptEnabled(), p.GetMinimumEnabledTlsProtocol(), p.GetNoTableScan(),
 		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetTransactionLifetimeLimitSeconds())
 }
 
-func configAdvancedDefaultWrite(orgID, projectName, name string, p *admin.ClusterDescriptionProcessArgs) string {
+func configAdvancedDefaultWrite(projectID, clusterName string, p *admin.ClusterDescriptionProcessArgs) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}	
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id             = mongodbatlas_project.cluster_project.id
-  name                   = %[3]q
-  cluster_type           = "REPLICASET"
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id             = %[1]q
+			name                   = %[2]q
+			cluster_type           = "REPLICASET"
 
-   replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "EU_WEST_1"
+				}
+			}
 
-  advanced_configuration  {
-    javascript_enabled                   = %[4]t
-    minimum_enabled_tls_protocol         = %[5]q
-    no_table_scan                        = %[6]t
-    oplog_size_mb                        = %[7]d
-    sample_size_bi_connector			 = %[8]d
-    sample_refresh_interval_bi_connector = %[9]d
-    default_read_concern                 = %[10]q
-    default_write_concern                = %[11]q
-  }
-}
-
-	`, orgID, projectName, name, p.GetJavascriptEnabled(), p.GetMinimumEnabledTlsProtocol(), p.GetNoTableScan(),
+			advanced_configuration  {
+				javascript_enabled                   = %[3]t
+				minimum_enabled_tls_protocol         = %[4]q
+				no_table_scan                        = %[5]t
+				oplog_size_mb                        = %[6]d
+				sample_size_bi_connector			 = %[7]d
+				sample_refresh_interval_bi_connector = %[8]d
+				default_read_concern                 = %[9]q
+				default_write_concern                = %[10]q
+			}
+		}
+	`, projectID, clusterName, p.GetJavascriptEnabled(), p.GetMinimumEnabledTlsProtocol(), p.GetNoTableScan(),
 		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetDefaultReadConcern(), p.GetDefaultWriteConcern())
 }
 
-func configReplicationSpecsAutoScaling(orgID, projectName, name string, p *admin.AdvancedAutoScalingSettings) string {
+func configReplicationSpecsAutoScaling(projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
 	return fmt.Sprintf(`
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}	
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id             = mongodbatlas_project.cluster_project.id
-  name                   = %[3]q
-  cluster_type           = "REPLICASET"
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id             = %[1]q
+			name                   = %[2]q
+			cluster_type           = "REPLICASET"
 
-   replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-	  auto_scaling {
-        compute_enabled = %[4]t
-        disk_gb_enabled = %[5]t
-		compute_max_instance_size = %[6]q
-	  }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
-}
-	`, orgID, projectName, name, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
-}
-
-func configReplicationSpecsAnalyticsAutoScaling(orgID, projectName, name string, p *admin.AdvancedAutoScalingSettings) string {
-	return fmt.Sprintf(`
-
-resource "mongodbatlas_project" "cluster_project" {
-	name   = %[2]q
-	org_id = %[1]q
-}
-
-resource "mongodbatlas_advanced_cluster" "test" {
-  project_id             = mongodbatlas_project.cluster_project.id
-  name                   = %[3]q
-  cluster_type           = "REPLICASET"
-
-   replication_specs {
-    region_configs {
-      electable_specs {
-        instance_size = "M10"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-	  analytics_auto_scaling {
-        compute_enabled = %[4]t
-        disk_gb_enabled = %[5]t
-		compute_max_instance_size = %[6]q
-	  }
-      provider_name = "AWS"
-      priority      = 7
-      region_name   = "EU_WEST_1"
-    }
-  }
-
-
-}
-
-	`, orgID, projectName, name, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
-}
-
-func configMultiZoneWithShards(orgID, projectName, name, numShardsFirstZone, numShardsSecondZone string) string {
-	return fmt.Sprintf(`
-
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-
-	resource "mongodbatlas_advanced_cluster" "test" {
-		project_id = mongodbatlas_project.cluster_project.id
-		name = %[3]q
-		backup_enabled = false
-		mongo_db_major_version = "7.0"
-		cluster_type   = "GEOSHARDED"
-
-		replication_specs {
-		  zone_name  = "zone n1"
-		  num_shards = %[4]q
-
-		  region_configs {
-			electable_specs {
-			  instance_size = "M10"
-			  node_count    = 3
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+				auto_scaling {
+						compute_enabled = %[3]t
+						disk_gb_enabled = %[4]t
+				compute_max_instance_size = %[5]q
+				}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_WEST_2"
+				}
 			}
-			analytics_specs {
-			  instance_size = "M10"
-			  node_count    = 0
-			}
-			provider_name = "AWS"
-			priority      = 7
-			region_name   = "US_EAST_1"
-		  }
 		}
+	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
+}
 
-		replication_specs {
-		  zone_name  = "zone n2"
-		  num_shards = %[5]q
+func configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id             = %[1]q
+			name                   = %[2]q
+			cluster_type           = "REPLICASET"
 
-		  region_configs {
-			electable_specs {
-			  instance_size = "M10"
-			  node_count    = 3
+			replication_specs {
+				region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 1
+					}
+				analytics_auto_scaling {
+						compute_enabled = %[3]t
+						disk_gb_enabled = %[4]t
+				compute_max_instance_size = %[5]q
+				}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "EU_WEST_1"
+				}
 			}
-			analytics_specs {
-			  instance_size = "M10"
-			  node_count    = 0
-			}
-			provider_name = "AWS"
-			priority      = 7
-			region_name   = "EU_WEST_1"
-		  }
 		}
-	  }
-	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone)
+	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
+}
+
+func configMultiZoneWithShards(projectID, clusterName, numShardsFirstZone, numShardsSecondZone string) string {
+	return fmt.Sprintf(`
+			resource "mongodbatlas_advanced_cluster" "test" {
+				project_id =  %[1]q
+				name = %[2]q
+				backup_enabled = false
+				mongo_db_major_version = "7.0"
+				cluster_type   = "GEOSHARDED"
+
+				replication_specs {
+					zone_name  = "zone n1"
+					num_shards = %[3]q
+
+					region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 0
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "US_EAST_1"
+					}
+				}
+
+				replication_specs {
+					zone_name  = "zone n2"
+					num_shards = %[4]q
+
+					region_configs {
+					electable_specs {
+						instance_size = "M10"
+						node_count    = 3
+					}
+					analytics_specs {
+						instance_size = "M10"
+						node_count    = 0
+					}
+					provider_name = "AWS"
+					priority      = 7
+					region_name   = "EU_WEST_1"
+					}
+				}
+			}
+	`, projectID, clusterName, numShardsFirstZone, numShardsSecondZone)
 }


### PR DESCRIPTION
## Description

Reuses project in tests for `advanced_cluster` resource.

Link to any related issue(s): CLOUDP-237989

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
