### PR TITLE
chore: Fixes send notification when test suite fails

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -87,7 +87,7 @@ jobs:
   
   slack-notification:
     needs: [mig-tests, acc-tests, clean-after]
-    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (needs.mig-tests.result == 'failure' || needs.acc-tests.result == 'failure')}}
+    if: ${{ !cancelled() && github.event_name == 'schedule' && (needs.mig-tests.result == 'failure' || needs.acc-tests.result == 'failure')}}
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack message


### PR DESCRIPTION
## Description

Fixes send notification when test suite fails

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
