### PR TITLE
fix: Ensures accepter_region_name is set on data_source_network_peering when it is the same region as the network_container

### DIFF
--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -124,13 +124,13 @@ func dataSourceMongoDBAtlasNetworkPeeringRead(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf(errorPeersRead, peerID, err))
 	}
 
-	// Workaround until fix.
-	if peer.AccepterRegionName != "" {
-		if err := d.Set("accepter_region_name", peer.AccepterRegionName); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting `accepter_region_name` for Network Peering Connection (%s): %s", peerID, err))
-		}
+	accepterRegionName, err := ensureAccepterRegionName(ctx, peer, conn, projectID)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-
+	if err := d.Set("accepter_region_name", accepterRegionName); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `accepter_region_name` for Network Peering Connection (%s): %s", peerID, err))
+	}
 	if err := d.Set("aws_account_id", peer.AWSAccountID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `aws_account_id` for Network Peering Connection (%s): %s", peerID, err))
 	}

--- a/internal/service/networkpeering/data_source_network_peerings.go
+++ b/internal/service/networkpeering/data_source_network_peerings.go
@@ -123,8 +123,11 @@ func dataSourceMongoDBAtlasNetworkPeeringsRead(ctx context.Context, d *schema.Re
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting network peering connections information: %s", err))
 	}
-
-	if err := d.Set("results", flattenNetworkPeerings(peers)); err != nil {
+	peersMap, err := flattenNetworkPeerings(ctx, conn, peers, projectID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("results", peersMap); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `result` for network peering connections: %s", err))
 	}
 
@@ -133,16 +136,20 @@ func dataSourceMongoDBAtlasNetworkPeeringsRead(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func flattenNetworkPeerings(peers []matlas.Peer) []map[string]any {
+func flattenNetworkPeerings(ctx context.Context, conn *matlas.Client, peers []matlas.Peer, projectID string) ([]map[string]any, error) {
 	var peersMap []map[string]any
 
 	if len(peers) > 0 {
 		peersMap = make([]map[string]any, len(peers))
 		for i := range peers {
+			accepterRegionName, err := ensureAccepterRegionName(ctx, &peers[i], conn, projectID)
+			if err != nil {
+				return peersMap, err
+			}
 			peersMap[i] = map[string]any{
 				"peering_id":             peers[i].ID,
 				"container_id":           peers[i].ContainerID,
-				"accepter_region_name":   peers[i].AccepterRegionName,
+				"accepter_region_name":   accepterRegionName,
 				"aws_account_id":         peers[i].AWSAccountID,
 				"provider_name":          getProviderNameByPeer(&peers[i]),
 				"route_table_cidr_block": peers[i].RouteTableCIDRBlock,
@@ -164,7 +171,7 @@ func flattenNetworkPeerings(peers []matlas.Peer) []map[string]any {
 		}
 	}
 
-	return peersMap
+	return peersMap, nil
 }
 
 func getProviderNameByPeer(peer *matlas.Peer) string {

--- a/internal/service/networkpeering/data_source_network_peerings.go
+++ b/internal/service/networkpeering/data_source_network_peerings.go
@@ -144,7 +144,7 @@ func flattenNetworkPeerings(ctx context.Context, conn *matlas.Client, peers []ma
 		for i := range peers {
 			accepterRegionName, err := ensureAccepterRegionName(ctx, &peers[i], conn, projectID)
 			if err != nil {
-				return peersMap, err
+				return nil, err
 			}
 			peersMap[i] = map[string]any{
 				"peering_id":             peers[i].ID,

--- a/internal/service/networkpeering/resource_network_peering_migration_test.go
+++ b/internal/service/networkpeering/resource_network_peering_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigNetworkNetworkPeering_basicAWS(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.16.0")
 	mig.CreateAndRunTest(t, basicAWSTestCase(t))
 }

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -184,14 +184,14 @@ func commonChecksAWS(vpcID, providerName, awsAccountID, vpcCIDRBlock, regionPeer
 		"provider_name":          providerName,
 		"aws_account_id":         awsAccountID,
 		"route_table_cidr_block": vpcCIDRBlock,
+		"accepter_region_name":   regionPeer,
 	}
 	checks := []resource.TestCheckFunc{checkExists(resourceName, &matlas.Peer{})}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
-	checks = append(checks, resource.TestCheckResourceAttr(resourceName, "accepter_region_name", regionPeer))
 	checks = acc.AddAttrChecks(dataSourceName, checks, attributes)
 	checks = acc.AddAttrSetChecks(resourceName, checks, "project_id", "container_id", "accepter_region_name")
 	checks = acc.AddAttrSetChecks(dataSourceName, checks, "project_id", "container_id")
-	checks = acc.AddAttrSetChecks(pluralDataSourceName, checks, "results.#", "results.0.provider_name", "results.0.vpc_id", "results.0.aws_account_id")
+	checks = acc.AddAttrSetChecks(pluralDataSourceName, checks, "results.#", "results.0.provider_name", "results.0.vpc_id", "results.0.aws_account_id", "results.0.accepter_region_name")
 	return checks
 }
 


### PR DESCRIPTION
## Description

Ensures accepter_region_name is set on data_source_network_peering when it is the same region as the network_container

Link to any related issue(s): CLOUDP-240700

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
