### PR TITLE
chore: Fixes prefix of 2 changelog entries and adds validation to ensure correct prefix is defined

### DIFF
--- a/.changelog/2234.txt
+++ b/.changelog/2234.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/mongodbatlas_cloud_backup_snapshot_export_job: Marks `id` as computed not required
+data-source/mongodbatlas_cloud_backup_snapshot_export_job: Marks `id` as computed and therefore, not required
 ```

--- a/.changelog/2234.txt
+++ b/.changelog/2234.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/cloud_backup_snapshot_export_job: Marks `id` as computed not required
+data-source/mongodbatlas_cloud_backup_snapshot_export_job: Marks `id` as computed not required
 ```

--- a/.changelog/2258.txt
+++ b/.changelog/2258.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/federated_settings_org_rolemapping: Exposes role_mapping_id
+resource/mongodbatlas_federated_settings_org_rolemapping: Exposes role_mapping_id
 ```

--- a/.changelog/2258.txt
+++ b/.changelog/2258.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_federated_settings_org_rolemapping: Exposes role_mapping_id
+resource/mongodbatlas_federated_settings_org_rolemapping: Adds `role_mapping_id` computed attribute
 ```


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-249943

 Fix 2 entries which defined an incorrect prefix, and adjust our CI check to ensure this is caught at the PR level. Changelog will be updated after the merge.



## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
