### PR TITLE
fix: Sets all attributes of Azure `mongodbatlas_network_peering` as ForceNew, forcing recreation of the resource when updating 

### DIFF
--- a/.changelog/2299.txt
+++ b/.changelog/2299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_network_peering: sets all necessary attributes for update of Azure network peering
+```

--- a/.changelog/2299.txt
+++ b/.changelog/2299.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_network_peering: sets all necessary attributes for update of Azure network peering
+resource/mongodbatlas_network_peering: Sets all necessary attributes for update of Azure network peering
 ```

--- a/.changelog/2299.txt
+++ b/.changelog/2299.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_network_peering: Sets all necessary attributes for update of Azure network peering
+resource/mongodbatlas_network_peering: Sets all attributes of Azure network peering as ForceNew, forcing recreation of the resource when updating 
 ```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -104,6 +104,16 @@ on:
         required: true
       mongodb_atlas_private_endpoint_dns_name:
         required: true
+      azure_directory_id:
+        required: true
+      azure_resource_group_name:
+        required: true
+      azure_subscription_id:
+        required: true
+      azure_vnet_name:
+        required: true
+      azure_vnet_name_updated:
+        required: true
           
 env:
   TF_ACC: 1
@@ -616,6 +626,11 @@ jobs:
           AWS_SECURITY_GROUP_2: ${{ vars.AWS_SECURITY_GROUP_2 }}
           AWS_VPC_CIDR_BLOCK: ${{ vars.AWS_VPC_CIDR_BLOCK }}
           AWS_VPC_ID: ${{ vars.AWS_VPC_ID }}
+          AZURE_DIRECTORY_ID: ${{ secrets.azure_directory_id }}
+          AZURE_RESOURCE_GROUP_NAME: ${{ secrets.azure_resource_group_name }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.azure_subscription_id }}
+          AZURE_VNET_NAME: ${{ secrets.azure_vnet_name }}
+          AZURE_VNET_NAME_UPDATED: ${{ secrets.azure_vnet_name_updated }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/networkcontainer

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -64,6 +64,11 @@ jobs:
       mongodb_atlas_ldap_ca_certificate: ${{ secrets.MONGODB_ATLAS_LDAP_CA_CERTIFICATE }}
       mongodb_atlas_private_endpoint_id: ${{ secrets.MONGODB_ATLAS_PRIVATE_ENDPOINT_ID }}
       mongodb_atlas_private_endpoint_dns_name: ${{ secrets.MONGODB_ATLAS_PRIVATE_ENDPOINT_DNS_NAME }}
+      azure_directory_id: ${{ secrets.AZURE_DIRECTORY_ID }}
+      azure_resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_vnet_name: ${{ secrets.AZURE_VNET_NAME }}
+      azure_vnet_name_updated: ${{ secrets.AZURE_VNET_NAME_UPDATED }}
 
     with:
       terraform_version: ${{ inputs.terraform_version || vars.TF_VERSION_LATEST }}

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -410,15 +410,12 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		ContainerId:  conversion.GetEncodedID(d.Get("container_id").(string), "container_id"),
 	}
 
+	// Updating any of the attributes for Azure Network Peering forces a recreation of the network peering.
+	// Need to check if GCP and AWS have the same behavior
 	switch peer.GetProviderName() {
 	case "GCP":
 		peer.SetGcpProjectId(d.Get("gcp_project_id").(string))
 		peer.SetNetworkName(d.Get("network_name").(string))
-	case "AZURE":
-		peer.SetAzureDirectoryId(d.Get("azure_directory_id").(string))
-		peer.SetAzureSubscriptionId(d.Get("azure_subscription_id").(string))
-		peer.SetResourceGroupName(d.Get("resource_group_name").(string))
-		peer.SetVnetName(d.Get("vnet_name").(string))
 	default: // AWS by default
 		region, _ := conversion.ValRegion(d.Get("accepter_region_name"), "network_peering")
 		peer.SetAccepterRegionName(region)

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -411,21 +411,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		peer.SetGcpProjectId(d.Get("gcp_project_id").(string))
 		peer.SetNetworkName(d.Get("network_name").(string))
 	case "AZURE":
-		if d.HasChange("azure_directory_id") {
-			peer.SetAzureDirectoryId(d.Get("azure_directory_id").(string))
-		}
-
-		if d.HasChange("azure_subscription_id") {
-			peer.SetAzureSubscriptionId(d.Get("azure_subscription_id").(string))
-		}
-
-		if d.HasChange("resource_group_name") {
-			peer.SetResourceGroupName(d.Get("resource_group_name").(string))
-		}
-
-		if d.HasChange("vnet_name") {
-			peer.SetVnetName(d.Get("vnet_name").(string))
-		}
+		peer.SetAzureDirectoryId(d.Get("azure_directory_id").(string))
+		peer.SetAzureSubscriptionId(d.Get("azure_subscription_id").(string))
+		peer.SetResourceGroupName(d.Get("resource_group_name").(string))
+		peer.SetVnetName(d.Get("vnet_name").(string))
 	default: // AWS by default
 		region, _ := conversion.ValRegion(d.Get("accepter_region_name"), "network_peering")
 		peer.SetAccepterRegionName(region)

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -103,21 +103,25 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"azure_subscription_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"resource_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"vnet_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"error_state": {
 				Type:     schema.TypeString,
@@ -422,6 +426,13 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		peer.SetRouteTableCidrBlock(d.Get("route_table_cidr_block").(string))
 		peer.SetVpcId(d.Get("vpc_id").(string))
 	}
+	peerConn, resp, getErr := conn.NetworkPeeringApi.GetPeeringConnection(ctx, projectID, peerID).Execute()
+	if getErr != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return nil
+		}
+	}
+	fmt.Print(peerConn.GetStatus())
 
 	_, _, err := conn.NetworkPeeringApi.UpdatePeeringConnection(ctx, projectID, peerID, peer).Execute()
 	if err != nil {

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -36,7 +36,7 @@ func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvAzure(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
 		Steps: []resource.TestStep{
@@ -74,7 +74,7 @@ func TestAccNetworkRSNetworkPeering_updateBasicAzure(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvAzure(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
 		Steps: []resource.TestStep{

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -26,10 +26,8 @@ func TestAccNetworkNetworkPeering_basicAWS(t *testing.T) {
 }
 
 func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
-	acc.SkipTestForCI(t) // needs Azure configuration
-
 	var (
-		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID         = acc.ProjectIDExecution(t)
 		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
 		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
@@ -65,10 +63,8 @@ func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
 }
 
 func TestAccNetworkRSNetworkPeering_updateBasicAzure(t *testing.T) {
-	acc.SkipTestForCI(t) // needs Azure configuration
-
 	var (
-		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID         = acc.ProjectIDExecution(t)
 		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
 		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -275,7 +275,7 @@ func configAzure(projectID, providerName, directoryID, subscriptionID, resourceG
 			azure_directory_id    = "%[3]s"
 			azure_subscription_id = "%[4]s"
 			resource_group_name   = "%[5]s"
-			vnet_name	            = "%[6]s"
+			vnet_name	          = "%[6]s"
 		}
 	`, projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
 }

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -64,6 +64,50 @@ func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
 	})
 }
 
+func TestAccNetworkRSNetworkPeering_updateBasicAzure(t *testing.T) {
+	acc.SkipTestForCI(t) // needs Azure configuration
+
+	var (
+		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
+		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+		vNetName          = os.Getenv("AZURE_VNET_NAME")
+		updatedvNetName   = os.Getenv("AZURE_VNET_NAME_UPDATED")
+		providerName      = "AZURE"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvAzure(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyNetworkPeering,
+		Steps: []resource.TestStep{
+			{
+				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
+					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+				),
+			},
+			{
+				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, updatedvNetName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "vnet_name", updatedvNetName),
+					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -302,20 +302,20 @@ func configAWS(orgID, projectName, providerName, vpcID, awsAccountID, vpcCIDRBlo
 func configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_network_container" "test" {
-			project_id   		  = "%[1]s"
+			project_id   		  = %[1]q
 			atlas_cidr_block  = "192.168.208.0/21"
-			provider_name		  = "%[2]s"
+			provider_name		  = %[2]q
 			region    			  = "US_EAST_2"
 		}
 
 		resource "mongodbatlas_network_peering" "test" {
-			project_id   		      = "%[1]s"
+			project_id   		  = %[1]q
 			container_id          = mongodbatlas_network_container.test.container_id
-			provider_name         = "%[2]s"
-			azure_directory_id    = "%[3]s"
-			azure_subscription_id = "%[4]s"
-			resource_group_name   = "%[5]s"
-			vnet_name	          = "%[6]s"
+			provider_name         = %[2]q
+			azure_directory_id    = %[3]q
+			azure_subscription_id = %[4]q
+			resource_group_name   = %[5]q
+			vnet_name	          = %[6]q
 		}
 	`, projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
 }
@@ -323,17 +323,17 @@ func configAzure(projectID, providerName, directoryID, subscriptionID, resourceG
 func configGCP(projectID, providerName, gcpProjectID, networkName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_network_container" "test" {
-			project_id       = "%[1]s"
+			project_id       = %[1]q
 			atlas_cidr_block = "192.168.192.0/18"
-			provider_name    = "%[2]s"
+			provider_name    = %[2]q
 		}
 
 		resource "mongodbatlas_network_peering" "test" {
-			project_id     = "%[1]s"
+			project_id     = %[1]q
 			container_id   = mongodbatlas_network_container.test.container_id
-			provider_name  = "%[2]s"
-			gcp_project_id = "%[3]s"
-			network_name   = "%[4]s"
+			provider_name  = %[2]q
+			gcp_project_id = %[3]q
+			network_name   = %[4]q
 		}
 	`, projectID, providerName, gcpProjectID, networkName)
 }


### PR DESCRIPTION
## Description

Sets all attributes when updating an Azure network peering resource. 
Fixes https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2281

Link to any related issue(s): CLOUDP-249269

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
