### PR TITLE
chore: Improves test coverage for cloud_provider_access_authorization.

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -395,6 +395,7 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_S3_BUCKET: ${{ secrets.aws_s3_bucket_federation }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -80,51 +80,6 @@ resource "mongodbatlas_federated_database_instance" "test" {
 			test_s3_bucket = %[5]q
 		}
 	}
-
-	storage_databases {
-	    name = "VirtualDatabase0"
-	    collections {
-			name = "VirtualCollection0"
-			data_sources {
-				collection = "listingsAndReviews"
-				database = "sample_airbnb"
-				store_name =  "ClusterTest"
-			}
-			data_sources {
-				store_name = %[5]q
-				path = "/{fileName string}.yaml"
-			}
-	    }
-	}
-
-	storage_stores {
-	    name = "ClusterTest"
-	    cluster_name = "ClusterTest"
-	    project_id = %[1]q
-	    provider = "atlas"
-	    read_preference {
-			mode = "secondary"
-	    }
-	}
-
-	storage_stores {
-	 bucket = %[5]q
-	 delimiter = "/"
-	 name = %[5]q
-	 prefix = "templates/"
-	 provider = "s3"
-	 region = "EU_WEST_1"
-	}
-
-	storage_stores {
-	 name = "dataStore0"
-	 cluster_name = "ClusterTest"
-	 project_id = %[1]q
-	 provider = "atlas"
-	 read_preference {
-		 mode = "secondary"
-	 }
-	}
 }
 
 resource "aws_iam_role_policy" "test_policy" {

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -42,6 +42,7 @@ func basicAuthorizationTestCase(tb testing.TB) *resource.TestCase {
 	tb.Helper()
 
 	var (
+		resourceName                  = "mongodbatlas_cloud_provider_access_authorization.auth_role"
 		projectID                     = acc.ProjectIDExecution(tb)
 		policyName                    = acc.RandomName()
 		roleName                      = acc.RandomIAMRole()
@@ -58,9 +59,23 @@ func basicAuthorizationTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configAuthorizationAWS(projectID, policyName, roleName, federatedDatabaseInstanceName, testS3Bucket),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.0.iam_assumed_role_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "feature_usages.#"),
+				),
 			},
 			{
 				Config: configAuthorizationAWS(projectID, policyName, roleNameUpdated, federatedDatabaseInstanceName, testS3Bucket),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "aws.0.iam_assumed_role_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "feature_usages.#"),
+				),
 			},
 		},
 	}


### PR DESCRIPTION
## Description

In https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/8994019768 we noticed that cloud_provider_access_authorization tests are not robust enough and a bug introduced in it was spotted with other tests workflows in the Test Suite (that are using cloud_provider_access_authorization).

So I worked backwards from the test that was able to trigger the bug and I added the test features to make sure cloud_provider_access_authorization tests are more robust.
In a nutshell, feature_ids are empty if there isn't federated database (or something similar) associated to it. That's why I am adding it.

One might argue that this is similar to the test in federated_database_instance, but in reality it shouldn't be a concern. Practically these resources are almost always touched independently, so it's better to keep tests in both of them

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-248348

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
