### PR TITLE
fix: Updates Read() in scaffolding resource template to remove resource if not found

### DIFF
--- a/tools/scaffold/template/resource.tmpl
+++ b/tools/scaffold/template/resource.tmpl
@@ -72,6 +72,10 @@ func (r *{{.NameCamelCase}}RS) Read(ctx context.Context, req resource.ReadReques
 
 	// connV2 := r.Client.AtlasV2
 	//if err != nil {
+	//	if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+	//		resp.State.RemoveResource(ctx)
+	//		return
+	//	}
 	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
 	//	return
 	//}


### PR DESCRIPTION
## Description

Updates Read() in scaffolding resource template to remove resource if not found

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
