### PR TITLE
chore: Sends automatic slack message to docs-oncall when review is required in PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 
 # Changelog entries reviewed by Docs Cloud Team
 /.changelog/ @mongodb/docs-cloud-team
+/website/ @mongodb/docs-cloud-team

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -2,10 +2,11 @@ name: Notify Docs team
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
 
 jobs:
   check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.changes.outputs.files }}

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -2,7 +2,7 @@ name: Notify Docs team
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   check:

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -1,0 +1,57 @@
+name: Notify Docs team
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.changes.outputs.files }}
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: changes
+        with:
+          filters: |
+            files:
+              - '.changelog/**'
+              - 'website/**'
+        
+  slack-notification:
+    needs: check
+    if: ${{ needs.check.outputs.files == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}  # WILL CHANGE BEFORE MERGING TO: SLACK_WEBHOOK_URL_DOCS
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "text": "PR to review",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*PR to review* for Terraform repo @cloud-docs-on-call"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":github: PR"
+                        },
+                        "url": "${{ github.event.pull_request.html_url }}"
+                    }
+                ]
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

Sends automatic slack message to docs-oncall when review is required in PR.

Slack message is sent if PR goes to ready for review and there are changes in changelog entries or documentation (resource / data source guides and migration guides)

Link to any related issue(s): CLOUDP-242971

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
