### PR TITLE
chore: Removes actions-permissions step and set minimal permissions for workflows that have run

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -120,10 +120,10 @@ jobs:
 
   get-provider-version:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       provider_version: ${{ inputs.provider_version || steps.get_last_release.outputs.last_provider_version }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Get Last Release
@@ -136,6 +136,7 @@ jobs:
 
   change-detection:
     runs-on: ubuntu-latest
+    permissions: {}
     env:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '')  }}
     outputs:
@@ -159,7 +160,6 @@ jobs:
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
       id: filter
@@ -246,8 +246,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -268,8 +268,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -308,8 +308,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.backup == 'true' || inputs.test_group == 'backup' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -341,8 +341,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.cluster == 'true' || inputs.test_group == 'cluster' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -365,8 +365,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.cluster_outage_simulation == 'true' || inputs.test_group == 'cluster_outage_simulation' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -387,8 +387,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.config == 'true' || inputs.test_group == 'config' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -432,8 +432,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.data_lake == 'true' || inputs.test_group == 'data_lake' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -454,8 +454,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.encryption == 'true' || inputs.test_group == 'encryption' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -476,8 +476,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -498,8 +498,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.federated == 'true' || inputs.test_group == 'federated' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -536,8 +536,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.generic == 'true' || inputs.test_group == 'generic' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -563,8 +563,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.ldap == 'true' || inputs.test_group == 'ldap' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -592,8 +592,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.network == 'true' || inputs.test_group == 'network' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -630,8 +630,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.project == 'true' || inputs.test_group == 'project' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -666,8 +666,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.push_based_log_export == 'true' || inputs.test_group == 'push_based_log_export' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -691,8 +691,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -713,8 +713,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.search_index == 'true' || inputs.test_group == 'search_index' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -735,8 +735,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.serverless == 'true' || inputs.test_group == 'serverless' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -762,8 +762,8 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.stream == 'true' || inputs.test_group == 'stream' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           ref: ${{ inputs.ref || github.ref }}

--- a/.github/workflows/check-changelog-entry-file.yml
+++ b/.github/workflows/check-changelog-entry-file.yml
@@ -11,8 +11,8 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:

--- a/.github/workflows/check-migration-guide.yml
+++ b/.github/workflows/check-migration-guide.yml
@@ -8,8 +8,8 @@ jobs:
   check:
     if: ${{ contains(github.event.pull_request.title, '!') }}  
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes

--- a/.github/workflows/cleanup-test-env.yml
+++ b/.github/workflows/cleanup-test-env.yml
@@ -8,8 +8,8 @@ on:
 jobs:  
   cleanup-test-env-general:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
@@ -26,8 +26,8 @@ jobs:
         run: ./scripts/cleanup-test-env.sh      
   cleanup-test-env-qa:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,8 +15,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
       with:
@@ -29,7 +29,6 @@ jobs:
     permissions:
       pull-requests: write # Needed by sticky-pull-request-comment
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
@@ -38,8 +37,8 @@ jobs:
         run: make test
   lint:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Install Go
@@ -56,8 +55,8 @@ jobs:
         shell: bash  
   website-lint:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
@@ -66,8 +65,8 @@ jobs:
         run: make tools && make website-lint
   shellcheck:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Run ShellCheck
         uses: bewuethr/shellcheck-action@d01912909579c4b1a335828b8fca197fbb8e0aa4

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform_version: ["${{vars.TF_VERSION_LATEST}}"]
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -57,8 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform_version: ["${{vars.TF_VERSION_LATEST}}"]
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -24,8 +24,8 @@ jobs:
     needs: [generate-and-update-changelog]
     if: ${{ !cancelled() && needs.generate-and-update-changelog.result == 'failure' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Send Slack message
         id: slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -13,8 +13,9 @@
       name: Create Jira issue
       if: github.event.action == 'opened'
       runs-on: ubuntu-latest
+      permissions:
+        issues: write
       steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Create JIRA ticket
         id: create
         shell: bash
@@ -73,8 +74,8 @@
       name: Reopen JIRA ticket
       if: github.event.action == 'reopened'
       runs-on: ubuntu-latest
+      permissions: {}
       steps:
-        - uses: GitHubSecurityLab/actions-permissions/monitor@v1
         - name: Reopened JIRA ticket if exists
           run: |
             ISSUE_NUMBER=${{ github.event.issue.number }}
@@ -123,7 +124,6 @@
       if: github.event.action == 'closed'
       runs-on: ubuntu-latest
       steps:
-        - uses: GitHubSecurityLab/actions-permissions/monitor@v1
         - name: Close JIRA ticket if exists
           run: |
             ISSUE_NUMBER=${{ github.event.issue.number }}

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.changes.outputs.files }}
+    permissions:
+      pull-requests: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
@@ -28,7 +29,6 @@ jobs:
     permissions:
       pull-requests: write # Needed by sticky-pull-request-comment
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       pull-requests: write # Needed by sticky-pull-request-comment
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: amannn/action-semantic-pull-request@cfb60706e18bc85e8aec535e3c577abe8f70378e
         id: lint_pr_title
         env:
@@ -76,7 +75,6 @@ jobs:
       contents: read
       pull-requests: write # Needed by labeler
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: srvaroa/labeler@1eec6d9e7c5fa5864840279978680302f955fc37
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-script-and-commit.yml
+++ b/.github/workflows/run-script-and-commit.yml
@@ -26,8 +26,8 @@ on:
 jobs:
   run_script_and_commit:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout repository
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,8 +10,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
         id: stale
         with:

--- a/.github/workflows/terraform-compatibility-matrix.yml
+++ b/.github/workflows/terraform-compatibility-matrix.yml
@@ -18,8 +18,8 @@ on:
 jobs:
   get-supported-versions:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Get HashiCorp Terraform supported versions
         shell: bash
@@ -53,8 +53,8 @@ jobs:
     needs: ["run-test-supported-versions"]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Get content of slack message
         id: slack-payload

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -75,8 +75,8 @@ jobs:
     needs: [tests, clean-after]
     if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure'}}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Send Slack message
         id: slack
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e

--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   update-sdk:
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7

--- a/.github/workflows/update_tf_compatibility_matrix.yml
+++ b/.github/workflows/update_tf_compatibility_matrix.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   update-tf-compatibility-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Update files


### PR DESCRIPTION

## Description

- Removes actions-permissions step and set minimal permissions for workflows that have run.
- [Github Actions permissions documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- actions-permissions is still in the `release.yml` and `jira-release-version.yml` because these actions have not been run and we can't be sure of which permissions are the minimal required. 

Link to any related issue(s): CLOUDP-223072

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
