### PR TITLE
chore: Reverts Go linter change to detect duplicate package use

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,11 +122,7 @@ issues:
       text: "SA1019:" # d.GetOkExists is deprecated: usage is discouraged due to undefined behaviors and may be removed in a future version of the SDK
     - linters:
         - gocritic
-      text: "^hugeParam: req is heavy|^dupImport" # TEMPORARY until SDK goes over v20231115008, then keep only first part
-    - linters:
-        - stylecheck
-      text: "^ST1019" # TEMPORARY until SDK goes over v20231115008
-
+      text: "^hugeParam: req is heavy"
 run:
   timeout: 10m
   tests: true


### PR DESCRIPTION
## Description

Reverts Go linter change to detect duplicate package use

This is a follow-up to: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2192

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
