### PR TITLE
chore: Fixes cluster tests

### DIFF
--- a/internal/service/cluster/resource_cluster_migration_test.go
+++ b/internal/service/cluster/resource_cluster_migration_test.go
@@ -1,111 +1,15 @@
 package cluster_test
 
 import (
-	"fmt"
 	"testing"
 
-	matlas "go.mongodb.org/atlas/mongodbatlas"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestMigClusterRSCluster_withDefaultBiConnectorAndAdvancedConfiguration_backwardCompatibility(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		cfg         = configAWS(projectID, clusterName, true, true)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t) },
-		CheckDestroy: acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            cfg,
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(cfg),
-		},
-	})
+func TestMigCluster_basicAWS_simple(t *testing.T) {
+	mig.CreateAndRunTest(t, basicTestCase(t))
 }
 
-func TestMigClusterRSCluster_basic_PartialAdvancedConf_backwardCompatibility(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		cfgPartial  = configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
-			MinimumEnabledTLSProtocol: "TLS1_2",
-		})
-		cfgPartialUpdated = configAdvancedConfPartialUpdated(projectID, clusterName, "false", &matlas.ProcessArgs{
-			MinimumEnabledTLSProtocol: "TLS1_2",
-			SampleSizeBIConnector:     conversion.Pointer[int64](110),
-		})
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t) },
-		CheckDestroy: acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            cfgPartial,
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(cfgPartial),
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   cfgPartialUpdated,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
-				),
-			},
-		},
-	})
-}
-
-func configAdvancedConfPartialUpdated(projectID, name, autoscalingEnabled string, p *matlas.ProcessArgs) string {
-	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "test" {
-			project_id   = %[1]q
-			name         = %[2]q
-			disk_size_gb = 10
-
-            cluster_type = "REPLICASET"
-		    replication_specs {
-			  num_shards = 1
-			  regions_config {
-			     region_name     = "US_WEST_2"
-			     electable_nodes = 3
-			     priority        = 7
-                 read_only_nodes = 0
-		       }
-		    }
-
-			backup_enabled               = false
-			auto_scaling_disk_gb_enabled =  %[3]s
-
-			// Provider Settings "block"
-			provider_name               = "AWS"
-			provider_instance_size_name = "M10"
-			provider_region_name        = "US_WEST_2"
-
-			advanced_configuration {
-				minimum_enabled_tls_protocol         = %[4]q
-				sample_size_bi_connector			 = %[5]d
-			}
-		}
-	`, projectID, name, autoscalingEnabled, p.MinimumEnabledTLSProtocol, *p.SampleSizeBIConnector)
+func TestMigCluster_partial_advancedConf(t *testing.T) {
+	mig.CreateAndRunTest(t, partialAdvancedConfTestCase(t))
 }

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -23,14 +23,20 @@ const (
 	dataSourceName = "data.mongodbatlas_cluster.test"
 )
 
-func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
+func TestAccCluster_basicAWS_simple(t *testing.T) {
+	resource.ParallelTest(t, *basicTestCase(t))
+}
+
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+
 	var (
-		projectID   = acc.ProjectIDExecution(t)
+		projectID   = acc.ProjectIDExecution(tb)
 		clusterName = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -80,52 +86,22 @@ func TestAccClusterRSCluster_basicAWS_simple(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"cloud_backup", "retain_backups_enabled"},
 			},
 		},
-	})
+	}
 }
 
-func TestAccClusterRSCluster_basicAWS_instanceScale(t *testing.T) {
+func TestAccCluster_partial_advancedConf(t *testing.T) {
+	resource.ParallelTest(t, *partialAdvancedConfTestCase(t))
+}
+func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+
 	var (
-		projectID   = acc.ProjectIDExecution(t)
+		projectID   = acc.ProjectIDExecution(tb)
 		clusterName = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M40_NVME"),
-					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
-				),
-			},
-			{
-				Config: configAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M50_NVME"),
-					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -177,10 +153,45 @@ func TestAccClusterRSCluster_basic_Partial_AdvancedConf(t *testing.T) {
 				),
 			},
 		},
+	}
+}
+
+func TestAccCluster_basicAWS_instanceScale(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config: configAWSNVMEInstance(projectID, clusterName, "M40_NVME"),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M40_NVME"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+			{
+				Config: configAWSNVMEInstance(projectID, clusterName, "M50_NVME"),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "provider_instance_size_name", "M50_NVME"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+		},
 	})
 }
 
-func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
+func TestAccCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -236,7 +247,7 @@ func TestAccClusterRSCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
+func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -278,7 +289,7 @@ func TestAccClusterRSCluster_emptyAdvancedConf(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
+func TestAccCluster_basicAdvancedConf(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -339,7 +350,7 @@ func TestAccClusterRSCluster_basicAdvancedConf(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicAzure(t *testing.T) {
+func TestAccCluster_basicAzure(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.basic_azure"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -378,7 +389,7 @@ func TestAccClusterRSCluster_basicAzure(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
+func TestAccCluster_AzureUpdateToNVME(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.basic_azure"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -418,7 +429,7 @@ func TestAccClusterRSCluster_AzureUpdateToNVME(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicGCP(t *testing.T) {
+func TestAccCluster_basicGCP(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.basic_gcp"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -459,7 +470,7 @@ func TestAccClusterRSCluster_basicGCP(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
+func TestAccCluster_WithBiConnectorGCP(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.basic_gcp"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -502,7 +513,7 @@ func TestAccClusterRSCluster_WithBiConnectorGCP(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
+func TestAccCluster_MultiRegion(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -575,7 +586,7 @@ func TestAccClusterRSCluster_MultiRegion(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
+func TestAccCluster_ProviderRegionName(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.multi_region"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -654,12 +665,11 @@ func TestAccClusterRSCluster_ProviderRegionName(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_Global(t *testing.T) {
+func TestAccCluster_Global(t *testing.T) {
 	var (
-		resourceSuffix = "global_cluster"
-		resourceName   = fmt.Sprintf("mongodbatlas_cluster.%s", resourceSuffix)
-		projectID      = acc.ProjectIDExecution(t)
-		clusterName    = acc.RandomClusterName()
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
+		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -668,7 +678,7 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigClusterGlobal(resourceSuffix, projectID, clusterName, "false"),
+				Config: acc.ConfigClusterGlobal(orgID, projectName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
@@ -688,7 +698,7 @@ func TestAccClusterRSCluster_Global(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
+func TestAccCluster_AWSWithLabels(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.aws_with_labels"
 		projectID    = acc.ProjectIDExecution(t)
@@ -763,7 +773,7 @@ func TestAccClusterRSCluster_AWSWithLabels(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_WithTags(t *testing.T) {
+func TestAccCluster_WithTags(t *testing.T) {
 	var (
 		dataSourceClustersName = "data.mongodbatlas_clusters.test"
 		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -843,7 +853,7 @@ func TestAccClusterRSCluster_WithTags(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
+func TestAccCluster_withPrivateEndpointLink(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
@@ -879,7 +889,7 @@ func TestAccClusterRSCluster_withPrivateEndpointLink(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
+func TestAccCluster_withAzureNetworkPeering(t *testing.T) {
 	acc.SkipTestForCI(t) // needs Azure configuration
 
 	var (
@@ -914,7 +924,7 @@ func TestAccClusterRSCluster_withAzureNetworkPeering(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
+func TestAccCluster_withGCPNetworkPeering(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
 	var (
@@ -948,7 +958,7 @@ func TestAccClusterRSCluster_withGCPNetworkPeering(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
+func TestAccCluster_withAzureAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t) // needs Azure configuration
 
 	var (
@@ -979,7 +989,7 @@ func TestAccClusterRSCluster_withAzureAndContainerID(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
+func TestAccCluster_withAWSAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
@@ -1010,7 +1020,7 @@ func TestAccClusterRSCluster_withAWSAndContainerID(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
+func TestAccCluster_withGCPAndContainerID(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
 	var (
@@ -1043,7 +1053,7 @@ func TestAccClusterRSCluster_withGCPAndContainerID(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
+func TestAccCluster_withAutoScalingAWS(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -1097,7 +1107,7 @@ func TestAccClusterRSCluster_withAutoScalingAWS(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_tenant(t *testing.T) {
+func TestAccCluster_tenant(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_cluster.tenant"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -1136,7 +1146,7 @@ func TestAccClusterRSCluster_tenant(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
+func TestAccCluster_tenant_m5(t *testing.T) {
 	var (
 		resourceName   = "mongodbatlas_cluster.tenant"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -1164,7 +1174,7 @@ func TestAccClusterRSCluster_tenant_m5(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
+func TestAccCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because no AWS
@@ -1189,7 +1199,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
+func TestAccCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -1214,7 +1224,7 @@ func TestAccClusterRSCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
+func TestAccCluster_RegionsConfig(t *testing.T) {
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -1332,7 +1342,7 @@ func TestAccClusterRSCluster_RegionsConfig(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
+func TestAccCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -1380,7 +1390,7 @@ func TestAccClusterRSCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 	})
 }
 
-func TestAccClusterRSCluster_basicAWS_PausedToUnpaused(t *testing.T) {
+func TestAccCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -29,17 +29,17 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		providerName           = "AWS"
 		region                 = os.Getenv("AWS_REGION")
 		projectID              = acc.ProjectIDExecution(t)
+		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName            = acc.RandomProjectName()
 		clusterName            = acc.RandomClusterName()
-		clusterResourceName    = "global_cluster"
+		clusterResourceName    = "test"
+		clusterResource        = acc.ConfigClusterGlobal(orgID, projectName, clusterName)
+		clusterDataSource      = modeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
+		endpointResources      = testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(
+			awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,
+		)
+		dependencies = []string{clusterResource, clusterDataSource, endpointResources}
 	)
-
-	clusterResource := acc.ConfigClusterGlobal(clusterResourceName, projectID, clusterName, "false")
-	clusterDataSource := modeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
-	endpointResources := testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(
-		awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,
-	)
-
-	dependencies := []string{clusterResource, clusterDataSource, endpointResources}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -49,7 +49,7 @@ func ConfigClusterGlobal(orgID, projectName, clusterName string) string {
 		}
 
 		resource "mongodbatlas_cluster" test {
-			project_id              = mongodbatlas_project.test.project_id
+			project_id              = mongodbatlas_project.test.id
 			name                    = %[3]q
 			disk_size_gb            = 80
 			num_shards              = 1

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -40,14 +40,20 @@ func CheckDestroyCluster(s *terraform.State) error {
 	return nil
 }
 
-func ConfigClusterGlobal(resourceName, projectID, name, backupEnabled string) string {
+func ConfigClusterGlobal(orgID, projectName, clusterName string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" %[1]q {
-			project_id              = %[2]q
+	
+		resource "mongodbatlas_project" "test" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
+		resource "mongodbatlas_cluster" test {
+			project_id              = mongodbatlas_project.test.project_id
 			name                    = %[3]q
 			disk_size_gb            = 80
 			num_shards              = 1
-			cloud_backup            = %[4]s
+			cloud_backup            = false
 			cluster_type            = "GEOSHARDED"
 
 			// Provider Settings "block"
@@ -76,7 +82,7 @@ func ConfigClusterGlobal(resourceName, projectID, name, backupEnabled string) st
 				}
 			}
 		}
-	`, resourceName, projectID, name, backupEnabled)
+	`, orgID, projectName, clusterName)
 }
 
 func ImportStateClusterIDFunc(resourceName string) resource.ImportStateIdFunc {


### PR DESCRIPTION
## Description

Fixes cluster tests
- Uses common pattern for migration tests
- Removes heavy tests TestAccCluster_AzureUpdateToNVME and  TestAccCluster_basicAWS_instanceScale that only checks  provider_instance_size_name attribute change

Link to any related issue(s): CLOUDP-245163

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
