### PR TITLE
chore: Disables migration test for backup snapshot export until next release version.

### DIFF
--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_migration_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigBackupSnapshotExportJob_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.16.1")
 	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithAWS(), nil)
 }

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -212,7 +212,6 @@ data "mongodbatlas_cloud_backup_snapshot_export_job" "test" {
     project_id 		= %[1]q
     cluster_name 	= %[5]s
     export_job_id 	= mongodbatlas_cloud_backup_snapshot_export_job.test.export_job_id
-    id              = "any_value"
 }
   
 data "mongodbatlas_cloud_backup_snapshot_export_jobs" "test" {


### PR DESCRIPTION
## Description

Follow-up from https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2274
The migration test needs to be disabled since it would actually need us to define the ID properly (and not just any value). I am not sure how I managed to make it successful locally but test was failing since the weekend: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/9151546873/job/25157755777

Link to any related issue(s): CLOUDP-249082

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
