### PR TITLE
chore: Migrates `privatelink_endpoint_regional_mode` to the new auto-generated SDK

### DIFF
--- a/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
@@ -26,14 +26,11 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)
+	setting, _, err := conn.PrivateEndpointServicesApi.GetRegionalizedPrivateEndpointSetting(ctx, projectID).Execute()
 	if err != nil {
-		// case 404
-		// deleted in the backend case
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
 			return nil
@@ -50,3 +47,29 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	return nil
 }
+
+// func dataSourceReadLegacy(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+// 	// Get client connection.
+// 	conn := meta.(*config.MongoDBClient).Atlas
+// 	projectID := d.Get("project_id").(string)
+
+// 	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)
+// 	if err != nil {
+// 		// case 404
+// 		// deleted in the backend case
+// 		if strings.Contains(err.Error(), "404") {
+// 			d.SetId("")
+// 			return nil
+// 		}
+
+// 		return diag.Errorf("error getting private endpoint regional mode: %s", err)
+// 	}
+
+// 	if err := d.Set("enabled", setting.Enabled); err != nil {
+// 		return diag.Errorf("error setting `enabled` for enabled (%s): %s", d.Id(), err)
+// 	}
+
+// 	d.SetId(projectID)
+
+// 	return nil
+// }

--- a/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
@@ -47,29 +47,3 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	return nil
 }
-
-// func dataSourceReadLegacy(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-// 	// Get client connection.
-// 	conn := meta.(*config.MongoDBClient).Atlas
-// 	projectID := d.Get("project_id").(string)
-
-// 	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)
-// 	if err != nil {
-// 		// case 404
-// 		// deleted in the backend case
-// 		if strings.Contains(err.Error(), "404") {
-// 			d.SetId("")
-// 			return nil
-// 		}
-
-// 		return diag.Errorf("error getting private endpoint regional mode: %s", err)
-// 	}
-
-// 	if err := d.Set("enabled", setting.Enabled); err != nil {
-// 		return diag.Errorf("error setting `enabled` for enabled (%s): %s", d.Id(), err)
-// 	}
-
-// 	d.SetId(projectID)
-
-// 	return nil
-// }

--- a/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/data_source_private_endpoint_regional_mode.go
@@ -11,7 +11,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasPrivateEndpointRegionalModeRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -25,7 +25,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Get("project_id").(string)

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
+	"go.mongodb.org/atlas-sdk/v20231115013/admin"
 )
 
 type permCtxKey string
@@ -65,11 +66,11 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Id()
 
-	setting, resp, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
+	setting, resp, err := conn.PrivateEndpointServicesApi.GetRegionalizedPrivateEndpointSetting(ctx, projectID).Execute()
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -87,8 +88,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Id()
 	enabled := d.Get("enabled").(bool)
@@ -97,10 +97,12 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if timeoutKey == nil {
 		timeoutKey = schema.TimeoutUpdate
 	}
-
-	_, resp, err := conn.PrivateEndpoints.UpdateRegionalizedPrivateEndpointSetting(ctx, projectID, enabled)
+	settingParam := admin.ProjectSettingItem{
+		Enabled: enabled,
+	}
+	_, resp, err := conn.PrivateEndpointServicesApi.ToggleRegionalizedPrivateEndpointSetting(ctx, projectID, &settingParam).Execute()
 	if err != nil {
-		if resp != nil && resp.Response.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			return nil
 		}
 
@@ -112,12 +114,11 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
-		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
+		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, conn.ClustersApi),
 		Timeout:    d.Timeout(timeoutKey.(string)),
 		MinTimeout: 5 * time.Second,
 		Delay:      3 * time.Second,
 	}
-	// Wait, catching any errors
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf(errorPrivateEndpointRegionalModeUpdate, projectID, err)
@@ -139,10 +140,10 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Id()
 
-	setting, _, err := conn.PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(ctx, projectID)
+	setting, _, err := conn.PrivateEndpointServicesApi.GetRegionalizedPrivateEndpointSetting(ctx, projectID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import Private Endpoint Regional Mode for project %s error: %s", projectID, err)
 	}

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
@@ -26,12 +26,12 @@ var regionalModeTimeoutCtxKey permCtxKey = "regionalModeTimeout"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasPrivateEndpointRegionalModeCreate,
-		ReadContext:   resourceMongoDBAtlasPrivateEndpointRegionalModeRead,
-		UpdateContext: resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate,
-		DeleteContext: resourceMongoDBAtlasPrivateEndpointRegionalModeDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceMongoDBAtlasPrivateEndpointRegionalModeImportState,
+			StateContext: resourceImportState,
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {
@@ -53,18 +53,18 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasPrivateEndpointRegionalModeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	d.SetId(d.Get("project_id").(string))
-	err := resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(context.WithValue(ctx, regionalModeTimeoutCtxKey, schema.TimeoutCreate), d, meta)
+	err := resourceUpdate(context.WithValue(ctx, regionalModeTimeoutCtxKey, schema.TimeoutCreate), d, meta)
 
 	if err != nil {
 		return err
 	}
 
-	return resourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 
 	projectID := d.Id()
@@ -86,7 +86,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeRead(ctx context.Context, d 
 	return nil
 }
 
-func resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).Atlas
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
@@ -126,9 +126,9 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(ctx context.Context, 
 	return nil
 }
 
-func resourceMongoDBAtlasPrivateEndpointRegionalModeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	if err := d.Set("enabled", false); err == nil {
-		resourceMongoDBAtlasPrivateEndpointRegionalModeUpdate(context.WithValue(ctx, regionalModeTimeoutCtxKey, schema.TimeoutDelete), d, meta)
+		resourceUpdate(context.WithValue(ctx, regionalModeTimeoutCtxKey, schema.TimeoutDelete), d, meta)
 	} else {
 		log.Printf(errorPrivateEndpointRegionalModeSetting, "enabled", d.Id(), err)
 	}
@@ -138,7 +138,7 @@ func resourceMongoDBAtlasPrivateEndpointRegionalModeDelete(ctx context.Context, 
 	return nil
 }
 
-func resourceMongoDBAtlasPrivateEndpointRegionalModeImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	conn := meta.(*config.MongoDBClient).Atlas
 	projectID := d.Id()
 

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -35,7 +35,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		clusterResourceName    = "test"
 		clusterResource        = acc.ConfigClusterGlobal(orgID, projectName, clusterName)
 		clusterDataSource      = modeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
-		endpointResources      = testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(
+		endpointResources      = testConfigUnmanagedAWS(
 			awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,
 		)
 		dependencies = []string{clusterResource, clusterDataSource, endpointResources}
@@ -218,7 +218,7 @@ func checkDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMongoDBAtlasPrivateLinkEndpointServiceConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, serviceResourceName string) string {
+func testConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, serviceResourceName string) string {
 	return fmt.Sprintf(`
 		provider "aws" {
 			region     = "%[5]s"


### PR DESCRIPTION
## Description

Migrates`privatelink_endpoint_regional_mode`to new auto-generated SDK

Link to any related issue(s): CLOUDP-246327

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
