### PR TITLE
feat: Adds `yearly` frequency and `years` unit to `mongodbatlas_cloud_backup_schedule` and `mongodbatlas_backup_compliance_policy`

### DIFF
--- a/examples/mongodbatlas_cloud_backup_schedule/main.tf
+++ b/examples/mongodbatlas_cloud_backup_schedule/main.tf
@@ -69,6 +69,11 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
     retention_unit  = "months"
     retention_value = 4
   }
+  policy_item_yearly {
+    frequency_interval = 1 # accepted values = 1 to 12 -> 1st day of nth month  
+    retention_unit     = "years"
+    retention_value    = 1
+  }
 
   depends_on = [
     mongodbatlas_advanced_cluster.automated_backup_test_cluster

--- a/internal/service/backupcompliancepolicy/data_source_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/data_source_backup_compliance_policy.go
@@ -201,6 +201,34 @@ func DataSource() *schema.Resource {
 					},
 				},
 			},
+			"policy_item_yearly": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"retention_unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retention_value": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -275,6 +303,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if err := d.Set("policy_item_monthly", flattenBackupPolicyItems(policy.GetScheduledPolicyItems(), cloudbackupschedule.Monthly)); err != nil {
 		return diag.Errorf(errorSnapshotBackupPolicySetting, "policy_item_monthly", projectID, err)
+	}
+
+	if err := d.Set("policy_item_yearly", flattenBackupPolicyItems(policy.GetScheduledPolicyItems(), cloudbackupschedule.Yearly)); err != nil {
+		return diag.Errorf(errorSnapshotBackupPolicySetting, "policy_item_yearly", projectID, err)
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
@@ -227,6 +227,34 @@ func Resource() *schema.Resource {
 					},
 				},
 			},
+			"policy_item_yearly": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_interval": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"retention_unit": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"retention_value": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -286,6 +314,18 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			itemObj := s.(map[string]any)
 			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
 				FrequencyType:     cloudbackupschedule.Monthly,
+				RetentionUnit:     itemObj["retention_unit"].(string),
+				FrequencyInterval: itemObj["frequency_interval"].(int),
+				RetentionValue:    itemObj["retention_value"].(int),
+			})
+		}
+	}
+	if v, ok := d.GetOk("policy_item_yearly"); ok {
+		items := v.([]any)
+		for _, s := range items {
+			itemObj := s.(map[string]any)
+			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+				FrequencyType:     cloudbackupschedule.Yearly,
 				RetentionUnit:     itemObj["retention_unit"].(string),
 				FrequencyInterval: itemObj["frequency_interval"].(int),
 				RetentionValue:    itemObj["retention_value"].(int),
@@ -387,6 +427,10 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf(errorSnapshotBackupPolicySetting, "policy_item_monthly", projectID, err)
 	}
 
+	if err := d.Set("policy_item_yearly", flattenBackupPolicyItems(policy.GetScheduledPolicyItems(), cloudbackupschedule.Yearly)); err != nil {
+		return diag.Errorf(errorSnapshotBackupPolicySetting, "policy_item_yearly", projectID, err)
+	}
+
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id": projectID,
 	}))
@@ -463,6 +507,18 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			itemObj := s.(map[string]any)
 			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
 				FrequencyType:     cloudbackupschedule.Monthly,
+				RetentionUnit:     itemObj["retention_unit"].(string),
+				FrequencyInterval: itemObj["frequency_interval"].(int),
+				RetentionValue:    itemObj["retention_value"].(int),
+			})
+		}
+	}
+	if v, ok := d.GetOk("policy_item_yearly"); ok {
+		items := v.([]any)
+		for _, s := range items {
+			itemObj := s.(map[string]any)
+			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+				FrequencyType:     cloudbackupschedule.Yearly,
 				RetentionUnit:     itemObj["retention_unit"].(string),
 				FrequencyInterval: itemObj["frequency_interval"].(int),
 				RetentionValue:    itemObj["retention_value"].(int),

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_migration_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigBackupCompliancePolicy_basic(t *testing.T) {
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	useYearly := mig.IsProviderVersionAtLeast("1.16.0") // attribute introduced in this version
+	mig.CreateAndRunTest(t, basicTestCase(t, useYearly))
 }

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -164,7 +164,7 @@ func configBasic(projectName, orgID, projectOwnerID string, useYearly bool) stri
 	if useYearly {
 		strYearly = `
 			policy_item_yearly {
-				frequency_interval = 0
+				frequency_interval = 1
 				retention_unit     = "years"
 				retention_value    = 1
 			}
@@ -264,7 +264,7 @@ func configWithoutOptionals(projectName, orgID, projectOwnerID string) string {
 			}
 
 			policy_item_yearly {
-				frequency_interval = 0
+				frequency_interval = 1
 				retention_unit     = "years"
 				retention_value    = 1
 			}
@@ -316,7 +316,7 @@ func configWithoutRestoreDays(projectName, orgID, projectOwnerID string) string 
 			}
 
 			policy_item_yearly {
-				frequency_interval = 0
+				frequency_interval = 1
 				retention_unit     = "years"
 				retention_value    = 1
 			}

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestAccBackupCompliancePolicy_basic(t *testing.T) {
-	resource.ParallelTest(t, *basicTestCase(t))
+	resource.ParallelTest(t, *basicTestCase(t, true))
 }
 
 func TestAccBackupCompliancePolicy_update(t *testing.T) {
@@ -45,7 +45,7 @@ func TestAccBackupCompliancePolicy_update(t *testing.T) {
 				),
 			},
 			{
-				Config: configBasic(projectName, orgID, projectOwnerID),
+				Config: configBasic(projectName, orgID, projectOwnerID, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authorized_user_first_name", "First"),
@@ -101,7 +101,7 @@ func TestAccBackupCompliancePolicy_withoutRestoreWindowDays(t *testing.T) {
 	})
 }
 
-func basicTestCase(tb testing.TB) *resource.TestCase {
+func basicTestCase(tb testing.TB, useYearly bool) *resource.TestCase {
 	tb.Helper()
 
 	var (
@@ -115,7 +115,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectName, orgID, projectOwnerID),
+				Config: configBasic(projectName, orgID, projectOwnerID, useYearly),
 				Check:  resource.ComposeTestCheckFunc(basicChecks()...),
 			},
 			{
@@ -159,8 +159,20 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	}
 }
 
-func configBasic(projectName, orgID, projectOwnerID string) string {
-	return acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false) + `	  
+func configBasic(projectName, orgID, projectOwnerID string, useYearly bool) string {
+	var strYearly string
+	if useYearly {
+		strYearly = `
+			policy_item_yearly {
+				frequency_interval = 0
+				retention_unit     = "years"
+				retention_value    = 1
+			}
+		`
+	}
+
+	return acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false) +
+		fmt.Sprintf(`	  
 	  resource "mongodbatlas_backup_compliance_policy" "backup_policy_res" {
 			project_id                 = mongodbatlas_project.test.id
 			authorized_email           = "test@example.com"
@@ -201,12 +213,14 @@ func configBasic(projectName, orgID, projectOwnerID string) string {
 				retention_unit     = "months"
 				retention_value    = 12
 			}
-	  }
 
+			%s
+	  }
+		
 		data "mongodbatlas_backup_compliance_policy" "backup_policy" {
 			project_id = mongodbatlas_backup_compliance_policy.backup_policy_res.project_id
 		}
-	`
+	`, strYearly)
 }
 
 func configWithoutOptionals(projectName, orgID, projectOwnerID string) string {
@@ -247,6 +261,12 @@ func configWithoutOptionals(projectName, orgID, projectOwnerID string) string {
 				frequency_interval = 0
 				retention_unit     = "months"
 				retention_value    = 12
+			}
+
+			policy_item_yearly {
+				frequency_interval = 0
+				retention_unit     = "years"
+				retention_value    = 1
 			}
 	  }
 	`
@@ -293,6 +313,12 @@ func configWithoutRestoreDays(projectName, orgID, projectOwnerID string) string 
 				frequency_interval = 0
 				retention_unit     = "months"
 				retention_value    = 12
+			}
+
+			policy_item_yearly {
+				frequency_interval = 0
+				retention_unit     = "years"
+				retention_value    = 1
 			}
 	  }
 	`

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -213,6 +213,34 @@ func DataSource() *schema.Resource {
 					},
 				},
 			},
+			"policy_item_yearly": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frequency_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"retention_unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retention_value": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -273,6 +301,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if err := d.Set("policy_item_monthly", flattenPolicyItem(backupPolicy.GetPolicies()[0].GetPolicyItems(), Monthly)); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_monthly", clusterName, err)
+	}
+
+	if err := d.Set("policy_item_yearly", flattenPolicyItem(backupPolicy.GetPolicies()[0].GetPolicyItems(), Yearly)); err != nil {
+		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_yearly", clusterName, err)
 	}
 
 	if err := d.Set("copy_settings", flattenCopySettings(backupPolicy.GetCopySettings())); err != nil {

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -19,6 +19,7 @@ const (
 	Daily                              = "daily"
 	Weekly                             = "weekly"
 	Monthly                            = "monthly"
+	Yearly                             = "yearly"
 	errorSnapshotBackupScheduleCreate  = "error creating a Cloud Backup Schedule: %s"
 	errorSnapshotBackupScheduleUpdate  = "error updating a Cloud Backup Schedule: %s"
 	errorSnapshotBackupScheduleRead    = "error getting a Cloud Backup Schedule for the cluster(%s): %s"

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -13,11 +13,12 @@ import (
 func TestMigBackupRSCloudBackupSchedule_basic(t *testing.T) {
 	var (
 		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true})
+		useYearly   = mig.IsProviderVersionAtLeast("1.16.0") // attribute introduced in this version
 		config      = configNewPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
 			ReferenceHourOfDay:    conversion.Pointer(0),
 			ReferenceMinuteOfHour: conversion.Pointer(0),
 			RestoreWindowDays:     conversion.Pointer(7),
-		})
+		}, useYearly)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -45,6 +45,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "reference_hour_of_day"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "reference_minute_of_hour"),
@@ -52,14 +53,16 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_hourly.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_daily.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_weekly.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_monthly.#")),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_monthly.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policy_item_yearly.#"),
+				),
 			},
 			{
 				Config: configNewPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(0),
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
-				}),
+				}, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
@@ -70,6 +73,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy_item_hourly.0.id"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
@@ -86,6 +90,10 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "3"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_item_yearly.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "reference_hour_of_day"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "reference_minute_of_hour"),
@@ -109,6 +117,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "policy_item_hourly.0.id"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
@@ -131,6 +140,9 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.frequency_interval", "6"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.1.retention_value", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
 				),
 			},
 		},
@@ -197,6 +209,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
@@ -209,6 +222,9 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
 				),
 			},
 			{
@@ -229,6 +245,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "0"),
 				),
 			},
 		},
@@ -262,6 +279,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
@@ -274,6 +292,9 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
 					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.cloud_provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.region_name", "US_EAST_1"),
 					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.should_copy_oplogs", "true"),
@@ -308,6 +329,7 @@ func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
@@ -320,6 +342,9 @@ func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
+					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
 				),
 			},
 			{
@@ -470,6 +495,11 @@ func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) s
 				retention_unit     = "months"
 				retention_value    = 4
 			}
+			policy_item_yearly {
+				frequency_interval = 1
+				retention_unit     = "years"
+				retention_value    = 1
+			}
 		}
 
 		data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
@@ -531,12 +561,18 @@ func configCopySettings(projectID, clusterName string, p *admin.DiskBackupSnapsh
 				retention_unit     = "months"
 				retention_value    = 4
 			}
+			policy_item_yearly {
+				frequency_interval = 1
+				retention_unit     = "years"
+				retention_value    = 1
+			}
 			copy_settings {
 				cloud_provider = "AWS"
 				frequencies = ["HOURLY",
 							"DAILY",
 							"WEEKLY",
 							"MONTHLY",
+							"YEARLY",
 							"ON_DEMAND"]
 				region_name = "US_EAST_1"
 				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
@@ -565,7 +601,18 @@ func configOnePolicy(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule)
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configNewPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {
+func configNewPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule, useYearly bool) string {
+	var strYearly string
+	if useYearly {
+		strYearly = `
+			policy_item_yearly {
+				frequency_interval = 1
+				retention_unit     = "years"
+				retention_value    = 1
+			}
+		`
+	}
+
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
@@ -595,13 +642,14 @@ func configNewPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedul
 				retention_unit     = "months"
 				retention_value    = 3
 			}
+			%[6]s
 		}
 
 		data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
 			project_id       = %[2]s
 		 }	
-	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
+	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), strYearly)
 }
 
 func configAzure(info *acc.ClusterInfo, policy *admin.DiskBackupApiPolicyItem) string {
@@ -664,6 +712,11 @@ func configAdvancedPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSc
 				frequency_interval = 6
 				retention_unit     = "months"
 				retention_value    = 4
+			}
+			policy_item_yearly {
+				frequency_interval = 1
+				retention_unit     = "years"
+				retention_value    = 1
 			}
 		}
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())

--- a/website/docs/d/backup_compliance_policy.html.markdown
+++ b/website/docs/d/backup_compliance_policy.html.markdown
@@ -58,6 +58,11 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
     retention_unit     = "months"
     retention_value    = 4
   }
+  policy_item_yearly {
+    frequency_interval = 1        # accepted values = 1 to 12 -> 1st day of nth month  
+    retention_unit     = "years"
+    retention_value    = 1
+  }
 
 }
 
@@ -111,6 +116,12 @@ resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
 			retention_value    = 12
 		  }
 
+      policy_item_yearly {
+        frequency_interval = 1
+        retention_unit     = "years"
+        retention_value    = 1
+      }
+
 }
 ```
 
@@ -138,28 +149,28 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `ondemand`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
 * 
 ### Policy Item Hourly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
@@ -168,7 +179,15 @@ In addition to all arguments above, the following attributes are exported:
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
   * `40` represents the last day of the month (depending on the month).
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
+
+### Policy Item Yearly
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For yearly policies, the frequency type is defined as `yearly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (yearly in this case). The supported values for yearly policies are 
+  * `1` through `12` the first day of the month where the number represents the month, i.e. `1` is January and `12` is December.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
+* `retention_value` - Value to associate with `retention_unit`. Yearly policy must have retention of at least 1 year.
 
 For more information, see [MongoDB Atlas API Reference](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Cloud-Backups/operation/getDataProtectionSettings) and [Backup Compliance Policy Prohibited Actions](https://www.mongodb.com/docs/atlas/backup/cloud-backup/backup-compliance-policy/#prohibited-actions)

--- a/website/docs/d/backup_compliance_policy.html.markdown
+++ b/website/docs/d/backup_compliance_policy.html.markdown
@@ -116,11 +116,11 @@ resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
 			retention_value    = 12
 		  }
 
-      policy_item_yearly {
-        frequency_interval = 1
-        retention_unit     = "years"
-        retention_value    = 1
-      }
+	          policy_item_yearly {
+	            frequency_interval = 1
+	            retention_unit     = "years"
+	            retention_value    = 1
+	          }
 
 }
 ```

--- a/website/docs/d/backup_compliance_policy.html.markdown
+++ b/website/docs/d/backup_compliance_policy.html.markdown
@@ -151,7 +151,7 @@ In addition to all arguments above, the following attributes are exported:
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
-* 
+  
 ### Policy Item Hourly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -62,9 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 * `policy_item_monthly` - Monthly policy item
 * `policy_item_yearly` - Yearly policy item
 * `auto_export_enabled` - Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled. Value can be one of the following:
-
-    true - enables automatic export of cloud backup snapshots to the AWS bucket
-    false - disables automatic export of cloud backup snapshots to the AWS bucket (default)
+    * true - enables automatic export of cloud backup snapshots to the AWS bucket
+    * false - disables automatic export of cloud backup snapshots to the AWS bucket (default)
 * `use_org_and_group_names_in_export_prefix` - Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your S3 bucket after it finishes exporting the snapshots. To learn more about the metadata files that Atlas uploads, see [Export Cloud Backup Snapshot](https://www.mongodb.com/docs/atlas/backup/cloud-backup/export/#std-label-cloud-provider-snapshot-export).
 ### Export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.

--- a/website/docs/d/cloud_backup_schedule.html.markdown
+++ b/website/docs/d/cloud_backup_schedule.html.markdown
@@ -60,6 +60,7 @@ In addition to all arguments above, the following attributes are exported:
 * `policy_item_daily` - Daily policy item
 * `policy_item_weekly` - Weekly policy item
 * `policy_item_monthly` - Monthly policy item
+* `policy_item_yearly` - Yearly policy item
 * `auto_export_enabled` - Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled. Value can be one of the following:
 
     true - enables automatic export of cloud backup snapshots to the AWS bucket
@@ -73,21 +74,21 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
@@ -96,12 +97,20 @@ In addition to all arguments above, the following attributes are exported:
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
   * `40` represents the last day of the month (depending on the month).
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
+
+### Policy Item Yearly
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For yearly policies, the frequency type is defined as `yearly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (yearly in this case). The supported values for yearly policies are 
+  * `1` through `12` the first day of the month where the number represents the month, i.e. `1` is January and `12` is December.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
+* `retention_value` - Value to associate with `retention_unit`. Yearly policy must have retention of at least 1 year.
 
 ### Snapshot Distribution
 * `cloud_provider` - Human-readable label that identifies the cloud provider that stores the snapshot copy. i.e. "AWS" "AZURE" "GCP"
-* `frequencies` - List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "ON_DEMAND"
+* `frequencies` - List that describes which types of snapshots to copy. i.e. "HOURLY" "DAILY" "WEEKLY" "MONTHLY" "YEARLY" "ON_DEMAND"
 * `region_name` - Target region to copy snapshots belonging to replicationSpecId to. Please supply the 'Atlas Region' which can be found under https://www.mongodb.com/docs/atlas/reference/cloud-providers/ 'regions' link
 * `replication_spec_id` - Unique 24-hexadecimal digit string that identifies the replication object for a zone in a cluster. For global clusters, there can be multiple zones to choose from. For sharded clusters and replica set clusters, there is only one zone in the cluster. To find the Replication Spec Id, consult the replicationSpecs array returned from [Return One Multi-Cloud Cluster in One Project](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/getCluster).
 * `should_copy_oplogs` - Flag that indicates whether to copy the oplogs to the target region. You can use the oplogs to perform point-in-time restores.

--- a/website/docs/r/backup_compliance_policy.html.markdown
+++ b/website/docs/r/backup_compliance_policy.html.markdown
@@ -208,6 +208,14 @@ In addition to all arguments above, the following attributes are exported:
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
+### Policy Item Yearly
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For yearly policies, the frequency type is defined as `yearly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (yearly in this case). The supported values for yearly policies are 
+  * `1` through `12` the first day of the month where the number represents the month, i.e. `1` is January and `12` is December.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
+* `retention_value` - Value to associate with `retention_unit`. Yearly policy must have retention of at least 1 year.
+
 ## Import
 
 Backup Compliance Policy entries can be imported using project project_id  in the format `project_id`, e.g.

--- a/website/docs/r/backup_compliance_policy.html.markdown
+++ b/website/docs/r/backup_compliance_policy.html.markdown
@@ -144,11 +144,11 @@ resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
 			retention_value    = 12
 		  }
 
-      policy_item_yearly {
-        frequency_interval = 1
-        retention_unit     = "years"
-        retention_value    = 1
-      }
+	          policy_item_yearly {
+	            frequency_interval = 1
+	            retention_unit     = "years"
+	            retention_value    = 1
+	          }
       
 }
 ```

--- a/website/docs/r/backup_compliance_policy.html.markdown
+++ b/website/docs/r/backup_compliance_policy.html.markdown
@@ -176,27 +176,28 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `ondemand`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
+
 ### Policy Item Hourly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
@@ -205,7 +206,7 @@ In addition to all arguments above, the following attributes are exported:
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month (i.e. `1` is the first of the month and `5` is the fifth day of the month).
   * `40` represents the last day of the month (depending on the month).
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 ### Policy Item Yearly

--- a/website/docs/r/backup_compliance_policy.html.markdown
+++ b/website/docs/r/backup_compliance_policy.html.markdown
@@ -86,6 +86,11 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
     retention_unit     = "months"
     retention_value    = 12
   }
+  policy_item_yearly {
+    frequency_interval = 1        # accepted values = 1 to 12 -> 1st day of nth month  
+    retention_unit     = "years"
+    retention_value    = 1
+  }
 
 }
 
@@ -139,6 +144,12 @@ resource "mongodbatlas_backup_compliance_policy" "backup_policy" {
 			retention_value    = 12
 		  }
 
+      policy_item_yearly {
+        frequency_interval = 1
+        retention_unit     = "years"
+        retention_value    = 1
+      }
+      
 }
 ```
 

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -240,6 +240,14 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
+### Policy Item Yearly
+* `id` - Unique identifier of the backup policy item.
+* `frequency_type` - Frequency associated with the backup policy item. For yearly policies, the frequency type is defined as `yearly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
+* `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (yearly in this case). The supported values for yearly policies are 
+  * `1` through `12` the first day of the month where the number represents the month, i.e. `1` is January and `12` is December.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
+* `retention_value` - Value to associate with `retention_unit`. Yearly policy must have retention of at least 1 year.
+
 ### Snapshot Distribution
 *
 * `cloud_provider` - (Required) Human-readable label that identifies the cloud provider that stores the snapshot copy. i.e. "AWS" "AZURE" "GCP"

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -132,6 +132,11 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
     retention_unit     = "months"
     retention_value    = 4
   }
+  policy_item_yearly {
+    frequency_interval = 1        # accepted values = 1 to 12 -> 1st day of nth month  
+    retention_unit     = "years"
+    retention_value    = 1
+  }
 
 }
 ```
@@ -195,6 +200,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `policy_item_daily` - (Optional) Daily policy item
 * `policy_item_weekly` - (Optional) Weekly policy item
 * `policy_item_monthly` - (Optional) Monthly policy item
+* `policy_item_yearly` - (Optional) Yearly policy item
 * `auto_export_enabled` - Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled. Value can be one of the following:
 
     true - enables automatic export of cloud backup snapshots to the AWS bucket

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -214,21 +214,21 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For hourly policies, the frequency type is defined as `hourly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (hourly in this case). The supported values for hourly policies are `1`, `2`, `4`, `6`, `8` or `12` hours. Note that `12` hours is the only accepted value for NVMe clusters.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.
 
 ### Policy Item Daily
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For daily policies, the frequency type is defined as `daily`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (daily in this case). The only supported value for daily policies is `1` day.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`.  Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the hourly policy item specifies a retention of two days, the daily retention policy must specify two days or greater.
 
 ### Policy Item Weekly
 * `id` - Unique identifier of the backup policy item.
 * `frequency_type` - Frequency associated with the backup policy item. For weekly policies, the frequency type is defined as `weekly`. Note that this is a read-only value and not required in plan files - its value is implied from the policy resource type.
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (weekly in this case). The supported values for weekly policies are `1` through `7`, where `1` represents Monday and `7` represents Sunday.
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Weekly policy must have retention of at least 7 days or 1 week. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the daily policy item specifies a retention of two weeks, the weekly retention policy must specify two weeks or greater.
 
 ### Policy Item Monthly
@@ -237,7 +237,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `frequency_interval` - Desired frequency of the new backup policy item specified by `frequency_type` (monthly in this case). The supported values for weekly policies are 
   * `1` through `28` where the number represents the day of the month i.e. `1` is the first of the month and `5` is the fifth day of the month.
   * `40` represents the last day of the month (depending on the month).
-* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, or `months`.
+* `retention_unit` - Scope of the backup policy item: `days`, `weeks`, `months`, or `years`.
 * `retention_value` - Value to associate with `retention_unit`. Monthly policy must have retention days of at least 31 days or 5 weeks or 1 month. Note that for less frequent policy items, Atlas requires that you specify a retention period greater than or equal to the retention period specified for more frequent policy items. For example: If the weekly policy item specifies a retention of two weeks, the montly retention policy must specify two weeks or greater.
 
 ### Policy Item Yearly

--- a/website/docs/r/cloud_backup_schedule.html.markdown
+++ b/website/docs/r/cloud_backup_schedule.html.markdown
@@ -174,10 +174,11 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
   copy_settings {
     cloud_provider = "AWS"
     frequencies = ["HOURLY",
-							"DAILY",
-							"WEEKLY",
-							"MONTHLY",
-							"ON_DEMAND"]
+		   "DAILY",
+		   "WEEKLY",
+		   "MONTHLY",
+                   "YEARLY",
+		   "ON_DEMAND"]
     region_name = "US_EAST_1"
     replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
     should_copy_oplogs = false
@@ -202,9 +203,8 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `policy_item_monthly` - (Optional) Monthly policy item
 * `policy_item_yearly` - (Optional) Yearly policy item
 * `auto_export_enabled` - Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled. Value can be one of the following:
-
-    true - enables automatic export of cloud backup snapshots to the AWS bucket
-    false - disables automatic export of cloud backup snapshots to the AWS bucket (default)
+	* true - enables automatic export of cloud backup snapshots to the AWS bucket
+ 	* false - disables automatic export of cloud backup snapshots to the AWS bucket (default)
 * `use_org_and_group_names_in_export_prefix` - Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your S3 bucket after it finishes exporting the snapshots. To learn more about the metadata files that Atlas uploads, see [Export Cloud Backup Snapshot](https://www.mongodb.com/docs/atlas/backup/cloud-backup/export/#std-label-cloud-provider-snapshot-export).
 ### Export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.


### PR DESCRIPTION
## Description

Adds `yearly` frequency and `years` unit to `mongodbatlas_cloud_backup_schedule` and `mongodbatlas_backup_compliance_policy`

Link to any related issue(s): CLOUDP-237632

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
