### PR TITLE
feat: Allows user to specify to use an existing tag for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
         required: true
       skip_tests:
         description: 'Skip QA acceptance tests, define value to `true` to explicitly skip'
+      use_existing_tag:
+        description: 'Set value to `true` to use an existing tag for this release version, default is `false`'
 
 jobs:
 
@@ -28,6 +30,7 @@ jobs:
     uses: ./.github/workflows/acceptance-tests.yml
     with:
       atlas_cloud_env: "qa"
+      ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number }}
 
   release:
     runs-on: ubuntu-latest
@@ -36,14 +39,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number || github.ref }}
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Create release tag
-        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # will fail if existing tag is present
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
         with:
           tag: ${{ inputs.version_number }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
+          tag_exists_error: ${{ inputs.use_existing_tag == 'true' && false || true }}
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,11 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set the user terminal
         run: export GPG_TTY=$(tty)
-      # - name: Run GoReleaser
-      #   uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
-      #   with:
-      #     version: latest
-      #     args: release --rm-dist
-      #   env:
-      #     GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/acceptance-tests.yml
     with:
       atlas_cloud_env: "qa"
-      ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number }}
+      ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number  || github.ref }}
 
   release:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
           tag: ${{ inputs.version_number }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
-          tag_exists_error: ${{ inputs.use_existing_tag == 'true' && false || true }}
+          tag_exists_error: ${{ inputs.use_existing_tag != 'true' }}
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
@@ -62,11 +62,11 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Set the user terminal
         run: export GPG_TTY=$(tty)
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Run GoReleaser
+      #   uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
+      #   with:
+      #     version: latest
+      #     args: release --rm-dist
+      #   env:
+      #     GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,7 @@ We pre-release the provider to make for testing purpose. **A Pre-release is not 
 - Using our [Release GitHub Action](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/workflows/release.yml) run a new workflow using `master` and the following inputs:
   - Version number: vX.Y.Z-pre
   - Skip QA acceptance tests: Should be left empty. Only used in case failing tests have been encountered in QA and the team agrees the release can still de done, or successful run of QA acceptance tests has already been done with the most recent changes.
+  - Using an existing tag: Should be left empty (default `false` creates a new tag from `master`). This should be set to `true` only if you want to re-use an existing tag for the release and the tag name should adhere to our version number format.
 
 - You will see the release in the [GitHub Release page](https://github.com/mongodb/terraform-provider-mongodbatlas/releases) once the [release action](.github/workflows/release.yml) has completed.
 


### PR DESCRIPTION
## Description

Currently in case of any failure during release, we need to manually delete the created tag and re-run release workflow at which point a new tag is created from master. It is possible that other PRs are merged to master during this time which causes below issues:
 - It may require us to re-run QA acceptance tests
 - Changelog might be required to be updated again
 - We may need to request the team to stop new PR merges until release is done

This PR allows us to specify if we want to use an existing tag during TF release so any new PR merges to master wouldn't impact an ongoing release.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
Testing:
1. Created a temporary release workflow with `use_existing_tag` not set (default) -> New tag was created ([test run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/8375101336/job/22931745049))
2. Created a temporary release workflow with `use_existing_tag=true` -> Existing tag was used ([test run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/8375120626/job/22931804342)), see below partial logs:

```
[action-create-tag] Create tag 'v0.1.0-pre1'.
[action-create-tag] Tag 'v0.1.0-pre1' already exists.
[action-create-tag] Please set 'force_push_tag' to 'true' if you want to overwrite it.
[action-create-tag] Ignoring error since 'tag_exists_error' is set to 'false'.
```