### PR TITLE
chore: Allows MONGODB_ATLAS_PROJECT_ID for local executions

### DIFF
--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -29,11 +29,31 @@ func deleteProject(id string) {
 	}
 }
 
+// ProjectID returns the id for a project name.
+// When `MONGODB_ATLAS_PROJECT_ID` is defined, it is used instead of creating a project. This is useful for local execution but not intended for CI executions.
 func ProjectID(tb testing.TB, name string) string {
 	tb.Helper()
 	SkipInUnitTest(tb)
+
+	if id := projectIDLocal(tb); id != "" {
+		return id
+	}
+
 	resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), name).Execute()
 	id := resp.GetId()
 	require.NotEmpty(tb, id, "Project name not found: %s", name)
+	return id
+}
+
+func projectIDLocal(tb testing.TB) string {
+	tb.Helper()
+	id := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	if id == "" {
+		return ""
+	}
+	if InCI() {
+		tb.Fatal("MONGODB_ATLAS_PROJECT_ID can't be used in CI")
+	}
+	tb.Logf("Using MONGODB_ATLAS_PROJECT_ID: %s", id)
 	return id
 }

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -50,6 +50,7 @@ func RandomLDAPName() string {
 
 // ProjectIDGlobal returns a common global project.
 // Consider mig.ProjectIDGlobal for mig tests.
+// When `MONGODB_ATLAS_PROJECT_ID` is defined, it is used instead of creating a project. This is useful for local execution but not intended for CI executions.
 func ProjectIDGlobal(tb testing.TB) string {
 	tb.Helper()
 	return ProjectID(tb, PrefixProjectKeep+"-global")

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -24,6 +24,7 @@ func cleanupSharedResources() {
 
 // ProjectIDExecution returns a project id created for the execution of the tests in the resource package.
 // Even if a GH test group is run, every resource/package will create its own project, not a shared project for all the test group.
+// When `MONGODB_ATLAS_PROJECT_ID` is defined, it is used instead of creating a project. This is useful for local execution but not intended for CI executions.
 func ProjectIDExecution(tb testing.TB) string {
 	tb.Helper()
 	SkipInUnitTest(tb)
@@ -31,6 +32,10 @@ func ProjectIDExecution(tb testing.TB) string {
 
 	sharedInfo.mu.Lock()
 	defer sharedInfo.mu.Unlock()
+
+	if id := projectIDLocal(tb); id != "" {
+		return id
+	}
 
 	// lazy creation so it's only done if really needed
 	if sharedInfo.projectID == "" {

--- a/internal/testutil/acc/skip.go
+++ b/internal/testutil/acc/skip.go
@@ -9,9 +9,13 @@ import (
 // SkipTestForCI is added to tests that cannot run as part of CI, e.g. in Github actions.
 func SkipTestForCI(tb testing.TB) {
 	tb.Helper()
-	if strings.EqualFold(os.Getenv("CI"), "true") {
+	if InCI() {
 		tb.Skip()
 	}
+}
+
+func InCI() bool {
+	return strings.EqualFold(os.Getenv("CI"), "true")
 }
 
 // SkipInUnitTest allows skipping a test entirely when TF_ACC=1 is not defined.

--- a/internal/testutil/mig/name.go
+++ b/internal/testutil/mig/name.go
@@ -8,6 +8,7 @@ import (
 
 // ProjectIDGlobal returns a common global project to be used by migration tests.
 // As there is a small number of mig tests this project won't hit limits.
+// When `MONGODB_ATLAS_PROJECT_ID` is defined, it is used instead of creating a project. This is useful for local execution but not intended for CI executions.
 func ProjectIDGlobal(tb testing.TB) string {
 	tb.Helper()
 	return acc.ProjectID(tb, acc.PrefixProjectKeep+"-global-mig")


### PR DESCRIPTION
## Description

Allows MONGODB_ATLAS_PROJECT_ID for local executions.

In this way it uses an existing project instead of creating test execution projects or trying to use global projects.

Link to any related issue(s): CLOUDP-239072

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
