### PR TITLE
deprecate: Deprecates unused pagination attributes in `federated_settings_identity_providers`

### DIFF
--- a/.changelog/2207.txt
+++ b/.changelog/2207.txt
@@ -1,0 +1,3 @@
+```release-note:note
+data-source/mongodbatlas_federated_settings_identity_providers: Deprecates `page_num` and `items_per_page` attributes. They are not being used and will not be relevant once all results all fetched internally. 
+```

--- a/.changelog/2207.txt
+++ b/.changelog/2207.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-data-source/mongodbatlas_federated_settings_identity_providers: Deprecates `page_num` and `items_per_page` attributes. They are not being used and will not be relevant once all results all fetched internally. 
+data-source/mongodbatlas_federated_settings_identity_providers: Deprecates `page_num` and `items_per_page` attributes. They are not being used and will not be relevant once all results are fetched internally. 
 ```

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
@@ -260,8 +260,8 @@ func dataSourceMongoDBAtlasFederatedSettingsIdentityProvidersRead(ctx context.Co
 		return diag.FromErr(errors.New("federation_settings_id must be configured"))
 	}
 
-	// once the SDK is upgraded to version v20231115010 we can use pagination parameters to iterate over all results
-	// pagination attribute are deprecated and can be removed as we move towards not exposing these pagination options to the user
+	// once the SDK is upgraded above version v20231115010 we can use pagination parameters to iterate over all results (and adjust documentation)
+	// pagination attributes are deprecated and can be removed as we move towards not exposing these pagination options to the user
 	params := &admin20231115008.ListIdentityProvidersApiParams{
 		FederationSettingsId: federationSettingsID.(string),
 		Protocol:             &[]string{OIDC, SAML},

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -22,12 +23,14 @@ func PluralDataSource() *schema.Resource {
 				Required: true,
 			},
 			"page_num": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 			},
 			"items_per_page": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:       schema.TypeInt,
+				Optional:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 			},
 			"results": {
 				Type:     schema.TypeList,
@@ -257,6 +260,8 @@ func dataSourceMongoDBAtlasFederatedSettingsIdentityProvidersRead(ctx context.Co
 		return diag.FromErr(errors.New("federation_settings_id must be configured"))
 	}
 
+	// once the SDK is upgraded to version v20231115010 we can use pagination parameters to iterate over all results
+	// pagination attribute are deprecated and can be removed as we move towards not exposing these pagination options
 	params := &admin20231115008.ListIdentityProvidersApiParams{
 		FederationSettingsId: federationSettingsID.(string),
 		Protocol:             &[]string{OIDC, SAML},

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers.go
@@ -261,7 +261,7 @@ func dataSourceMongoDBAtlasFederatedSettingsIdentityProvidersRead(ctx context.Co
 	}
 
 	// once the SDK is upgraded to version v20231115010 we can use pagination parameters to iterate over all results
-	// pagination attribute are deprecated and can be removed as we move towards not exposing these pagination options
+	// pagination attribute are deprecated and can be removed as we move towards not exposing these pagination options to the user
 	params := &admin20231115008.ListIdentityProvidersApiParams{
 		FederationSettingsId: federationSettingsID.(string),
 		Protocol:             &[]string{OIDC, SAML},

--- a/website/docs/d/federated_settings_identity_providers.html.markdown
+++ b/website/docs/d/federated_settings_identity_providers.html.markdown
@@ -34,8 +34,8 @@ data "mongodbatlas_federated_settings_identity_providers" "identitty_provider" {
 ## Argument Reference
 
 * `federation_settings_id` - (Required) Unique 24-hexadecimal digit string that identifies the federated authentication configuration.
-* `page_num` - (Optional)  	The page to return. Defaults to `1`.
-* `items_per_page` - (Optional) Number of items to return per page, up to a maximum of 500. Defaults to `100`.
+* `page_num` - (Optional) The page to return. Defaults to `1`. **Note**: This attribute is deprecated and not being used.
+* `items_per_page` - (Optional) Number of items to return per page, up to a maximum of 500. Defaults to `100`. **Note**: This attribute is deprecated and not being used. The implementation is currently limited to returning a maximum of 100 results.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-221367

### Current state

`federated_settings_identity_providers` defines 2 paginations attributes which are not being used. Users are not aware of this in any way. 
Why we cant use them? The fixed SDK version used in `federated_settings_identity_providers` does not expose these parameters, and while the latest version does have them we cannot make this upgrade as it has a breaking change. This upgrade will be handled as part of CLOUDP-220481 epic.

### New state

Both attributes are deprecated (targeting 1.18.0) and clarified in docs that they are not useful.
Once we are able to use the latest SDK version, we can iterate over all results internally (moving toward the direction of not exposing pagination options to users).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
