### PR TITLE
test: Converting a test case to a migration test

### DIFF
--- a/internal/service/searchindex/resource_search_index_migration_test.go
+++ b/internal/service/searchindex/resource_search_index_migration_test.go
@@ -11,5 +11,5 @@ func TestMigSearchIndex_basic(t *testing.T) {
 }
 
 func TestMigSearchIndex_withVector(t *testing.T) {
-	mig.CreateAndRunTest(t, basicTestCaseVector(t))
+	mig.CreateAndRunTest(t, basicVectorTestCase(t))
 }

--- a/internal/service/searchindex/resource_search_index_migration_test.go
+++ b/internal/service/searchindex/resource_search_index_migration_test.go
@@ -3,14 +3,13 @@ package searchindex_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestMigSearchIndex_basic(t *testing.T) {
-	resource.ParallelTest(t, mig.CreateTest(t, basicTestCase(t)))
+	mig.CreateAndRunTest(t, basicTestCase(t))
 }
 
 func TestMigSearchIndex_withVector(t *testing.T) {
-	resource.ParallelTest(t, mig.CreateTest(t, basicTestCaseVector(t)))
+	mig.CreateAndRunTest(t, basicTestCaseVector(t))
 }

--- a/internal/service/searchindex/resource_search_index_migration_test.go
+++ b/internal/service/searchindex/resource_search_index_migration_test.go
@@ -4,68 +4,15 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestMigSearchIndex_basic(t *testing.T) {
-	var (
-		clusterInfo  = acc.GetClusterInfo(t, nil)
-		indexName    = acc.RandomName()
-		databaseName = acc.RandomName()
-		config       = configBasic(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr, false)
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
-		CheckDestroy: acc.CheckDestroySearchIndex,
-		Steps: []resource.TestStep{
-			{
-				Config:            config,
-				ExternalProviders: mig.ExternalProviders(),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", indexName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
-					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
-					resource.TestCheckResourceAttr(resourceName, "collection_name", collectionName),
-					resource.TestCheckResourceAttr(resourceName, "search_analyzer", searchAnalyzer),
-					resource.TestCheckResourceAttr(resourceName, "type", ""),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(config),
-		},
-	})
+func TestMigSearchIndexRS_basic(t *testing.T) {
+	testCase := mig.ConvertToMigrationTest(t, basicTestCase(t))
+	resource.ParallelTest(t, testCase)
 }
 
-func TestMigSearchIndex_withVector(t *testing.T) {
-	var (
-		clusterInfo  = acc.GetClusterInfo(t, nil)
-		indexName    = acc.RandomName()
-		databaseName = acc.RandomName()
-		config       = configVector(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
-		CheckDestroy: acc.CheckDestroySearchIndex,
-		Steps: []resource.TestStep{
-			{
-				Config:            config,
-				ExternalProviders: mig.ExternalProviders(),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", indexName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
-					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
-					resource.TestCheckResourceAttr(resourceName, "collection_name", collectionName),
-					resource.TestCheckResourceAttr(resourceName, "type", "vectorSearch"),
-					resource.TestCheckResourceAttrSet(resourceName, "fields"),
-					resource.TestCheckResourceAttrWith(resourceName, "fields", acc.JSONEquals(fieldsJSON)),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(config),
-		},
-	})
+func TestMigSearchIndexRS_withVector(t *testing.T) {
+	testCase := mig.ConvertToMigrationTest(t, basicTestCaseVector(t))
+	resource.ParallelTest(t, testCase)
 }

--- a/internal/service/searchindex/resource_search_index_migration_test.go
+++ b/internal/service/searchindex/resource_search_index_migration_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestMigSearchIndexRS_basic(t *testing.T) {
+func TestMigSearchIndex_basic(t *testing.T) {
 	testCase := mig.ConvertToMigrationTest(t, basicTestCase(t))
 	resource.ParallelTest(t, testCase)
 }
 
-func TestMigSearchIndexRS_withVector(t *testing.T) {
+func TestMigSearchIndex_withVector(t *testing.T) {
 	testCase := mig.ConvertToMigrationTest(t, basicTestCaseVector(t))
 	resource.ParallelTest(t, testCase)
 }

--- a/internal/service/searchindex/resource_search_index_migration_test.go
+++ b/internal/service/searchindex/resource_search_index_migration_test.go
@@ -8,11 +8,9 @@ import (
 )
 
 func TestMigSearchIndex_basic(t *testing.T) {
-	testCase := mig.ConvertToMigrationTest(t, basicTestCase(t))
-	resource.ParallelTest(t, testCase)
+	resource.ParallelTest(t, mig.CreateTest(t, basicTestCase(t)))
 }
 
 func TestMigSearchIndex_withVector(t *testing.T) {
-	testCase := mig.ConvertToMigrationTest(t, basicTestCaseVector(t))
-	resource.ParallelTest(t, testCase)
+	resource.ParallelTest(t, mig.CreateTest(t, basicTestCaseVector(t)))
 }

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func basicTestCase(t *testing.T) *resource.TestCase {
-	t.Helper()
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
 	var (
-		clusterInfo     = acc.GetClusterInfo(t, nil)
+		clusterInfo     = acc.GetClusterInfo(tb, nil)
 		indexName       = acc.RandomName()
 		databaseName    = acc.RandomName()
 		indexType       = ""
@@ -23,7 +23,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 	checks := commonChecks(indexName, indexType, mappingsDynamic, databaseName, clusterInfo)
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{
@@ -43,8 +43,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 }
 
 func TestAccSearchIndex_basic(t *testing.T) {
-	basicCase := basicTestCase(t)
-	resource.ParallelTest(t, *basicCase)
+	resource.ParallelTest(t, *basicTestCase(t))
 }
 
 func TestAccSearchIndex_withSearchType(t *testing.T) {
@@ -212,10 +211,10 @@ func TestAccSearchIndex_updatedToEmptyMappingsFields(t *testing.T) {
 		},
 	})
 }
-func basicTestCaseVector(t *testing.T) *resource.TestCase {
-	t.Helper()
+func basicTestCaseVector(tb testing.TB) *resource.TestCase {
+	tb.Helper()
 	var (
-		clusterInfo  = acc.GetClusterInfo(t, nil)
+		clusterInfo  = acc.GetClusterInfo(tb, nil)
 		indexName    = acc.RandomName()
 		indexType    = "vectorSearch"
 		databaseName = acc.RandomName()
@@ -233,7 +232,7 @@ func basicTestCaseVector(t *testing.T) *resource.TestCase {
 	checks = append(checks, resource.TestCheckResourceAttrWith(datasourceName, "fields", acc.JSONEquals(fieldsJSON)))
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -11,37 +11,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func basicTestCase(tb testing.TB) *resource.TestCase {
-	tb.Helper()
-	var (
-		clusterInfo     = acc.GetClusterInfo(tb, nil)
-		indexName       = acc.RandomName()
-		databaseName    = acc.RandomName()
-		indexType       = ""
-		mappingsDynamic = "true"
-	)
-	checks := commonChecks(indexName, indexType, mappingsDynamic, databaseName, clusterInfo)
-
-	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(tb) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroySearchIndex,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr, false),
-				Check:  resource.ComposeTestCheckFunc(checks...),
-			},
-			{
-				Config:            configBasic(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr, false),
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	}
-}
-
 func TestAccSearchIndex_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
 }
@@ -211,7 +180,43 @@ func TestAccSearchIndex_updatedToEmptyMappingsFields(t *testing.T) {
 		},
 	})
 }
-func basicTestCaseVector(tb testing.TB) *resource.TestCase {
+
+func TestAccSearchIndex_withVector(t *testing.T) {
+	resource.ParallelTest(t, *basicVectorTestCase(t))
+}
+
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+	var (
+		clusterInfo     = acc.GetClusterInfo(tb, nil)
+		indexName       = acc.RandomName()
+		databaseName    = acc.RandomName()
+		indexType       = ""
+		mappingsDynamic = "true"
+	)
+	checks := commonChecks(indexName, indexType, mappingsDynamic, databaseName, clusterInfo)
+
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroySearchIndex,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr, false),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+			{
+				Config:            configBasic(clusterInfo.ProjectIDStr, indexName, databaseName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr, false),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	}
+}
+
+func basicVectorTestCase(tb testing.TB) *resource.TestCase {
 	tb.Helper()
 	var (
 		clusterInfo  = acc.GetClusterInfo(tb, nil)
@@ -242,10 +247,6 @@ func basicTestCaseVector(tb testing.TB) *resource.TestCase {
 			},
 		},
 	}
-}
-
-func TestAccSearchIndex_withVector(t *testing.T) {
-	resource.ParallelTest(t, *basicTestCaseVector(t))
 }
 
 func commonChecks(indexName, indexType, mappingsDynamic, databaseName string, clusterInfo acc.ClusterInfo) []resource.TestCheckFunc {

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -245,7 +245,7 @@ func basicTestCaseVector(t *testing.T) *resource.TestCase {
 	}
 }
 
-func TestAccSearchIndexRS_withVector(t *testing.T) {
+func TestAccSearchIndex_withVector(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCaseVector(t))
 }
 

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func TestAccSearchIndex_basic(t *testing.T) {
+func basicTestCase(t *testing.T) *resource.TestCase {
+	t.Helper()
 	var (
 		clusterInfo     = acc.GetClusterInfo(t, nil)
 		indexName       = acc.RandomName()
@@ -21,7 +22,7 @@ func TestAccSearchIndex_basic(t *testing.T) {
 	)
 	checks := commonChecks(indexName, indexType, mappingsDynamic, databaseName, clusterInfo)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
@@ -38,7 +39,12 @@ func TestAccSearchIndex_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		},
-	})
+	}
+}
+
+func TestAccSearchIndex_basic(t *testing.T) {
+	basicCase := basicTestCase(t)
+	resource.ParallelTest(t, *basicCase)
 }
 
 func TestAccSearchIndex_withSearchType(t *testing.T) {
@@ -206,8 +212,8 @@ func TestAccSearchIndex_updatedToEmptyMappingsFields(t *testing.T) {
 		},
 	})
 }
-
-func TestAccSearchIndex_withVector(t *testing.T) {
+func basicTestCaseVector(t *testing.T) *resource.TestCase {
+	t.Helper()
 	var (
 		clusterInfo  = acc.GetClusterInfo(t, nil)
 		indexName    = acc.RandomName()
@@ -225,7 +231,8 @@ func TestAccSearchIndex_withVector(t *testing.T) {
 	checks = acc.AddAttrSetChecks(resourceName, checks, "project_id")
 	checks = acc.AddAttrSetChecks(datasourceName, checks, "project_id", "index_id")
 	checks = append(checks, resource.TestCheckResourceAttrWith(datasourceName, "fields", acc.JSONEquals(fieldsJSON)))
-	resource.ParallelTest(t, resource.TestCase{
+
+	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
@@ -235,8 +242,13 @@ func TestAccSearchIndex_withVector(t *testing.T) {
 				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
-	})
+	}
 }
+
+func TestAccSearchIndexRS_withVector(t *testing.T) {
+	resource.ParallelTest(t, *basicTestCaseVector(t))
+}
+
 func commonChecks(indexName, indexType, mappingsDynamic, databaseName string, clusterInfo acc.ClusterInfo) []resource.TestCheckFunc {
 	attributes := map[string]string{
 		"name":             indexName,

--- a/internal/testutil/acc/provider.go
+++ b/internal/testutil/acc/provider.go
@@ -4,6 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+const AwsProviderVersion = "5.1.0"
+
 func ExternalProviders(versionAtlasProvider string) map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
 		"mongodbatlas": *providerAtlas(versionAtlasProvider),
@@ -32,7 +34,7 @@ func providerAtlas(versionAtlasProvider string) *resource.ExternalProvider {
 
 func providerAWS() *resource.ExternalProvider {
 	return &resource.ExternalProvider{
-		VersionConstraint: "5.1.0",
+		VersionConstraint: AwsProviderVersion,
 		Source:            "hashicorp/aws",
 	}
 }

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ConvertToMigrationTest returns an updated TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan
+// CreateTest returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan
 // Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
-func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.TestCase {
+func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 	t.Helper()
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]
@@ -20,11 +20,11 @@ func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.Test
 	return reuseCase(test, steps)
 }
 
-// ConvertToMigrationTestUseExternalProvider returns an updated TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders
+// CreateTestUseExternalProvider returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders
 // Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
 // externalProviders: e.g., ExternalProvidersWithAWS() or ExternalProviders("specific_sem_ver")
 // additionalProviders: e.g., acc.ExternalProvidersOnlyAWS(), can also be nil
-func ConvertToMigrationTestUseExternalProvider(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) resource.TestCase {
+func CreateTestUseExternalProvider(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) resource.TestCase {
 	t.Helper()
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -7,30 +7,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ConvertToMigrationTest(t *testing.T, test *resource.TestCase, externalProviders ...map[string]resource.ExternalProvider) resource.TestCase {
+// ConvertToMigrationTest returns an updated TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan
+// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
+func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.TestCase {
+	t.Helper()
+	validateReusableCase(t, test)
+	firstStep := test.Steps[0]
+	steps := []resource.TestStep{
+		*useExternalProvider(firstStep, ExternalProviders()),
+		TestStepCheckEmptyPlan(firstStep.Config),
+	}
+	return reuseCase(test, steps)
+}
+
+// ConvertToMigrationTestUseExternalProvider returns an updated TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders
+// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
+// externalProviders: e.g., ExternalProvidersWithAWS() or ExternalProviders("specific_sem_ver")
+// additionalProviders: e.g., acc.ExternalProvidersOnlyAWS(), can also be nil
+func ConvertToMigrationTestUseExternalProvider(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) resource.TestCase {
+	t.Helper()
+	validateReusableCase(t, test)
+	firstStep := test.Steps[0]
+	require.NotContains(t, additionalProviders, "mongodbatlas", "Will use the local provider, cannot specify mongodbatlas provider")
+	steps := []resource.TestStep{
+		*useExternalProvider(firstStep, externalProviders),
+		*useExternalProvider(TestStepCheckEmptyPlan(firstStep.Config), additionalProviders),
+	}
+	return reuseCase(test, steps)
+}
+
+func validateReusableCase(t *testing.T, test *resource.TestCase) {
 	t.Helper()
 	checkLastVersion(t)
 	require.GreaterOrEqual(t, len(test.Steps), 1, "Must have at least 1 test step.")
-	firstStep := test.Steps[0]
-
-	if len(externalProviders) == 0 {
-		externalProviders = append(externalProviders, ExternalProviders())
-	}
-	steps := []resource.TestStep{}
-
-	for _, provider := range externalProviders {
-		steps = append(steps, *useExternalProvider(firstStep, provider))
-	}
-	steps = append(steps, TestStepCheckEmptyPlan(firstStep.Config))
-	return resource.TestCase{
-		PreCheck:     test.PreCheck,
-		CheckDestroy: test.CheckDestroy,
-		Steps:        steps,
-	}
+	require.NotEmpty(t, test.Steps[0].Config, "First step of migration test must use Config")
 }
 
 //nolint:gocritic
 func useExternalProvider(step resource.TestStep, provider map[string]resource.ExternalProvider) *resource.TestStep {
 	step.ExternalProviders = provider
 	return &step
+}
+
+func reuseCase(test *resource.TestCase, steps []resource.TestStep) resource.TestCase {
+	return resource.TestCase{
+		PreCheck:     test.PreCheck,
+		CheckDestroy: test.CheckDestroy,
+		ErrorCheck:   test.ErrorCheck,
+		Steps:        steps,
+	}
 }

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func CreateAndRunTest(t *testing.T, test *resource.TestCase) {
+	t.Helper()
+	resource.ParallelTest(t, CreateTest(t, test))
+}
+
+func CreateTestAndRunUseExternalProvider(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) {
+	t.Helper()
+	resource.ParallelTest(t, CreateTestUseExternalProvider(t, test, externalProviders, additionalProviders))
+}
+
 // CreateTest returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan
 // Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
 func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
@@ -17,7 +27,8 @@ func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 		useExternalProvider(&firstStep, ExternalProviders()),
 		TestStepCheckEmptyPlan(firstStep.Config),
 	}
-	return reuseCase(test, steps)
+	newTest := reuseCase(test, steps)
+	return newTest
 }
 
 // CreateTestUseExternalProvider returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders
@@ -37,11 +48,11 @@ func CreateTestUseExternalProvider(t *testing.T, test *resource.TestCase, extern
 	return reuseCase(test, steps)
 }
 
-func validateReusableCase(t *testing.T, test *resource.TestCase) {
-	t.Helper()
-	checkLastVersion(t)
-	require.GreaterOrEqual(t, len(test.Steps), 1, "Must have at least 1 test step.")
-	require.NotEmpty(t, test.Steps[0].Config, "First step of migration test must use Config")
+func validateReusableCase(tb testing.TB, test *resource.TestCase) {
+	tb.Helper()
+	checkLastVersion(tb)
+	require.GreaterOrEqual(tb, len(test.Steps), 1, "Must have at least 1 test step.")
+	require.NotEmpty(tb, test.Steps[0].Config, "First step of migration test must use Config")
 }
 
 func useExternalProvider(step *resource.TestStep, provider map[string]resource.ExternalProvider) resource.TestStep {

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -17,8 +17,8 @@ func CreateTestAndRunUseExternalProvider(t *testing.T, test *resource.TestCase, 
 	resource.ParallelTest(t, CreateTestUseExternalProvider(t, test, externalProviders, additionalProviders))
 }
 
-// CreateTest returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan
-// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
+// CreateTest returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan.
+// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present.
 func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 	t.Helper()
 	validateReusableCase(t, test)
@@ -31,10 +31,10 @@ func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 	return newTest
 }
 
-// CreateTestUseExternalProvider returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders
-// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present
-// externalProviders: e.g., ExternalProvidersWithAWS() or ExternalProviders("specific_sem_ver")
-// additionalProviders: e.g., acc.ExternalProvidersOnlyAWS(), can also be nil
+// CreateTestUseExternalProvider returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan with the additionalProviders.
+// Requires: `MONGODB_ATLAS_LAST_VERSION` to be present.
+// externalProviders: e.g., ExternalProvidersWithAWS() or ExternalProviders("specific_sem_ver").
+// additionalProviders: e.g., acc.ExternalProvidersOnlyAWS(), can also be nil.
 func CreateTestUseExternalProvider(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) resource.TestCase {
 	t.Helper()
 	validateReusableCase(t, test)
@@ -60,7 +60,7 @@ func useExternalProvider(step *resource.TestStep, provider map[string]resource.E
 	return *step
 }
 
-// Note how we don't set ProtoV6ProviderFactories and instead specify providers on each step
+// Note how we don't set ProtoV6ProviderFactories and instead specify providers on each step.
 func reuseCase(test *resource.TestCase, steps []resource.TestStep) resource.TestCase {
 	return resource.TestCase{
 		PreCheck:     test.PreCheck,

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -1,0 +1,24 @@
+package mig
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.TestCase {
+	t.Helper()
+	checkLastVersion(t)
+
+	firstStep := test.Steps[0]
+	firstStep.ExternalProviders = ExternalProviders()
+
+	return resource.TestCase{
+		PreCheck:     test.PreCheck,
+		CheckDestroy: test.CheckDestroy,
+		Steps: []resource.TestStep{
+			firstStep,
+			TestStepCheckEmptyPlan(firstStep.Config),
+		},
+	}
+}

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -14,7 +14,7 @@ func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.Test
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]
 	steps := []resource.TestStep{
-		*useExternalProvider(firstStep, ExternalProviders()),
+		useExternalProvider(&firstStep, ExternalProviders()),
 		TestStepCheckEmptyPlan(firstStep.Config),
 	}
 	return reuseCase(test, steps)
@@ -29,9 +29,10 @@ func ConvertToMigrationTestUseExternalProvider(t *testing.T, test *resource.Test
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]
 	require.NotContains(t, additionalProviders, "mongodbatlas", "Will use the local provider, cannot specify mongodbatlas provider")
+	emptyPlanStep := TestStepCheckEmptyPlan(firstStep.Config)
 	steps := []resource.TestStep{
-		*useExternalProvider(firstStep, externalProviders),
-		*useExternalProvider(TestStepCheckEmptyPlan(firstStep.Config), additionalProviders),
+		useExternalProvider(&firstStep, externalProviders),
+		useExternalProvider(&emptyPlanStep, additionalProviders),
 	}
 	return reuseCase(test, steps)
 }
@@ -43,12 +44,12 @@ func validateReusableCase(t *testing.T, test *resource.TestCase) {
 	require.NotEmpty(t, test.Steps[0].Config, "First step of migration test must use Config")
 }
 
-//nolint:gocritic
-func useExternalProvider(step resource.TestStep, provider map[string]resource.ExternalProvider) *resource.TestStep {
+func useExternalProvider(step *resource.TestStep, provider map[string]resource.ExternalProvider) resource.TestStep {
 	step.ExternalProviders = provider
-	return &step
+	return *step
 }
 
+// Note how we don't set ProtoV6ProviderFactories and instead specify providers on each step
 func reuseCase(test *resource.TestCase, steps []resource.TestStep) resource.TestCase {
 	return resource.TestCase{
 		PreCheck:     test.PreCheck,

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -4,21 +4,33 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 )
 
-func ConvertToMigrationTest(t *testing.T, test *resource.TestCase) resource.TestCase {
+func ConvertToMigrationTest(t *testing.T, test *resource.TestCase, externalProviders ...map[string]resource.ExternalProvider) resource.TestCase {
 	t.Helper()
 	checkLastVersion(t)
-
+	require.GreaterOrEqual(t, len(test.Steps), 1, "Must have at least 1 test step.")
 	firstStep := test.Steps[0]
-	firstStep.ExternalProviders = ExternalProviders()
 
+	if len(externalProviders) == 0 {
+		externalProviders = append(externalProviders, ExternalProviders())
+	}
+	steps := []resource.TestStep{}
+
+	for _, provider := range externalProviders {
+		steps = append(steps, *useExternalProvider(firstStep, provider))
+	}
+	steps = append(steps, TestStepCheckEmptyPlan(firstStep.Config))
 	return resource.TestCase{
 		PreCheck:     test.PreCheck,
 		CheckDestroy: test.CheckDestroy,
-		Steps: []resource.TestStep{
-			firstStep,
-			TestStepCheckEmptyPlan(firstStep.Config),
-		},
+		Steps:        steps,
 	}
+}
+
+//nolint:gocritic
+func useExternalProvider(step resource.TestStep, provider map[string]resource.ExternalProvider) *resource.TestStep {
+	step.ExternalProviders = provider
+	return &step
 }

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestConvertToMigration(t *testing.T) {
+	acc.SkipInUnitTest(t) // requires MONGODB_ATLAS_LAST_VERSION
 	var (
 		preCheckCalled     = false
 		checkDestroyCalled = false

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestConvertToMigration(t *testing.T) {
-	acc.SkipInUnitTest(t) // requires MONGODB_ATLAS_LAST_VERSION
+	t.Setenv("MONGODB_ATLAS_LAST_VERSION", "1.2.3")
 	var (
 		preCheckCalled     = false
 		checkDestroyCalled = false

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -28,7 +28,7 @@ func TestConvertToMigration(t *testing.T) {
 	asserter := assert.New(t)
 
 	convertAndCall := func(test resource.TestCase) resource.TestCase {
-		newTest := mig.ConvertToMigrationTest(t, &test)
+		newTest := mig.CreateTest(t, &test)
 		newTest.PreCheck()
 		if newTest.CheckDestroy != nil {
 			asserter.NoError(newTest.CheckDestroy(nil))
@@ -88,7 +88,7 @@ func TestConvertToMigration(t *testing.T) {
 	// ConvertToMigrationTestUseExternalProvider
 
 	t.Run("explicit ExternalProvider version an no additional providers", func(t *testing.T) {
-		test := mig.ConvertToMigrationTestUseExternalProvider(t, &resource.TestCase{
+		test := mig.CreateTestUseExternalProvider(t, &resource.TestCase{
 			PreCheck: preCheck,
 			Steps:    []resource.TestStep{firstStep},
 		}, acc.ExternalProviders("1.2.3"), nil)
@@ -99,7 +99,7 @@ func TestConvertToMigration(t *testing.T) {
 	})
 
 	t.Run("explicit ExternalProviders and additional providers", func(t *testing.T) {
-		test := mig.ConvertToMigrationTestUseExternalProvider(t, &resource.TestCase{
+		test := mig.CreateTestUseExternalProvider(t, &resource.TestCase{
 			PreCheck: preCheck,
 			Steps:    []resource.TestStep{firstStep},
 		}, acc.ExternalProvidersWithAWS("1.2.3"), acc.ExternalProvidersOnlyAWS())

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -108,8 +108,7 @@ func TestConvertToMigration(t *testing.T) {
 		asserter.Equal(config, newFirstStep.Config)
 
 		asserter.Equal("1.2.3", test.Steps[0].ExternalProviders["mongodbatlas"].VersionConstraint)
-		// must be upgraded when the aws provider version is changed
-		asserter.Equal("5.1.0", test.Steps[0].ExternalProviders["aws"].VersionConstraint)
-		asserter.Equal("5.1.0", test.Steps[1].ExternalProviders["aws"].VersionConstraint)
+		asserter.Equal(acc.AwsProviderVersion, test.Steps[0].ExternalProviders["aws"].VersionConstraint)
+		asserter.Equal(acc.AwsProviderVersion, test.Steps[1].ExternalProviders["aws"].VersionConstraint)
 	})
 }

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -3,9 +3,107 @@ package mig_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertToMigration(t *testing.T) {
-	require.True(t, true, "always true")
+	var (
+		preCheckCalled     = false
+		checkDestroyCalled = false
+		config             = "someTerraformConfig"
+	)
+	preCheck := func() {
+		preCheckCalled = true
+	}
+	firstStep := resource.TestStep{
+		Config: config,
+		Check:  resource.TestCheckResourceAttrSet("someTarget", "someAttribute"),
+	}
+
+	asserter := assert.New(t)
+
+	convertAndCall := func(test resource.TestCase) resource.TestCase {
+		newTest := mig.ConvertToMigrationTest(t, &test)
+		newTest.PreCheck()
+		if newTest.CheckDestroy != nil {
+			asserter.NoError(newTest.CheckDestroy(nil))
+		}
+		return newTest
+	}
+	defaultAssertions := func(test resource.TestCase) {
+		asserter.Len(test.Steps, 2, "Expected 2 steps (one extra test step)")
+		newFirstStep := test.Steps[0]
+		asserter.Equal(config, newFirstStep.Config)
+
+		planStep := test.Steps[1]
+		asserter.Equal(mig.TestStepCheckEmptyPlan(config), planStep)
+	}
+
+	t.Run("normal call with check and destroy", func(t *testing.T) {
+		checkDestroy := func(*terraform.State) error {
+			checkDestroyCalled = true
+			return nil
+		}
+		test := convertAndCall(resource.TestCase{
+			PreCheck:     preCheck,
+			CheckDestroy: checkDestroy,
+			Steps: []resource.TestStep{
+				firstStep,
+			},
+		})
+		asserter.True(preCheckCalled)
+		asserter.True(checkDestroyCalled)
+		defaultAssertions(test)
+	})
+
+	t.Run("check destroy is nil has no panic", func(t *testing.T) {
+		test := convertAndCall(resource.TestCase{
+			PreCheck: preCheck,
+			Steps: []resource.TestStep{
+				firstStep,
+			},
+		})
+		defaultAssertions(test)
+	})
+
+	t.Run("more than 1 step uses only 1 step", func(t *testing.T) {
+		test := convertAndCall(resource.TestCase{
+			PreCheck: preCheck,
+			Steps: []resource.TestStep{
+				firstStep,
+				{
+					Config: "differentConfig",
+					Check:  resource.TestCheckResourceAttrSet("target", "attribute"),
+				},
+			},
+		})
+		defaultAssertions(test)
+	})
+
+	t.Run("explicit ExternalProvider version", func(t *testing.T) {
+		test := mig.ConvertToMigrationTest(t, &resource.TestCase{
+			PreCheck: preCheck,
+			Steps:    []resource.TestStep{firstStep},
+		}, acc.ExternalProviders("1.2.3"))
+		defaultAssertions(test)
+		asserter.Equal("1.2.3", test.Steps[0].ExternalProviders["mongodbatlas"].VersionConstraint)
+	})
+
+	t.Run("multiple ExternalProviders", func(t *testing.T) {
+		test := mig.ConvertToMigrationTest(t, &resource.TestCase{
+			PreCheck: preCheck,
+			Steps:    []resource.TestStep{firstStep},
+		}, acc.ExternalProviders("1.2.3"), acc.ExternalProvidersWithAWS("4.5.6"))
+		asserter.Len(test.Steps, 3)
+		asserter.Equal("1.2.3", test.Steps[0].ExternalProviders["mongodbatlas"].VersionConstraint)
+		asserter.Equal("4.5.6", test.Steps[1].ExternalProviders["mongodbatlas"].VersionConstraint)
+		// must be upgraded when the aws provider version is changed
+		asserter.Equal("5.1.0", test.Steps[1].ExternalProviders["aws"].VersionConstraint)
+		planStep := test.Steps[2]
+		asserter.Equal(mig.TestStepCheckEmptyPlan(config), planStep)
+	})
 }

--- a/internal/testutil/mig/test_case_test.go
+++ b/internal/testutil/mig/test_case_test.go
@@ -1,0 +1,11 @@
+package mig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToMigration(t *testing.T) {
+	require.True(t, true, "always true")
+}


### PR DESCRIPTION
## Description

support converting a test case to a migration test

Link to any related issue(s): CLOUDP-239310

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Introduces two helper functions:

1. `ConvertToMigrationTest`: default way of creating a new test case from an existing basic test
2. `ConvertToMigrationTestUseExternalProvider`: when the test case requires a specific version or `aws` provider
    - e.g., `resource_privatelink_endpoint_service_migration_test.go`
    - `resource_encryption_at_rest_migration_test.go`