### PR TITLE
fix: Uses `snapshot_restore_job_id` instead of encodedID in `job_id` for data-source/mongodbatlas_cloud_backup_snapshot_restore_job

### DIFF
--- a/.changelog/2257.txt
+++ b/.changelog/2257.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_snapshot_restore_job: Uses `snapshot_restore_job_id` instead of encodedID in `job_id`
+```

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -108,7 +108,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if restoreIDInField {
 		restoreID = restoreIDRaw.(string)
 	} else {
-		restoreID = conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id")
+		idEncoded, restoreIDInField := d.GetOk("job_id")
+		if !restoreIDInField {
+			return diag.Errorf("either snapshot_restore_job_id or job_id must be set")
+		}
+		restoreID = conversion.GetEncodedID(idEncoded.(string), "snapshot_restore_job_id")
 	}
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -15,6 +15,10 @@ func DataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
+			"snapshot_restore_job_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -27,8 +31,10 @@ func DataSource() *schema.Resource {
 			},
 			"job_id": {
 				Type:     schema.TypeString,
-				Required: true,
 				ForceNew: true,
+				Optional: true,
+				// When deprecating, change snapshot_restore_job_id to Required: true and implementation below
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0") + " Use snapshot_restore_job_id instead.",
 			},
 			"cancelled": {
 				Type:     schema.TypeBool,
@@ -97,7 +103,17 @@ func DataSource() *schema.Resource {
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
-	restoreID := conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id")
+	var restoreID string
+	var err error
+	restoreIDRaw, restoreIDInField := d.GetOk("snapshot_restore_job_id")
+	if restoreIDInField {
+		restoreID = restoreIDRaw.(string)
+	} else {
+		restoreID = conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id")
+		if err = d.Set("snapshot_restore_job_id", restoreID); err != nil {
+			return diag.FromErr(fmt.Errorf("error setting `snapshot_restore_job_id` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
+		}
+	}
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -104,15 +104,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	var restoreID string
-	var err error
 	restoreIDRaw, restoreIDInField := d.GetOk("snapshot_restore_job_id")
 	if restoreIDInField {
 		restoreID = restoreIDRaw.(string)
 	} else {
 		restoreID = conversion.GetEncodedID(d.Get("job_id").(string), "snapshot_restore_job_id")
-		if err = d.Set("snapshot_restore_job_id", restoreID); err != nil {
-			return diag.FromErr(fmt.Errorf("error setting `snapshot_restore_job_id` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
-		}
 	}
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_migration_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigCloudBackupSnapshotRestoreJob_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.16.1")
 	mig.CreateAndRunTest(t, basicTestCase(t))
 }

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
@@ -176,7 +176,8 @@ func configBasic(projectID, clusterName, description, retentionInDays string) st
 		data "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
 			project_id      = mongodbatlas_cloud_backup_snapshot.test.project_id
 			cluster_name    = mongodbatlas_cloud_backup_snapshot.test.cluster_name
-			job_id       = mongodbatlas_cloud_backup_snapshot_restore_job.test.id  
+			job_id       = mongodbatlas_cloud_backup_snapshot_restore_job.test.id # remove after 1.18.0
+			snapshot_restore_job_id       = mongodbatlas_cloud_backup_snapshot_restore_job.test.snapshot_restore_job_id
 		}
 
 		data "mongodbatlas_cloud_backup_snapshot_restore_jobs" "test" {

--- a/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
@@ -45,7 +45,7 @@ data "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
 
 * `project_id` - (Required) The unique identifier of the project for the Atlas cluster.
 * `cluster_name` - (Required) The name of the Atlas cluster for which you want to retrieve the restore job.
-* `job_id` - (Optional) A base64 encoded ID  of `project_id`, `cluster_name`, and `job_id` of this resource. **Note**: This attribute is deprecated use `snapshot_restore_job_id` instead.
+* `job_id` - (Optional) A base64-encoded ID  of `project_id`, `cluster_name`, and `job_id` of this resource. **Note**: This attribute is deprecated, use `snapshot_restore_job_id` instead.
 * `snapshot_restore_job_id` - (Required) The unique identifier of the restore job to retrieve.
 
 ## Attributes Reference

--- a/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
@@ -46,7 +46,7 @@ data "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
 * `project_id` - (Required) The unique identifier of the project for the Atlas cluster.
 * `cluster_name` - (Required) The name of the Atlas cluster for which you want to retrieve the restore job.
 * `job_id` - (Optional) A base64-encoded ID  of `project_id`, `cluster_name`, and `job_id` of this resource. **Note**: This attribute is deprecated, use `snapshot_restore_job_id` instead.
-* `snapshot_restore_job_id` - (Required) The unique identifier of the restore job to retrieve.
+* `snapshot_restore_job_id` - (Optional) The unique identifier of the restore job to retrieve. Will be required from 1.18.0
 
 ## Attributes Reference
 

--- a/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
+++ b/website/docs/d/cloud_backup_snapshot_restore_job.html.markdown
@@ -45,7 +45,8 @@ data "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
 
 * `project_id` - (Required) The unique identifier of the project for the Atlas cluster.
 * `cluster_name` - (Required) The name of the Atlas cluster for which you want to retrieve the restore job.
-* `job_id` - (Required) The unique identifier of the restore job to retrieve.
+* `job_id` - (Optional) A base64 encoded ID  of `project_id`, `cluster_name`, and `job_id` of this resource. **Note**: This attribute is deprecated use `snapshot_restore_job_id` instead.
+* `snapshot_restore_job_id` - (Required) The unique identifier of the restore job to retrieve.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Uses `snapshot_restore_job_id` instead of encodedID in `job_id` for data-source/mongodbatlas_cloud_backup_snapshot_restore_job

Link to any related issue(s): CLOUDP-247721

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
