### PR TITLE
fix: Update `mongodbatlas_project` to use RegionUsageRestrictions from API

### DIFF
--- a/internal/service/project/model_project.go
+++ b/internal/service/project/model_project.go
@@ -3,10 +3,12 @@ package project
 import (
 	"context"
 
+	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 )
 
 func NewTFProjectDataSourceModel(ctx context.Context, project *admin.Group, projectProps AdditionalProperties) (*TFProjectDSModel, diag.Diagnostics) {
@@ -16,12 +18,13 @@ func NewTFProjectDataSourceModel(ctx context.Context, project *admin.Group, proj
 	}
 	projectSettings := projectProps.Settings
 	return &TFProjectDSModel{
-		ID:           types.StringValue(project.GetId()),
-		ProjectID:    types.StringValue(project.GetId()),
-		Name:         types.StringValue(project.Name),
-		OrgID:        types.StringValue(project.OrgId),
-		ClusterCount: types.Int64Value(project.ClusterCount),
-		Created:      types.StringValue(conversion.TimeToString(project.Created)),
+		ID:                      types.StringValue(project.GetId()),
+		ProjectID:               types.StringValue(project.GetId()),
+		Name:                    types.StringValue(project.Name),
+		OrgID:                   types.StringValue(project.OrgId),
+		ClusterCount:            types.Int64Value(project.ClusterCount),
+		Created:                 types.StringValue(conversion.TimeToString(project.Created)),
+		RegionUsageRestrictions: types.StringPointerValue(project.RegionUsageRestrictions),
 		IsCollectDatabaseSpecificsStatisticsEnabled: types.BoolValue(*projectSettings.IsCollectDatabaseSpecificsStatisticsEnabled),
 		IsDataExplorerEnabled:                       types.BoolValue(*projectSettings.IsDataExplorerEnabled),
 		IsExtendedStorageSizesEnabled:               types.BoolValue(*projectSettings.IsExtendedStorageSizesEnabled),
@@ -99,6 +102,7 @@ func NewTFProjectResourceModel(ctx context.Context, projectRes *admin.Group, pro
 		Name:                      types.StringValue(projectRes.Name),
 		OrgID:                     types.StringValue(projectRes.OrgId),
 		ClusterCount:              types.Int64Value(projectRes.ClusterCount),
+		RegionUsageRestrictions:   types.StringPointerValue(projectRes.RegionUsageRestrictions),
 		Created:                   types.StringValue(conversion.TimeToString(projectRes.Created)),
 		WithDefaultAlertsSettings: types.BoolPointerValue(projectRes.WithDefaultAlertsSettings),
 		Teams:                     newTFTeamsResourceModel(ctx, projectProps.Teams),

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -11,15 +11,17 @@ import (
 	"strings"
 	"testing"
 
+	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/project"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	"github.com/stretchr/testify/mock"
-	"go.mongodb.org/atlas-sdk/v20231115008/admin"
-	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
 )
 
 var (
@@ -610,16 +612,17 @@ func TestAccProjectGov_withProjectOwner(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckGov(t) },
+		PreCheck:                 func() { acc.PreCheckGovBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyProject,
 		Steps: []resource.TestStep{
 			{
-				Config: configGovWithOwner(projectName, orgID, projectOwnerID),
+				Config: configGovWithOwner(orgID, projectName, projectOwnerID),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
+					resource.TestCheckResourceAttr(resourceName, "region_usage_restrictions", "GOV_REGIONS_ONLY"),
 				),
 			},
 		},

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -94,14 +94,21 @@ func GetProjectTeamsIDsWithPos(pos int) string {
 	return teamsIDs[pos]
 }
 
-func PreCheckGov(tb testing.TB) {
+func PreCheckGovBasic(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
 		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_ID_GOV") == "" ||
 		os.Getenv("MONGODB_ATLAS_ORG_ID_GOV") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_ID_GOV` and `MONGODB_ATLAS_ORG_ID_GOV` must be set for acceptance testing")
+		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`and `MONGODB_ATLAS_ORG_ID_GOV` must be set for acceptance testing")
 	}
+}
+
+func PreCheckGov(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_PROJECT_ID_GOV") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_ID_GOV` must be set for acceptance testing")
+	}
+	PreCheckGovBasic(tb)
 }
 
 func PreCheckGPCEnv(tb testing.TB) {


### PR DESCRIPTION
## Description

Update `mongodbatlas_project` to use RegionUsageRestrictions from API. The value of this attribute was previously not being returned by the API and so was not being read in the provider as well.
The API is now fixed and returns the value of this attribute if set by the user. This PR ensure the resources reads and sets this attribute value in the resource models correctly.

Link to any related issue(s): [CLOUDP-228420](https://jira.mongodb.org/browse/CLOUDP-228420)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
