### PR TITLE
test: Adds test for stream_instance stream_config.tier

### DIFF
--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -50,10 +50,10 @@ func TestAccStreamRSStreamInstance_withStreamConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
+				Config: acc.StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider, "SP10"), // as of now there are no values that can be updated because only one region is supported
 				Check: resource.ComposeTestCheckFunc(
 					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
 				),
 			},
 			{

--- a/internal/testutil/acc/stream_instance.go
+++ b/internal/testutil/acc/stream_instance.go
@@ -20,7 +20,7 @@ func StreamInstanceConfig(projectID, instanceName, region, cloudProvider string)
 	`, projectID, instanceName, region, cloudProvider)
 }
 
-func StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider string) string {
+func StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider, configTier string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_stream_instance" "test" {
 			project_id = %[1]q
@@ -30,10 +30,10 @@ func StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloud
 				cloud_provider = %[4]q
 			}
 			stream_config = {
-				tier = "SP30"
+				tier = %[5]q
 			}
 		}
-	`, projectID, instanceName, region, cloudProvider)
+	`, projectID, instanceName, region, cloudProvider, configTier)
 }
 
 func CheckDestroyStreamInstance(state *terraform.State) error {


### PR DESCRIPTION
## Description

Adds test for stream_instance SP10 stream_config.tier
The issue describes adding a new parameter, `InstanceType` support.
However, this is already supported with the `stream_config.tier` attribute.
I updated the 2nd test to include the `configTier` to validate that SP10 also works. (SP30 is the default tier)
Note that updating the `tier` is not supported in the [API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/updateStreamInstance)

Link to any related issue(s): CLOUDP-230986

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
