### PR TITLE
doc: Removes duplicated cluster_type field definition in the documentation.

### DIFF
--- a/website/docs/r/advanced_cluster.html.markdown
+++ b/website/docs/r/advanced_cluster.html.markdown
@@ -363,7 +363,6 @@ Refer to the following for full privatelink endpoint connection string examples:
 
 * `project_id` - (Required) Unique ID for the project to create the database user.
 * `name` - (Required) Name of the cluster as it appears in Atlas. Once the cluster is created, its name cannot be changed. **WARNING** Changing the name will result in destruction of the existing cluster and the creation of a new cluster.
-* `cluster_type` - (Required) Atlas provides different instance sizes, each with a default storage capacity and RAM size. The instance size you select is used for all the data-bearing servers in your cluster. See [Create a Cluster](https://docs.atlas.mongodb.com/reference/api/clusters-create-one/) `providerSettings.instanceSizeName` for valid values and default resources.
 
 * `backup_enabled` - (Optional) Flag that indicates whether the cluster can perform backups.
   If `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters.


### PR DESCRIPTION
## Description

The field `cluster_type` in the advanced_configuration documentation is repeated twice and of them is also incorrect. Removing it as suggested in #2238 

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2238

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
