### PR TITLE
chore: Define check in release process ensuring migration guide is defined in a major version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,21 @@ jobs:
             echo "runs_tests=$(if [ '${{ inputs.skip_tests }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
           } >> "$GITHUB_OUTPUT"
 
-  validate-version-input:
+  validate-inputs:
     runs-on: ubuntu-latest
     steps:
       - name: Validation of version format
         run: |
           echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number || 'master' }}
+      - name: Check for Upgrade Guide
+        run: './scripts/check-upgrade-guide-exists.sh ${{inputs.version_number}}'
 
   update-examples-reference-in-docs:
-    needs: [ release-config, validate-version-input ]
+    needs: [ release-config, validate-inputs ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
@@ -58,7 +64,7 @@ jobs:
       passphrase: ${{ secrets.APIX_BOT_PASSPHRASE }}      
 
   update-changelog-header:
-    needs: [ release-config, validate-version-input, update-examples-reference-in-docs ]
+    needs: [ release-config, validate-inputs, update-examples-reference-in-docs ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
@@ -77,7 +83,7 @@ jobs:
 
   create-tag:
     runs-on: ubuntu-latest
-    needs: [ release-config, validate-version-input, update-examples-reference-in-docs, update-changelog-header ]
+    needs: [ release-config, validate-inputs, update-examples-reference-in-docs, update-changelog-header ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure') 
@@ -99,7 +105,7 @@ jobs:
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
 
   run-qa-acceptance-tests:
-    needs: [ release-config, validate-version-input, update-examples-reference-in-docs, update-changelog-header, create-tag ]
+    needs: [ release-config, validate-inputs, update-examples-reference-in-docs, update-changelog-header, create-tag ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
@@ -112,7 +118,7 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
-    needs: [ validate-version-input, update-examples-reference-in-docs, update-changelog-header, create-tag, run-qa-acceptance-tests ]
+    needs: [ validate-inputs, update-examples-reference-in-docs, update-changelog-header, create-tag, run-qa-acceptance-tests ]
     # Release is skipped if there are failures in previous steps
     if: >-
       !cancelled()

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ While QA acceptance tests are run in the release process automatically, we check
 
 **Note**: Only applies if the right most version digit is 0 (considered a major or minor version in [semantic versioning](https://semver.org/)).
 
-- A doc in /website/docs/guides/X.Y.0-upgrade-guide.html must be defined containing a summary of the most significant features, breaking changes, and additional information that can be helpful. The expectation is that this file is created during relevant pull requests and not during the release process.
+- A doc in /website/docs/guides/X.Y.0-upgrade-guide.html must be defined containing a summary of the most significant features, breaking changes, and additional information that can be helpful. If not defined the release process will be stopped automatically. The expectation is that this file is created during relevant pull requests (breaking changes, significant features), and not before the release process.
 
 ### Trigger release workflow
 

--- a/scripts/check-upgrade-guide-exists.sh
+++ b/scripts/check-upgrade-guide-exists.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${1?"Tag of new release must be provided"}"
+
+RELEASE_TAG=$1
+RELEASE_NUMBER=$(echo "${RELEASE_TAG}" | tr -d v)
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_NUMBER"
+
+# Check if it's a major release (patch version is 0)
+if [ "$PATCH" -eq 0 ]; then
+    UPGRADE_GUIDE_PATH="website/docs/guides/$MAJOR.$MINOR.$PATCH-upgrade-guide.html.markdown"
+    echo "Checking for the presence of $UPGRADE_GUIDE_PATH"
+    if [ ! -f "$UPGRADE_GUIDE_PATH" ]; then
+        echo "Stopping release procees, upgrade guide $UPGRADE_GUIDE_PATH does not exist."
+        exit 1
+    else
+        echo "Upgrade guide $UPGRADE_GUIDE_PATH exists."
+    fi
+else
+    echo "No upgrade guide needed."
+fi

--- a/scripts/check-upgrade-guide-exists.sh
+++ b/scripts/check-upgrade-guide-exists.sh
@@ -13,7 +13,7 @@ if [ "$PATCH" -eq 0 ]; then
     UPGRADE_GUIDE_PATH="website/docs/guides/$MAJOR.$MINOR.$PATCH-upgrade-guide.html.markdown"
     echo "Checking for the presence of $UPGRADE_GUIDE_PATH"
     if [ ! -f "$UPGRADE_GUIDE_PATH" ]; then
-        echo "Stopping release procees, upgrade guide $UPGRADE_GUIDE_PATH does not exist."
+        echo "Stopping release process, upgrade guide $UPGRADE_GUIDE_PATH does not exist. Please visit our releasing documentation for more details."
         exit 1
     else
         echo "Upgrade guide $UPGRADE_GUIDE_PATH exists."

--- a/scripts/check-upgrade-guide-exists.sh
+++ b/scripts/check-upgrade-guide-exists.sh
@@ -13,7 +13,7 @@ if [ "$PATCH" -eq 0 ]; then
     UPGRADE_GUIDE_PATH="website/docs/guides/$MAJOR.$MINOR.$PATCH-upgrade-guide.html.markdown"
     echo "Checking for the presence of $UPGRADE_GUIDE_PATH"
     if [ ! -f "$UPGRADE_GUIDE_PATH" ]; then
-        echo "Stopping release process, upgrade guide $UPGRADE_GUIDE_PATH does not exist. Please visit our releasing documentation for more details."
+        echo "Stopping release process, upgrade guide $UPGRADE_GUIDE_PATH does not exist. Please visit our docs for more details: https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/RELEASING.md"
         exit 1
     else
         echo "Upgrade guide $UPGRADE_GUIDE_PATH exists."


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-244149

If we ever forget to define the migration guide for a major version (vX.Y.0) the release process will stop automatically. This is already stated in [our docs](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/RELEASING.md#verify-upgrade-guide-is-defined).

## Testing

- Release of minor does not check for upgrade guide: https://github.com/AgustinBettati/terraform-provider-mongodbatlas/actions/runs/8738232136
- Release of major version missing upgrade guide: https://github.com/AgustinBettati/terraform-provider-mongodbatlas/actions/runs/8740057703
- Release of major version using existing tag that defined guide: https://github.com/AgustinBettati/terraform-provider-mongodbatlas/actions/runs/8740162743

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
