### PR TITLE
fix: Marks `id` as computed not required for `data-source/mongodbatlas_cloud_backup_snapshot_export_bucket`

### DIFF
--- a/.changelog/2241.txt
+++ b/.changelog/2241.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_snapshot_export_bucket: Marks `id` as computed not required
+```

--- a/internal/service/cloudbackupsnapshotexportbucket/data_source_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/data_source_cloud_backup_snapshot_export_bucket.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -14,8 +15,10 @@ func DataSource() *schema.Resource {
 		ReadContext: datasourceRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0") + " Will not be an input parameter, only computed.",
 			},
 			"export_bucket_id": {
 				Type:     schema.TypeString,
@@ -45,7 +48,7 @@ func datasourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
-	bucketID := d.Get("id").(string)
+	bucketID := d.Get("export_bucket_id").(string)
 
 	bucket, _, err := conn.CloudBackupsApi.GetExportBucket(ctx, projectID, bucketID).Execute()
 	if err != nil {

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_migration_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigBackupSnapshotExportBucket_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.16.1")
 	mig.CreateAndRunTest(t, basicTestCase(t))
 }

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -113,18 +113,17 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 
 func configBasic(projectID, bucketName, iamRoleID string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
+		resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
 			project_id     = "%[1]s"
     	  	iam_role_id    = "%[3]s"
        		bucket_name    = "%[2]s"
        		cloud_provider = "AWS"
-    }
+    	}
 
 		data "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
 			project_id   =  mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id
 			export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
-			id = mongodbatlas_cloud_backup_snapshot_export_bucket.test.export_bucket_id
-		}		
+		}
 
 		data "mongodbatlas_cloud_backup_snapshot_export_buckets" "test" {
 			project_id   =  mongodbatlas_cloud_backup_snapshot_export_bucket.test.project_id


### PR DESCRIPTION
## Description

Marks `id` as computed not required for `data-source/mongodbatlas_cloud_backup_snapshot_export_bucket`

Link to any related issue(s): CLOUDP-247721

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
