### PR TITLE
chore: Define changelog entries for PRs merged after 1.15.3 and note for new changelog format

### DIFF
--- a/.changelog/2100.txt
+++ b/.changelog/2100.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_serverless_instance: Adds `auto_indexing` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_serverless_instance: Adds `auto_indexing` attribute
+```

--- a/.changelog/2104.txt
+++ b/.changelog/2104.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_project: Reads `region_usage_restrictions` attribute value from get request
+```

--- a/.changelog/2105.txt
+++ b/.changelog/2105.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/mongodbatlas_network_peering: Ensures `accepter_region_name` is set when it is has the same value as the container resource
+```

--- a/.changelog/2109.txt
+++ b/.changelog/2109.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/mongodbatlas_cloud_backup_schedule: Adds `policy_item_yearly` attribute
+```
+
+```release-note:enhancement
+resource/mongodbatlas_backup_compliance_policy: Adds `policy_item_yearly` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_schedule: Adds `policy_item_yearly` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_backup_compliance_policy: Adds `policy_item_yearly` attribute
+```

--- a/.changelog/2124.txt
+++ b/.changelog/2124.txt
@@ -1,0 +1,3 @@
+```release-note:note
+provider: New changelog format has been incorporated following [Terraform Changelog Specification](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#changelog-specification)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
-# Changelog
+## (Unreleased)
+
+NOTES:
+
+* provider: New changelog format has been incorporated following [Terraform Changelog Specification](https://developer.hashicorp.com/terraform/plugin/best-practices/versioning#changelog-specification) ([#2124](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2124))
+
+ENHANCEMENTS:
+
+* data-source/mongodbatlas_backup_compliance_policy: Adds `policy_item_yearly` attribute ([#2109](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2109))
+* data-source/mongodbatlas_cloud_backup_schedule: Adds `policy_item_yearly` attribute ([#2109](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2109))
+* data-source/mongodbatlas_serverless_instance: Adds `auto_indexing` attribute ([#2100](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2100))
+* resource/mongodbatlas_backup_compliance_policy: Adds `policy_item_yearly` attribute ([#2109](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2109))
+* resource/mongodbatlas_cloud_backup_schedule: Adds `policy_item_yearly` attribute ([#2109](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2109))
+* resource/mongodbatlas_serverless_instance: Adds `auto_indexing` attribute ([#2100](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2100))
+
+BUG FIXES:
+
+* data-source/mongodbatlas_network_peering: Ensures `accepter_region_name` is set when it is has the same value as the container resource ([#2105](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2105))
+* resource/mongodbatlas_project: Reads `region_usage_restrictions` attribute value from get request ([#2104](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2104))
 
 ## [v1.15.3](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/v1.15.3) (2024-03-27)
 


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-241733

Following new changelog guidelines defined in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2123 this PR includes changelog entries for PRs merged after our last release (1.15.3).

Note:
- Updating entries for multiple merged PRs is an exception, each PR will handle its changelog entries moving forward.
- Updating the CHANGELOG.md is also an exception for this PR needed to set the new Unreleased header. When CLOUDP-241727 is completed PRs will only include the changelog entry files (under `/.changelog`) and then an automated commit will update the changelog file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
