### PR TITLE
fix: Fixes push-based log export migration tests

### DIFF
--- a/internal/service/pushbasedlogexport/resource_migration_test.go
+++ b/internal/service/pushbasedlogexport/resource_migration_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestMigPushBasedLogExport_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // this feature was introduced in provider version 1.16.0
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	mig.CreateTestAndRunUseExternalProvider(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }
 
 func TestMigPushBasedLogExport_noPrefixPath(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // this feature was introduced in provider version 1.16.0
-	mig.CreateAndRunTest(t, noPrefixPathTestCase(t))
+	mig.CreateTestAndRunUseExternalProvider(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }

--- a/internal/service/pushbasedlogexport/resource_migration_test.go
+++ b/internal/service/pushbasedlogexport/resource_migration_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestMigPushBasedLogExport_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // this feature was introduced in provider version 1.16.0
-	mig.CreateTestAndRunUseExternalProvider(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
+	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }
 
 func TestMigPushBasedLogExport_noPrefixPath(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // this feature was introduced in provider version 1.16.0
-	mig.CreateTestAndRunUseExternalProvider(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
+	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }

--- a/internal/service/pushbasedlogexport/resource_migration_test.go
+++ b/internal/service/pushbasedlogexport/resource_migration_test.go
@@ -13,5 +13,5 @@ func TestMigPushBasedLogExport_basic(t *testing.T) {
 
 func TestMigPushBasedLogExport_noPrefixPath(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.16.0") // this feature was introduced in provider version 1.16.0
-	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
+	mig.CreateTestAndRunUseExternalProviderNonParallel(t, noPrefixPathTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
 func CreateAndRunTest(t *testing.T, test *resource.TestCase) {
@@ -25,6 +26,12 @@ func CreateTestAndRunUseExternalProvider(t *testing.T, test *resource.TestCase, 
 	t.Helper()
 	acc.SkipInUnitTest(t) // Migration tests create external resources and use MONGODB_ATLAS_LAST_VERSION env-var.
 	resource.ParallelTest(t, CreateTestUseExternalProvider(t, test, externalProviders, additionalProviders))
+}
+
+func CreateTestAndRunUseExternalProviderNonParallel(t *testing.T, test *resource.TestCase, externalProviders, additionalProviders map[string]resource.ExternalProvider) {
+	t.Helper()
+	acc.SkipInUnitTest(t) // Migration tests create external resources and use MONGODB_ATLAS_LAST_VERSION env-var.
+	resource.Test(t, CreateTestUseExternalProvider(t, test, externalProviders, additionalProviders))
 }
 
 // CreateTest returns a new TestCase that reuses step 1 and adds a TestStepCheckEmptyPlan.


### PR DESCRIPTION
## Description

Fixes push-based log export migration tests

Link to any related issue(s):

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
