### PR TITLE
fix: Fixes nil pointer dereference if `advanced_configuration` update fails in `mongodbatlas_cluster`

### DIFF
--- a/.changelog/2139.txt
+++ b/.changelog/2139.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_cluster: Fixes nil pointer dereference if `advanced_configuration` update fails in `mongodbatlas_cluster`
+resource/mongodbatlas_cluster: Fixes nil pointer dereference if `advanced_configuration` update fails
 ```

--- a/.changelog/2139.txt
+++ b/.changelog/2139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_cluster: Fixes nil pointer dereference if `advanced_configuration` update fails in `mongodbatlas_cluster`
+```

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -12,17 +12,19 @@ import (
 	"strings"
 	"time"
 
+	matlas "go.mongodb.org/atlas/mongodbatlas"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/spf13/cast"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
-	"github.com/spf13/cast"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
@@ -926,9 +928,9 @@ func resourceMongoDBAtlasClusterUpdate(ctx context.Context, d *schema.ResourceDa
 		if aclist, ok1 := ac.([]any); ok1 && len(aclist) > 0 {
 			advancedConfReq := expandProcessArgs(d, aclist[0].(map[string]any))
 			if !reflect.DeepEqual(advancedConfReq, matlas.ProcessArgs{}) {
-				argResp, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)
+				_, _, err := conn.Clusters.UpdateProcessArgs(ctx, projectID, clusterName, advancedConfReq)
 				if err != nil {
-					return diag.FromErr(fmt.Errorf(errorAdvancedConfUpdate, clusterName+argResp.DefaultReadConcern, err))
+					return diag.FromErr(fmt.Errorf(errorAdvancedConfUpdate, clusterName, err))
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Fixes nil pointer exception if `advanced_configuration` update fails in `mongodbatlas_cluster`

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-241758 
Fixes https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2122 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
