### PR TITLE
chore: Removes actions-permissions step and set minimal permissions for release workflows 

### DIFF
--- a/.github/workflows/jira-release-version.yml
+++ b/.github/workflows/jira-release-version.yml
@@ -18,8 +18,8 @@ on:
 jobs:
   release-version:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Validation of version format, no pre-releases
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
 
   release-config:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       creates_new_tag: ${{ steps.evaluate_inputs.outputs.creates_new_tag }}
       is_official_release: ${{ steps.evaluate_inputs.outputs.is_official_release }}
       runs_tests: ${{ steps.evaluate_inputs.outputs.runs_tests }}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - id: evaluate_inputs
         run: |
           {
@@ -35,8 +35,8 @@ jobs:
 
   validate-inputs:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Validation of version format
         run: |
           echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
@@ -85,13 +85,14 @@ jobs:
 
   create-tag:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     needs: [ release-config, validate-inputs, update-examples-reference-in-docs, update-changelog-header ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure') 
       && needs.release-config.outputs.creates_new_tag == 'true'
     steps: 
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
@@ -121,13 +122,14 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: write
     needs: [ validate-inputs, update-examples-reference-in-docs, update-changelog-header, create-tag, run-qa-acceptance-tests ]
     # Release is skipped if there are failures in previous steps
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:


### PR DESCRIPTION
## Description

Removes actions-permissions step and set minimal permissions for release workflows 

Link to any related issue(s): CLOUDP-223072

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
