### PR TITLE
fix: Fixes `mongodbatlas_ldap_configuration` Delete function

### DIFF
--- a/.changelog/2221.txt
+++ b/.changelog/2221.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_ldap_configuration: Disables LDAP when the resource is destroyed, instead of deleting userToDNMapping document 
+```

--- a/internal/service/ldapconfiguration/resource_ldap_configuration.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration.go
@@ -242,7 +242,13 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
-	_, _, err := connV2.LDAPConfigurationApi.DeleteLDAPConfiguration(ctx, d.Id()).Execute()
+	params := &admin.UserSecurity{
+		Ldap: &admin.LDAPSecuritySettings{
+			AuthenticationEnabled: conversion.Pointer(false),
+			AuthorizationEnabled:  conversion.Pointer(false),
+		},
+	}
+	_, _, err := connV2.LDAPConfigurationApi.SaveLDAPConfiguration(ctx, d.Id(), params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorDelete, d.Id(), err))
 	}

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_migration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_migration_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMigLDAPConfiguration_basic(t *testing.T) {
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -151,6 +151,7 @@ func configBasic(projectID, hostname, username, password string, authEnabled boo
 		
 		data "mongodbatlas_ldap_configuration" "test" {
 			project_id = mongodbatlas_ldap_configuration.test.id
+			depends_on = [mongodbatlas_ldap_configuration.test]
 		}
 	`, projectID, hostname, username, password, authEnabled, port)
 }

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -151,7 +151,6 @@ func configBasic(projectID, hostname, username, password string, authEnabled boo
 		
 		data "mongodbatlas_ldap_configuration" "test" {
 			project_id = mongodbatlas_ldap_configuration.test.id
-			depends_on = [mongodbatlas_ldap_configuration.test]
 		}
 	`, projectID, hostname, username, password, authEnabled, port)
 }

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -95,7 +95,6 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "hostname", hostname),
 					resource.TestCheckResourceAttr(dataSourceName, "bind_username", username),
-					resource.TestCheckResourceAttr(dataSourceName, "authentication_enabled", strconv.FormatBool(authEnabled)),
 					resource.TestCheckResourceAttr(dataSourceName, "port", port),
 				),
 			},

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -95,6 +95,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "hostname", hostname),
 					resource.TestCheckResourceAttr(dataSourceName, "bind_username", username),
+					resource.TestCheckResourceAttr(dataSourceName, "authentication_enabled", strconv.FormatBool(authEnabled)),
 					resource.TestCheckResourceAttr(dataSourceName, "port", port),
 				),
 			},

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestAccLDAPConfiguration_basic(t *testing.T) {
-	resource.ParallelTest(t, *basicTestCase(t))
+	resource.Test(t, *basicTestCase(t))
 }
 
 func TestAccLDAPConfiguration_withVerify_CACertificateComplete(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes `mongodbatlas_ldap_configuration` Delete function.

Disables LDAP authentication and authorization.  Previously it called [deleteLDAPConfiguration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/LDAP-Configuration/operation/deleteLDAPConfiguration) that deleted userToDNMapping document but kept LDAP enabled.

The same behavior is being done in CFN.

Link to any related issue(s): CLOUDP-246435

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
