### PR TITLE
chore: Restores notification when changelog update fails

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -37,22 +37,9 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Automatic Changelog update failed* ${{ secrets.SLACK_ONCALL_TAG }}"
+                    "text": "*Automatic Changelog update failed* ${{ secrets.SLACK_ONCALL_TAG }}. <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Failed action >"
                   }
                 },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                        "type": "button",
-                        "text": {
-                            "type": "plain_text",
-                            "text": ":github: Failed action"
-                        },
-                        "url": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-                    }
-                ]
-                }
               ]
             }
         env:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -20,4 +20,41 @@ jobs:
       gpg_private_key: ${{ secrets.APIX_BOT_GPG_PRIVATE_KEY }}
       passphrase: ${{ secrets.APIX_BOT_PASSPHRASE }}     
 
-  
+  slack-notification:
+    needs: [generate-and-update-changelog]
+    if: ${{ !cancelled() && needs.generate-and-update-changelog.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack message
+        id: slack
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
+        with:
+          payload: |
+            {
+              "text": "Automatic Changelog update failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Automatic Changelog update failed* ${{ secrets.SLACK_ONCALL_TAG }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":github: Failed action"
+                        },
+                        "url": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+                    }
+                ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -39,7 +39,7 @@ jobs:
                     "type": "mrkdwn",
                     "text": "*Automatic Changelog update failed* ${{ secrets.SLACK_ONCALL_TAG }}. <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Failed action >"
                   }
-                },
+                }
               ]
             }
         env:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       script_call: 'make tools update-changelog-unreleased-section'
       file_to_commit: 'CHANGELOG.md'
-      commit_message: ${{ github.event_name == 'workflow_dispatch' && 'Update CHANGELOG.md (Manual Trigger)' || format('{0}{1}', 'Update CHANGELOG.md for \#', github.event.pull_request.number) }}
+      commit_message: ${{ github.event_name == 'workflow_dispatch' && format('{0}{1}', 'chore:',' Updates CHANGELOG.md (Manual Trigger)') || format('{0}{1}{2}{3}', 'chore:', ' Updates CHANGELOG.md for ', '#', github.event.pull_request.number) }}
     secrets:
       apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
       remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       script_call: './scripts/update-examples-reference-in-docs.sh ${{inputs.version_number}}'
       file_to_commit: 'website/docs/index.html.markdown'
-      commit_message: 'Update examples link in index.html.markdown for ${{ github.event.inputs.version_number }} release'
+      commit_message: 'chore: Updates examples link in index.html.markdown for ${{ github.event.inputs.version_number }} release'
     secrets:
       apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
       remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}  
@@ -68,7 +68,7 @@ jobs:
     with:
       script_call: './scripts/update-changelog-header-for-release.sh ${{inputs.version_number}}'
       file_to_commit: 'CHANGELOG.md'
-      commit_message: 'Update CHANGELOG.md header for ${{ github.event.inputs.version_number }} release'
+      commit_message: 'chore: Updates CHANGELOG.md header for ${{ github.event.inputs.version_number }} release'
     secrets:
       apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
       remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}  


### PR DESCRIPTION
## Description

Reverts #2155 now that the automatic commit works

- Restores notification when changelog update fails
- Improves automatic commit message to follow guidelines


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
