### PR TITLE
fix: Missing replication_specs on mongodbatlas_advanced_cluster(s) data sources

### DIFF
--- a/.changelog/2076.txt
+++ b/.changelog/2076.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` to TypeList
+data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` to TypeList
+```

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -100,7 +100,7 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"replication_specs": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -113,7 +113,7 @@ func DataSource() *schema.Resource {
 							Computed: true,
 						},
 						"region_configs": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -208,7 +208,6 @@ func DataSource() *schema.Resource {
 						},
 					},
 				},
-				Set: replicationSpecsHashSet,
 			},
 			"root_cert_type": {
 				Type:     schema.TypeString,
@@ -299,7 +298,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "pit_enabled", clusterName, err))
 	}
 
-	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").(*schema.Set).List(), d, connV2)
+	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -108,7 +108,7 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"replication_specs": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -121,7 +121,7 @@ func PluralDataSource() *schema.Resource {
 										Computed: true,
 									},
 									"region_configs": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -216,7 +216,6 @@ func PluralDataSource() *schema.Resource {
 									},
 								},
 							},
-							Set: replicationSpecsHashSet,
 						},
 						"root_cert_type": {
 							Type:     schema.TypeString,

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -290,7 +290,6 @@ func Resource() *schema.Resource {
 						},
 					},
 				},
-				// Set: replicationSpecsHashSet,
 			},
 			"root_cert_type": {
 				Type:     schema.TypeString,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -136,8 +136,10 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals("3")),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
+					resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals("3")),
 				),
 			},
 			{
@@ -813,14 +815,23 @@ func configMultiCloud(orgID, projectName, name string) string {
 					priority      = 7
 					region_name   = "EU_WEST_1"
 				}
-				region_configs {
-					electable_specs {
-						instance_size = "M10"
-						node_count    = 2
+
+				dynamic "region_configs" {
+					for_each = [
+						"US_EAST_4",
+						"NORTH_AMERICA_NORTHEAST_1"
+					]
+
+					content {
+						provider_name = "GCP"
+						priority      = 0
+						region_name   = region_configs.value
+
+						read_only_specs {
+							instance_size = "M10"
+							node_count    = 2
+						}
 					}
-					provider_name = "GCP"
-					priority      = 6
-					region_name   = "NORTH_AMERICA_NORTHEAST_1"
 				}
 			}
 		}


### PR DESCRIPTION
I couldn't quite understand what triggered the `Set: replicationSpecsHashSet` line in the resource to be commented out but making the data source match fixes the issue. Possibly because the `region_configs` set would also need a custom `Set` function?, but either way there aren't any tests that caught this and I don't have an Atlas organization I can run the tests against to add one. I did install the provider locally and ran a plan to confirm this fixes the issue in my Terraformm .One likely reason is that none of the examples seem to have similar configs across multiple regions (like two with two electable nodes each).

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
