### PR TITLE
chore: Adds new step in release process for updating header of changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,27 @@ jobs:
       atlas_cloud_env: "qa"
       ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number  || github.ref }}
 
+  update-changelog-header:
+    needs: [ run-qa-acceptance-tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          fetch-depth: 0
+      - run: ./scripts/update-changelog-header-for-release.sh ${{inputs.version_number}}
+      - run: |
+          if [[ $(git status --porcelain) ]]; then
+            MSG="Update CHANGELOG.md header for ${{inputs.version_number}} release"
+            git config --local user.email changelogbot@mongodb.com
+            git config --local user.name changelogbot
+            git add CHANGELOG.md
+            git commit -m "$MSG"
+            git push
+          fi
+    
   release:
     runs-on: ubuntu-latest
-    needs: [ validate-version-input, run-qa-acceptance-tests ]
+    needs: [ validate-version-input, run-qa-acceptance-tests, update-changelog-header ]
     if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Get the latest commit SHA
         id: get-sha
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Create release tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
 
   run-qa-acceptance-tests:
     needs: [ validate-version-input ]
-    # Skipped when explicit input parameter is used
+    # QA acceptance tests are skipped when explicit input parameter is used
+    # As this job may be skipped following jobs require using 'always()' to make sure they are still run
     if: needs.validate-version-input.result == 'success' && inputs.skip_tests != 'true'
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
@@ -35,8 +36,13 @@ jobs:
   update-changelog-header:
     runs-on: ubuntu-latest
     needs: [ validate-version-input, run-qa-acceptance-tests ]
-    # Skipped if use_existing_tag is defined to true or previous jobs failed.
-    if: ${{ always() && inputs.use_existing_tag != 'true' && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
+    # Skipped if use_existing_tag is defined, is a pre-release, or previous jobs failed.
+    if: >-
+      always() 
+      && inputs.use_existing_tag != 'true' 
+      && !contains(inputs.version_number, 'pre') 
+      && needs.validate-version-input.result == 'success' 
+      && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success')
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
@@ -55,8 +61,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [ validate-version-input, run-qa-acceptance-tests, update-changelog-header ]
-    # previous jobs must either be successful or skipped
-    if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') && (needs.update-changelog-header.result == 'skipped' || needs.update-changelog-header.result == 'success') }}
+    # Release is skipped if there are failures in previous steps
+    if: >- 
+      always() 
+      && needs.validate-version-input.result == 'success' 
+      && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') 
+      && (needs.update-changelog-header.result == 'skipped' || needs.update-changelog-header.result == 'success')
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
         run: |
           echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'  
 
-    # QA acceptance tests are skipped when explicit input parameter is used
   run-qa-acceptance-tests:
     needs: [ validate-version-input ]
+    # Skipped when explicit input parameter is used
     if: needs.validate-version-input.result == 'success' && inputs.skip_tests != 'true'
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
@@ -33,8 +33,10 @@ jobs:
       ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number  || github.ref }}
 
   update-changelog-header:
-    needs: [ run-qa-acceptance-tests ]
     runs-on: ubuntu-latest
+    needs: [ validate-version-input, run-qa-acceptance-tests ]
+    # Skipped if use_existing_tag is defined to true or previous jobs failed.
+    if: ${{ always() && inputs.use_existing_tag != 'true' && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
@@ -53,18 +55,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [ validate-version-input, run-qa-acceptance-tests, update-changelog-header ]
-    if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') }}
+    # previous jobs must either be successful or skipped
+    if: ${{ always() && needs.validate-version-input.result == 'success' && (needs.run-qa-acceptance-tests.result == 'skipped' || needs.run-qa-acceptance-tests.result == 'success') && (needs.update-changelog-header.result == 'skipped' || needs.update-changelog-header.result == 'success') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
-          ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number || github.ref }}
+          ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number || 'master' }}
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Get the latest commit SHA
+        id: get-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Create release tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
         with:
           tag: ${{ inputs.version_number }}
+          commit_sha: ${{ steps.get-sha.outputs.sha }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
           tag_exists_error: ${{ inputs.use_existing_tag != 'true' }}

--- a/scripts/update-changelog-header-for-release.sh
+++ b/scripts/update-changelog-header-for-release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${1?"Tag of new release must be provided"}"
+
+CHANGELOG_FILE_PATH=CHANGELOG.md
+RELEASE_TAG=$1
+RELEASE_NUMBER=$(echo "${RELEASE_TAG}" | tr -d v)
+
+# exit out if changelog already has the header updated with version number being released.
+if grep -q "## $RELEASE_NUMBER (" "$CHANGELOG_FILE_PATH"; then
+    echo "CHANGELOG already has a header defined for $RELEASE_NUMBER, no changes made to changelog."
+    exit 0
+fi
+
+# Prepare the new version header
+TODAYS_DATE=$(date "+%B %d, %Y")  # Format the date as "Month day, Year"
+NEW_RELEASE_HEADER="## $RELEASE_NUMBER ($TODAYS_DATE)"
+
+# Insert the new version header after the "(Unreleased)" line
+sed -i "" -e "/(Unreleased)/a \\
+\\
+$NEW_RELEASE_HEADER" $CHANGELOG_FILE_PATH
+
+echo "Changelog updated successfully defining header for new $RELEASE_TAG release."

--- a/scripts/update-changelog-header-for-release.sh
+++ b/scripts/update-changelog-header-for-release.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 : "${1?"Tag of new release must be provided"}"
 
-CHANGELOG_FILE_PATH=CHANGELOG.md
+CHANGELOG_FILE_NAME=CHANGELOG.md
 RELEASE_TAG=$1
 RELEASE_NUMBER=$(echo "${RELEASE_TAG}" | tr -d v)
 
 # exit out if changelog already has the header updated with version number being released.
-if grep -q "## $RELEASE_NUMBER (" "$CHANGELOG_FILE_PATH"; then
+if grep -q "## $RELEASE_NUMBER (" "$CHANGELOG_FILE_NAME"; then
     echo "CHANGELOG already has a header defined for $RELEASE_NUMBER, no changes made to changelog."
     exit 0
 fi
@@ -17,9 +17,14 @@ fi
 TODAYS_DATE=$(date "+%B %d, %Y")  # Format the date as "Month day, Year"
 NEW_RELEASE_HEADER="## $RELEASE_NUMBER ($TODAYS_DATE)"
 
+
+
+CHANGELOG_TMP_FILE_NAME="CHANGELOG.tmp"
+rm -f $CHANGELOG_TMP_FILE_NAME
+
 # Insert the new version header after the "(Unreleased)" line
-sed -i "" -e "/(Unreleased)/a \\
+sed "/(Unreleased)/a \\
 \\
-$NEW_RELEASE_HEADER" $CHANGELOG_FILE_PATH
+$NEW_RELEASE_HEADER" $CHANGELOG_FILE_NAME > $CHANGELOG_TMP_FILE_NAME && mv $CHANGELOG_TMP_FILE_NAME $CHANGELOG_FILE_NAME
 
 echo "Changelog updated successfully defining header for new $RELEASE_TAG release."


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-241731

Defines a new job that automatically adjusts the CHANGELOG.md header section during a new release.

This PR contemplates the possibility of doing pre-releases (by skipping this job), this will not be needed for our regular release process but could be useful in the future if we want to share a preview to customers (pointed out by Melissa in the scope).

## Testing

- Triggered a release process in a forked repository: [Generated commit which is included in release](https://github.com/AgustinBettati/terraform-provider-mongodbatlas/commit/8b1ecfc6cedf83e1d79a3862e997ae7154467583), [triggered release action](https://github.com/AgustinBettati/terraform-provider-mongodbatlas/actions/runs/8643807283).
- Triggered a pre-release making sure it will not modify the changelog: https://github.com/AgustinBettati/terraform-provider-mongodbatlas/actions/runs/8643839887

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
