### PR TITLE
fix: Removes update logic for the global_cluster_config resource.

### DIFF
--- a/.changelog/2282.txt
+++ b/.changelog/2282.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/global_cluster_config: Blocks updates on global_cluster_config resource to avoid leaving the cluster in an inconsistent state.
+resource/mongodbatlas_global_cluster_config: Blocks updates on global_cluster_config resource to avoid leaving the cluster in an inconsistent state.
 ```

--- a/.changelog/2282.txt
+++ b/.changelog/2282.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/global_cluster_config: Blocks updates on global_cluster_config resource to avoid leaving the cluster in an inconsistent state.
+```

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -193,7 +193,9 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return diag.Errorf("Updating a global cluster configuration resource is not allowed.")
+	return diag.Errorf("Updating a global cluster configuration resource is not allowed as it would " +
+		"leave the index and shard key on the related collection in an inconsistent state.\n" +
+		"Please read our official documentation for more information.")
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -103,7 +103,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 				),
 			},
 			{
-				Config:      configBasic(&clusterInfo, true, false),
+				Config:      configWithDBConfig(&clusterInfo, customZoneUpdated),
 				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed."),
 			},
 			{

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -39,7 +39,7 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 			},
 			{
 				Config:      configBasic(&clusterInfo, true, false),
-				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed."),
+				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed"),
 			},
 		},
 	})
@@ -104,7 +104,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 			},
 			{
 				Config:      configWithDBConfig(&clusterInfo, customZoneUpdated),
-				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed."),
+				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed"),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -3,6 +3,7 @@ package globalclusterconfig_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -37,22 +38,8 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: configBasic(&clusterInfo, true, false),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "true"),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "false"),
-				),
-			},
-			{
-				Config: configBasic(&clusterInfo, false, true),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_custom_shard_key_hashed", "false"),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.0.is_shard_key_unique", "true"),
-				),
+				Config:      configBasic(&clusterInfo, true, false),
+				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed."),
 			},
 		},
 	})
@@ -116,19 +103,8 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithDBConfig(&clusterInfo, customZoneUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "5"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.US"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.IE"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.DE"),
-					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.JP"),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
-				),
+				Config:      configBasic(&clusterInfo, true, false),
+				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed."),
 			},
 			{
 				ResourceName:            resourceName,

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -13,7 +13,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
-~> **IMPORTANT:** A Global Cluster Configuration, once created, can only be deleted and never re-created again with the same data if not without the help of the Atlas UI. This is because the configuration and its related collection with shard key and indexes are managed separately and they would end up in an inconsistent state. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
+~> **IMPORTANT:** A Global Cluster Configuration, once created, can only be deleted. You can recreate the Global Cluster with the same data only in the Atlas UI. This is because the configuration and its related collection with shard key and indexes are managed separately and they would end up in an inconsistent state. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
 
 ## Examples Usage
 

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -152,4 +152,4 @@ Global Clusters can be imported using project ID and cluster name, in the format
 $ terraform import mongodbatlas_global_cluster_config.config 1112222b3bf99403840e8934-Cluster0
 ```
 
-See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters)
+See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/)

--- a/website/docs/r/global_cluster_config.html.markdown
+++ b/website/docs/r/global_cluster_config.html.markdown
@@ -13,6 +13,7 @@ description: |-
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.
 
+~> **IMPORTANT:** A Global Cluster Configuration, once created, can only be deleted and never re-created again with the same data if not without the help of the Atlas UI. This is because the configuration and its related collection with shard key and indexes are managed separately and they would end up in an inconsistent state. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
 
 ## Examples Usage
 
@@ -151,4 +152,4 @@ Global Clusters can be imported using project ID and cluster name, in the format
 $ terraform import mongodbatlas_global_cluster_config.config 1112222b3bf99403840e8934-Cluster0
 ```
 
-See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/)
+See detailed information for arguments and attributes: [MongoDB API Global Clusters](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters)


### PR DESCRIPTION
## Description

More info on https://jira.mongodb.org/browse/HELP-59447 

tl;dr: updating the global_cluster_config resource leaves the collection and index in an inconsistent state because they are on the data plane side and they would remain unchanged. 
That's also why the API does not have any PATCH endpoint.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
