### PR TITLE
test: Adds mig tests and refactors for `cloud_backup_snapshot_restore_job`

### DIFF
--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_migration_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_migration_test.go
@@ -1,0 +1,11 @@
+package cloudbackupsnapshotrestorejob_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestMigCloudBackupSnapshotRestoreJob_basic(t *testing.T) {
+	mig.CreateAndRunTest(t, basicTestCase(t))
+}

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
@@ -21,42 +21,7 @@ const (
 )
 
 func TestAccCloudBackupSnapshotRestoreJob_basic(t *testing.T) {
-	var (
-		snapshotsDataSourceName           = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.test"
-		snapshotsDataSourcePaginationName = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.pagination"
-		projectID                         = acc.ProjectIDExecution(t)
-		clusterName                       = acc.RandomClusterName()
-		targetClusterName                 = acc.RandomClusterName()
-		description                       = fmt.Sprintf("My description in %s", clusterName)
-		retentionInDays                   = "1"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(projectID, clusterName, description, retentionInDays, targetClusterName),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.automated", "true"),
-					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.target_cluster_name", targetClusterName),
-					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "snapshot_id"),
-					resource.TestCheckResourceAttrSet(snapshotsDataSourceName, "results.#"),
-					resource.TestCheckResourceAttrSet(snapshotsDataSourcePaginationName, "results.#"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retention_in_days", "snapshot_id"},
-			},
-		},
-	})
+	resource.ParallelTest(t, *basicTestCase(t))
 }
 
 func TestAccCloudBackupSnapshotRestoreJob_basicDownload(t *testing.T) {
@@ -110,6 +75,47 @@ func TestAccCloudBackupSnapshotRestoreJobWithPointTime_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+
+	var (
+		snapshotsDataSourceName           = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.test"
+		snapshotsDataSourcePaginationName = "data.mongodbatlas_cloud_backup_snapshot_restore_jobs.pagination"
+		projectID                         = acc.ProjectIDExecution(tb)
+		clusterName                       = acc.RandomClusterName()
+		targetClusterName                 = acc.RandomClusterName()
+		description                       = fmt.Sprintf("My description in %s", clusterName)
+		retentionInDays                   = "1"
+	)
+
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(projectID, clusterName, description, retentionInDays, targetClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.automated", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.target_cluster_name", targetClusterName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "snapshot_id"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourceName, "results.#"),
+					resource.TestCheckResourceAttrSet(snapshotsDataSourcePaginationName, "results.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_in_days", "snapshot_id"},
+			},
+		},
+	}
 }
 
 func checkExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

Adds mig tests and refactors for `cloud_backup_snapshot_restore_job`

Enables previously skipped test in CI.

Link to any related issue(s): CLOUDP-237020

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
