### PR TITLE
test: Moves basic import tests to basic acc tests

### DIFF
--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -42,6 +42,12 @@ func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ip_address", updatedIPAddress),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -109,32 +115,6 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),
 				),
-			},
-		},
-	})
-}
-
-func TestAccProjectRSAccessListAPIKey_importBasic(t *testing.T) {
-	var (
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		ipAddress    = acc.RandomIP(179, 154, 226)
-		resourceName = "mongodbatlas_access_list_api_key.test"
-		description  = acc.RandomName()
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithIPAddress(orgID, description, ipAddress),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -48,6 +48,13 @@ func TestAccConfigRSAlertConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "updated"},
+			},
 		},
 	})
 }
@@ -119,6 +126,13 @@ func TestAccConfigRSAlertConfiguration_withNotifications(t *testing.T) {
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "updated"},
 			},
 		},
 	})
@@ -287,32 +301,6 @@ func TestAccConfigRSAlertConfiguration_withoutOptionalAttributes(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSAlertConfiguration_importBasic(t *testing.T) {
-	proxyPort := replay.SetupReplayProxy(t)
-
-	var (
-		projectID = replay.ManageProjectID(t, acc.ProjectIDExecution)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6FactoriesWithProxy(proxyPort),
-		CheckDestroy:             checkDestroyUsingProxy(proxyPort),
-		Steps: []resource.TestStep{
-			{
-				Config: configBasicRS(projectID, true),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id", "updated"},
-			},
-		},
-	})
-}
-
 func TestAccConfigRSAlertConfiguration_importIncorrectId(t *testing.T) {
 	proxyPort := replay.SetupReplayProxy(t)
 
@@ -338,67 +326,9 @@ func TestAccConfigRSAlertConfiguration_importIncorrectId(t *testing.T) {
 	})
 }
 
-func TestAccConfigRSAlertConfiguration_importConfigNotifications(t *testing.T) {
-	proxyPort := replay.SetupReplayProxy(t)
-
-	var (
-		projectID = replay.ManageProjectID(t, acc.ProjectIDExecution)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6FactoriesWithProxy(proxyPort),
-		CheckDestroy:             checkDestroyUsingProxy(proxyPort),
-		Steps: []resource.TestStep{
-			{
-				Config: configWithNotifications(projectID, true, true, false),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id", "updated"},
-			},
-		},
-	})
-}
-
 // dummy keys used for credential values in third party notifications
 const dummy32CharKey = "11111111111111111111111111111111"
 const dummy36CharKey = "11111111-1111-1111-1111-111111111111"
-
-// used for testing notification that does not define interval_min attribute
-func TestAccConfigRSAlertConfiguration_importPagerDuty(t *testing.T) {
-	proxyPort := replay.SetupReplayProxy(t)
-
-	var (
-		projectID  = replay.ManageProjectID(t, acc.ProjectIDExecution)
-		serviceKey = dummy32CharKey
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6FactoriesWithProxy(proxyPort),
-		CheckDestroy:             checkDestroyUsingProxy(proxyPort),
-		Steps: []resource.TestStep{
-			{
-				Config: configWithPagerDuty(projectID, serviceKey, true),
-				Check: resource.ComposeTestCheckFunc(
-					checkExistsUsingProxy(proxyPort, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"updated", "notification.0.service_key"}, // service key is not returned by api in import operation
-			},
-		},
-	})
-}
 
 func TestAccConfigRSAlertConfiguration_updatePagerDutyWithNotifierId(t *testing.T) {
 	proxyPort := replay.SetupReplayProxy(t)
@@ -479,6 +409,13 @@ func TestAccConfigRSAlertConfiguration_withPagerDuty(t *testing.T) {
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateProjectIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated", "notification.0.service_key"}, // service key is not returned by api in import operation
 			},
 		},
 	})

--- a/internal/service/apikey/resource_api_key_test.go
+++ b/internal/service/apikey/resource_api_key_test.go
@@ -43,26 +43,6 @@ func TestAccConfigRSAPIKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdate),
 				),
 			},
-		},
-	})
-}
-
-func TestAccConfigRSAPIKey_importBasic(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_api_key.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		description  = acc.RandomName()
-		roleName     = "ORG_MEMBER"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, description, roleName),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -36,27 +36,6 @@ func TestAccBackupRSBackupSnapshotExportBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccBackupRSBackupSnapshotExportBucket_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceName = "mongodbatlas_cloud_backup_snapshot_export_bucket.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		bucketName   = os.Getenv("AWS_S3_BUCKET")
-		iamRoleID    = os.Getenv("IAM_ROLE_ID")
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckS3Bucket(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportBucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasBackupSnapshotExportBucketConfig(projectID, bucketName, iamRoleID),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccCheckMongoDBAtlasBackupSnapshotExportBucketImportStateIDFunc(resourceName),

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -36,27 +36,6 @@ func TestAccBackupRSBackupSnapshotExportJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccBackupRSBackupSnapshotExportJob_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceName = "mongodbatlas_cloud_backup_snapshot_export_job.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		bucketName   = os.Getenv("AWS_S3_BUCKET")
-		iamRoleID    = os.Getenv("IAM_ROLE_ID")
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckS3Bucket(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasBackupSnapshotExportJobDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasBackupSnapshotExportJobConfig(projectID, bucketName, iamRoleID),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccCheckMongoDBAtlasBackupSnapshotExportJobImportStateIDFunc(resourceName),

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -72,6 +72,13 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_disk_gb_enabled", "false"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       acc.ImportStateClusterIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cloud_backup", "retain_backups_enabled"},
+			},
 		},
 	})
 }
@@ -1079,31 +1086,6 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_auto_scaling_compute_min_instance_size", minSizeUpdated),
 					resource.TestCheckResourceAttr(resourceName, "provider_auto_scaling_compute_max_instance_size", maxSizeUpdated),
 				),
-			},
-		},
-	})
-}
-
-func TestAccClusterRSCluster_importBasic(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configAWS(projectID, clusterName, true, false),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       acc.ImportStateClusterIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"cloud_backup", "retain_backups_enabled"},
 			},
 		},
 	})

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
@@ -48,28 +48,6 @@ func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccConfigRSCustomDNSConfigurationAWS_importBasic(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -60,6 +60,13 @@ func TestAccConfigRSDatabaseUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "roles.0.role_name", "read"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
 		},
 	})
 }
@@ -86,6 +93,13 @@ func TestAccConfigRSDatabaseUser_withX509TypeCustomer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
 					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
 			},
 		},
 	})
@@ -134,32 +148,6 @@ func TestAccConfigRSDatabaseUser_withAWSIAMType(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
-					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
-					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccConfigRSDatabaseUser_withAWSIAMType_import(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomIAMUser()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigDatabaseUserWithAWSIAMType(projectID, username, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
 					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
@@ -474,98 +462,6 @@ func TestAccConfigRSDatabaseUser_updateToEmptyLabels(t *testing.T) {
 }
 
 func TestAccConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomLDAPName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigDatabaseUserWithLDAPAuthType(projectID, username, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "ldap_auth_type", "USER"),
-					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
-					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccConfigRSDatabaseUser_importBasic(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigDatabaseUserBasic(projectID, username, "read", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
-					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
-					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
-			},
-		},
-	})
-}
-
-func TestAccConfigRSDatabaseUser_importX509TypeCustomer(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomLDAPName()
-		x509Type  = "CUSTOMER"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigDatabaseUserWithX509Type(projectID, username, x509Type, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
-					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
-					resource.TestCheckResourceAttr(resourceName, "labels.#", "1"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
-			},
-		},
-	})
-}
-
-func TestAccConfigRSDatabaseUser_importLDAPAuthType(t *testing.T) {
 	var (
 		projectID = acc.ProjectIDExecution(t)
 		username  = acc.RandomLDAPName()

--- a/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
+++ b/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
@@ -45,24 +45,6 @@ func TestAccFederatedSettingsIdentityProviderRS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "mongodb_federation_test"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccFederatedSettingsIdentityProviderRS_importBasic(t *testing.T) {
-	var (
-		resourceName         = "mongodbatlas_federated_settings_identity_provider.test"
-		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
-		idpID                = os.Getenv("MONGODB_ATLAS_FEDERATED_OKTA_IDP_ID")
-		ssoURL               = os.Getenv("MONGODB_ATLAS_FEDERATED_SSO_URL")
-		issuerURI            = os.Getenv("MONGODB_ATLAS_FEDERATED_ISSUER_URI")
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckFederatedSettings(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-
 			{
 				Config:            testAccMongoDBAtlasFederatedSettingsIdentityProviderConfig(federationSettingsID, ssoURL, issuerURI),
 				ResourceName:      resourceName,

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
@@ -45,24 +45,6 @@ func TestAccFederatedSettingsOrg_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "mongodb_federation_test"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccFederatedSettingsOrg_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceName         = "mongodbatlas_federated_settings_org_config.test"
-		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
-		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
-		idpID                = os.Getenv("MONGODB_ATLAS_FEDERATED_OKTA_IDP_ID")
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckFederatedSettings(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-
 			{
 				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationConfig(federationSettingsID, orgID, idpID),
 				ResourceName:      resourceName,

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
@@ -37,25 +37,6 @@ func TestAccFederatedSettingsOrgRoleMapping_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "external_group_name", "newtestgroup"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccFederatedSettingsOrgRoleMapping_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceName         = "mongodbatlas_federated_settings_org_role_mapping.test"
-		federationSettingsID = os.Getenv("MONGODB_ATLAS_FEDERATION_SETTINGS_ID")
-		orgID                = os.Getenv("MONGODB_ATLAS_FEDERATED_ORG_ID")
-		groupID              = os.Getenv("MONGODB_ATLAS_FEDERATED_GROUP_ID")
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckFederatedSettings(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasFederatedSettingsOrganizationRoleMappingDestroy,
-		Steps: []resource.TestStep{
-
 			{
 				Config:            testAccMongoDBAtlasFederatedSettingsOrganizationRoleMappingConfig(federationSettingsID, orgID, groupID),
 				ResourceName:      resourceName,

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -80,23 +80,6 @@ func TestAccClusterRSGlobalCluster_withAWSAndBackup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 				),
 			},
-		},
-	})
-}
-
-func TestAccClusterRSGlobalCluster_importBasic(t *testing.T) {
-	var (
-		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true})
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(&clusterInfo, false, false),
-			},
 			{
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       importStateIDFunc(resourceName),

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -49,33 +49,6 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccConfigRSMaintenanceWindow_importBasic(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		dayOfWeek   = 1
-		hourOfDay   = 3
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-					resource.TestCheckResourceAttr(resourceName, "start_asap", "false"),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -41,6 +41,13 @@ func TestAccNetworkContainer_basicAWS(t *testing.T) {
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, "US_EAST_2"),
 				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
 		},
 	})
 }
@@ -113,31 +120,6 @@ func TestAccNetworkContainer_withRegionsGCP(t *testing.T) {
 			{
 				Config: configBasic(projectID, gcpWithRegionsCidrBlock, constant.GCP, regions),
 				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
-			},
-		},
-	})
-}
-
-func TestAccNetworkContainer_importBasic(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		randInt   = acctest.RandIntRange(0, 255)
-		cidrBlock = fmt.Sprintf("10.8.%d.0/24", randInt)
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(projectID, cidrBlock, constant.AWS, "US_WEST_2"),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
 			},
 		},
 	})

--- a/internal/service/orginvitation/resource_org_invitation_test.go
+++ b/internal/service/orginvitation/resource_org_invitation_test.go
@@ -50,33 +50,6 @@ func TestAccConfigRSOrgInvitation_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "roles.*", updateRoles[1]),
 				),
 			},
-		},
-	})
-}
-
-func TestAccConfigRSOrgInvitation_importBasic(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_org_invitation.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		name         = acc.RandomEmail()
-		initialRole  = []string{"ORG_OWNER"}
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyOrgInvitation,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
-					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
-					resource.TestCheckResourceAttr(resourceName, "username", name),
-					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "roles.*", initialRole[0]),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
+++ b/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
@@ -37,35 +37,6 @@ func TestAccNetworkRSPrivateLinkEndpointAWS_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", region),
 				),
 			},
-		},
-	})
-}
-
-func TestAccNetworkRSPrivateLinkEndpointAWS_import(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_privatelink_endpoint.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
-		region       = "us-east-1"
-		providerName = "AWS"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "region"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
-					resource.TestCheckResourceAttr(resourceName, "region", region),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),
@@ -75,36 +46,8 @@ func TestAccNetworkRSPrivateLinkEndpointAWS_import(t *testing.T) {
 		},
 	})
 }
+
 func TestAccNetworkRSPrivateLinkEndpointAzure_basic(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_privatelink_endpoint.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
-		region       = "US_EAST_2"
-		providerName = "AZURE"
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "region"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
-					resource.TestCheckResourceAttr(resourceName, "region", region),
-				),
-			},
-		},
-	})
-}
-
-func TestAccNetworkRSPrivateLinkEndpointAzure_import(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_privatelink_endpoint.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -46,44 +46,6 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccNetworkRSPrivateLinkEndpointServiceAWS_import(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		resourceSuffix = "test"
-		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
-
-		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
-		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-
-		providerName    = "AWS"
-		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		region          = os.Getenv("AWS_REGION")
-		vpcID           = os.Getenv("AWS_VPC_ID")
-		subnetID        = os.Getenv("AWS_SUBNET_ID")
-		securityGroupID = os.Getenv("AWS_SECURITY_GROUP_ID")
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckAwsEnv(t) },
-		CheckDestroy:             testAccCheckMongoDBAtlasPrivateLinkEndpointServiceDestroy,
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasPrivateLinkEndpointServiceConfigCompleteAWS(
-					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
-				),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMongoDBAtlasPrivateLinkEndpointServiceExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "endpoint_service_id"),
-				),
-			},
 			{
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       testAccCheckMongoDBAtlasPrivateLinkEndpointServiceImportStateIDFunc(resourceName),

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
@@ -40,30 +40,6 @@ func TestAccServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "instance_name"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccServerlessPrivateLinkEndpointService_importBasic(t *testing.T) {
-	var (
-		resourceName  = "mongodbatlas_privatelink_endpoint_service_serverless.test"
-		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName   = acc.RandomProjectName()
-		instanceName  = acc.RandomClusterName()
-		commentOrigin = "this is a comment for serverless private link endpoint"
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, instanceName, commentOrigin),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
-					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
-				),
-			},
 			{
 				Config:            configBasic(orgID, projectName, instanceName, commentOrigin),
 				ResourceName:      resourceName,

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -599,6 +599,13 @@ func TestAccProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "teams.#", "2"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       acc.ImportStateProjectIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"with_default_alerts_settings"},
+			},
 		},
 	})
 }
@@ -777,31 +784,6 @@ func TestAccProject_updatedToEmptyRoles(t *testing.T) {
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "teams.#", "0"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccProject_importBasic(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyProject,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, "", false, nil),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       acc.ImportStateProjectIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"with_default_alerts_settings"},
 			},
 		},
 	})

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -604,7 +604,7 @@ func TestAccProject_basic(t *testing.T) {
 				ImportStateIdFunc:       acc.ImportStateProjectIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"with_default_alerts_settings"},
+				ImportStateVerifyIgnore: []string{"with_default_alerts_settings", "project_owner_id"},
 			},
 		},
 	})

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -39,6 +39,12 @@ func TestAccConfigRSProjectAPIKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
 		},
 	})
 }
@@ -189,30 +195,6 @@ func TestAccConfigRSProjectAPIKey_updateDescription(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
 				),
-			},
-		},
-	})
-}
-
-func TestAccConfigRSProjectAPIKey_importBasic(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		description = acc.RandomName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(projectID, description, roleName, false),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: false,
 			},
 		},
 	})

--- a/internal/service/projectinvitation/resource_project_invitation_test.go
+++ b/internal/service/projectinvitation/resource_project_invitation_test.go
@@ -51,34 +51,6 @@ func TestAccProjectRSProjectInvitation_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "roles.*", updateRoles[0]),
 				),
 			},
-		},
-	})
-}
-
-func TestAccProjectRSProjectInvitation_importBasic(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_project_invitation.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
-		name         = acc.RandomEmail()
-		initialRole  = []string{"GROUP_OWNER"}
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
-					resource.TestCheckResourceAttr(resourceName, "username", name),
-					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "roles.*", initialRole[0]),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -41,6 +41,12 @@ func TestAccProjectIPAccesslist_settingIPAddress(t *testing.T) {
 				Config: configWithIPAddress(projectID, updatedIPAddress, updatedComment),
 				Check:  resource.ComposeTestCheckFunc(commonChecks(updatedIPAddress, "", "", updatedComment)...),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -143,31 +149,6 @@ func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
 			{
 				Config: configWithMultiple(projectID, accessList, true),
 				Check:  resource.ComposeTestCheckFunc(checks...),
-			},
-		},
-	})
-}
-
-func TestAccProjectIPAccessList_importBasic(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		ipAddress = acc.RandomIP(179, 154, 226)
-		comment   = fmt.Sprintf("TestAcc for ipaddres (%s)", ipAddress)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithIPAddress(projectID, ipAddress, comment),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/teams/resource_teams_test.go
+++ b/internal/service/teams/resource_teams_test.go
@@ -55,36 +55,6 @@ func TestAccConfigRSTeam_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccConfigRSTeam_importBasic(t *testing.T) {
-	var (
-		resourceName = "mongodbatlas_teams.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		username     = os.Getenv("MONGODB_ATLAS_USERNAME")
-		name         = acc.RandomName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAtlasUsername(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyTeam,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, name, []string{username}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "name"),
-					resource.TestCheckResourceAttrSet(resourceName, "usernames.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "team_id"),
-
-					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
@@ -47,44 +47,6 @@ func TestAccConfigRSThirdPartyIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", cfg.Region),
 				),
 			},
-		},
-	},
-	)
-}
-
-func TestAccConfigRSThirdPartyIntegration_importBasic(t *testing.T) {
-	acc.SkipTestForCI(t)
-	var (
-		targetIntegration = matlas.ThirdPartyIntegration{}
-		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		apiKey            = os.Getenv("OPS_GENIE_API_KEY")
-		cfg               = testAccCreateThirdPartyIntegrationConfig()
-		testExecutionName = "test_3rd_party_" + cfg.AccountID
-		resourceName      = "mongodbatlas_third_party_integration." + testExecutionName
-	)
-
-	cfg.Type = "OPS_GENIE"
-	cfg.APIKey = apiKey
-
-	seedConfig := thirdPartyConfig{
-		Name:        testExecutionName,
-		ProjectID:   projectID,
-		Integration: *cfg,
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasThirdPartyIntegrationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasThirdPartyIntegrationResourceConfig(&seedConfig),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckThirdPartyIntegrationExists(resourceName, &targetIntegration),
-					resource.TestCheckResourceAttr(resourceName, "type", cfg.Type),
-					resource.TestCheckResourceAttr(resourceName, "region", cfg.Region),
-				),
-			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: testAccCheckMongoDBAtlasThirdPartyIntegrationImportStateIDFunc(resourceName),

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -41,6 +41,11 @@ func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "username", username),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFuncBasic(resourceName),
+				ImportState:       true,
+			},
 		},
 	})
 }
@@ -66,25 +71,6 @@ func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "customer_x509_cas"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccGenericX509AuthDBUser_importBasic(t *testing.T) {
-	var (
-		projectID = acc.ProjectIDExecution(t)
-		username  = acc.RandomName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acc.PreCheckBasic(t)
-		},
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(projectID, username),
 			},
 			{
 				ResourceName:      resourceName,
@@ -116,29 +102,6 @@ func TestAccGenericX509AuthDBUser_withDatabaseUser(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "months_until_expiration", cast.ToString(months)),
 				),
-			},
-		},
-	})
-}
-
-func TestAccGenericX509AuthDBUser_importWithCustomerX509(t *testing.T) {
-	var (
-		cas         = os.Getenv("CA_CERT")
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid CANNOT_GENERATE_CERT_IF_ADVANCED_X509
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckCert(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithCustomerX509(orgID, projectName, cas),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFuncBasic(resourceName),
-				ImportState:       true,
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Move basic import tests to basic acc test.

This is already done in the other resources.

- Improves use of resources as both tests are the same so only create resources once.
- Improves code legibility reducing redundant code to set up the same test configuration.

Link to any related issue(s): CLOUDP-240949

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
