### PR TITLE
fix: Calls DeleteExportBucket before checking the status to catch any errors.

### DIFF
--- a/.changelog/2269.txt
+++ b/.changelog/2269.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Calls DeleteExportBucket before checking for a status update. It avoids the delete operation to hang.
+resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Calls DeleteExportBucket before checking for a status update so that the delete operation doesn't hang.
 ```

--- a/.changelog/2269.txt
+++ b/.changelog/2269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Calls DeleteExportBucket before checking for a status update. It avoids the delete operation to hang.
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -88,6 +88,8 @@ on:
         required: true
       aws_s3_bucket_federation:
         required: true
+      aws_s3_bucket_backup:
+        required: true
       mongodb_atlas_ldap_hostname:
         required: true
       mongodb_atlas_ldap_username:
@@ -325,6 +327,7 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          AWS_S3_BUCKET: ${{ secrets.aws_s3_bucket_backup }}
           ACCTEST_PACKAGES: |
             ./internal/service/cloudbackupschedule
             ./internal/service/cloudbackupsnapshot

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -322,6 +322,9 @@ jobs:
         env:
           MONGODB_ATLAS_PROJECT_OWNER_ID: ${{ inputs.mongodb_atlas_project_owner_id }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ACCTEST_PACKAGES: |
             ./internal/service/cloudbackupschedule
             ./internal/service/cloudbackupsnapshot

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -56,6 +56,7 @@ jobs:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws_s3_bucket_federation: ${{ secrets.AWS_S3_BUCKET_FEDERATION }}
+      aws_s3_bucket_backup: ${{ secrets.AWS_S3_BUCKET_BACKUP }}
       mongodb_atlas_ldap_hostname: ${{ secrets.MONGODB_ATLAS_LDAP_HOSTNAME }}
       mongodb_atlas_ldap_username: ${{ secrets.MONGODB_ATLAS_LDAP_USERNAME }}
       mongodb_atlas_ldap_password: ${{ secrets.MONGODB_ATLAS_LDAP_PASSWORD }}

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -147,16 +147,16 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		MinTimeout: 5 * time.Second,
 		Delay:      3 * time.Second,
 	}
-	// Wait, catching any errors
-	_, err := stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.Errorf("error deleting snapshot export bucket %s %s", projectID, err)
-	}
-
-	_, _, err = conn.CloudBackupsApi.DeleteExportBucket(ctx, projectID, bucketID).Execute()
+	_, _, err := conn.CloudBackupsApi.DeleteExportBucket(ctx, projectID, bucketID).Execute()
 
 	if err != nil {
 		return diag.Errorf("error deleting snapshot export bucket (%s): %s", bucketID, err)
+	}
+
+	// Wait, catching any errors
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error deleting snapshot export bucket %s %s", projectID, err)
 	}
 
 	return nil

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -153,7 +153,6 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.Errorf("error deleting snapshot export bucket (%s): %s", bucketID, err)
 	}
 
-	// Wait, catching any errors
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return diag.Errorf("error deleting snapshot export bucket %s %s", projectID, err)

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -31,7 +31,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 	)
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		PreCheck:                 func() { acc.PreCheckBasic(tb); acc.PreCheckS3Bucket(tb) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -112,7 +112,7 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 func configBasic(projectID, bucketName string) string {
 	return fmt.Sprintf(`
     resource "aws_iam_role_policy" "test_policy" {
-        name = "mongo_setup_policy_export_bucket"
+        name = "mongodb-atlas-policy-export-bucket"
         role = aws_iam_role.test_role.id
 
         policy = <<-EOF
@@ -130,7 +130,7 @@ func configBasic(projectID, bucketName string) string {
       }
 
       resource "aws_iam_role" "test_role" {
-        name = "mongo_setup_role_export_bucket"
+        name = "mongodb-atlas-role-export-bucket"
 
         assume_role_policy = <<EOF
       {

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -30,7 +30,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 	)
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(tb); acc.PreCheckS3Bucket(tb) },
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,


### PR DESCRIPTION
While trying to delete the snapshot export bucket resource, we noticed that the deletion hanged. The cause is due to the fact that we don't call the Delete API before checking the status update.

In addition, I've activated the related tests to be included in the nightly and PR run. There wasn't really any strong reason not to do that, since we can create S3 buckets, policies and anything else needed.

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
