### PR TITLE
fix: Converts `replication_specs` to TypeList for the advanced_cluster data_source

### DIFF
--- a/.changelog/2076.txt
+++ b/.changelog/2076.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` to TypeList
+data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` to TypeList
+```

--- a/.changelog/2076.txt
+++ b/.changelog/2076.txt
@@ -1,4 +1,0 @@
-```release-note:bug
-data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` to TypeList
-data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` to TypeList
-```

--- a/.changelog/2145.txt
+++ b/.changelog/2145.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` to TypeList
-data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` to TypeList
+data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` from TypeSet to TypeList. This fixes an issue where some items were not returned in the results.
+data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` from TypeSet to TypeList. This fixes an issue where some items were not returned in the results.
 ```

--- a/.changelog/2145.txt
+++ b/.changelog/2145.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+data-source/mongodbatlas_advanced_cluster: Converts `replication_specs` to TypeList
+data-source/mongodbatlas_advanced_clusters: Converts `replication_specs` to TypeList
+```

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -100,7 +100,7 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"replication_specs": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -113,7 +113,7 @@ func DataSource() *schema.Resource {
 							Computed: true,
 						},
 						"region_configs": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -208,6 +208,7 @@ func DataSource() *schema.Resource {
 						},
 					},
 				},
+				Set: replicationSpecsHashSet,
 			},
 			"root_cert_type": {
 				Type:     schema.TypeString,
@@ -298,7 +299,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "pit_enabled", clusterName, err))
 	}
 
-	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
+	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").(*schema.Set).List(), d, connV2)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -100,7 +100,7 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"replication_specs": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -113,7 +113,7 @@ func DataSource() *schema.Resource {
 							Computed: true,
 						},
 						"region_configs": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -208,7 +208,6 @@ func DataSource() *schema.Resource {
 						},
 					},
 				},
-				Set: replicationSpecsHashSet,
 			},
 			"root_cert_type": {
 				Type:     schema.TypeString,
@@ -299,7 +298,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "pit_enabled", clusterName, err))
 	}
 
-	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").(*schema.Set).List(), d, connV2)
+	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -108,7 +108,7 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"replication_specs": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -121,7 +121,7 @@ func PluralDataSource() *schema.Resource {
 										Computed: true,
 									},
 									"region_configs": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -216,7 +216,6 @@ func PluralDataSource() *schema.Resource {
 									},
 								},
 							},
-							Set: replicationSpecsHashSet,
 						},
 						"root_cert_type": {
 							Type:     schema.TypeString,

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -108,7 +108,7 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"replication_specs": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -121,7 +121,7 @@ func PluralDataSource() *schema.Resource {
 										Computed: true,
 									},
 									"region_configs": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -216,6 +216,7 @@ func PluralDataSource() *schema.Resource {
 									},
 								},
 							},
+							Set: replicationSpecsHashSet,
 						},
 						"root_cert_type": {
 							Type:     schema.TypeString,

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -290,7 +290,6 @@ func Resource() *schema.Resource {
 						},
 					},
 				},
-				// Set: replicationSpecsHashSet,
 			},
 			"root_cert_type": {
 				Type:     schema.TypeString,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -139,6 +139,7 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals("3")),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
+					resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals("3")),
 				),
 			},
 			{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -830,6 +830,7 @@ func configMultiCloud(orgID, projectName, name string) string {
 							instance_size = "M10"
 							node_count    = 2
 						}
+					}
 				}
 			}
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -136,7 +136,7 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.region_configs.#", acc.JSONEquals("3")),
+					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals("3")),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
 				),

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -136,6 +136,7 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
+					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.region_configs.#", acc.JSONEquals("3")),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
 				),
@@ -813,14 +814,22 @@ func configMultiCloud(orgID, projectName, name string) string {
 					priority      = 7
 					region_name   = "EU_WEST_1"
 				}
-				region_configs {
-					electable_specs {
-						instance_size = "M10"
-						node_count    = 2
-					}
-					provider_name = "GCP"
-					priority      = 6
-					region_name   = "NORTH_AMERICA_NORTHEAST_1"
+
+				dynamic "region_configs" {
+					for_each = [
+						"NORTH_AMERICA_NORTHEAST_1",
+						"US_EAST_4"
+					]
+
+					content {
+						provider_name = "GCP"
+						priority      = 0
+						region_name   = region_configs.value
+
+						read_only_specs {
+							instance_size = "M10"
+							node_count    = 2
+						}
 				}
 			}
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -817,8 +817,8 @@ func configMultiCloud(orgID, projectName, name string) string {
 
 				dynamic "region_configs" {
 					for_each = [
-						"NORTH_AMERICA_NORTHEAST_1",
-						"US_EAST_4"
+						"US_EAST_4",
+						"NORTH_AMERICA_NORTHEAST_1"
 					]
 
 					content {


### PR DESCRIPTION
## Description

Thanks to @drcapulet for reporting this bug.
1. We are changing `replication_specs` to TypeList in the data_sources because the Set data structure was not showing all the results (due to key clashing most likely)
2. We opted for this option because it's in line with how the resource structure is. So now all `replication_specs` in `advanced_cluster` have TypeList.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
