### PR TITLE
fix: Handles resource deletion in ReadResource

### DIFF
--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,23 +1,23 @@
 ```release-note:bug
-resource/cloud_backup_schedule: Fixes logic when resource is deleted outside of Terraform
+resource/cloud_backup_schedule: Fixes behavior when resource is deleted outside of Terraform.
 ```
 
 ```release-note:bug
-resource/encryption_at_rest: Fixes logic when resource is deleted outside of Terraform
+resource/encryption_at_rest: Fixes behavior when resource is deleted outside of Terraform.
 ```
 
 ```release-note:bug
-resource/push_based_log_export: Fixes logic when resource is deleted outside of Terraform
+resource/push_based_log_export: Fixes behavior when resource is deleted outside of Terraform.
 ```
 
 ```release-note:bug
-resource/search_deployment: Fixes logic when resource is deleted outside of Terraform
+resource/search_deployment: Fixes behavior when resource is deleted outside of Terraform.
 ```
 
 ```release-note:bug
-resource/stream_connection: Fixes logic when resource is deleted outside of Terraform
+resource/stream_connection: Fixes behavior when resource is deleted outside of Terraform.
 ```
 
 ```release-note:bug
-resource/stream_instance: Fixes logic when resource is deleted outside of Terraform
+resource/stream_instance: Fixes behavior when resource is deleted outside of Terraform.
 ```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,9 +1,3 @@
 ```release-note:bug
-Deletes resource outside of Terraform for the following: 
-- resource/cloud_backup_schedule
-- resource/encryption_at_rest
-- resource/push_based_log_export
-- resource/search_deployment
-- resource/stream_connection
-- resource/stream_instance
+Fixes logic when resource is deleted outside of Terraform
 ```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,0 +1,8 @@
+```release-note:bug
+resource/cloud_backup_schedule: Handle resource deletion outside of Terraform
+resource/encryption_at_rest: Handle resource deletion outside of Terraform
+resource/push_based_log_export: Handle resource deletion outside of Terraform
+resource/search_deployment: Handle resource deletion outside of Terraform
+resource/stream_connection: Handle resource deletion outside of Terraform
+resource/stream_instance: Handle resource deletion outside of Terraform
+```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,3 +1,9 @@
 ```release-note:bug
-Deletes resource outside of Terraform
+Deletes resource outside of Terraform for the following: 
+- resource/cloud_backup_schedule
+- resource/encryption_at_rest
+- resource/push_based_log_export
+- resource/search_deployment
+- resource/stream_connection
+- resource/stream_instance
 ```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,8 +1,8 @@
 ```release-note:bug
-resource/cloud_backup_schedule: Handle resource deletion outside of Terraform
-resource/encryption_at_rest: Handle resource deletion outside of Terraform
-resource/push_based_log_export: Handle resource deletion outside of Terraform
-resource/search_deployment: Handle resource deletion outside of Terraform
-resource/stream_connection: Handle resource deletion outside of Terraform
-resource/stream_instance: Handle resource deletion outside of Terraform
+resource/cloud_backup_schedule: Handles resource deletion outside of Terraform
+resource/encryption_at_rest: Handles resource deletion outside of Terraform
+resource/push_based_log_export: Handles resource deletion outside of Terraform
+resource/search_deployment: Handles resource deletion outside of Terraform
+resource/stream_connection: Handles resource deletion outside of Terraform
+resource/stream_instance: Handles resource deletion outside of Terraform
 ```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,8 +1,3 @@
 ```release-note:bug
-resource/cloud_backup_schedule: Handles resource deletion outside of Terraform
-resource/encryption_at_rest: Handles resource deletion outside of Terraform
-resource/push_based_log_export: Handles resource deletion outside of Terraform
-resource/search_deployment: Handles resource deletion outside of Terraform
-resource/stream_connection: Handles resource deletion outside of Terraform
-resource/stream_instance: Handles resource deletion outside of Terraform
+Deletes resource outside of Terraform
 ```

--- a/.changelog/2268.txt
+++ b/.changelog/2268.txt
@@ -1,3 +1,23 @@
 ```release-note:bug
-Fixes logic when resource is deleted outside of Terraform
+resource/cloud_backup_schedule: Fixes logic when resource is deleted outside of Terraform
+```
+
+```release-note:bug
+resource/encryption_at_rest: Fixes logic when resource is deleted outside of Terraform
+```
+
+```release-note:bug
+resource/push_based_log_export: Fixes logic when resource is deleted outside of Terraform
+```
+
+```release-note:bug
+resource/search_deployment: Fixes logic when resource is deleted outside of Terraform
+```
+
+```release-note:bug
+resource/stream_connection: Fixes logic when resource is deleted outside of Terraform
+```
+
+```release-note:bug
+resource/stream_instance: Fixes logic when resource is deleted outside of Terraform
 ```

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -343,8 +344,12 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	backupPolicy, _, err := connV2.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusterName).Execute()
+	backupPolicy, resp, err := connV2.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusterName).Execute()
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf(errorSnapshotBackupScheduleRead, clusterName, err)
 	}
 

--- a/internal/service/encryptionatrest/resource_encryption_at_rest.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest.go
@@ -289,8 +289,12 @@ func (r *encryptionAtRestRS) Read(ctx context.Context, req resource.ReadRequest,
 
 	connV2 := r.Client.AtlasV2
 
-	encryptionResp, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
+	encryptionResp, getResp, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
 	if err != nil {
+		if getResp != nil && getResp.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("error when getting encryption at rest resource during read", fmt.Sprintf(errorReadEncryptionAtRest, err.Error()))
 		return
 	}

--- a/internal/service/project/resource_project.go
+++ b/internal/service/project/resource_project.go
@@ -449,7 +449,7 @@ func (r *projectRS) Read(ctx context.Context, req resource.ReadRequest, resp *re
 	// get project
 	projectRes, atlasResp, err := connV2.ProjectsApi.GetProject(ctx, projectID).Execute()
 	if err != nil {
-		if resp != nil && atlasResp.StatusCode == http.StatusNotFound {
+		if atlasResp != nil && atlasResp.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
## Description

Handles resource deletion in ReadResource.
Terraform informs you about the resource deleted outside of Terraform, and the plan will re-create the resource

Link to any related issue(s): CLOUDP-248670

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
