### PR TITLE
chore: Enables mongodbatlas_push_based_log_export tests in CI and adds unit tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -154,6 +154,7 @@ jobs:
       search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
@@ -234,6 +235,8 @@ jobs:
           stream:
             - 'internal/service/streamconnection/*.go'
             - 'internal/service/streaminstance/*.go'
+          push_based_log_export:
+            - 'internal/service/pushbasedlogexport/*.go'
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
@@ -726,4 +729,28 @@ jobs:
           ACCTEST_PACKAGES: |
             ./internal/service/streamconnection
             ./internal/service/streaminstance
+        run: make testacc
+
+  push_based_log_export:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.push_based_log_export == 'true' || inputs.test_group == 'push_based_log_export' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false  
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -748,9 +748,13 @@ jobs:
           terraform_wrapper: false  
       - name: Acceptance Tests
         env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
+          SECRET_NAME: ${{ inputs.aws_secret_name }}
+          AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
+          AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -150,11 +150,11 @@ jobs:
       ldap: ${{ steps.filter.outputs.ldap == 'true' || env.mustTrigger == 'true' }}
       network: ${{ steps.filter.outputs.network == 'true' || env.mustTrigger == 'true' }}
       project: ${{ steps.filter.outputs.project == 'true' || env.mustTrigger == 'true' }}
+      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
       search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
-      push_based_log_export: ${{ steps.filter.outputs.push_based_log_export == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
@@ -224,6 +224,8 @@ jobs:
             - 'internal/service/project/*.go'
             - 'internal/service/projectinvitation/*.go'  
             - 'internal/service/projectipaccesslist/*.go'
+          push_based_log_export:
+            - 'internal/service/pushbasedlogexport/*.go'
           search_deployment:
             - 'internal/service/searchdeployment/*.go'
           search_index:
@@ -235,8 +237,6 @@ jobs:
           stream:
             - 'internal/service/streamconnection/*.go'
             - 'internal/service/streaminstance/*.go'
-          push_based_log_export:
-            - 'internal/service/pushbasedlogexport/*.go'
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
@@ -662,7 +662,7 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc
-        
+
   search_deployment:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -639,6 +639,30 @@ jobs:
             ./internal/service/projectipaccesslist
         run: make testacc
 
+  push_based_log_export:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.push_based_log_export == 'true' || inputs.test_group == 'push_based_log_export' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false  
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
+        run: make testacc
+        
   search_deployment:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' }}
@@ -729,28 +753,4 @@ jobs:
           ACCTEST_PACKAGES: |
             ./internal/service/streamconnection
             ./internal/service/streaminstance
-        run: make testacc
-
-  push_based_log_export:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.push_based_log_export == 'true' || inputs.test_group == 'push_based_log_export' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false  
-      - name: Acceptance Tests
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -748,9 +748,9 @@ jobs:
           terraform_wrapper: false  
       - name: Acceptance Tests
         env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -748,13 +748,9 @@ jobs:
           terraform_wrapper: false  
       - name: Acceptance Tests
         env:
-          ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
-          SECRET_NAME: ${{ inputs.aws_secret_name }}
-          AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
-          AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/pushbasedlogexport
         run: make testacc

--- a/internal/service/pushbasedlogexport/model_test.go
+++ b/internal/service/pushbasedlogexport/model_test.go
@@ -113,7 +113,7 @@ func TestNewPushBasedLogExportReq(t *testing.T) {
 			},
 		},
 		{
-			name: "Valid TF state",
+			name: "Valid TF state with empty prefix path",
 			input: &pushbasedlogexport.TFPushBasedLogExportRSModel{
 				BucketName: types.StringValue(testBucketName),
 				IamRoleID:  types.StringValue(testIAMRoleID),

--- a/internal/service/pushbasedlogexport/model_test.go
+++ b/internal/service/pushbasedlogexport/model_test.go
@@ -2,7 +2,6 @@ package pushbasedlogexport_test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/pushbasedlogexport"
@@ -78,7 +78,7 @@ func TestNewTFPushBasedLogExport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			resultModel, _ := pushbasedlogexport.NewTFPushBasedLogExport(context.Background(), tc.projectID, tc.apiResp, tc.timeout)
-			if !reflect.DeepEqual(resultModel, tc.expectedTFModel) {
+			if !assert.Equal(t, tc.expectedTFModel, resultModel) {
 				t.Errorf("result model does not match expected output: expected %+v, got %+v", tc.expectedTFModel, resultModel)
 			}
 		})
@@ -135,13 +135,13 @@ func TestNewPushBasedLogExportReq(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name+" Create", func(t *testing.T) {
 			createReq := pushbasedlogexport.NewPushBasedLogExportCreateReq(tc.input)
-			if !reflect.DeepEqual(createReq, tc.expectedCreateReq) {
+			if !assert.Equal(t, tc.expectedCreateReq, createReq) {
 				t.Errorf("Create request does not match expected output: expected %+v, got %+v", tc.expectedCreateReq, createReq)
 			}
 		})
 		t.Run(tc.name+" Update", func(t *testing.T) {
 			updateReq := pushbasedlogexport.NewPushBasedLogExportUpdateReq(tc.input)
-			if !reflect.DeepEqual(updateReq, tc.expectedUpdateReq) {
+			if !assert.Equal(t, tc.expectedUpdateReq, updateReq) {
 				t.Errorf("Update request does not match expected output: expected %+v, got %+v", tc.expectedUpdateReq, updateReq)
 			}
 		})

--- a/internal/service/pushbasedlogexport/model_test.go
+++ b/internal/service/pushbasedlogexport/model_test.go
@@ -1,0 +1,149 @@
+package pushbasedlogexport_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.mongodb.org/atlas-sdk/v20231115010/admin"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/pushbasedlogexport"
+)
+
+var (
+	testBucketName  = "test-bucket-name"
+	testIAMRoleID   = "661fe3ad234b02027ddee196"
+	testPrefixPath  = "prefix/path"
+	prefixPathEmpty = ""
+	testProjectID   = "661fe3ad234b02027dabcabc"
+)
+
+type sdkToTFModelTestCase struct {
+	apiResp         *admin.PushBasedLogExportProject
+	timeout         *timeouts.Value
+	expectedTFModel *pushbasedlogexport.TFPushBasedLogExportRSModel
+	name            string
+	projectID       string
+}
+
+func TestNewTFPushBasedLogExport(t *testing.T) {
+	currentTime := time.Now()
+
+	testCases := []sdkToTFModelTestCase{
+		{
+			name:      "Complete API response",
+			projectID: testProjectID,
+			apiResp: &admin.PushBasedLogExportProject{
+				BucketName: admin.PtrString(testBucketName),
+				CreateDate: admin.PtrTime(currentTime),
+				IamRoleId:  admin.PtrString(testIAMRoleID),
+				PrefixPath: admin.PtrString(testPrefixPath),
+				State:      admin.PtrString(activeState),
+			},
+			expectedTFModel: &pushbasedlogexport.TFPushBasedLogExportRSModel{
+				ProjectID:  types.StringValue(testProjectID),
+				BucketName: types.StringValue(testBucketName),
+				IamRoleID:  types.StringValue(testIAMRoleID),
+				PrefixPath: types.StringValue(testPrefixPath),
+				State:      types.StringValue(activeState),
+				CreateDate: types.StringPointerValue(conversion.TimePtrToStringPtr(&currentTime)),
+			},
+		},
+		{
+			name:      "Complete API response with empty prefix path",
+			projectID: testProjectID,
+			apiResp: &admin.PushBasedLogExportProject{
+				BucketName: admin.PtrString(testBucketName),
+				CreateDate: admin.PtrTime(currentTime),
+				IamRoleId:  admin.PtrString(testIAMRoleID),
+				PrefixPath: admin.PtrString(prefixPathEmpty),
+				State:      admin.PtrString(activeState),
+			},
+			expectedTFModel: &pushbasedlogexport.TFPushBasedLogExportRSModel{
+				ProjectID:  types.StringValue(testProjectID),
+				BucketName: types.StringValue(testBucketName),
+				IamRoleID:  types.StringValue(testIAMRoleID),
+				PrefixPath: types.StringValue(prefixPathEmpty),
+				State:      types.StringValue(activeState),
+				CreateDate: types.StringPointerValue(conversion.TimePtrToStringPtr(&currentTime)),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resultModel, _ := pushbasedlogexport.NewTFPushBasedLogExport(context.Background(), tc.projectID, tc.apiResp, tc.timeout)
+			if !reflect.DeepEqual(resultModel, tc.expectedTFModel) {
+				t.Errorf("result model does not match expected output: expected %+v, got %+v", tc.expectedTFModel, resultModel)
+			}
+		})
+	}
+}
+
+type pushBasedLogExportReqTestCase struct {
+	input             *pushbasedlogexport.TFPushBasedLogExportRSModel
+	expectedCreateReq *admin.CreatePushBasedLogExportProjectRequest
+	expectedUpdateReq *admin.PushBasedLogExportProject
+	name              string
+}
+
+func TestNewPushBasedLogExportReq(t *testing.T) {
+	testCases := []pushBasedLogExportReqTestCase{
+		{
+			name: "Valid TF state",
+			input: &pushbasedlogexport.TFPushBasedLogExportRSModel{
+				BucketName: types.StringValue(testBucketName),
+				IamRoleID:  types.StringValue(testIAMRoleID),
+				PrefixPath: types.StringValue(testPrefixPath),
+			},
+			expectedCreateReq: &admin.CreatePushBasedLogExportProjectRequest{
+				BucketName: testBucketName,
+				IamRoleId:  testIAMRoleID,
+				PrefixPath: testPrefixPath,
+			},
+			expectedUpdateReq: &admin.PushBasedLogExportProject{
+				BucketName: admin.PtrString(testBucketName),
+				IamRoleId:  admin.PtrString(testIAMRoleID),
+				PrefixPath: admin.PtrString(testPrefixPath),
+			},
+		},
+		{
+			name: "Valid TF state",
+			input: &pushbasedlogexport.TFPushBasedLogExportRSModel{
+				BucketName: types.StringValue(testBucketName),
+				IamRoleID:  types.StringValue(testIAMRoleID),
+				PrefixPath: types.StringValue(prefixPathEmpty),
+			},
+			expectedCreateReq: &admin.CreatePushBasedLogExportProjectRequest{
+				BucketName: testBucketName,
+				IamRoleId:  testIAMRoleID,
+				PrefixPath: prefixPathEmpty,
+			},
+			expectedUpdateReq: &admin.PushBasedLogExportProject{
+				BucketName: admin.PtrString(testBucketName),
+				IamRoleId:  admin.PtrString(testIAMRoleID),
+				PrefixPath: admin.PtrString(prefixPathEmpty),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name+" Create", func(t *testing.T) {
+			createReq := pushbasedlogexport.NewPushBasedLogExportCreateReq(tc.input)
+			if !reflect.DeepEqual(createReq, tc.expectedCreateReq) {
+				t.Errorf("Create request does not match expected output: expected %+v, got %+v", tc.expectedCreateReq, createReq)
+			}
+		})
+		t.Run(tc.name+" Update", func(t *testing.T) {
+			updateReq := pushbasedlogexport.NewPushBasedLogExportUpdateReq(tc.input)
+			if !reflect.DeepEqual(updateReq, tc.expectedUpdateReq) {
+				t.Errorf("Update request does not match expected output: expected %+v, got %+v", tc.expectedUpdateReq, updateReq)
+			}
+		})
+	}
+}

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -110,9 +110,7 @@ func addAttrChecks(checks []resource.TestCheckFunc, mapChecks map[string]string)
 func configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath string, usePrefixPath bool) string {
 	test := fmt.Sprintf(`
 	 	locals {
-		 		#project_name = %[1]q
 				project_id = %[1]q
-		 		#org_id = %[2]q
 		 		s3_bucket_name_1 = %[2]q
 				s3_bucket_name_2 = %[3]q
 		 		s3_bucket_policy_name = %[4]q
@@ -131,9 +129,7 @@ func configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, aw
 func configBasicUpdated(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, prefixPath string, usePrefixPath bool) string {
 	test := fmt.Sprintf(`
 	 	locals {
-			#project_name = %[1]q
 				project_id = %[1]q
-		 		#org_id = %[2]q
 		 		s3_bucket_name_1 = %[2]q
 				s3_bucket_name_2 = %[3]q
 		 		s3_bucket_policy_name = %[4]q

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -71,7 +71,7 @@ func noPrefixPathTestCase(tb testing.TB) *resource.TestCase {
 
 	var (
 		projectID            = acc.ProjectIDExecution(tb)
-		s3BucketNamePrefix   = fmt.Sprintf("tf-%s", acc.RandomName())
+		s3BucketNamePrefix   = acc.RandomS3BucketName()
 		s3BucketName1        = fmt.Sprintf("%s-1", s3BucketNamePrefix)
 		s3BucketName2        = fmt.Sprintf("%s-2", s3BucketNamePrefix)
 		s3BucketPolicyName   = fmt.Sprintf("%s-s3-policy", s3BucketNamePrefix)

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -3,6 +3,7 @@ package pushbasedlogexport_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -17,6 +18,12 @@ const (
 	datasourceName     = "data.mongodbatlas_push_based_log_export.test"
 	nonEmptyPrefixPath = "push-log-prefix"
 	defaultPrefixPath  = ""
+)
+
+var (
+	awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+	awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	awsRegion    = os.Getenv("AWS_REGION")
 )
 
 func TestAccPushBasedLogExport_basic(t *testing.T) {
@@ -121,8 +128,10 @@ func configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, aw
 			   %[7]s
 
 			   %[8]s
+
+			   %[9]s
 	`, projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName,
-		awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(false, usePrefixPath, prefixPath))
+		awsProviderConfig(), awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(false, usePrefixPath, prefixPath))
 	return test
 }
 
@@ -140,8 +149,10 @@ func configBasicUpdated(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyN
 			   %[7]s
 
 			   %[8]s
+
+			   %[9]s
 	`, projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName,
-		awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(true, usePrefixPath, prefixPath)) // updating the S3 bucket to use for push-based log config
+		awsProviderConfig(), awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(true, usePrefixPath, prefixPath)) // updating the S3 bucket to use for push-based log config
 	return test
 }
 
@@ -292,6 +303,15 @@ resource "aws_iam_role_policy" "s3_bucket_policy" {
   EOF
 }
 		`
+}
+
+func awsProviderConfig() string {
+	return fmt.Sprintf(`
+	provider "aws" {
+		region        = "%[1]s"
+		access_key = "%[2]s"
+		secret_key = "%[3]s"
+	}`, awsRegion, awsAccessKey, awsSecretKey)
 }
 
 func checkDestroy(state *terraform.State) error {

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -3,7 +3,6 @@ package pushbasedlogexport_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,12 +19,6 @@ const (
 	defaultPrefixPath  = ""
 )
 
-var (
-	awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
-	awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	awsRegion    = os.Getenv("AWS_REGION")
-)
-
 func TestAccPushBasedLogExport_basic(t *testing.T) {
 	resource.Test(t, *basicTestCase(t))
 }
@@ -35,7 +28,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 
 	var (
 		projectID            = acc.ProjectIDExecution(tb)
-		s3BucketNamePrefix   = fmt.Sprintf("tf-%s", acc.RandomName())
+		s3BucketNamePrefix   = acc.RandomS3BucketName()
 		s3BucketName1        = fmt.Sprintf("%s-1", s3BucketNamePrefix)
 		s3BucketName2        = fmt.Sprintf("%s-2", s3BucketNamePrefix)
 		s3BucketPolicyName   = fmt.Sprintf("%s-s3-policy", s3BucketNamePrefix)
@@ -127,11 +120,9 @@ func configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, aw
 
 			   %[7]s
 
-			   %[8]s
-
-			   %[9]s
+			   %[8]s		
 	`, projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName,
-		awsProviderConfig(), awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(false, usePrefixPath, prefixPath))
+		awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(false, usePrefixPath, prefixPath))
 	return test
 }
 
@@ -149,10 +140,8 @@ func configBasicUpdated(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyN
 			   %[7]s
 
 			   %[8]s
-
-			   %[9]s
 	`, projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName,
-		awsProviderConfig(), awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(true, usePrefixPath, prefixPath)) // updating the S3 bucket to use for push-based log config
+		awsIAMroleAuthAndS3Config(), pushBasedLogExportConfig(true, usePrefixPath, prefixPath)) // updating the S3 bucket to use for push-based log config
 	return test
 }
 
@@ -303,15 +292,6 @@ resource "aws_iam_role_policy" "s3_bucket_policy" {
   EOF
 }
 		`
-}
-
-func awsProviderConfig() string {
-	return fmt.Sprintf(`
-	provider "aws" {
-		region        = "%[1]s"
-		access_key = "%[2]s"
-		secret_key = "%[3]s"
-	}`, awsRegion, awsAccessKey, awsSecretKey)
 }
 
 func checkDestroy(state *terraform.State) error {

--- a/internal/service/pushbasedlogexport/state_transition_test.go
+++ b/internal/service/pushbasedlogexport/state_transition_test.go
@@ -1,0 +1,166 @@
+package pushbasedlogexport_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.mongodb.org/atlas-sdk/v20231115010/admin"
+	"go.mongodb.org/atlas-sdk/v20231115010/mockadmin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/pushbasedlogexport"
+)
+
+var (
+	activeState           = "ACTIVE"
+	unconfiguredState     = "UNCONFIGURED"
+	initiatingState       = "INITIATING"
+	bucketVerifiedState   = "BUCKET_VERIFIED"
+	assumeRoleFailedState = "ASSUME_ROLE_FAILED"
+	unknown               = ""
+	sc500                 = conversion.IntPtr(500)
+	currentTime           = time.Now()
+)
+
+var testTimeoutConfig = retrystrategy.TimeConfig{
+	Timeout:    30 * time.Second,
+	MinTimeout: 100 * time.Millisecond,
+	Delay:      0,
+}
+
+type testCase struct {
+	expectedState *string
+	name          string
+	mockResponses []response
+	expectedError bool
+}
+
+func TestPushBasedLogExportStateTransition(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Successful transition to ACTIVE",
+			mockResponses: []response{
+				{state: &initiatingState},
+				{state: &bucketVerifiedState},
+				{state: &activeState},
+			},
+			expectedState: &activeState,
+			expectedError: false,
+		},
+		{
+			name: "Error when transitioning to an unknown state",
+			mockResponses: []response{
+				{state: &initiatingState},
+				{state: &assumeRoleFailedState},
+			},
+			expectedState: nil,
+			expectedError: true,
+		},
+		{
+			name: "Error when API responds with error",
+			mockResponses: []response{
+				{statusCode: sc500, err: errors.New("Internal server error")},
+			},
+			expectedState: nil,
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mockadmin.NewPushBasedLogExportApi(t)
+			m.EXPECT().GetPushBasedLogConfiguration(mock.Anything, mock.Anything).Return(admin.GetPushBasedLogConfigurationApiRequest{ApiService: m})
+
+			for _, resp := range tc.mockResponses {
+				modelResp, httpResp, err := resp.get()
+				m.EXPECT().GetPushBasedLogConfigurationExecute(mock.Anything).Return(modelResp, httpResp, err).Once()
+			}
+			resp, err := pushbasedlogexport.WaitStateTransition(context.Background(), testProjectID, m, testTimeoutConfig)
+			assert.Equal(t, tc.expectedError, err != nil)
+			assert.Equal(t, responseWithState(tc.expectedState), resp)
+		})
+	}
+}
+
+func TestPushBasedLogExportStateTransitionForDelete(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Successful transition to UNCONFIGURED from ACTIVE",
+			mockResponses: []response{
+				{state: &activeState},
+				{state: &unconfiguredState},
+			},
+			expectedError: false,
+		},
+		{
+			name: "Successful transition to UNCONFIGURED",
+			mockResponses: []response{
+				{state: &unconfiguredState},
+			},
+			expectedError: false,
+		},
+		{
+			name: "Error when API responds with error",
+			mockResponses: []response{
+				{statusCode: sc500, err: errors.New("Internal server error")},
+			},
+			expectedError: true,
+		},
+		{
+			name: "Failed delete when responding with unknown state",
+			mockResponses: []response{
+				{state: &activeState},
+				{state: &unknown},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mockadmin.NewPushBasedLogExportApi(t)
+			m.EXPECT().GetPushBasedLogConfiguration(mock.Anything, mock.Anything).Return(admin.GetPushBasedLogConfigurationApiRequest{ApiService: m})
+
+			for _, resp := range tc.mockResponses {
+				modelResp, httpResp, err := resp.get()
+				m.EXPECT().GetPushBasedLogConfigurationExecute(mock.Anything).Return(modelResp, httpResp, err).Once()
+			}
+			err := pushbasedlogexport.WaitResourceDelete(context.Background(), testProjectID, m, testTimeoutConfig)
+			assert.Equal(t, tc.expectedError, err != nil)
+		})
+	}
+}
+
+type response struct {
+	state      *string
+	statusCode *int
+	err        error
+}
+
+func (r *response) get() (*admin.PushBasedLogExportProject, *http.Response, error) {
+	var httpResp *http.Response
+	if r.statusCode != nil {
+		httpResp = &http.Response{StatusCode: *r.statusCode}
+	}
+	return responseWithState(r.state), httpResp, r.err
+}
+
+func responseWithState(state *string) *admin.PushBasedLogExportProject {
+	if state == nil {
+		return nil
+	}
+	return &admin.PushBasedLogExportProject{
+		BucketName: admin.PtrString(testBucketName),
+		CreateDate: admin.PtrTime(currentTime),
+		IamRoleId:  admin.PtrString(testIAMRoleID),
+		PrefixPath: admin.PtrString(testPrefixPath),
+		State:      state,
+	}
+}

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	prefixName    = "test-acc-tf"
-	prefixProject = prefixName + "-p"
-	prefixCluster = prefixName + "-c"
-	prefixIAMRole = "mongodb-atlas-" + prefixName
-	prefixIAMUser = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
+	prefixName     = "test-acc-tf"
+	prefixProject  = prefixName + "-p"
+	prefixCluster  = prefixName + "-c"
+	prefixIAMRole  = "mongodb-atlas-" + prefixName
+	prefixIAMUser  = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
+	prefixS3Bucket = "mongodb-atlas"
 )
 
 func RandomName() string {
@@ -44,4 +45,8 @@ func RandomEmail() string {
 
 func RandomLDAPName() string {
 	return fmt.Sprintf("CN=%s-%s@example.com,OU=users,DC=example,DC=com", prefixName, acctest.RandString(10))
+}
+
+func RandomS3BucketName() string {
+	return fmt.Sprintf("%s-%s", prefixS3Bucket, acctest.RandString(10))
 }

--- a/internal/testutil/acc/name.go
+++ b/internal/testutil/acc/name.go
@@ -12,7 +12,7 @@ const (
 	prefixCluster  = prefixName + "-c"
 	prefixIAMRole  = "mongodb-atlas-" + prefixName
 	prefixIAMUser  = "arn:aws:iam::358363220050:user/mongodb-aws-iam-auth-test-user"
-	prefixS3Bucket = "mongodb-atlas"
+	prefixS3Bucket = "mongodb-atlas-tf"
 )
 
 func RandomName() string {


### PR DESCRIPTION
## Description

Enables mongodbatlas_push_based_log_export tests in CI and adds unit tests

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-240975

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
