### PR TITLE
chore: Fixes test names for `network_container` resource

### DIFF
--- a/internal/service/networkcontainer/resource_network_container_migration_test.go
+++ b/internal/service/networkcontainer/resource_network_container_migration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestMigNetworkContainerRS_basicAWS(t *testing.T) {
+func TestMigNetworkContainer_basicAWS(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		randInt   = acctest.RandIntRange(0, 255)
@@ -38,7 +38,7 @@ func TestMigNetworkContainerRS_basicAWS(t *testing.T) {
 	})
 }
 
-func TestMigNetworkContainerRS_basicAzure(t *testing.T) {
+func TestMigNetworkContainer_basicAzure(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		randInt   = acctest.RandIntRange(0, 255)
@@ -65,7 +65,7 @@ func TestMigNetworkContainerRS_basicAzure(t *testing.T) {
 	})
 }
 
-func TestMigNetworkContainerRS_basicGCP(t *testing.T) {
+func TestMigNetworkContainer_basicGCP(t *testing.T) {
 	var (
 		projectID    = acc.ProjectIDExecution(t)
 		randInt      = acctest.RandIntRange(0, 255)

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -19,7 +19,7 @@ const (
 	dataSourcePluralName = "data.mongodbatlas_network_containers.test"
 )
 
-func TestAccNetworkContainerRS_basicAWS(t *testing.T) {
+func TestAccNetworkContainer_basicAWS(t *testing.T) {
 	var (
 		projectID        = acc.ProjectIDExecution(t)
 		randInt          = acctest.RandIntRange(0, 255)
@@ -65,7 +65,7 @@ func TestAccNetworkContainerRS_basicAWS(t *testing.T) {
 	})
 }
 
-func TestAccNetworkContainerRS_basicAzure(t *testing.T) {
+func TestAccNetworkContainer_basicAzure(t *testing.T) {
 	var (
 		randInt          = acctest.RandIntRange(0, 255)
 		cidrBlock        = fmt.Sprintf("10.8.%d.0/24", randInt)
@@ -111,7 +111,7 @@ func TestAccNetworkContainerRS_basicAzure(t *testing.T) {
 	})
 }
 
-func TestAccNetworkContainerRS_basicGCP(t *testing.T) {
+func TestAccNetworkContainer_basicGCP(t *testing.T) {
 	var (
 		randInt          = acctest.RandIntRange(0, 255)
 		gcpCidrBlock     = fmt.Sprintf("10.%d.0.0/18", randInt)
@@ -157,7 +157,7 @@ func TestAccNetworkContainerRS_basicGCP(t *testing.T) {
 	})
 }
 
-func TestAccNetworkContainerRS_withRegionsGCP(t *testing.T) {
+func TestAccNetworkContainer_withRegionsGCP(t *testing.T) {
 	var (
 		projectID               = acc.ProjectIDExecution(t)
 		randInt                 = acctest.RandIntRange(0, 255)
@@ -193,7 +193,7 @@ func TestAccNetworkContainerRS_withRegionsGCP(t *testing.T) {
 	})
 }
 
-func TestAccNetworkContainerRS_importBasic(t *testing.T) {
+func TestAccNetworkContainer_importBasic(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		randInt   = acctest.RandIntRange(0, 255)


### PR DESCRIPTION
## Description

Fixes test names for `network_container` resource.

No RS in the name as it now tests resource and datasource.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
