### PR TITLE
feat: Defines id value returned from API for `third_party_integration` resource and data sources

### DIFF
--- a/.changelog/2217.txt
+++ b/.changelog/2217.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_third_party_integration: New `id` value which can be used for referencing a third party integration
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_third_party_integration: New `id` value which can be used for referencing a third party integration
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_third_party_integrations: New `id` value which can be used for referencing a third party integration
+```

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -430,7 +430,7 @@ func TestAccConfigAlertConfiguration_PagerDutyUsingIntegrationID(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckPagerDutyIntegrationID(t); acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6FactoriesWithProxy(proxyPort),
 		CheckDestroy:             checkDestroyUsingProxy(proxyPort),
 		Steps: []resource.TestStep{

--- a/internal/service/thirdpartyintegration/data_source_third_party_integration.go
+++ b/internal/service/thirdpartyintegration/data_source_third_party_integration.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -32,6 +31,10 @@ func DataSource() *schema.Resource {
 func thirdPartyIntegrationSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"project_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -128,10 +131,6 @@ func dataSourceMongoDBAtlasThirdPartyIntegrationRead(ctx context.Context, d *sch
 		}
 	}
 
-	d.SetId(conversion.EncodeStateID(map[string]string{
-		"project_id": projectID,
-		"type":       queryType,
-	}))
-
+	d.SetId(integration.GetId())
 	return nil
 }

--- a/internal/service/thirdpartyintegration/data_source_third_party_integrations.go
+++ b/internal/service/thirdpartyintegration/data_source_third_party_integrations.go
@@ -91,6 +91,7 @@ func integrationToSchema(d *schema.ResourceData, integration *admin.ThirdPartyIn
 	}
 
 	out := map[string]any{
+		"id":                          integration.Id,
 		"type":                        integration.Type,
 		"api_key":                     integrationSchema.ApiKey,
 		"region":                      integration.Region,

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -277,10 +277,3 @@ func PreCheckS3Bucket(tb testing.TB) {
 		tb.Fatal("`AWS_S3_BUCKET` must be set ")
 	}
 }
-
-func PreCheckPagerDutyIntegrationID(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PAGER_DUTY_THIRD_PARTY_INTEGRATION_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PAGER_DUTY_THIRD_PARTY_INTEGRATION_ID` must be set ")
-	}
-}

--- a/website/docs/d/third_party_integration.markdown
+++ b/website/docs/d/third_party_integration.markdown
@@ -45,8 +45,7 @@ data "mongodbatlas_third_party_integration" "test" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Unique identifier used for terraform for internal manages and can be used to import.
-* `type` -  Property equal to its own integration type
+* `id` - Unique identifier of the integration.
 
 Additional values based on Type
 

--- a/website/docs/d/third_party_integrations.markdown
+++ b/website/docs/d/third_party_integrations.markdown
@@ -48,8 +48,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Third-Party Service Integration 
 
-* `project_id`  - (Required) ID of the Atlas project the Third-Party Service Integration belongs to.
-* `type`        - (Required) Thirt-Party service integration type.
+* `project_id` - ID of the Atlas project the Third-Party Service Integration belongs to.
+* `type` - Thirt-Party service integration type.
+* `id` - Unique identifier of the integration.
 
      * PAGER_DUTY
      * DATADOG

--- a/website/docs/r/alert_configuration.html.markdown
+++ b/website/docs/r/alert_configuration.html.markdown
@@ -123,6 +123,11 @@ resource "mongodbatlas_alert_configuration" "test" {
 
 
 ```terraform
+data "mongodbatlas_third_party_integration" "test" {
+    project_id = "PROJECT ID"
+    type = "PAGER_DUTY"
+}
+
 resource "mongodbatlas_alert_configuration" "test" {
   project_id = "PROJECT ID"
   enabled    = true
@@ -130,7 +135,7 @@ resource "mongodbatlas_alert_configuration" "test" {
 
   notification {
     type_name     = "PAGER_DUTY"
-    integration_id = "THIRD PARTY INTEGRATION ID"
+    integration_id = data.mongodbatlas_third_party_integration.test.id
   }
 }
 ```

--- a/website/docs/r/third_party_integration.markdown
+++ b/website/docs/r/third_party_integration.markdown
@@ -71,7 +71,7 @@ resource "mongodbatlas_third_party_integration" "test_datadog" {
 
 ## Attributes Reference
 
-* `id` - Unique identifier used by terraform for internal management, which can also be used to import.
+* `id` - Unique identifier of the integration.
 
 ## Import
 


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-245942

Modifies value of `id` attribute in `mongodbatlas_third_party_integration` resource and data sources. This enables referencing a third party integration resource/data source directly when making use of `integration_id` in `mongodbatlas_alert_configuration`.

Not marking this as a breaking change as this value was previously an encoded value which was of no use for external users (also mentioned in [docs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/third_party_integration#attributes-reference) that is was for internal management).


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
