### PR TITLE
chore: Uses PAT of bot to commit changelog updates

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
@@ -25,8 +26,9 @@ jobs:
             else
               MSG="Update CHANGELOG.md for #${{ github.event.pull_request.number }}"
             fi
-            git config --local user.email changelogbot@mongodb.com
-            git config --local user.name changelogbot
+            git config --local user.email svc-api-experience-integrations-escalation@mongodb.com
+            git config --local user.name svc-apix-bot
+            git remote set-url origin https://x-access-token/:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}
             git add CHANGELOG.md
             git commit -m "$MSG"
             git push

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{secrets.APIX_BOT_PAT}}
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
           go-version-file: 'go.mod'
@@ -26,9 +26,6 @@ jobs:
             else
               MSG="Update CHANGELOG.md for #${{ github.event.pull_request.number }}"
             fi
-            git config --local user.email svc-api-experience-integrations-escalation@mongodb.com
-            git config --local user.name svc-apix-bot
-            git remote set-url origin https://x-access-token/:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}
             git add CHANGELOG.md
             git commit -m "$MSG"
             git push


### PR DESCRIPTION
## Description

Uses PAT of bot to commit changelog updates to bypass branch protection rules 

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
