### PR TITLE
chore: Fixes markdown sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ## (Unreleased)
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## (Unreleased)
 
 NOTES:

--- a/contributing/atlas-sdk.md
+++ b/contributing/atlas-sdk.md
@@ -1,7 +1,9 @@
+# Atlas SDK update
+
 Most of the new features of the provider are using [atlas-sdk](https://github.com/mongodb/atlas-sdk-go)
 SDK is updated automatically, tracking all new Atlas features.
 
-### Updating Atlas SDK 
+## How to update Atlas SDK 
 
 To update Atlas SDK run:
 
@@ -13,7 +15,7 @@ make update-atlas-sdk
 
 > NOTE: Command can make import changes to +500 files. Please make sure that you perform update on main branch without any uncommited changes.
 
-### SDK Major Release Update Procedure
+## SDK Major Release Update Procedure
 
 1. If the SDK update doesn’t cause any compilation issues create a new SDK update PR
    1. Review [API Changelog](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/changelog) for any deprecated fields and breaking changes.

--- a/contributing/development-best-practices.md
+++ b/contributing/development-best-practices.md
@@ -1,5 +1,5 @@
 
-## Development Best Practices
+# Development Best Practices
 
 ## Table of Contents
 - [Creating New Resource and Data Sources](#creating-new-resources-and-data-sources)

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -1,4 +1,4 @@
-## Development Setup
+# Development Setup
 
 ## Table of Contents
 - [Prerequisite Tools](#prerequisite-tools)

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -1,12 +1,12 @@
-## Documentation
+# Documentation
 
 - In our documentation, when a resource field allows a maximum of only one item, we do not format that field as an array. Instead, we create a subsection specifically for this field. Within this new subsection, we enumerate all the attributes of the field. Let's illustrate this with an example: [cloud_backup_schedule.html.markdown](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/website/docs/r/cloud_backup_schedule.html.markdown?plain=1#L207)
 - You can check how the documentation is rendered on the Terraform Registry via [doc-preview](https://registry.terraform.io/tools/doc-preview).
 
-### Creating Resource and Data source Documentation
+## Creating Resource and Data source Documentation
 We autogenerate the documentation of our provider resources and data sources via [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs).
 
-#### How to generate the documentation for a resource
+### How to generate the documentation for a resource
 - Make sure that the resource and data source schemas have defined the fields `MarkdownDescription` and `Description`.
   - We recommend to use [Scaffolding Schema and Model Definitions](#scaffolding-schema-and-model-definitions) to autogenerate the schema via the Open API specification.
 - Add the resource/data source templates to the [templates](templates) folder. See [README.md](templates/README.md) for more info.

--- a/examples/mongodbatlas_alert_configuration/README.md
+++ b/examples/mongodbatlas_alert_configuration/README.md
@@ -1,3 +1,5 @@
+# Example - Alert Configuration
+
 ## Using the data source
 Example exists in `alert-configurations-data.tf`. To use this example exactly:
 - Copy directory to local disk


### PR DESCRIPTION
## Description

Fixes markdown sections so they start with one # and they don't skip any one. PR and bug templates are not updated.

This is a follow-up PR to @gssbzn comments on https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2132

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
