### PR TITLE
fix: Correctly handle GCP updates of `mongodbatlas_network_peering`

### DIFF
--- a/.changelog/2306.txt
+++ b/.changelog/2306.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_network_peering: Correctly handle GCP updates of mongodbatlas_network_peering
+resource/mongodbatlas_network_peering: Correctly handles GCP updates of mongodbatlas_network_peering
 ```

--- a/.changelog/2306.txt
+++ b/.changelog/2306.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-mongodbatlas_network_peering: Correctly handle GCP updates of mongodbatlas_network_peering
+resource/mongodbatlas_network_peering: Correctly handle GCP updates of mongodbatlas_network_peering
 ```

--- a/.changelog/2306.txt
+++ b/.changelog/2306.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mongodbatlas_network_peering: Correctly handle GCP updates of mongodbatlas_network_peering
+```

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -135,11 +135,13 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"network_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"atlas_gcp_project_id": {
 				Type:     schema.TypeString,
@@ -412,11 +414,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	// Updating any of the attributes for Azure Network Peering forces a recreation of the network peering.
 	// Need to check if GCP and AWS have the same behavior
-	switch peer.GetProviderName() {
-	case "GCP":
-		peer.SetGcpProjectId(d.Get("gcp_project_id").(string))
-		peer.SetNetworkName(d.Get("network_name").(string))
-	default: // AWS by default
+	if peer.GetProviderName() == "AWS" {
 		region, _ := conversion.ValRegion(d.Get("accepter_region_name"), "network_peering")
 		peer.SetAccepterRegionName(region)
 		peer.SetAwsAccountId(d.Get("aws_account_id").(string))

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -412,8 +412,6 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		ContainerId:  conversion.GetEncodedID(d.Get("container_id").(string), "container_id"),
 	}
 
-	// Updating any of the attributes for Azure Network Peering forces a recreation of the network peering.
-	// Need to check if GCP and AWS have the same behavior
 	if peer.GetProviderName() == "AWS" {
 		region, _ := conversion.ValRegion(d.Get("accepter_region_name"), "network_peering")
 		peer.SetAccepterRegionName(region)

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -142,6 +142,52 @@ func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
 	})
 }
 
+func TestAccNetworkRSNetworkPeering_updateBasicGCP(t *testing.T) {
+	acc.SkipTestForCI(t) // needs GCP configuration
+
+	var (
+		projectID          = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		providerName       = "GCP"
+		gcpProjectID       = os.Getenv("GCP_PROJECT_ID")
+		networkName        = acc.RandomName()
+		updatedNetworkName = acc.RandomName()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvGCP(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyNetworkPeering,
+		Steps: []resource.TestStep{
+			{
+				Config: configGCP(projectID, providerName, gcpProjectID, networkName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
+
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
+					resource.TestCheckResourceAttr(resourceName, "network_name", networkName),
+				),
+			},
+			{
+				Config: configGCP(projectID, providerName, gcpProjectID, updatedNetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
+
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
+					resource.TestCheckResourceAttr(resourceName, "network_name", updatedNetworkName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkRSNetworkPeering_AWSDifferentRegionName(t *testing.T) {
 	var (
 		vpcID           = os.Getenv("AWS_VPC_ID")


### PR DESCRIPTION
## Description

Correctly handle GCP updates of `mongodbatlas_network_peering`

Link to any related issue(s): CLOUDP-250605

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
