### PR TITLE
chore: Fail fast when migration test is detecting TF_CLI_CONFIG_FILE

### DIFF
--- a/internal/testutil/mig/provider.go
+++ b/internal/testutil/mig/provider.go
@@ -1,6 +1,7 @@
 package mig
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -32,11 +33,19 @@ func ExternalProvidersWithAWS() map[string]resource.ExternalProvider {
 
 func checkLastVersion(tb testing.TB) {
 	tb.Helper()
+	validateConflictingEnvVars()
 	if os.Getenv("MONGODB_ATLAS_LAST_VERSION") == "" {
 		tb.Fatal("`MONGODB_ATLAS_LAST_VERSION` must be set for migration acceptance testing")
 	}
 }
 
 func versionConstraint() string {
+	validateConflictingEnvVars()
 	return os.Getenv("MONGODB_ATLAS_LAST_VERSION")
+}
+
+func validateConflictingEnvVars() {
+	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
+		log.Fatal("found `TF_CLI_CONFIG_FILE` in env-var when running migration tests, this might override the terraform provider for MONGODB_ATLAS_LAST_VERSION and instead use local latest build!")
+	}
 }

--- a/internal/testutil/mig/provider.go
+++ b/internal/testutil/mig/provider.go
@@ -1,7 +1,6 @@
 package mig
 
 import (
-	"log"
 	"os"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 
 func SkipIfVersionBelow(tb testing.TB, minVersion string) {
 	tb.Helper()
+	validateConflictingEnvVars(tb)
 	if !IsProviderVersionAtLeast(minVersion) {
 		tb.Skipf("Skipping because version %s below %s", versionConstraint(), minVersion)
 	}
@@ -33,19 +33,19 @@ func ExternalProvidersWithAWS() map[string]resource.ExternalProvider {
 
 func checkLastVersion(tb testing.TB) {
 	tb.Helper()
-	validateConflictingEnvVars()
+	validateConflictingEnvVars(tb)
 	if os.Getenv("MONGODB_ATLAS_LAST_VERSION") == "" {
 		tb.Fatal("`MONGODB_ATLAS_LAST_VERSION` must be set for migration acceptance testing")
 	}
 }
 
 func versionConstraint() string {
-	validateConflictingEnvVars()
 	return os.Getenv("MONGODB_ATLAS_LAST_VERSION")
 }
 
-func validateConflictingEnvVars() {
+func validateConflictingEnvVars(tb testing.TB) {
+	tb.Helper()
 	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
-		log.Fatal("found `TF_CLI_CONFIG_FILE` in env-var when running migration tests, this might override the terraform provider for MONGODB_ATLAS_LAST_VERSION and instead use local latest build!")
+		tb.Fatal("found `TF_CLI_CONFIG_FILE` in env-var when running migration tests, this might override the terraform provider for MONGODB_ATLAS_LAST_VERSION and instead use local latest build!")
 	}
 }


### PR DESCRIPTION
## Description

Using TF_CLI_CONFIG_FILE might cause your local "latest" build version of TF provider to be used instead of latest released version (e.g., 1.16.0)

Link to any related issue(s): CLOUDP-248697

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
