### PR TITLE
chore: Migrates `federated_query_limit` to new auto-generated SDK

### DIFF
--- a/internal/service/federatedquerylimit/data_source_federated_query_limits.go
+++ b/internal/service/federatedquerylimit/data_source_federated_query_limits.go
@@ -7,13 +7,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115012/admin"
 )
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasFederatedDatabaseQueryLimitsRead,
+		ReadContext: dataSourcesRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -27,25 +28,25 @@ func PluralDataSource() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
-					Schema: schemaMongoDBAtlasFederatedDatabaseQueryLimitDataSource(),
+					Schema: schemaDataSource(),
 				},
 			},
 		},
 	}
 }
 
-func dataSourceMongoDBAtlasFederatedDatabaseQueryLimitsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+func dataSourcesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	tenantName := d.Get("tenant_name").(string)
 
-	queryLimits, _, err := conn.DataFederation.ListQueryLimits(ctx, projectID, tenantName)
+	queryLimits, _, err := conn.DataFederationApi.ReturnFederatedDatabaseQueryLimits(ctx, projectID, tenantName).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting federated database query limits for project (%s), tenant (%s), error: %s", projectID, tenantName, err))
 	}
 
-	if results := flattenFederatedDatabaseQueryLimits(projectID, tenantName, queryLimits); results != nil {
+	if results := flattenFederatedDatabaseQueryLimits(projectID, queryLimits); results != nil {
 		if err := d.Set("results", results); err != nil {
 			return diag.FromErr(fmt.Errorf(errorFederatedDatabaseQueryLimit, "results", projectID, err))
 		}
@@ -56,7 +57,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseQueryLimitsRead(ctx context.Context,
 	return nil
 }
 
-func flattenFederatedDatabaseQueryLimits(projectID, tenantName string, queryLimits []*matlas.DataFederationQueryLimit) []map[string]any {
+func flattenFederatedDatabaseQueryLimits(projectID string, queryLimits []admin.DataFederationTenantQueryLimit) []map[string]any {
 	var federatedDatabaseQueryLimitMap []map[string]any
 	if len(queryLimits) == 0 {
 		return federatedDatabaseQueryLimitMap
@@ -66,14 +67,14 @@ func flattenFederatedDatabaseQueryLimits(projectID, tenantName string, queryLimi
 	for i := range queryLimits {
 		federatedDatabaseQueryLimitMap[i] = map[string]any{
 			"project_id":         projectID,
-			"tenant_name":        queryLimits[i].TenantName,
+			"tenant_name":        queryLimits[i].GetTenantName(),
 			"limit_name":         queryLimits[i].Name,
-			"overrun_policy":     queryLimits[i].OverrunPolicy,
+			"overrun_policy":     queryLimits[i].GetOverrunPolicy(),
 			"value":              queryLimits[i].Value,
-			"current_usage":      queryLimits[i].CurrentUsage,
-			"default_limit":      queryLimits[i].DefaultLimit,
-			"last_modified_date": queryLimits[i].LastModifiedDate,
-			"maximum_limit":      queryLimits[i].MaximumLimit,
+			"current_usage":      queryLimits[i].GetCurrentUsage(),
+			"default_limit":      queryLimits[i].GetDefaultLimit(),
+			"last_modified_date": conversion.TimeToString(queryLimits[i].GetLastModifiedDate()),
+			"maximum_limit":      queryLimits[i].GetMaximumLimit(),
 		}
 	}
 

--- a/internal/service/federatedquerylimit/resource_federated_query_limit.go
+++ b/internal/service/federatedquerylimit/resource_federated_query_limit.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115012/admin"
 )
 
 const (
@@ -24,12 +24,12 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBFederatedDatabaseQueryLimitCreate,
-		ReadContext:   resourceMongoDBFederatedDatabaseQueryLimitRead,
-		UpdateContext: resourceMongoDBFederatedDatabaseQueryLimitUpdate,
-		DeleteContext: resourceMongoDBFederatedDatabaseQueryLimitDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasFederatedDatabaseQueryLimitImportState,
+			StateContext: resourceImportState,
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -72,39 +72,42 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBFederatedDatabaseQueryLimitCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	return createOrUpdate(ctx, meta, d, errorFederatedDatabaseQueryLimitCreate)
+}
 
+func createOrUpdate(ctx context.Context, meta any, d *schema.ResourceData, errorTemplate string) diag.Diagnostics {
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get(string("project_id")).(string)
 	tenantName := d.Get("tenant_name").(string)
 	limitName := d.Get("limit_name").(string)
 
-	requestBody := &matlas.DataFederationQueryLimit{
-		OverrunPolicy: d.Get("overrun_policy").(string),
+	requestBody := &admin.DataFederationTenantQueryLimit{
+		OverrunPolicy: conversion.StringPtr(d.Get("overrun_policy").(string)),
 		Value:         int64(d.Get("value").(int)),
 	}
 
-	federatedDatabaseQueryLimit, _, err := conn.DataFederation.ConfigureQueryLimit(ctx, projectID, tenantName, limitName, requestBody)
+	federatedDatabaseQueryLimit, _, err := conn.DataFederationApi.CreateOneDataFederationQueryLimit(ctx, projectID, tenantName, limitName, requestBody).Execute()
 	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseQueryLimitCreate, limitName, err))
+		return diag.FromErr(fmt.Errorf(errorTemplate, limitName, err))
 	}
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":  projectID,
-		"tenant_name": federatedDatabaseQueryLimit.TenantName,
+		"tenant_name": federatedDatabaseQueryLimit.GetTenantName(),
 		"limit_name":  federatedDatabaseQueryLimit.Name,
 	}))
 
-	return resourceMongoDBFederatedDatabaseQueryLimitRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBFederatedDatabaseQueryLimitRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	tenantName := ids["tenant_name"]
 	limitName := ids["limit_name"]
 
-	queryLimit, resp, err := conn.DataFederation.GetQueryLimit(ctx, projectID, tenantName, limitName)
+	queryLimit, resp, err := conn.DataFederationApi.ReturnFederatedDatabaseQueryLimit(ctx, projectID, tenantName, limitName).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -119,50 +122,34 @@ func resourceMongoDBFederatedDatabaseQueryLimitRead(ctx context.Context, d *sche
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":  projectID,
-		"tenant_name": queryLimit.TenantName,
+		"tenant_name": queryLimit.GetTenantName(),
 		"limit_name":  queryLimit.Name,
 	}))
 
 	return nil
 }
 
-func resourceMongoDBFederatedDatabaseQueryLimitUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
-
-	ids := conversion.DecodeStateID(d.Id())
-	projectID := ids["project_id"]
-	tenantName := ids["tenant_name"]
-	limitName := ids["limit_name"]
-
-	requestBody := &matlas.DataFederationQueryLimit{
-		OverrunPolicy: d.Get("overrun_policy").(string),
-		Value:         int64(d.Get("value").(int)),
-	}
-
-	if _, _, err := conn.DataFederation.ConfigureQueryLimit(ctx, projectID, tenantName, limitName, requestBody); err != nil {
-		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseQueryLimitUpdate, limitName, err))
-	}
-
-	return resourceMongoDBFederatedDatabaseQueryLimitRead(ctx, d, meta)
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	return createOrUpdate(ctx, meta, d, errorFederatedDatabaseQueryLimitUpdate)
 }
 
-func resourceMongoDBFederatedDatabaseQueryLimitDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	tenantName := ids["tenant_name"]
 	limitName := ids["limit_name"]
 
-	if _, err := conn.DataFederation.DeleteQueryLimit(ctx, projectID, tenantName, limitName); err != nil {
+	if _, _, err := conn.DataFederationApi.DeleteOneDataFederationInstanceQueryLimit(ctx, projectID, tenantName, limitName).Execute(); err != nil {
 		return diag.FromErr(fmt.Errorf(errorFederatedDatabaseQueryLimitDelete, limitName, err))
 	}
 
 	return nil
 }
 
-func resourceMongoDBAtlasFederatedDatabaseQueryLimitImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	parts := strings.Split(d.Id(), "--")
 
 	var projectID, tenantName, limitName string
@@ -172,7 +159,7 @@ func resourceMongoDBAtlasFederatedDatabaseQueryLimitImportState(ctx context.Cont
 	}
 	projectID, tenantName, limitName = parts[0], parts[1], parts[2]
 
-	queryLimit, _, err := conn.DataFederation.GetQueryLimit(ctx, projectID, tenantName, limitName)
+	queryLimit, _, err := conn.DataFederationApi.ReturnFederatedDatabaseQueryLimit(ctx, projectID, tenantName, limitName).Execute()
 
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import federated database query limit(%s) for project (%s), tenant (%s), error: %s", limitName, projectID, tenantName, err)
@@ -184,14 +171,14 @@ func resourceMongoDBAtlasFederatedDatabaseQueryLimitImportState(ctx context.Cont
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":  projectID,
-		"tenant_name": queryLimit.TenantName,
+		"tenant_name": queryLimit.GetTenantName(),
 		"limit_name":  queryLimit.Name,
 	}))
 
 	return []*schema.ResourceData{d}, nil
 }
 
-func setResourceFieldsFromFederatedDatabaseQueryLimit(d *schema.ResourceData, projectID string, queryLimit *matlas.DataFederationQueryLimit) error {
+func setResourceFieldsFromFederatedDatabaseQueryLimit(d *schema.ResourceData, projectID string, queryLimit *admin.DataFederationTenantQueryLimit) error {
 	if err := d.Set("project_id", projectID); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "project_id", d.Id(), err)
 	}
@@ -200,11 +187,11 @@ func setResourceFieldsFromFederatedDatabaseQueryLimit(d *schema.ResourceData, pr
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "limit_name", d.Id(), err)
 	}
 
-	if err := d.Set("tenant_name", queryLimit.TenantName); err != nil {
+	if err := d.Set("tenant_name", queryLimit.GetTenantName()); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "tenant_name", d.Id(), err)
 	}
 
-	if err := d.Set("overrun_policy", queryLimit.OverrunPolicy); err != nil {
+	if err := d.Set("overrun_policy", queryLimit.GetOverrunPolicy()); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "overrun_policy", d.Id(), err)
 	}
 
@@ -212,19 +199,19 @@ func setResourceFieldsFromFederatedDatabaseQueryLimit(d *schema.ResourceData, pr
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "value", d.Id(), err)
 	}
 
-	if err := d.Set("current_usage", queryLimit.CurrentUsage); err != nil {
+	if err := d.Set("current_usage", queryLimit.GetCurrentUsage()); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "current_usage", d.Id(), err)
 	}
 
-	if err := d.Set("default_limit", queryLimit.DefaultLimit); err != nil {
+	if err := d.Set("default_limit", queryLimit.GetDefaultLimit()); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "default_limit", d.Id(), err)
 	}
 
-	if err := d.Set("last_modified_date", queryLimit.LastModifiedDate); err != nil {
+	if err := d.Set("last_modified_date", conversion.TimeToString(queryLimit.GetLastModifiedDate())); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "last_modified_date", d.Id(), err)
 	}
 
-	if err := d.Set("maximum_limit", queryLimit.MaximumLimit); err != nil {
+	if err := d.Set("maximum_limit", queryLimit.GetMaximumLimit()); err != nil {
 		return fmt.Errorf(errorFederatedDatabaseQueryLimit, "maximum_limit", d.Id(), err)
 	}
 

--- a/internal/service/federatedquerylimit/resource_federated_query_limit_migration_test.go
+++ b/internal/service/federatedquerylimit/resource_federated_query_limit_migration_test.go
@@ -3,9 +3,10 @@ package federatedquerylimit_test
 import (
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestMigFederatedDatabaseQueryLimit_basic(t *testing.T) {
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	mig.CreateTestAndRunUseExternalProvider(t, basicTestCase(t), acc.ExternalProvidersOnlyAWS(), nil)
 }

--- a/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
+++ b/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
@@ -246,7 +246,7 @@ func checkDestroy(s *terraform.State) error {
 			continue
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := acc.Conn().DataFederation.GetQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"])
+		_, _, err := acc.ConnV2().DataFederationApi.ReturnFederatedDatabaseQueryLimit(context.Background(), ids["project_id"], ids["tenant_name"], ids["limit_name"]).Execute()
 		if err == nil {
 			return fmt.Errorf("federated database query limit (%s) for project (%s) and tenant (%s)still exists", ids["project_id"], ids["tenant_name"], ids["limit_name"])
 		}


### PR DESCRIPTION
## Description

Migrates `federated_query_limit` to new auto-generated SDK

Link to any related issue(s): CLOUDP-246322

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
Acceptance test:
![image](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/6596097/91783fc7-1b81-4f6e-98c3-d89e11c72125)

Migration test:

![image](https://github.com/mongodb/terraform-provider-mongodbatlas/assets/6596097/aee84d93-6ed2-4631-84b7-eec927dabbb5)
