### PR TITLE
doc: Adjustments in online archive resource contemplating new support for azure provider

### DIFF
--- a/website/docs/r/federated_database_instance.html.markdown
+++ b/website/docs/r/federated_database_instance.html.markdown
@@ -96,13 +96,13 @@ resource "mongodbatlas_federated_database_instance" "test" {
 
 * `project_id` - (Required) The unique ID for the project to create a Federated Database Instance.
 * `name` - (Required) Name of the Atlas Federated Database Instance.
-  ### `cloud_provider_config` - (Optional) Cloud provider linked to this data federated instance.
-  #### `aws` - (Required) AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket. Note this parameter is only required if using `cloud_provider_config` since AWS is currently the only supported Cloud vendor on this feature at this time. 
-  * `role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `test_s3_bucket`.
-  * `test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `role_id`.
-  ### `data_process_region` - (Optional) The cloud provider region to which the Federated Instance routes client connections for data processing.
-  * `cloud_provider` - (Required) Name of the cloud service provider. Atlas Federated Database only supports AWS.
-  * `region` - (Required) Name of the region to which the Federanted Instnace routes client connections for data processing. See the [documention](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/createFederatedDatabase) for the available region.
+* `cloud_provider_config` - (Optional) Cloud provider linked to this data federated instance.
+  * `cloud_provider_config.aws` - (Required) AWS provider of the cloud service where the Federated Database Instance can access the S3 Bucket. Note this parameter is only required if using `cloud_provider_config` since AWS is currently the only supported Cloud vendor on this feature at this time. 
+      * `cloud_provider_config.aws.role_id` - (Required) Unique identifier of the role that the Federated Instance can use to access the data stores. If necessary, use the Atlas [UI](https://docs.atlas.mongodb.com/security/manage-iam-roles/) or [API](https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/) to retrieve the role ID. You must also specify the `test_s3_bucket`.
+      * `cloud_provider_config.aws.test_s3_bucket` - (Required) Name of the S3 data bucket that the provided role ID is authorized to access. You must also specify the `role_id`.
+* `data_process_region` - (Optional) The cloud provider region to which the Federated Instance routes client connections for data processing.
+  * `data_process_region.cloud_provider` - (Required) Name of the cloud service provider. Atlas Federated Database only supports AWS.
+  * `data_process_region.region` - (Required) Name of the region to which the Federanted Instnace routes client connections for data processing. See the [documention](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Federation/operation/createFederatedDatabase) for the available region.
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -154,18 +154,16 @@ In addition to all arguments above, the following attributes are exported:
       * `storage_stores.#.read_preference.tags` - List of all tags within a tag set
         * `storage_stores.#.read_preference.tags.name` - Human-readable label of the tag.
         * `storage_stores.#.read_preference.tags.value` - Value of the tag.
-
-### `aws` - Name of the cloud service that hosts the data lake's data stores.
-* `iam_assumed_role_arn` - Amazon Resource Name (ARN) of the IAM Role that the Federated Database Instance assumes when accessing S3 Bucket data stores. The IAM Role must support the following actions against each S3 bucket:
-  * `s3:GetObject`
-  * `s3:ListBucket`
-  * `s3:GetObjectVersion` 
+* `cloud_provider_config.aws` - Name of the cloud service that hosts the data lake's data stores.
+  * `iam_assumed_role_arn` - Amazon Resource Name (ARN) of the IAM Role that the Federated Database Instance assumes when accessing S3 Bucket data stores. The IAM Role must support the following actions against each S3 bucket:
+      * `s3:GetObject`
+      * `s3:ListBucket`
+      * `s3:GetObjectVersion` 
     
   For more information on S3 actions, see [Actions, Resources, and Condition Keys for Amazon S3](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html).
-
-* `iam_user_arn` - Amazon Resource Name (ARN) of the user that the Federated Database Instance assumes when accessing S3 Bucket data stores.
-* `external_id` - Unique identifier associated with the IAM Role that the Federated Database Instance assumes when accessing the data stores.
-* `role_id` - Unique identifier of the role that the data lake can use to access the data stores.
+  * `iam_user_arn` - Amazon Resource Name (ARN) of the user that the Federated Database Instance assumes when accessing S3 Bucket data stores.
+  * `external_id` - Unique identifier associated with the IAM Role that the Federated Database Instance assumes when accessing the data stores.
+  * `role_id` - Unique identifier of the role that the data lake can use to access the data stores.
 
 
 

--- a/website/docs/r/online_archive.html.markdown
+++ b/website/docs/r/online_archive.html.markdown
@@ -83,6 +83,32 @@ resource "mongodbatlas_online_archive" "test" {
 
 ```
 
+Defining custom provider and region example
+
+```terraform
+resource "mongodbatlas_online_archive" "test" {
+    project_id   = var.project_id
+    cluster_name = var.cluster_name
+    coll_name    = var.collection_name
+    db_name      = var.database_name
+
+    data_process_region {
+        cloud_provider = "AZURE"
+        region = "US_EAST_2"
+    }
+
+    partition_fields {
+        field_name = "firstName"
+        order      = 0 
+    }
+
+    criteria {
+        type  = "CUSTOM"
+        query =  "{ \"department\": \"engineering\" }"
+    }
+}
+```
+
 ## Argument Reference
 * `project_id` - (Required) The unique ID for the project
 * `cluster_name` - (Required) Name of the cluster that contains the collection.
@@ -120,7 +146,7 @@ The only field required for criteria type `CUSTOM`
 * `expire_after_days` - Number of days used in the date criteria for nominating documents for deletion. Value must be between 7 and 9215.
 
 ### Data Process Region
-* `cloud_provider` - Human-readable label that identifies the Cloud service provider where you wish to store your archived data.
+* `cloud_provider` - Human-readable label that identifies the Cloud service provider where you wish to store your archived data. `AZURE` may be selected only if Azure is the Cloud service provider for the cluster and no AWS online archive has been created for the cluster.
 * `region` - Human-readable label that identifies the geographic location of the region where you wish to store your archived data. For allowed values, see [MongoDB Atlas API documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Online-Archive/operation/createOnlineArchive)
 
 ### Schedule


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-239897

As part of the ticket I verified that that azure provider can be used with the existing [online_archive](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/online_archive) implementation. Adding small adjustment to documentation and an example.

There is already an existing acceptance test verifying the usage of `data_process_region.cloud_provider` and `data_process_region.region` so do not see a real need in adding a new one for azure.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
