### PR TITLE
chore: Improves performance in codehealth checks

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build:
+  build-unit-test:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -21,38 +21,60 @@ jobs:
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
       with:
         go-version-file: 'go.mod'
+        cache: false
+    - id: cache-restore
+      uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: go-build-${{ hashFiles('**/go.sum') }}
     - name: Build
       run: make build
-  unit-test:
-    needs: build
+    - name: Unit Test
+      run: make test
+    - id: cache-save
+      if: steps.cache-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+      uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: go-build-${{ hashFiles('**/go.sum') }}
+  lint:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Needed by sticky-pull-request-comment
+    permissions: {}
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
         with:
           go-version-file: 'go.mod'
-      - name: Unit Test
-        run: make test
-  lint:
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - name: Install Go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+          cache: false
+      - id: cache-restore
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
-          go-version-file: 'go.mod'
-          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
-      - name: golangci-lint
+          key: go-lint-${{ hashFiles('**/go.sum', '**/GNUmakefile') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.cache/golangci-lint
+      - id: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64
         with:
-          version: v1.57.2
-      - name: actionlint
+          version: v1.57.2 # Also update GOLANGCI_VERSION variable in GNUmakefile when updating this version
+          skip-cache: true
+      - id: actionlint
         run: make tools && actionlint -verbose -color
         shell: bash  
+      - id: cache-save
+        if: steps.cache-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          key: go-lint-${{ hashFiles('**/go.sum', '**/GNUmakefile') }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.cache/golangci-lint
   website-lint:
     runs-on: ubuntu-latest
     permissions: {}
@@ -71,6 +93,6 @@ jobs:
       - name: Run ShellCheck
         uses: bewuethr/shellcheck-action@d01912909579c4b1a335828b8fca197fbb8e0aa4
   call-acceptance-tests-workflow:
-    needs: [build, lint, shellcheck, unit-test, website-lint]
+    needs: [build-unit-test, lint, shellcheck, website-lint]
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   build-unit-test:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      pull-requests: write # Needed by sticky-pull-request-comment
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
     - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ GITTAG=$(shell git describe --always --tags)
 VERSION=$(GITTAG:v%=%)
 LINKER_FLAGS=-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=${VERSION}'
 
-GOLANGCI_VERSION=v1.57.2
+GOLANGCI_VERSION=v1.57.2 # Also update golangci-lint GH action in code-health.yml when updating this version
 
 export PATH := $(shell go env GOPATH)/bin:$(PATH)
 export SHELL := env PATH=$(PATH) /bin/bash


### PR DESCRIPTION
## Description

Improves performance in codehealth checks using cache.

This allows to start running acc tests about 30s after commits are pushed instead of about 3-4m.

Caches are only created in master to avoid hitting the 10G cache limit. They're not created per branch as they are not so useful and branches can use the caches in master.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
