### PR TITLE
test: Modifies stream_connection and stream_instance tests to use shared cluster and project

### DIFF
--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -51,9 +51,9 @@ func TestAccStreamDSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccStreamDSStreamConnection_cluster(t *testing.T) {
 	var (
-		dataSourceName = "data.mongodbatlas_stream_connection.test"
-		clusterInfo    = acc.GetClusterInfo(t, nil)
-		instanceName   = acc.RandomName()
+		dataSourceName         = "data.mongodbatlas_stream_connection.test"
+		projectID, clusterName = acc.ClusterNameExecution(t)
+		instanceName           = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckPreviewFlag(t); acc.PreCheckBasic(t) },
@@ -61,8 +61,8 @@ func TestAccStreamDSStreamConnection_cluster(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionDataSourceConfig(clusterStreamConnectionConfig(clusterInfo.ProjectIDStr, instanceName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr)),
-				Check:  clusterStreamConnectionAttributeChecks(dataSourceName, clusterInfo.ClusterName),
+				Config: streamConnectionDataSourceConfig(clusterStreamConnectionConfig(projectID, instanceName, clusterName)),
+				Check:  clusterStreamConnectionAttributeChecks(dataSourceName, clusterName),
 			},
 		},
 	})

--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -2,7 +2,6 @@ package streamconnection_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,8 +11,7 @@ import (
 func TestAccStreamDSStreamConnection_kafkaPlaintext(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_connection.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,8 +20,8 @@ func TestAccStreamDSStreamConnection_kafkaPlaintext(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionDataSourceConfig(kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
-				Check:  kafkaStreamConnectionAttributeChecks(dataSourceName, orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false, false),
+				Config: streamConnectionDataSourceConfig(kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
+				Check:  kafkaStreamConnectionAttributeChecks(dataSourceName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false, false),
 			},
 		},
 	})
@@ -31,8 +29,7 @@ func TestAccStreamDSStreamConnection_kafkaPlaintext(t *testing.T) {
 
 func TestAccStreamDSStreamConnection_kafkaSSL(t *testing.T) {
 	var (
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 		dataSourceName = "data.mongodbatlas_stream_connection.test"
 	)
@@ -42,8 +39,8 @@ func TestAccStreamDSStreamConnection_kafkaSSL(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionDataSourceConfig(kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true)),
-				Check:  kafkaStreamConnectionAttributeChecks(dataSourceName, orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true, false),
+				Config: streamConnectionDataSourceConfig(kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true)),
+				Check:  kafkaStreamConnectionAttributeChecks(dataSourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true, false),
 			},
 		},
 	})
@@ -71,8 +68,7 @@ func TestAccStreamDSStreamConnection_cluster(t *testing.T) {
 func TestAccStreamDSStreamConnection_sample(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_connection.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 		sampleName     = "sample_stream_solar"
 	)
@@ -82,7 +78,7 @@ func TestAccStreamDSStreamConnection_sample(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionDataSourceConfig(sampleStreamConnectionConfig(orgID, projectName, instanceName, sampleName)),
+				Config: streamConnectionDataSourceConfig(sampleStreamConnectionConfig(projectID, instanceName, sampleName)),
 				Check:  sampleStreamConnectionAttributeChecks(dataSourceName, instanceName, sampleName),
 			},
 		},

--- a/internal/service/streamconnection/data_source_stream_connections_test.go
+++ b/internal/service/streamconnection/data_source_stream_connections_test.go
@@ -2,7 +2,6 @@ package streamconnection_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,8 +12,7 @@ import (
 func TestAccStreamDSStreamConnections_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_connections.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,7 +21,7 @@ func TestAccStreamDSStreamConnections_basic(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionsDataSourceConfig(kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
+				Config: streamConnectionsDataSourceConfig(kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
 				Check:  streamConnectionsAttributeChecks(dataSourceName, nil, nil, 1),
 			},
 		},
@@ -33,8 +31,7 @@ func TestAccStreamDSStreamConnections_basic(t *testing.T) {
 func TestAccStreamDSStreamConnections_withPageConfig(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_connections.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,7 +40,7 @@ func TestAccStreamDSStreamConnections_withPageConfig(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: streamConnectionsWithPageAttrDataSourceConfig(kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
+				Config: streamConnectionsWithPageAttrDataSourceConfig(kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false)),
 				Check:  streamConnectionsAttributeChecks(dataSourceName, admin.PtrInt(2), admin.PtrInt(1), 0),
 			},
 		},

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -2,7 +2,6 @@ package streamconnection_test
 
 import (
 	_ "embed"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,8 +13,7 @@ import (
 func TestMigStreamRSStreamConnection_kafkaPlaintext(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_stream_connection.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		instanceName = acc.RandomName()
 	)
 	mig.SkipIfVersionBelow(t, "1.14.0")
@@ -26,12 +24,12 @@ func TestMigStreamRSStreamConnection_kafkaPlaintext(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false),
-				Check:             kafkaStreamConnectionAttributeChecks(resourceName, orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false, true),
+				Config:            kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false),
+				Check:             kafkaStreamConnectionAttributeChecks(resourceName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false, true),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false),
+				Config:                   kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", false),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),
@@ -46,8 +44,7 @@ func TestMigStreamRSStreamConnection_kafkaPlaintext(t *testing.T) {
 func TestMigStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_stream_connection.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		instanceName = acc.RandomName()
 	)
 	mig.SkipIfVersionBelow(t, "1.14.0")
@@ -58,12 +55,12 @@ func TestMigStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true),
-				Check:             kafkaStreamConnectionAttributeChecks(resourceName, orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true, true),
+				Config:            kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true),
+				Check:             kafkaStreamConnectionAttributeChecks(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true, true),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   kafkaStreamConnectionConfig(orgID, projectName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true),
+				Config:                   kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/service/streamconnection/resource_stream_connection_migration_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_migration_test.go
@@ -77,9 +77,9 @@ func TestMigStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestMigStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_stream_connection.test"
-		clusterInfo  = acc.GetClusterInfo(t, nil)
-		instanceName = acc.RandomName()
+		resourceName           = "mongodbatlas_stream_connection.test"
+		projectID, clusterName = acc.ClusterNameExecution(t)
+		instanceName           = acc.RandomName()
 	)
 	mig.SkipIfVersionBelow(t, "1.15.2")
 
@@ -89,12 +89,12 @@ func TestMigStreamRSStreamConnection_cluster(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            clusterStreamConnectionConfig(clusterInfo.ProjectIDStr, instanceName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr),
-				Check:             clusterStreamConnectionAttributeChecks(resourceName, clusterInfo.ClusterName),
+				Config:            clusterStreamConnectionConfig(projectID, instanceName, clusterName),
+				Check:             clusterStreamConnectionAttributeChecks(resourceName, clusterName),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   clusterStreamConnectionConfig(clusterInfo.ProjectIDStr, instanceName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr),
+				Config:                   clusterStreamConnectionConfig(projectID, instanceName, clusterName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -75,9 +75,9 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 
 func TestAccStreamRSStreamConnection_cluster(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_stream_connection.test"
-		clusterInfo  = acc.GetClusterInfo(t, nil)
-		instanceName = acc.RandomName()
+		resourceName           = "mongodbatlas_stream_connection.test"
+		projectID, clusterName = acc.ClusterNameExecution(t)
+		instanceName           = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckPreviewFlag(t); acc.PreCheckBasic(t) },
@@ -85,8 +85,8 @@ func TestAccStreamRSStreamConnection_cluster(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: clusterStreamConnectionConfig(clusterInfo.ProjectIDStr, instanceName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr),
-				Check:  clusterStreamConnectionAttributeChecks(resourceName, clusterInfo.ClusterName),
+				Config: clusterStreamConnectionConfig(projectID, instanceName, clusterName),
+				Check:  clusterStreamConnectionAttributeChecks(resourceName, clusterName),
 			},
 			{
 				ResourceName:      resourceName,
@@ -216,11 +216,10 @@ func kafkaStreamConnectionAttributeChecks(
 	return resource.ComposeTestCheckFunc(resourceChecks...)
 }
 
-func clusterStreamConnectionConfig(projectIDStr, instanceName, clusterNameStr, clusterTerraformStr string) string {
-	return clusterTerraformStr + fmt.Sprintf(`
-		
+func clusterStreamConnectionConfig(projectID, instanceName, clusterName string) string {
+	return fmt.Sprintf(`
 		resource "mongodbatlas_stream_instance" "test" {
-			project_id = %[1]s
+			project_id = %[1]q
 			instance_name = %[2]q
 			data_process_region = {
 				region = "VIRGINIA_USA"
@@ -233,13 +232,13 @@ func clusterStreamConnectionConfig(projectIDStr, instanceName, clusterNameStr, c
 			instance_name = mongodbatlas_stream_instance.test.instance_name
 		 	connection_name = "ConnectionNameKafka"
 		 	type = "Cluster"
-		 	cluster_name = %[3]s
+		 	cluster_name = %[3]q
 			db_role_to_execute = {
 				role = "atlasAdmin"
 				type = "BUILT_IN"
 			}
 		}
-	`, projectIDStr, instanceName, clusterNameStr)
+	`, projectID, instanceName, clusterName)
 }
 
 func clusterStreamConnectionAttributeChecks(resourceName, clusterName string) resource.TestCheckFunc {

--- a/internal/service/streaminstance/data_source_stream_instance_test.go
+++ b/internal/service/streaminstance/data_source_stream_instance_test.go
@@ -2,7 +2,6 @@ package streaminstance_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,8 +11,7 @@ import (
 func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_instance.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 
@@ -23,7 +21,7 @@ func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: streamInstanceDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider),
+				Config: streamInstanceDataSourceConfig(projectID, instanceName, region, cloudProvider),
 				Check: resource.ComposeTestCheckFunc(
 					streamInstanceAttributeChecks(dataSourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(dataSourceName, "stream_config.tier", "SP30"),
@@ -33,7 +31,7 @@ func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 	})
 }
 
-func streamInstanceDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+func streamInstanceDataSourceConfig(projectID, instanceName, region, cloudProvider string) string {
 	return fmt.Sprintf(`
 		%s
 
@@ -41,5 +39,5 @@ func streamInstanceDataSourceConfig(orgID, projectName, instanceName, region, cl
 			project_id = mongodbatlas_stream_instance.test.project_id
 			instance_name = mongodbatlas_stream_instance.test.instance_name
 		}
-	`, acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider))
+	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider))
 }

--- a/internal/service/streaminstance/data_source_stream_instances_test.go
+++ b/internal/service/streaminstance/data_source_stream_instances_test.go
@@ -2,7 +2,6 @@ package streaminstance_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,8 +12,7 @@ import (
 func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_instances.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -23,7 +21,7 @@ func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: streamInstancesDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider),
+				Config: streamInstancesDataSourceConfig(projectID, instanceName, region, cloudProvider),
 				Check:  streamInstancesAttributeChecks(dataSourceName, nil, nil, 1),
 			},
 		},
@@ -33,8 +31,7 @@ func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 func TestAccStreamDSStreamInstances_withPageConfig(t *testing.T) {
 	var (
 		dataSourceName = "data.mongodbatlas_stream_instances.test"
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
+		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
 
@@ -44,24 +41,24 @@ func TestAccStreamDSStreamInstances_withPageConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: streamInstancesWithPageAttrDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider),
+				Config: streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider),
 				Check:  streamInstancesAttributeChecks(dataSourceName, admin.PtrInt(2), admin.PtrInt(1), 0),
 			},
 		},
 	})
 }
 
-func streamInstancesDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+func streamInstancesDataSourceConfig(projectID, instanceName, region, cloudProvider string) string {
 	return fmt.Sprintf(`
 		%s
 
 		data "mongodbatlas_stream_instances" "test" {
 			project_id = mongodbatlas_stream_instance.test.project_id
 		}
-	`, acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider))
+	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider))
 }
 
-func streamInstancesWithPageAttrDataSourceConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+func streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider string) string {
 	return fmt.Sprintf(`
 		%s
 
@@ -70,7 +67,7 @@ func streamInstancesWithPageAttrDataSourceConfig(orgID, projectName, instanceNam
 			page_num = 2
 			items_per_page = 1
 		}
-	`, acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider))
+	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider))
 }
 
 func streamInstancesAttributeChecks(resourceName string, pageNum, itemsPerPage *int, totalCount int) resource.TestCheckFunc {

--- a/internal/service/streaminstance/data_source_stream_instances_test.go
+++ b/internal/service/streaminstance/data_source_stream_instances_test.go
@@ -15,6 +15,14 @@ func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
 	)
+
+	checks := paginatedAttrChecks(dataSourceName, nil, nil)
+	// created instance is present in results
+	checks = append(checks, resource.TestCheckResourceAttrWith(dataSourceName, "results.#", acc.IntGreatThan(0)),
+		resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "results.*", map[string]string{
+			"instance_name": instanceName,
+		}))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckPreviewFlag(t); acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -22,7 +30,7 @@ func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstancesDataSourceConfig(projectID, instanceName, region, cloudProvider),
-				Check:  streamInstancesAttributeChecks(dataSourceName, nil, nil, 1),
+				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -33,7 +41,11 @@ func TestAccStreamDSStreamInstances_withPageConfig(t *testing.T) {
 		dataSourceName = "data.mongodbatlas_stream_instances.test"
 		projectID      = acc.ProjectIDExecution(t)
 		instanceName   = acc.RandomName()
+		pageNumber     = 1000 // high page number so no results are returned
 	)
+
+	checks := paginatedAttrChecks(dataSourceName, admin.PtrInt(pageNumber), admin.PtrInt(1))
+	checks = append(checks, resource.TestCheckResourceAttr(dataSourceName, "results.#", "0")) // expecting no results
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckPreviewFlag(t); acc.PreCheckBasic(t) },
@@ -41,8 +53,8 @@ func TestAccStreamDSStreamInstances_withPageConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider),
-				Check:  streamInstancesAttributeChecks(dataSourceName, admin.PtrInt(2), admin.PtrInt(1), 0),
+				Config: streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider, pageNumber),
+				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -58,29 +70,28 @@ func streamInstancesDataSourceConfig(projectID, instanceName, region, cloudProvi
 	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider))
 }
 
-func streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider string) string {
+func streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider string, pageNum int) string {
 	return fmt.Sprintf(`
 		%s
 
 		data "mongodbatlas_stream_instances" "test" {
 			project_id = mongodbatlas_stream_instance.test.project_id
-			page_num = 2
+			page_num = %d
 			items_per_page = 1
 		}
-	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider))
+	`, acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider), pageNum)
 }
 
-func streamInstancesAttributeChecks(resourceName string, pageNum, itemsPerPage *int, totalCount int) resource.TestCheckFunc {
-	resourceChecks := []resource.TestCheckFunc{
+func paginatedAttrChecks(resourceName string, pageNum, itemsPerPage *int) []resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 		resource.TestCheckResourceAttrSet(resourceName, "total_count"),
-		resource.TestCheckResourceAttr(resourceName, "results.#", fmt.Sprint(totalCount)),
 	}
 	if pageNum != nil {
-		resourceChecks = append(resourceChecks, resource.TestCheckResourceAttr(resourceName, "page_num", fmt.Sprint(*pageNum)))
+		checks = append(checks, resource.TestCheckResourceAttr(resourceName, "page_num", fmt.Sprint(*pageNum)))
 	}
 	if itemsPerPage != nil {
-		resourceChecks = append(resourceChecks, resource.TestCheckResourceAttr(resourceName, "items_per_page", fmt.Sprint(*itemsPerPage)))
+		checks = append(checks, resource.TestCheckResourceAttr(resourceName, "items_per_page", fmt.Sprint(*itemsPerPage)))
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return checks
 }

--- a/internal/service/streaminstance/resource_stream_instance_migration_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_migration_test.go
@@ -1,7 +1,6 @@
 package streaminstance_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,9 +12,8 @@ import (
 
 func TestMigStreamRSStreamInstance_basic(t *testing.T) {
 	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		resourceName = "mongodbatlas_stream_instance.test"
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		instanceName = acc.RandomName()
 	)
 	mig.SkipIfVersionBelow(t, "1.14.0")
@@ -26,12 +24,12 @@ func TestMigStreamRSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider),
+				Config:            acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider),
 				Check:             streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider),
+				Config:                   acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -3,7 +3,6 @@ package streaminstance_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,8 +13,7 @@ import (
 func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_stream_instance.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		instanceName = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -24,7 +22,7 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
+				Config: acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
 				Check: resource.ComposeTestCheckFunc(
 					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
@@ -43,8 +41,7 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 func TestAccStreamRSStreamInstance_withStreamConfig(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_stream_instance.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
+		projectID    = acc.ProjectIDExecution(t)
 		instanceName = acc.RandomName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
@@ -53,7 +50,7 @@ func TestAccStreamRSStreamInstance_withStreamConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.StreamInstanceWithStreamConfigConfig(orgID, projectName, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
+				Config: acc.StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
 				Check: resource.ComposeTestCheckFunc(
 					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),

--- a/internal/testutil/acc/stream_instance.go
+++ b/internal/testutil/acc/stream_instance.go
@@ -7,43 +7,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func StreamInstanceConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+func StreamInstanceConfig(projectID, instanceName, region, cloudProvider string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_stream_instance" "test" {
-			project_id = mongodbatlas_project.test.id
-			instance_name = %[3]q
+			project_id = %[1]q
+			instance_name = %[2]q
 			data_process_region = {
-				region = %[4]q
-				cloud_provider = %[5]q
+				region = %[3]q
+				cloud_provider = %[4]q
 			}
 		}
-	`, orgID, projectName, instanceName, region, cloudProvider)
+	`, projectID, instanceName, region, cloudProvider)
 }
 
-func StreamInstanceWithStreamConfigConfig(orgID, projectName, instanceName, region, cloudProvider string) string {
+func StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_stream_instance" "test" {
-			project_id = mongodbatlas_project.test.id
-			instance_name = %[3]q
+			project_id = %[1]q
+			instance_name = %[2]q
 			data_process_region = {
-				region = %[4]q
-				cloud_provider = %[5]q
+				region = %[3]q
+				cloud_provider = %[4]q
 			}
 			stream_config = {
 				tier = "SP30"
 			}
 		}
-	`, orgID, projectName, instanceName, region, cloudProvider)
+	`, projectID, instanceName, region, cloudProvider)
 }
 
 func CheckDestroyStreamInstance(state *terraform.State) error {


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-239134

- Modifies stream connection acceptance/migration tests to share a single cluster, no risk in multiple stream connections referencing a same cluster.
- Modifies stream connection and stream instance acceptance/migration tests to share a single project, no risk as a each test creates a new stream instance within the project.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
