### PR TITLE
chore: Adjusts check-changelog-entry-file to verify the entry types our guidelines define

### DIFF
--- a/tools/check-changelog-entry-file/main.go
+++ b/tools/check-changelog-entry-file/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -55,7 +54,7 @@ func validateChangelog(filePath, body string) {
 	entry := changelog.Entry{
 		Body: body,
 	}
-	// grabbing validation logic from https://github.com/hashicorp/go-changelog/blob/main/entry.go#L66, if it becomes configurable we can invoke entry.Validate() directly
+	// grabbing validation logic from https://github.com/hashicorp/go-changelog/blob/main/entry.go#L66, if entry types become configurable we can invoke entry.Validate() directly
 	notes := changelog.NotesFromEntry(entry)
 
 	if len(notes) < 1 {
@@ -103,19 +102,11 @@ func skipLabel(labels []string) bool {
 }
 
 func getValidTypes(path string) []string {
-	file, err := os.Open(path)
-	if err != nil {
+	content, errFile := os.ReadFile(path)
+	if errFile != nil {
 		log.Fatalf("Error getting allowed entry types from %s", path)
 	}
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			lines = append(lines, line)
-		}
-	}
-	return lines
+	lines := strings.Split(string(content), "\n")
+	allowedTypes := lines[:len(lines)-1] // remove last element as it is an empty string
+	return allowedTypes
 }

--- a/tools/check-changelog-entry-file/main.go
+++ b/tools/check-changelog-entry-file/main.go
@@ -55,6 +55,7 @@ func validateChangelog(filePath, body string) {
 	entry := changelog.Entry{
 		Body: body,
 	}
+	// grabbing validation logic from https://github.com/hashicorp/go-changelog/blob/main/entry.go#L66, if it becomes configurable we can invoke entry.Validate() directly
 	notes := changelog.NotesFromEntry(entry)
 
 	if len(notes) < 1 {
@@ -74,9 +75,9 @@ func validateChangelog(filePath, body string) {
 	fmt.Printf("Changelog entry file is valid: %s\n", filePath)
 }
 
-func isValidType(t string) bool {
+func isValidType(entryType string) bool {
 	for _, a := range allowedTypeValues {
-		if a == t {
+		if a == entryType {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-244157

Our `check-changelog-entry-file` script was currently delegating the validation logic completely to [go-changelog entry.Validate()](https://github.com/hashicorp/go-changelog/blob/main/entry.go#L66), but this does have to downside that its allowed types are [hardcoded](https://github.com/hashicorp/go-changelog/blob/main/entry.go#L22) and not configurable (https://github.com/hashicorp/go-changelog/issues/6). The hardcoded values are not fully aligned with our allowed entry types.

This PR extracts the validation logic and ensures that we verify our [allowed entry types](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/scripts/changelog/allowed-types.txt). 

## Testing

- Using an unknown type: ```2024/04/19 12:50:26 Error validating changelog file: .changelog/3000.txt. Unknown changelog types [other], please use only the configured changelog entry types [breaking-change new-resource new-datasource new-guide note enhancement bug]```
- Using `new-guide` type (this was throwing an error before the changes): ```Changelog entry file is valid: .changelog/3000.txt```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
