### PR TITLE
fix: Uses `toMap()` when setting `feature_id`

### DIFF
--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -338,8 +338,9 @@ func featureUsagesSchema() *schema.Resource {
 }
 
 func featureToSchema(feature admin.CloudProviderAccessFeatureUsage) map[string]any {
+	featureID, _ := feature.GetFeatureId().ToMap()
 	return map[string]any{
 		"feature_type": feature.GetFeatureType(),
-		"feature_id":   feature.GetFeatureId(),
+		"feature_id":   featureID,
 	}
 }


### PR DESCRIPTION
## Description

Tests failed for `federated` and `push_based_log_export`. Failure is caused by this [PR](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2235/files), specifically [this](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2235/files#diff-2d8a9b4bcd0626d79ae9b41b10ef1c0ed6a1cf11ad3c0c34fc100fa0bf60f344R343) change. Now GetFeatureId() returns an entity `admin.CloudProviderAccessFeatureUsagePushBasedLogExportFeatureId` instead of an interface like the old [SDK](https://pkg.go.dev/go.mongodb.org/atlas@v0.36.0/mongodbatlas#FeatureUsage), which was set as a map. 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
