### PR TITLE
chore: Migrates`cloud_backup_snapshot_restore_job` to new auto-generated SDK

### DIFF
--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -34,8 +35,9 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 			},
 			"delivery_type": {
 				Type:     schema.TypeString,

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 func DataSource() *schema.Resource {
@@ -94,76 +93,46 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		JobID:       conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id"),
-		GroupID:     d.Get("project_id").(string),
-		ClusterName: d.Get("cluster_name").(string),
-	}
+	restoreID := conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id")
+	projectID := d.Get("project_id").(string)
+	clusterName := d.Get("cluster_name").(string)
 
-	snapshotRes, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(ctx, requestParameters)
+	snapshotRes, _, err := conn.CloudBackupsApi.GetBackupRestoreJob(ctx, projectID, clusterName, restoreID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err))
 	}
 
-	if err = d.Set("cancelled", snapshotRes.Cancelled); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `cancelled` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("created_at", snapshotRes.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("delivery_type", snapshotRes.DeliveryType); err != nil {
+	if err = d.Set("delivery_type", snapshotRes.GetDeliveryType()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `delivery_type` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("delivery_url", snapshotRes.DeliveryURL); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("expired", snapshotRes.Expired); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `expired` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("expires_at", snapshotRes.ExpiresAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("finished_at", snapshotRes.FinishedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `finished_at` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("snapshot_id", snapshotRes.SnapshotID); err != nil {
+	if err = d.Set("snapshot_id", snapshotRes.GetSnapshotId()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `snapshotId` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("target_project_id", snapshotRes.TargetGroupID); err != nil {
+	if err = d.Set("target_project_id", snapshotRes.GetTargetGroupId()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `targetGroupId` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("target_cluster_name", snapshotRes.TargetClusterName); err != nil {
+	if err = d.Set("target_cluster_name", snapshotRes.GetTargetClusterName()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `targetClusterName` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("timestamp", snapshotRes.Timestamp); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-	}
-
-	if err = d.Set("oplog_ts", snapshotRes.OplogTs); err != nil {
+	if err = d.Set("oplog_ts", snapshotRes.GetOplogTs()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `oplog_ts` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("point_in_time_utc_seconds", snapshotRes.PointInTimeUTCSeconds); err != nil {
+	if err = d.Set("point_in_time_utc_seconds", snapshotRes.GetPointInTimeUTCSeconds()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `point_in_time_utc_seconds` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	if err = d.Set("oplog_inc", snapshotRes.OplogInc); err != nil {
+	if err = d.Set("oplog_inc", snapshotRes.GetOplogInc()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `oplog_inc` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
-	d.SetId(snapshotRes.ID)
+	d.SetId(snapshotRes.GetId())
 
 	return nil
 }

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115012/admin"
@@ -46,8 +47,9 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"created_at": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:       schema.TypeString,
+							Computed:   true,
+							Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 						},
 						"delivery_type": {
 							Type:     schema.TypeString,
@@ -146,9 +148,8 @@ func flattenCloudProviderSnapshotRestoreJobs(cloudProviderSnapshotRestoreJobs []
 		for k := range cloudProviderSnapshotRestoreJobs {
 			cloudProviderSnapshotRestoreJob := cloudProviderSnapshotRestoreJobs[k]
 			results[k] = map[string]any{
-				"id":        cloudProviderSnapshotRestoreJob.GetId(),
-				"cancelled": cloudProviderSnapshotRestoreJob.GetCancelled(),
-				// "created_at":                cloudProviderSnapshotRestoreJob.CreatedAt NOT FOUND anymore,
+				"id":                        cloudProviderSnapshotRestoreJob.GetId(),
+				"cancelled":                 cloudProviderSnapshotRestoreJob.GetCancelled(),
 				"delivery_type":             cloudProviderSnapshotRestoreJob.GetDeliveryType(),
 				"delivery_url":              cloudProviderSnapshotRestoreJob.GetDeliveryUrl(),
 				"expired":                   cloudProviderSnapshotRestoreJob.GetExpired(),

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20231115012/admin"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 func PluralDataSource() *schema.Resource {

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -380,10 +380,9 @@ func buildRequestSnapshotReq(d *schema.ResourceData) *admin.DiskBackupSnapshotRe
 		if aut, _ := delivery["point_in_time"].(bool); aut {
 			deliveryType = "pointInTime"
 		}
-
 		snapshotID := conversion.GetEncodedID(d.Get("snapshot_id").(string), "snapshot_id")
 		return &admin.DiskBackupSnapshotRestoreJob{
-			SnapshotId:            &snapshotID,
+			SnapshotId:            conversion.StringPtr(snapshotID),
 			DeliveryType:          deliveryType,
 			TargetClusterName:     conversion.StringPtr(delivery["target_cluster_name"].(string)),
 			TargetGroupId:         conversion.StringPtr(delivery["target_project_id"].(string)),

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -171,36 +171,40 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err))
 	}
 
-	if err = d.Set("delivery_url", snapshotReq.GetDeliveryUrl()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+	if err = d.Set("snapshot_restore_job_id", snapshotReq.GetId()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `snapshot_restore_job_id` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
-	if err = d.Set("cancelled", snapshotReq.GetCancelled()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `cancelled` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
-	}
+	return setCommonFields(d, snapshotReq, restoreID)
+}
+
+func setCommonFields(d *schema.ResourceData, snapshotReq *admin.DiskBackupSnapshotRestoreJob, restoreID string) diag.Diagnostics {
+	var err error
+
 	// not found any more
 	// if err = d.Set("created_at", conversion.TimeToString(snapshotReq.CreatedAt); err != nil {
 	// 	return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	// }
-
+	if err = d.Set("delivery_url", snapshotReq.GetDeliveryUrl()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
+	}
+	if err = d.Set("cancelled", snapshotReq.GetCancelled()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `cancelled` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
+	}
 	if err = d.Set("expired", snapshotReq.GetExpired()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `expired` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+		return diag.FromErr(fmt.Errorf("error setting `expired` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
 	if err = d.Set("expires_at", conversion.TimePtrToStringPtr(snapshotReq.ExpiresAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
 	if err = d.Set("finished_at", conversion.TimePtrToStringPtr(snapshotReq.FinishedAt)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `Finished_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+		return diag.FromErr(fmt.Errorf("error setting `Finished_at` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
 	if err = d.Set("timestamp", conversion.TimePtrToStringPtr(snapshotReq.Timestamp)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
-	}
-
-	if err = d.Set("snapshot_restore_job_id", snapshotReq.GetId()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `snapshot_restore_job_id` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+		return diag.FromErr(fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
 	return nil

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20231115012/admin"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 func Resource() *schema.Resource {

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115012/admin"
@@ -101,8 +102,9 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 			},
 			"expired": {
 				Type:     schema.TypeBool,
@@ -181,10 +183,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 func setCommonFields(d *schema.ResourceData, snapshotReq *admin.DiskBackupSnapshotRestoreJob, restoreID string) diag.Diagnostics {
 	var err error
 
-	// not found any more
-	// if err = d.Set("created_at", conversion.TimeToString(snapshotReq.CreatedAt); err != nil {
-	// 	return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
-	// }
 	if err = d.Set("delivery_url", snapshotReq.GetDeliveryUrl()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -12,8 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/spf13/cast"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115012/admin"
 )
 
 func Resource() *schema.Resource {
@@ -130,14 +129,10 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		GroupID:     d.Get("project_id").(string),
-		ClusterName: d.Get("cluster_name").(string),
-	}
-
+	projectID := d.Get("project_id").(string)
+	clusterName := d.Get("cluster_name").(string)
 	err := validateDeliveryType(d.Get("delivery_type_config").([]any))
 	if err != nil {
 		return diag.FromErr(err)
@@ -145,7 +140,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	snapshotReq := buildRequestSnapshotReq(d)
 
-	cloudProviderSnapshotRestoreJob, _, err := conn.CloudProviderSnapshotRestoreJobs.Create(ctx, requestParameters, snapshotReq)
+	cloudProviderSnapshotRestoreJob, _, err := conn.CloudBackupsApi.CreateBackupRestoreJob(ctx, projectID, clusterName, snapshotReq).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error restore a snapshot: %s", err))
 	}
@@ -153,24 +148,20 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":              d.Get("project_id").(string),
 		"cluster_name":            d.Get("cluster_name").(string),
-		"snapshot_restore_job_id": cloudProviderSnapshotRestoreJob.ID,
+		"snapshot_restore_job_id": cloudProviderSnapshotRestoreJob.GetId(),
 	}))
 
 	return resourceRead(ctx, d, meta)
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		JobID:       ids["snapshot_restore_job_id"],
-		GroupID:     ids["project_id"],
-		ClusterName: ids["cluster_name"],
-	}
-
-	snapshotReq, resp, err := conn.CloudProviderSnapshotRestoreJobs.Get(context.Background(), requestParameters)
+	projectID := ids["project_id"]
+	clusterName := ids["cluster_name"]
+	restoreID := ids["snapshot_restore_job_id"]
+	snapshotReq, resp, err := conn.CloudBackupsApi.GetBackupRestoreJob(ctx, projectID, clusterName, restoreID).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -180,35 +171,35 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshotRestoreJob Information: %s", err))
 	}
 
-	if err = d.Set("delivery_url", snapshotReq.DeliveryURL); err != nil {
+	if err = d.Set("delivery_url", snapshotReq.GetDeliveryUrl()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `delivery_url` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
-	if err = d.Set("cancelled", snapshotReq.Cancelled); err != nil {
+	if err = d.Set("cancelled", snapshotReq.GetCancelled()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `cancelled` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
+	// not found any more
+	// if err = d.Set("created_at", conversion.TimeToString(snapshotReq.CreatedAt); err != nil {
+	// 	return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
+	// }
 
-	if err = d.Set("created_at", snapshotReq.CreatedAt); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `created_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
-	}
-
-	if err = d.Set("expired", snapshotReq.Expired); err != nil {
+	if err = d.Set("expired", snapshotReq.GetExpired()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `expired` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
-	if err = d.Set("expires_at", snapshotReq.ExpiresAt); err != nil {
+	if err = d.Set("expires_at", conversion.TimePtrToStringPtr(snapshotReq.ExpiresAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
-	if err = d.Set("finished_at", snapshotReq.FinishedAt); err != nil {
+	if err = d.Set("finished_at", conversion.TimePtrToStringPtr(snapshotReq.FinishedAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `Finished_at` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
-	if err = d.Set("timestamp", snapshotReq.Timestamp); err != nil {
+	if err = d.Set("timestamp", conversion.TimePtrToStringPtr(snapshotReq.Timestamp)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `timestamp` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
-	if err = d.Set("snapshot_restore_job_id", snapshotReq.ID); err != nil {
+	if err = d.Set("snapshot_restore_job_id", snapshotReq.GetId()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `snapshot_restore_job_id` for cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 	}
 
@@ -216,14 +207,12 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		JobID:       ids["snapshot_restore_job_id"],
-		GroupID:     ids["project_id"],
-		ClusterName: ids["cluster_name"],
-	}
+	projectID := ids["project_id"]
+	clusterName := ids["cluster_name"]
+	restoreID := ids["snapshot_restore_job_id"]
 
 	shouldDelete := true
 
@@ -239,7 +228,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if shouldDelete {
-		_, err := conn.CloudProviderSnapshotRestoreJobs.Delete(context.Background(), requestParameters)
+		_, _, err := conn.CloudBackupsApi.CancelBackupRestoreJob(ctx, projectID, clusterName, restoreID).Execute()
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error deleting a cloudProviderSnapshotRestoreJob (%s): %s", ids["snapshot_restore_job_id"], err))
 		}
@@ -249,33 +238,26 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
-	projectID, clusterName, snapshotJobID, err := splitSnapshotRestoreJobImportID(d.Id())
+	projectID, clusterName, restoreID, err := splitSnapshotRestoreJobImportID(d.Id())
 	if err != nil {
 		return nil, err
 	}
-
-	requestParameters := &matlas.SnapshotReqPathParameters{
-		GroupID:     *projectID,
-		ClusterName: *clusterName,
-		JobID:       *snapshotJobID,
-	}
-
-	u, _, err := conn.CloudProviderSnapshotRestoreJobs.Get(ctx, requestParameters)
+	u, _, err := conn.CloudBackupsApi.GetBackupRestoreJob(ctx, projectID, clusterName, restoreID).Execute()
 	if err != nil {
-		return nil, fmt.Errorf("couldn't import cloudProviderSnapshotRestoreJob %s in project %s, error: %s", requestParameters.ClusterName, requestParameters.GroupID, err)
+		return nil, fmt.Errorf("couldn't import cloudProviderSnapshotRestoreJob %s in project %s, error: %s", clusterName, projectID, err)
 	}
 
-	if err := d.Set("project_id", requestParameters.GroupID); err != nil {
+	if err := d.Set("project_id", projectID); err != nil {
 		log.Printf("[WARN] Error setting project_id for (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("cluster_name", requestParameters.ClusterName); err != nil {
+	if err := d.Set("cluster_name", clusterName); err != nil {
 		log.Printf("[WARN] Error setting cluster_name for (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("snapshot_id", u.SnapshotID); err != nil {
+	if err := d.Set("snapshot_id", u.GetSnapshotId()); err != nil {
 		log.Printf("[WARN] Error setting snapshot_id for (%s): %s", d.Id(), err)
 	}
 
@@ -284,12 +266,11 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 
 	if u.DeliveryType == "automated" {
 		deliveryType["automated"] = "true"
-		deliveryType["target_cluster_name"] = u.TargetClusterName
-		deliveryType["target_project_id"] = u.TargetGroupID
-		// For delivery_type_config
+		deliveryType["target_cluster_name"] = u.GetTargetClusterName()
+		deliveryType["target_project_id"] = u.GetTargetGroupId()
 		deliveryTypeConfig["automated"] = true
-		deliveryTypeConfig["target_cluster_name"] = u.TargetClusterName
-		deliveryTypeConfig["target_project_id"] = u.TargetGroupID
+		deliveryTypeConfig["target_cluster_name"] = u.GetTargetClusterName()
+		deliveryTypeConfig["target_project_id"] = u.GetTargetGroupId()
 	}
 
 	if err := d.Set("delivery_type_config", []any{deliveryTypeConfig}); err != nil {
@@ -297,15 +278,14 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"project_id":              *projectID,
-		"cluster_name":            *clusterName,
-		"snapshot_restore_job_id": *snapshotJobID,
-	}))
+		"project_id":              projectID,
+		"cluster_name":            clusterName,
+		"snapshot_restore_job_id": restoreID}))
 
 	return []*schema.ResourceData{d}, nil
 }
 
-func splitSnapshotRestoreJobImportID(id string) (projectID, clusterName, snapshotJobID *string, err error) {
+func splitSnapshotRestoreJobImportID(id string) (projectID, clusterName, snapshotJobID string, err error) {
 	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-([0-9a-fA-F]{24})$`)
 	parts := re.FindStringSubmatch(id)
 
@@ -314,9 +294,9 @@ func splitSnapshotRestoreJobImportID(id string) (projectID, clusterName, snapsho
 		return
 	}
 
-	projectID = &parts[1]
-	clusterName = &parts[2]
-	snapshotJobID = &parts[3]
+	projectID = parts[1]
+	clusterName = parts[2]
+	snapshotJobID = parts[3]
 
 	return
 }
@@ -384,7 +364,7 @@ func validateDeliveryType(dt []any) error {
 	return nil
 }
 
-func buildRequestSnapshotReq(d *schema.ResourceData) *matlas.CloudProviderSnapshotRestoreJob {
+func buildRequestSnapshotReq(d *schema.ResourceData) *admin.DiskBackupSnapshotRestoreJob {
 	if _, ok := d.GetOk("delivery_type_config"); ok {
 		deliveryList := d.Get("delivery_type_config").([]any)
 
@@ -399,16 +379,17 @@ func buildRequestSnapshotReq(d *schema.ResourceData) *matlas.CloudProviderSnapsh
 			deliveryType = "pointInTime"
 		}
 
-		return &matlas.CloudProviderSnapshotRestoreJob{
-			SnapshotID:            conversion.GetEncodedID(d.Get("snapshot_id").(string), "snapshot_id"),
+		snapshotID := conversion.GetEncodedID(d.Get("snapshot_id").(string), "snapshot_id")
+		return &admin.DiskBackupSnapshotRestoreJob{
+			SnapshotId:            &snapshotID,
 			DeliveryType:          deliveryType,
-			TargetClusterName:     delivery["target_cluster_name"].(string),
-			TargetGroupID:         delivery["target_project_id"].(string),
-			OplogTs:               cast.ToInt64(delivery["oplog_ts"]),
-			OplogInc:              cast.ToInt64(delivery["oplog_inc"]),
-			PointInTimeUTCSeconds: cast.ToInt64(delivery["point_in_time_utc_seconds"]),
+			TargetClusterName:     conversion.StringPtr(delivery["target_cluster_name"].(string)),
+			TargetGroupId:         conversion.StringPtr(delivery["target_project_id"].(string)),
+			OplogTs:               conversion.IntPtr(delivery["oplog_ts"].(int)),
+			OplogInc:              conversion.IntPtr(delivery["oplog_inc"].(int)),
+			PointInTimeUTCSeconds: conversion.IntPtr(delivery["point_in_time_utc_seconds"].(int)),
 		}
 	}
 
-	return &matlas.CloudProviderSnapshotRestoreJob{}
+	return &admin.DiskBackupSnapshotRestoreJob{}
 }


### PR DESCRIPTION
## Description

Migrates`cloud_backup_snapshot_restore_job`to new auto-generated SDK

Link to any related issue(s): CLOUDP-246319

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
