### PR TITLE
chore: Uses PAT to be able to create PRs when versions of Terraform Compatibility Matrix change 

### DIFF
--- a/.github/workflows/update_tf_compatibility_matrix.yml
+++ b/.github/workflows/update_tf_compatibility_matrix.yml
@@ -25,6 +25,7 @@ jobs:
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
+          token: ${{ secrets.APIX_BOT_PAT }}
           title: "doc: Updates Terraform Compatibility Matrix documentation"
           commit-message: "doc: Updates Terraform Compatibility Matrix documentation"
           delete-branch: true

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -191,7 +191,6 @@ For more information on configuring and managing programmatic API Keys see the [
 | 1.5.x | 2023-06-12 | 2025-06-30 | 2025-06-30 |
 | 1.4.x | 2023-03-08 | 2025-03-31 | 2025-03-31 |
 | 1.3.x | 2022-09-21 | 2024-09-30 | 2024-09-30 |
-| 1.2.x | 2022-05-18 | 2024-05-31 | 2024-05-31 |
 <!-- MATRIX_PLACEHOLDER_END -->
 For the safety of our users, we require only consuming versions of HashiCorp Terraform that are currently receiving Security / Maintenance Updates. For more details see [Support Period and End-of-Life (EOL) Policy](https://support.hashicorp.com/hc/en-us/articles/360021185113-Support-Period-and-End-of-Life-EOL-Policy).   
 


### PR DESCRIPTION
## Description

Uses PAT to be able to create PRs when versions of Terraform Compatibility Matrix change
Has run successfully and generated this PR: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2321 
Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
