### PR TITLE
fix: Fixes `network_container` resource update

### DIFF
--- a/internal/service/networkcontainer/resource_network_container.go
+++ b/internal/service/networkcontainer/resource_network_container.go
@@ -210,7 +210,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if !d.HasChange("region_name") && !d.HasChange("atlas_cidr_block") && !d.HasChange("region_name") && !d.HasChange("region") && !d.HasChange("regions") {
+	if !d.HasChange("provider_name") && !d.HasChange("atlas_cidr_block") && !d.HasChange("region_name") && !d.HasChange("region") && !d.HasChange("regions") {
 		return resourceRead(ctx, d, meta)
 	}
 

--- a/internal/service/networkcontainer/resource_network_container.go
+++ b/internal/service/networkcontainer/resource_network_container.go
@@ -51,6 +51,7 @@ func Resource() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      constant.AWS,
+				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{constant.AWS, constant.GCP, constant.AZURE}, false),
 			},
 			"region_name": {

--- a/internal/service/networkcontainer/resource_network_container.go
+++ b/internal/service/networkcontainer/resource_network_container.go
@@ -241,12 +241,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		params.SetRegion(region)
 	case constant.GCP:
-		regionList, ok := d.GetOk("regions")
-		if !ok {
-			return diag.FromErr(fmt.Errorf(errorContainerUpdate, containerID, "error updating regions"))
-		}
-		if regions := cast.ToStringSlice(regionList); regions != nil {
-			params.SetRegions(regions)
+		if regionList, ok := d.GetOk("regions"); ok {
+			if regions := cast.ToStringSlice(regionList); regions != nil {
+				params.SetRegions(regions)
+			}
 		}
 	}
 	_, _, err := connV2.NetworkPeeringApi.UpdatePeeringContainer(ctx, projectID, containerID, params).Execute()

--- a/internal/service/networkcontainer/resource_network_container_migration_test.go
+++ b/internal/service/networkcontainer/resource_network_container_migration_test.go
@@ -26,12 +26,7 @@ func TestMigNetworkContainer_basicAWS(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -53,12 +48,7 @@ func TestMigNetworkContainer_basicAzure(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AZURE),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -80,12 +70,7 @@ func TestMigNetworkContainer_basicGCP(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -53,7 +53,7 @@ func TestAccNetworkContainer_basicAWS(t *testing.T) {
 				),
 			},
 			{
-				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, "US_WEST_2"),
+				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, "US_EAST_2"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -225,8 +225,8 @@ func TestAccNetworkContainer_updateIndividualFields(t *testing.T) {
 		cidrBlock        = fmt.Sprintf("10.8.%d.0/24", randInt)
 		randIntUpdated   = (randInt + 1) % 256
 		cidrBlockUpdated = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
-		region           = "US_WEST_2"
-		regionUpdated    = "US_EAST_2"
+		region           = "EU_WEST_1"
+		regionUpdated    = "EU_WEST_2"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -35,31 +35,11 @@ func TestAccNetworkContainer_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AWS, "US_EAST_1"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.#", acc.IntGreatThan(0)),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.atlas_cidr_block"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provider_name"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, "US_EAST_2"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 		},
 	})
@@ -81,31 +61,11 @@ func TestAccNetworkContainer_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AZURE, "US_EAST_2"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AZURE),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "provider_name", constant.AZURE),
-					resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.#", acc.IntGreatThan(0)),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.atlas_cidr_block"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provider_name"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AZURE, "US_EAST_2"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AZURE),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 		},
 	})
@@ -127,31 +87,11 @@ func TestAccNetworkContainer_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, gcpCidrBlock, constant.GCP, ""),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.#", acc.IntGreatThan(0)),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.atlas_cidr_block"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provider_name"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.GCP, ""),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 		},
 	})
@@ -172,22 +112,7 @@ func TestAccNetworkContainer_withRegionsGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, gcpWithRegionsCidrBlock, constant.GCP, regions),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "provider_name", constant.GCP),
-					resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
-
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.#", acc.IntGreatThan(0)),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.id"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.atlas_cidr_block"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provider_name"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 		},
 	})
@@ -236,30 +161,15 @@ func TestAccNetworkContainer_updateIndividualFields(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AWS, region),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, region),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, regionUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
-					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
-				),
+				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 		},
 	})
@@ -306,6 +216,25 @@ func checkDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func commonChecks(providerName string) []resource.TestCheckFunc {
+	return []resource.TestCheckFunc{
+		checkExists(resourceName),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+		resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+
+		resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
+		resource.TestCheckResourceAttr(dataSourceName, "provider_name", providerName),
+		resource.TestCheckResourceAttrSet(dataSourceName, "provisioned"),
+
+		resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.#", acc.IntGreatThan(0)),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.id"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.atlas_cidr_block"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provider_name"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.provisioned"),
+	}
 }
 
 func configBasic(projectID, cidrBlock, providerName, region string) string {

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -24,7 +24,7 @@ func TestAccNetworkContainer_basicAWS(t *testing.T) {
 		projectID        = acc.ProjectIDExecution(t)
 		randInt          = acctest.RandIntRange(0, 255)
 		cidrBlock        = fmt.Sprintf("10.8.%d.0/24", randInt)
-		randIntUpdated   = acctest.RandIntRange(0, 255)
+		randIntUpdated   = (randInt + 1) % 256
 		cidrBlockUpdated = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
 	)
 
@@ -69,7 +69,7 @@ func TestAccNetworkContainer_basicAzure(t *testing.T) {
 	var (
 		randInt          = acctest.RandIntRange(0, 255)
 		cidrBlock        = fmt.Sprintf("10.8.%d.0/24", randInt)
-		randIntUpdated   = acctest.RandIntRange(0, 255)
+		randIntUpdated   = (randInt + 1) % 256
 		cidrBlockUpdated = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
 		projectID        = acc.ProjectIDExecution(t)
 	)
@@ -115,7 +115,7 @@ func TestAccNetworkContainer_basicGCP(t *testing.T) {
 	var (
 		randInt          = acctest.RandIntRange(0, 255)
 		gcpCidrBlock     = fmt.Sprintf("10.%d.0.0/18", randInt)
-		randIntUpdated   = acctest.RandIntRange(0, 255)
+		randIntUpdated   = (randInt + 1) % 256
 		cidrBlockUpdated = fmt.Sprintf("10.%d.0.0/18", randIntUpdated)
 		projectID        = acc.ProjectIDExecution(t)
 	)
@@ -213,6 +213,53 @@ func TestAccNetworkContainer_importBasic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccNetworkContainer_updateIndividualFields(t *testing.T) {
+	var (
+		projectID        = acc.ProjectIDExecution(t)
+		randInt          = acctest.RandIntRange(0, 255)
+		cidrBlock        = fmt.Sprintf("10.8.%d.0/24", randInt)
+		randIntUpdated   = (randInt + 1) % 256
+		cidrBlockUpdated = fmt.Sprintf("10.8.%d.0/24", randIntUpdated)
+		region           = "US_WEST_2"
+		regionUpdated    = "US_EAST_2"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(projectID, cidrBlock, constant.AWS, region),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+			{
+				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, region),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
+			},
+			{
+				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, regionUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", constant.AWS),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioned"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Fixes `network_container` resource update when only one field changes.

Based on this PR:  https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2031


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
