### PR TITLE
chore: Migrates `network_peering` to the new auto-generated SDK

### DIFF
--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -111,7 +111,6 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	peerID := conversion.GetEncodedID(d.Get("peering_id").(string), "peer_id")

--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20231115012/admin"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 func DataSource() *schema.Resource {

--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -124,85 +124,6 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(errorPeersRead, peerID, err))
 	}
 
-	accepterRegionName, err := ensureAccepterRegionName(ctx, peer, conn, projectID)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("accepter_region_name", accepterRegionName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `accepter_region_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-	if err := d.Set("aws_account_id", peer.AWSAccountID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `aws_account_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("container_id", peer.ContainerID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `container_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("route_table_cidr_block", peer.RouteTableCIDRBlock); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `route_table_cidr_block` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("vpc_id", peer.VpcID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `vpc_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("connection_id", peer.ConnectionID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `connection_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("error_state_name", peer.ErrorStateName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `error_state_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("atlas_id", peer.ID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `atlas_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("status_name", peer.StatusName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `status_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("atlas_cidr_block", peer.AtlasCIDRBlock); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `atlas_cidr_block` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("azure_directory_id", peer.AzureDirectoryID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `azure_directory_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("azure_subscription_id", peer.AzureSubscriptionID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `azure_subscription_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("resource_group_name", peer.ResourceGroupName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `resource_group_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("vnet_name", peer.VNetName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `vnet_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("error_state", peer.ErrorState); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `error_state` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("status", peer.Status); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `status` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("gcp_project_id", peer.GCPProjectID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `gcp_project_id` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("network_name", peer.NetworkName); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `network_name` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
-	if err := d.Set("error_message", peer.ErrorMessage); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `error_message` for Network Peering Connection (%s): %s", peerID, err))
-	}
-
 	provider := "AWS"
 	if peer.VNetName != "" {
 		provider = "AZURE"
@@ -220,5 +141,16 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		"provider_name": provider,
 	}))
 
-	return nil
+	accepterRegionName, err := ensureAccepterRegionName(ctx, peer, conn, projectID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("peering_id", peerID); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `peering_id` for Network Peering Connection (%s): %s", peerID, err))
+	}
+	if err := d.Set("container_id", peer.ContainerID); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `container_id` for Network Peering Connection (%s): %s", peerID, err))
+	}
+
+	return setCommonFields(d, peer, peerID, accepterRegionName)
 }

--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -13,7 +13,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasNetworkPeeringRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -109,7 +109,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasNetworkPeeringRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)

--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20231115012/admin"
 )
 
 func DataSource() *schema.Resource {
@@ -111,11 +112,11 @@ func DataSource() *schema.Resource {
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	peerID := conversion.GetEncodedID(d.Get("peering_id").(string), "peer_id")
 
-	peer, resp, err := conn.Peers.Get(ctx, projectID, peerID)
+	peer, resp, err := conn.NetworkPeeringApi.GetPeeringConnection(ctx, projectID, peerID).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil
@@ -125,32 +126,48 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	provider := "AWS"
-	if peer.VNetName != "" {
+	if peer.GetVnetName() != "" {
 		provider = "AZURE"
-	} else if peer.NetworkName != "" {
+	} else if peer.GetNetworkName() != "" {
 		provider = "GCP"
 	}
 
 	if err := d.Set("provider_name", provider); err != nil {
 		return diag.FromErr(fmt.Errorf("[WARN] Error setting provider_name for (%s): %s", d.Id(), err))
 	}
+	containerID := peer.GetContainerId()
+	atlasCidrBlock, err := readAtlasCidrBlock(ctx, conn.NetworkPeeringApi, projectID, containerID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("atlas_cidr_block", atlasCidrBlock); err != nil {
+		return diag.Errorf("error setting `atlas_cidr_block` for Network Peering Connection (%s): %s", peerID, err)
+	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"project_id":    projectID,
-		"peer_id":       peer.ID,
+		"peer_id":       peer.GetId(),
 		"provider_name": provider,
 	}))
 
-	accepterRegionName, err := ensureAccepterRegionName(ctx, peer, conn, projectID)
+	accepterRegionName, err := ensureAccepterRegionName(ctx, peer, conn.NetworkPeeringApi, projectID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("peering_id", peerID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `peering_id` for Network Peering Connection (%s): %s", peerID, err))
 	}
-	if err := d.Set("container_id", peer.ContainerID); err != nil {
+	if err := d.Set("container_id", containerID); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `container_id` for Network Peering Connection (%s): %s", peerID, err))
 	}
 
 	return setCommonFields(d, peer, peerID, accepterRegionName)
+}
+
+func readAtlasCidrBlock(ctx context.Context, conn admin.NetworkPeeringApi, projectID, containerID string) (string, error) {
+	container, _, err := conn.GetPeeringContainer(ctx, projectID, containerID).Execute()
+	if err != nil {
+		return "", err
+	}
+	return container.GetAtlasCidrBlock(), nil
 }

--- a/internal/service/networkpeering/data_source_network_peerings.go
+++ b/internal/service/networkpeering/data_source_network_peerings.go
@@ -14,7 +14,7 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasNetworkPeeringsRead,
+		ReadContext: dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -114,7 +114,7 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasNetworkPeeringsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)

--- a/internal/service/networkpeering/data_source_network_peerings.go
+++ b/internal/service/networkpeering/data_source_network_peerings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 
-	"go.mongodb.org/atlas-sdk/v20231115012/admin"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 func PluralDataSource() *schema.Resource {

--- a/internal/service/networkpeering/data_source_network_peerings.go
+++ b/internal/service/networkpeering/data_source_network_peerings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231115012/admin"
 )
 
 func PluralDataSource() *schema.Resource {
@@ -116,14 +116,14 @@ func PluralDataSource() *schema.Resource {
 
 func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	peers, _, err := conn.Peers.List(ctx, projectID, nil)
+	peers, _, err := conn.NetworkPeeringApi.ListPeeringConnections(ctx, projectID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting network peering connections information: %s", err))
 	}
-	peersMap, err := flattenNetworkPeerings(ctx, conn, peers, projectID)
+	peersMap, err := flattenNetworkPeerings(ctx, conn.NetworkPeeringApi, peers.GetResults(), projectID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -136,37 +136,42 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 	return nil
 }
 
-func flattenNetworkPeerings(ctx context.Context, conn *matlas.Client, peers []matlas.Peer, projectID string) ([]map[string]any, error) {
+func flattenNetworkPeerings(ctx context.Context, conn admin.NetworkPeeringApi, peers []admin.BaseNetworkPeeringConnectionSettings, projectID string) ([]map[string]any, error) {
 	var peersMap []map[string]any
 
 	if len(peers) > 0 {
 		peersMap = make([]map[string]any, len(peers))
 		for i := range peers {
-			accepterRegionName, err := ensureAccepterRegionName(ctx, &peers[i], conn, projectID)
+			p := peers[i]
+			accepterRegionName, err := ensureAccepterRegionName(ctx, &p, conn, projectID)
+			if err != nil {
+				return nil, err
+			}
+			atlasCidrBlock, err := readAtlasCidrBlock(ctx, conn, projectID, p.GetContainerId())
 			if err != nil {
 				return nil, err
 			}
 			peersMap[i] = map[string]any{
-				"peering_id":             peers[i].ID,
-				"container_id":           peers[i].ContainerID,
+				"peering_id":             p.GetId(),
+				"container_id":           p.GetContainerId(),
 				"accepter_region_name":   accepterRegionName,
-				"aws_account_id":         peers[i].AWSAccountID,
-				"provider_name":          getProviderNameByPeer(&peers[i]),
-				"route_table_cidr_block": peers[i].RouteTableCIDRBlock,
-				"vpc_id":                 peers[i].VpcID,
-				"connection_id":          peers[i].ConnectionID,
-				"error_state_name":       peers[i].ErrorStateName,
-				"status_name":            peers[i].StatusName,
-				"atlas_cidr_block":       peers[i].AtlasCIDRBlock,
-				"azure_directory_id":     peers[i].AzureDirectoryID,
-				"azure_subscription_id":  peers[i].AzureSubscriptionID,
-				"resource_group_name":    peers[i].ResourceGroupName,
-				"vnet_name":              peers[i].VNetName,
-				"error_state":            peers[i].ErrorState,
-				"status":                 peers[i].Status,
-				"gcp_project_id":         peers[i].GCPProjectID,
-				"network_name":           peers[i].NetworkName,
-				"error_message":          peers[i].ErrorMessage,
+				"aws_account_id":         p.GetAwsAccountId(),
+				"provider_name":          getProviderNameByPeer(&p),
+				"route_table_cidr_block": p.GetRouteTableCidrBlock(),
+				"vpc_id":                 p.GetVpcId(),
+				"connection_id":          p.GetConnectionId(),
+				"error_state_name":       p.GetErrorStateName(),
+				"status_name":            p.GetStatusName(),
+				"atlas_cidr_block":       atlasCidrBlock,
+				"azure_directory_id":     p.GetAzureDirectoryId(),
+				"azure_subscription_id":  p.GetAzureSubscriptionId(),
+				"resource_group_name":    p.GetResourceGroupName(),
+				"vnet_name":              p.GetVnetName(),
+				"error_state":            p.GetErrorState(),
+				"status":                 p.GetStatus(),
+				"gcp_project_id":         p.GetGcpProjectId(),
+				"network_name":           p.GetNetworkName(),
+				"error_message":          p.GetErrorMessage(),
 			}
 		}
 	}
@@ -174,11 +179,11 @@ func flattenNetworkPeerings(ctx context.Context, conn *matlas.Client, peers []ma
 	return peersMap, nil
 }
 
-func getProviderNameByPeer(peer *matlas.Peer) string {
+func getProviderNameByPeer(peer *admin.BaseNetworkPeeringConnectionSettings) string {
 	provider := "AWS"
-	if peer.VNetName != "" {
+	if peer.GetVnetName() != "" {
 		provider = "AZURE"
-	} else if peer.NetworkName != "" {
+	} else if peer.GetNetworkName() != "" {
 		provider = "GCP"
 	}
 

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/networkcontainer"
-	"go.mongodb.org/atlas-sdk/v20231115012/admin"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 const (

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -218,8 +218,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		log.Printf("[DEBUG] projectID: %s", ids["project_id"])
-		if peerResp, _, err := acc.ConnV2().NetworkPeeringApi.GetPeeringConnection(context.Background(), ids["project_id"], ids["peer_id"]).Execute(); err == nil {
-			peerResp.SetProviderName(ids["provider_name"])
+		if _, _, err := acc.ConnV2().NetworkPeeringApi.GetPeeringConnection(context.Background(), ids["project_id"], ids["peer_id"]).Execute(); err == nil {
 			return nil
 		}
 		return fmt.Errorf("peer(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["peer_id"])

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
 var (
@@ -30,7 +29,6 @@ func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
 	acc.SkipTestForCI(t) // needs Azure configuration
 
 	var (
-		peer              matlas.Peer
 		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
@@ -47,7 +45,7 @@ func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
 			{
 				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &peer),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
@@ -70,7 +68,6 @@ func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
 	var (
-		peer         matlas.Peer
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		providerName = "GCP"
 		gcpProjectID = os.Getenv("GCP_PROJECT_ID")
@@ -85,7 +82,7 @@ func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
 			{
 				Config: configGCP(projectID, providerName, gcpProjectID, networkName),
 				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName, &peer),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
@@ -188,7 +185,7 @@ func commonChecksAWS(vpcID, providerName, awsAccountID, vpcCIDRBlock, regionPeer
 		"route_table_cidr_block": vpcCIDRBlock,
 		"accepter_region_name":   regionPeer,
 	}
-	checks := []resource.TestCheckFunc{checkExists(resourceName, &matlas.Peer{})}
+	checks := []resource.TestCheckFunc{checkExists(resourceName)}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
 	checks = acc.AddAttrChecks(dataSourceName, checks, attributes)
 	checks = acc.AddAttrSetChecks(resourceName, checks, "project_id", "container_id", "accepter_region_name")
@@ -210,7 +207,7 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	}
 }
 
-func checkExists(resourceName string, peer *matlas.Peer) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -221,9 +218,8 @@ func checkExists(resourceName string, peer *matlas.Peer) resource.TestCheckFunc 
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
 		log.Printf("[DEBUG] projectID: %s", ids["project_id"])
-		if peerResp, _, err := acc.Conn().Peers.Get(context.Background(), ids["project_id"], ids["peer_id"]); err == nil {
-			*peer = *peerResp
-			peer.ProviderName = ids["provider_name"]
+		if peerResp, _, err := acc.ConnV2().NetworkPeeringApi.GetPeeringConnection(context.Background(), ids["project_id"], ids["peer_id"]).Execute(); err == nil {
+			peerResp.SetProviderName(ids["provider_name"])
 			return nil
 		}
 		return fmt.Errorf("peer(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["peer_id"])


### PR DESCRIPTION
## Description

Migrates `network_peering` to the new auto-generated SDK

Link to any related issue(s): CLOUDP-246325

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
