### PR TITLE
chore: Enables Github action linter and removes set terminal in release action

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -61,6 +61,11 @@ jobs:
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804
         with:
           version: v1.56.2
+      - name: actionlint
+        run: | 
+          make tools 
+          actionlint -verbose -color
+        shell: bash  
   website-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -62,9 +62,7 @@ jobs:
         with:
           version: v1.56.2
       - name: actionlint
-        run: | 
-          make tools 
-          actionlint -verbose -color
+        run: make tools && actionlint -verbose -color
         shell: bash  
   website-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,30 @@ on:
       version_number:
         description: 'Version number (e.g., v1.0.0, v1.0.0-pre, v1.0.0-pre1)'
         required: true
+      skip_tests:
+        description: 'Skip QA acceptance tests, define value to `true` to explicitly skip'
 
 jobs:
 
+  validate-version-input:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validation of version format
+        run: |
+          echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'  
+
+    # QA acceptance tests are skipped when explicit input parameter is used
+  run-qa-acceptance-tests:
+    needs: [ validate-version-input ]
+    if: needs.validate-version-input.result == 'success' && inputs.skip_tests != 'true'
+    secrets: inherit
+    uses: ./.github/workflows/acceptance-tests.yml
+    with:
+      atlas_cloud_env: "qa"
+
   release:
     runs-on: ubuntu-latest
+    needs: [ validate-version-input, run-qa-acceptance-tests ]
     if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,30 +8,11 @@ on:
       version_number:
         description: 'Version number (e.g., v1.0.0, v1.0.0-pre, v1.0.0-pre1)'
         required: true
-      skip_tests:
-        description: 'Skip QA acceptance tests, define value to `true` to explicitly skip'
 
 jobs:
 
-  validate-version-input:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validation of version format
-        run: |
-          echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'  
-
-    # QA acceptance tests are skipped when explicit input parameter is used
-  run-qa-acceptance-tests:
-    needs: [ validate-version-input ]
-    if: needs.validate-version-input.result == 'success' && inputs.skip_tests != 'true'
-    secrets: inherit
-    uses: ./.github/workflows/acceptance-tests.yml
-    with:
-      atlas_cloud_env: "qa"
-
   release:
     runs-on: ubuntu-latest
-    needs: [ validate-version-input, run-qa-acceptance-tests ]
     if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,6 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Set the user terminal
-        run: export GPG_TTY=$(tty)
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633


### PR DESCRIPTION
## Description

Enables Github action linter and removes set terminal in release action

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
