### PR TITLE
fix: Define values of `altas_gcp_project_id` and `atlas_vpc_name` in network peering by fetching associated container

### DIFF
--- a/.changelog/2315.txt
+++ b/.changelog/2315.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_network_peering: Fixes computed values of `altas_gcp_project_id` and `atlas_vpc_name` by obtaining values from associated container
+resource/mongodbatlas_network_peering: Fixes computed values of `altas_gcp_project_id` and `atlas_vpc_name` to provide GCP related values
 ```

--- a/.changelog/2315.txt
+++ b/.changelog/2315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_network_peering: Fixes computed values of `altas_gcp_project_id` and `atlas_vpc_name` by obtaining values from associated container
+```

--- a/internal/service/networkpeering/data_source_network_peering.go
+++ b/internal/service/networkpeering/data_source_network_peering.go
@@ -164,9 +164,14 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func readAtlasCidrBlock(ctx context.Context, conn admin.NetworkPeeringApi, projectID, containerID string) (string, error) {
-	container, _, err := conn.GetPeeringContainer(ctx, projectID, containerID).Execute()
+	container, err := getContainer(ctx, conn, projectID, containerID)
 	if err != nil {
 		return "", err
 	}
 	return container.GetAtlasCidrBlock(), nil
+}
+
+func getContainer(ctx context.Context, conn admin.NetworkPeeringApi, projectID, containerID string) (*admin.CloudProviderContainer, error) {
+	container, _, err := conn.GetPeeringContainer(ctx, projectID, containerID).Execute()
+	return container, err
 }

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -125,11 +125,14 @@ func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
 
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
 					resource.TestCheckResourceAttr(resourceName, "network_name", networkName),
+
+					// computed values that are obtain from associated container, checks for existing prefix convention to ensure they are gcp related values
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_gcp_project_id", acc.MatchesExpression("p-.*")),
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_vpc_name", acc.MatchesExpression("nt-.*")),
 				),
 			},
 			{

--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -408,7 +408,7 @@ In addition to all arguments above, the following attributes are exported:
 * `gcp_project_id` - GCP project ID of the owner of the network peer.
 * `error_message` - When `"status" : "FAILED"`, Atlas provides a description of the error.
 * `network_name` - Name of the network peer to which Atlas connects.
-* `atlas_gcp_project_id` - The Atlas GCP Project ID for the GCP VPC used by your atlas cluster that it is needed to set up the reciprocal connection.
+* `atlas_gcp_project_id` - The Atlas GCP Project ID for the GCP VPC used by your atlas cluster that is needed to set up the reciprocal connection.
 * `atlas_vpc_name` - Name of the GCP VPC used by your atlas cluster that is needed to set up the reciprocal connection.
   
 **AZURE ONLY:**

--- a/website/docs/r/network_peering.html.markdown
+++ b/website/docs/r/network_peering.html.markdown
@@ -408,7 +408,8 @@ In addition to all arguments above, the following attributes are exported:
 * `gcp_project_id` - GCP project ID of the owner of the network peer.
 * `error_message` - When `"status" : "FAILED"`, Atlas provides a description of the error.
 * `network_name` - Name of the network peer to which Atlas connects.
-* `atlas_gcp_project_id` - The Atlas GCP Project ID for the GCP VPC used by your atlas cluster that it is need to set up the reciprocal connection.
+* `atlas_gcp_project_id` - The Atlas GCP Project ID for the GCP VPC used by your atlas cluster that it is needed to set up the reciprocal connection.
+* `atlas_vpc_name` - Name of the GCP VPC used by your atlas cluster that is needed to set up the reciprocal connection.
   
 **AZURE ONLY:**
 


### PR DESCRIPTION
## Description

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2308 (CLOUDP-250959)

During the SDK migration (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2245) we changed the way we populate the computed values of `altas_gcp_project_id` and `atlas_vpc_name`. This breaks our [example](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/network_peering#example-with-gcp-1) for creating a gcp peering network as it makes use of these computed values related to gcp.

These values were (previous to 1.16.1) fetched by obtaining the associated container ([reference](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/v1.16.0/internal/service/networkpeering/resource_network_peering.go#L366)) and are now using values provided directly from the peering network response.

### Example network_peering state 1.16.0

```
"attributes": {
            "atlas_gcp_project_id": "p-c1zgxlsyh45xj2dwadq0nlbe",
            "atlas_vpc_name": "nt-66564bd12d057908c6243c07-ql63a9ab",
            "gcp_project_id": "ofuscating",
            "network_name": "randomName",
            ...
          },
```

### Example network_peering state 1.16.1

```
"attributes": {
            "atlas_gcp_project_id": "ofuscating",
            "atlas_vpc_name": "randomName",
            "gcp_project_id": "ofuscating",
            "network_name": "randomName",
            ...
          },
```

### Example network_peering state after fix

```
"attributes": {
            "atlas_gcp_project_id": "p-45nlqzaiphqffrdbmzjk3mvy",
            "atlas_vpc_name": "nt-66564bd12d057908c62e3c07-0o71uun2",
            "gcp_project_id": "ofuscating",
            "network_name": "randomName",
            ...
          },
```

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
