### PR TITLE
feat: Adds new `integration_id` attribute in `mongodbatlas_alert_configuration`

### DIFF
--- a/.changelog/2212.txt
+++ b/.changelog/2212.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_alert_configuration: Adds `integration_id` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_alert_configuration: Adds `integration_id` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_alert_configurations: Adds `integration_id` attribute
+```

--- a/internal/service/alertconfiguration/data_source_alert_configuration.go
+++ b/internal/service/alertconfiguration/data_source_alert_configuration.go
@@ -206,6 +206,9 @@ var alertConfigDSSchemaAttributes = map[string]schema.Attribute{
 				"notifier_id": schema.StringAttribute{
 					Computed: true,
 				},
+				"integration_id": schema.StringAttribute{
+					Computed: true,
+				},
 				"type_name": schema.StringAttribute{
 					Computed: true,
 				},

--- a/internal/service/alertconfiguration/model_alert_configuration.go
+++ b/internal/service/alertconfiguration/model_alert_configuration.go
@@ -46,6 +46,7 @@ func NewNotificationList(list []TfNotificationModel) (*[]admin.AlertsNotificatio
 			MicrosoftTeamsWebhookUrl: n.MicrosoftTeamsWebhookURL.ValueStringPointer(),
 			WebhookSecret:            n.WebhookSecret.ValueStringPointer(),
 			WebhookUrl:               n.WebhookURL.ValueStringPointer(),
+			IntegrationId:            n.IntegrationID.ValueStringPointer(),
 		}
 		if !n.NotifierID.IsUnknown() {
 			notifications[i].NotifierId = n.NotifierID.ValueStringPointer()
@@ -127,6 +128,7 @@ func NewTFNotificationModelList(n []admin.AlertsNotificationRootForGroup, currSt
 				OpsGenieRegion: conversion.StringPtrNullIfEmpty(value.OpsGenieRegion),
 				TeamID:         conversion.StringPtrNullIfEmpty(value.TeamId),
 				NotifierID:     types.StringPointerValue(value.NotifierId),
+				IntegrationID:  types.StringPointerValue(value.IntegrationId),
 				TypeName:       conversion.StringPtrNullIfEmpty(value.TypeName),
 				Username:       conversion.StringPtrNullIfEmpty(value.Username),
 				EmailEnabled:   types.BoolValue(value.EmailEnabled != nil && *value.EmailEnabled),
@@ -153,6 +155,7 @@ func NewTFNotificationModelList(n []admin.AlertsNotificationRootForGroup, currSt
 			WebhookSecret:            conversion.StringNullIfEmpty(currState.WebhookSecret.ValueString()),
 			MicrosoftTeamsWebhookURL: conversion.StringNullIfEmpty(currState.MicrosoftTeamsWebhookURL.ValueString()),
 			NotifierID:               types.StringPointerValue(value.NotifierId),
+			IntegrationID:            types.StringPointerValue(value.IntegrationId),
 			IntervalMin:              types.Int64PointerValue(conversion.IntPtrToInt64Ptr(value.IntervalMin)),
 			DelayMin:                 types.Int64PointerValue(conversion.IntPtrToInt64Ptr(value.DelayMin)),
 			EmailEnabled:             types.BoolValue(value.EmailEnabled != nil && *value.EmailEnabled),

--- a/internal/service/alertconfiguration/model_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/model_alert_configuration_test.go
@@ -22,6 +22,7 @@ const (
 	threshold           float64 = 99.0
 	units               string  = "RAW"
 	mode                string  = "AVERAGE"
+	integrationID       string  = "fake-intregration-id"
 )
 
 var (
@@ -39,14 +40,15 @@ func TestNotificationSDKToTFModel(t *testing.T) {
 			name: "Complete SDK response",
 			SDKResp: &[]admin.AlertsNotificationRootForGroup{
 				{
-					TypeName:     admin.PtrString(group),
-					IntervalMin:  admin.PtrInt(intervalMin),
-					DelayMin:     admin.PtrInt(delayMin),
-					SmsEnabled:   admin.PtrBool(disabled),
-					EmailEnabled: admin.PtrBool(enabled),
-					ChannelName:  admin.PtrString("#channel"),
-					Roles:        &roles,
-					ApiToken:     admin.PtrString("newApiToken"),
+					TypeName:      admin.PtrString(group),
+					IntervalMin:   admin.PtrInt(intervalMin),
+					DelayMin:      admin.PtrInt(delayMin),
+					SmsEnabled:    admin.PtrBool(disabled),
+					EmailEnabled:  admin.PtrBool(enabled),
+					ChannelName:   admin.PtrString("#channel"),
+					Roles:         &roles,
+					ApiToken:      admin.PtrString("newApiToken"),
+					IntegrationId: admin.PtrString(integrationID),
 				},
 			},
 			currentStateNotifications: []alertconfiguration.TfNotificationModel{
@@ -62,14 +64,15 @@ func TestNotificationSDKToTFModel(t *testing.T) {
 			},
 			expectedTFModel: []alertconfiguration.TfNotificationModel{
 				{
-					TypeName:     types.StringValue(group),
-					IntervalMin:  types.Int64Value(int64(intervalMin)),
-					DelayMin:     types.Int64Value(int64(delayMin)),
-					SMSEnabled:   types.BoolValue(disabled),
-					EmailEnabled: types.BoolValue(enabled),
-					ChannelName:  types.StringNull(),
-					APIToken:     types.StringValue("apiToken"),
-					Roles:        roles,
+					TypeName:      types.StringValue(group),
+					IntervalMin:   types.Int64Value(int64(intervalMin)),
+					DelayMin:      types.Int64Value(int64(delayMin)),
+					SMSEnabled:    types.BoolValue(disabled),
+					EmailEnabled:  types.BoolValue(enabled),
+					ChannelName:   types.StringNull(),
+					APIToken:      types.StringValue("apiToken"),
+					Roles:         roles,
+					IntegrationID: types.StringValue(integrationID),
 				},
 			},
 		},
@@ -265,22 +268,24 @@ func TestNotificationTFModelToSDK(t *testing.T) {
 			name: "Complete TF model",
 			tfModel: []alertconfiguration.TfNotificationModel{
 				{
-					TypeName:     types.StringValue(group),
-					IntervalMin:  types.Int64Value(int64(intervalMin)),
-					DelayMin:     types.Int64Value(int64(delayMin)),
-					SMSEnabled:   types.BoolValue(disabled),
-					EmailEnabled: types.BoolValue(enabled),
-					Roles:        roles,
+					TypeName:      types.StringValue(group),
+					IntervalMin:   types.Int64Value(int64(intervalMin)),
+					DelayMin:      types.Int64Value(int64(delayMin)),
+					SMSEnabled:    types.BoolValue(disabled),
+					EmailEnabled:  types.BoolValue(enabled),
+					Roles:         roles,
+					IntegrationID: types.StringValue(integrationID),
 				},
 			},
 			expectedSDKReq: &[]admin.AlertsNotificationRootForGroup{
 				{
-					TypeName:     admin.PtrString(group),
-					IntervalMin:  admin.PtrInt(intervalMin),
-					DelayMin:     admin.PtrInt(delayMin),
-					SmsEnabled:   admin.PtrBool(disabled),
-					EmailEnabled: admin.PtrBool(enabled),
-					Roles:        &roles,
+					TypeName:      admin.PtrString(group),
+					IntervalMin:   admin.PtrInt(intervalMin),
+					DelayMin:      admin.PtrInt(delayMin),
+					SmsEnabled:    admin.PtrBool(disabled),
+					EmailEnabled:  admin.PtrBool(enabled),
+					Roles:         &roles,
+					IntegrationId: admin.PtrString(integrationID),
 				},
 			},
 		},

--- a/internal/service/alertconfiguration/resource_alert_configuration.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration.go
@@ -101,6 +101,7 @@ type TfNotificationModel struct {
 	TeamID                   types.String `tfsdk:"team_id"`
 	TeamName                 types.String `tfsdk:"team_name"`
 	NotifierID               types.String `tfsdk:"notifier_id"`
+	IntegrationID            types.String `tfsdk:"integration_id"`
 	TypeName                 types.String `tfsdk:"type_name"`
 	ChannelName              types.String `tfsdk:"channel_name"`
 	VictorOpsAPIKey          types.String `tfsdk:"victor_ops_api_key"`
@@ -319,6 +320,9 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						},
 						"notifier_id": schema.StringAttribute{
 							Computed: true,
+							Optional: true,
+						},
+						"integration_id": schema.StringAttribute{
 							Optional: true,
 						},
 						"type_name": schema.StringAttribute{

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -277,3 +277,10 @@ func PreCheckS3Bucket(tb testing.TB) {
 		tb.Fatal("`AWS_S3_BUCKET` must be set ")
 	}
 }
+
+func PreCheckPagerDutyIntegrationID(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_PAGER_DUTY_THIRD_PARTY_INTEGRATION_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PAGER_DUTY_THIRD_PARTY_INTEGRATION_ID` must be set ")
+	}
+}

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -226,6 +226,7 @@ Notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
+* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
 * `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.

--- a/website/docs/d/alert_configuration.html.markdown
+++ b/website/docs/d/alert_configuration.html.markdown
@@ -226,8 +226,8 @@ Notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
-* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
-* `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
+* `integration_id` - The ID of the associated integration, the credentials of which to use for requests.
+* `notifier_id` - The notifier ID is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `victor_ops_routing_key` - VictorOps routing key. Optional for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -170,6 +170,7 @@ Notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
+* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
 * `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.

--- a/website/docs/d/alert_configurations.html.markdown
+++ b/website/docs/d/alert_configurations.html.markdown
@@ -170,8 +170,8 @@ Notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
-* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
-* `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
+* `integration_id` - The ID of the associated integration, the credentials of which to use for requests.
+* `notifier_id` - The notifier ID is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `victor_ops_routing_key` - VictorOps routing key. Optional for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -25,6 +25,7 @@ resource "mongodbatlas_third_party_integration" "test_datadog" {
 
 data "mongodbatlas_third_party_integration" "test" {
 	project_id = mongodbatlas_third_party_integration.test_datadog.project_id
+  type = "DATADOG"
 }
 ```
 

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -239,8 +239,8 @@ List of notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
-* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
-* `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
+* `integration_id` - The ID of the associated integration, the credentials of which to use for requests.
+* `notifier_id` - The notifier ID is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.
 * `victor_ops_routing_key` - VictorOps routing key. Optional for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -119,6 +119,22 @@ resource "mongodbatlas_alert_configuration" "test" {
 }
 ```
 
+### Create third party notification using credentials from existing third party integration
+
+
+```terraform
+resource "mongodbatlas_alert_configuration" "test" {
+  project_id = "PROJECT ID"
+  enabled    = true
+  event_type = "USERS_WITHOUT_MULTI_FACTOR_AUTH"
+
+  notification {
+    type_name     = "PAGER_DUTY"
+    integration_id = "THIRD PARTY INTEGRATION ID"
+  }
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) The ID of the project where the alert configuration will create.
@@ -223,6 +239,7 @@ List of notifications to send when an alert condition is detected.
     - `WEBHOOK`
     - `MICROSOFT_TEAMS`
 
+* `integration_id` - The id of the associated integration, the credentials of which to use for requests.
 * `notifier_id` - The notifier id is a system-generated unique identifier assigned to each notification method. This is needed when updating third-party notifications without requiring explicit authentication credentials.
 * `username` - Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Required for the `USER` notifications type.
 * `victor_ops_api_key` - VictorOps API key. Required for the `VICTOR_OPS` notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUD-228077


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
