### PR TITLE
chore: Defines internal guidelines for new changelog process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # Maintained by the MongoDB APIx-Integrations team
 * @mongodb/APIx-Integrations
+
+
+# Changelog entries reviewed by Docs Cloud Team
+/.changelog/ @mongodb/docs-cloud-team

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -5,4 +5,5 @@ Thanks for your interest in contributing to MongoDB Atlas Terraform Provider, th
 - [Development Setup](development-setup.md)
 - [Code and Test Best Practices](development-best-practices.md)
 - [Documentation](documentation.md)
+- [Changelog process](changelog-process.md)
 - [Atlas SDK](atlas-sdk.md)

--- a/contributing/changelog-process.md
+++ b/contributing/changelog-process.md
@@ -1,0 +1,131 @@
+# Changelog Process
+
+HashiCorp’s open-source projects have always maintained user-friendly, readable CHANGELOG.md that allow users to tell at a glance whether a release should have any effect on them, and to gauge the risk of an upgrade.
+
+We use the [go-changelog](https://github.com/hashicorp/go-changelog) to generate and update the changelog from files created in the `.changelog/` directory. It is important that when you raise your Pull Request, there is a changelog entry which describes the changes your contribution makes. Not all changes require an entry in the changelog, guidance follows on what changes do.
+
+`@mongodb/docs-cloud-team` will be required reviewers for new changelog entry files contained in a Pull Request. We will wait up to 24 hours for a review, and after that proceed with the merge. Exceptions for merging ahead of the 24 hours may also apply.
+
+## Changelog format
+
+The changelog format requires an entry in the following format, where HEADER corresponds to the changelog category, and the entry is the changelog entry itself. The entry should be included in a file in the `.changelog` directory with the naming convention `{PR-NUMBER}.txt`. For example, to create a changelog entry for pull request 1234, there should be a file named `.changelog/1234.txt`.
+
+``````markdown
+```release-note:{HEADER}
+{ENTRY}
+```
+``````
+
+If a pull request should contain multiple changelog entries, then multiple blocks can be added to the same changelog file. For example:
+
+``````markdown
+```release-note:note
+resource/mongodbatlas_project: Deprecates `labels` attribute. All configurations using `labels` should be updated to use the new `tags` attribute instead.
+```
+
+```release-note:enhancement
+resource/mongodbatlas_project: Adds `tags` attribute
+```
+``````
+
+
+## Changelog entry guidelines
+
+The CHANGELOG is intended to show operator-impacting changes to the codebase for a particular version. If every change or commit to the code resulted in an entry, the CHANGELOG would become less useful for operators. The lists below are general guidelines and examples for when a decision needs to be made to decide whether a change should have an entry.
+
+### Header and entry values
+
+``````markdown
+```release-note:{HEADER}
+{ENTRY}
+```
+``````
+
+ `HEADER`
+ - Must be one of the following values: `breaking-change`, `new-resource`, `new-data-source`, `new-guide`, `note`, `enhancement`, `bug`. Examples for each type can be seen below.
+
+`ENTRY`
+ - In the case of feature entry types (new-resource, new-data-source, new-guide) only the name of the new resource or guide is defined in the entry.
+ - For other entry types:
+    - Entry starts with the resource type, followed by its name (e.g. `resource/mongodbatlas_project: `). Use a `provider: ` prefix for provider-level changes.
+    - For the description use a third person point of view, [active voice](https://www.mongodb.com/docs/meta/style-guide/writing/use-active-voice/#std-label-use-active-voice), and start with an uppercase character.
+    - Surround attribute names with backticks (e.g. ```Adds `tags` attribute```). 
+
+### Changes that should have a CHANGELOG entry
+
+#### New resource
+
+A new resource entry should only contain the name of the resource, and use the `release-note:new-resource` header.
+
+``````markdown
+```release-note:new-resource
+mongodbatlas_stream_connection
+```
+``````
+
+#### New data source
+
+A new data source entry should only contain the name of the data source, and use the `release-note:new-data-source` header.
+
+``````markdown
+```release-note:new-data-source
+mongodbatlas_stream_connection
+```
+``````
+
+#### New full-length documentation guides (e.g., Upgrade Guide for a new major version)
+
+A new full length documentation entry gives the title of the documentation added, using the `release-note:new-guide` header.
+
+``````markdown
+```release-note:new-guide
+MongoDB Atlas Provider 1.15.0: Upgrade and Information Guide
+```
+``````
+
+#### Resource and provider bug fixes
+
+A new bug entry should use the `release-note:bug` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level fixes.
+
+``````markdown
+```release-note:bug
+resource/mongodbatlas_database_user: Avoids sending database user password in update request if the value has not changed
+```
+``````
+
+#### Resource and provider enhancements
+
+A new enhancement entry should use the `release-note:enhancement` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level enhancements.
+
+``````markdown
+```release-note:enhancement
+data-source/mongodbatlas_project: Adds `tags` attribute
+```
+``````
+
+#### Deprecations
+
+A deprecation entry should use the `release-note:note` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+
+``````markdown
+```release-note:note
+resource/mongodbatlas_project: Deprecates the `labels` attribute. All configurations using `labels` should be updated to use the new `tags` attribute instead.
+```
+``````
+
+#### Breaking changes and removals
+
+A breaking-change entry should use the `release-note:breaking-change` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+
+``````markdown
+```release-note:breaking-change
+data-source/mongodbatlas_search_indexes: Removes `page_num` and `items_per_page` attributes
+```
+``````
+
+### Changes that should _not_ have a CHANGELOG entry
+
+- Resource and provider documentation updates
+- Testing updates
+- Code refactoring
+- Dependency updates

--- a/contributing/changelog-process.md
+++ b/contributing/changelog-process.md
@@ -1,8 +1,12 @@
 # Changelog Process
 
+- [Changelog format](#changelog-format)
+- [Changelog entry guidelines](#changelog-entry-guidelines)
+- [Script for creating changelog entry files](#script-for-creating-changelog-entry-files)
+
 HashiCorp’s open-source projects have always maintained user-friendly, readable CHANGELOG.md that allow users to tell at a glance whether a release should have any effect on them, and to gauge the risk of an upgrade.
 
-We use the [go-changelog](https://github.com/hashicorp/go-changelog) to generate and update the changelog from files created in the `.changelog/` directory. It is important that when you raise your Pull Request, there is a changelog entry which describes the changes your contribution makes. Not all changes require an entry in the changelog, guidance follows on what changes do.
+We use the [go-changelog](https://github.com/hashicorp/go-changelog) to generate and update the changelog automatically from files created in the `.changelog/` directory. It is important that when you raise your Pull Request, there is a changelog entry which describes the changes your contribution makes. Not all changes require an entry in the changelog, guidance follows on what changes do.
 
 `@mongodb/docs-cloud-team` will be required reviewers for new changelog entry files contained in a Pull Request. We will wait up to 24 hours for a review, and after that proceed with the merge. Exceptions for merging ahead of the 24 hours may also apply.
 
@@ -129,3 +133,13 @@ data-source/mongodbatlas_search_indexes: Removes `page_num` and `items_per_page`
 - Testing updates
 - Code refactoring
 - Dependency updates
+
+## Script for creating changelog entry files
+
+A script is defined to guide the creation of new entry files, simplifying the process and avoiding errors. You can invoke the script using the following make command:
+
+```
+make generate-changelog-entry
+```
+
+- The `subcategory` input prompt refers to the prefix of the changelog entry, used for specifying the relevant resource/data source when needed (e.g. data-source/mongodbatlas_project)


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-241384

Leaving link to other provider changelog guidelines as reference:

- AWS: [hashicorp/terraform-provider-aws/blob/main/docs/changelog-process.md](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/changelog-process.md)
- GCP: [magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples)

HashiCorp guidelines: [hashicorp.com/terraform/plugin/best-practices/versioning#changelog-specification](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#changelog-specification)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
