### PR TITLE
feat: Supports Workload OIDC for `mongodbatlas_database_users`

### DIFF
--- a/.changelog/2323.txt
+++ b/.changelog/2323.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-mongodbatlas_database_user: Supports Workload OIDC database_user
+resource/mongodbatlas_database_user: Supports Workload OIDC database_user
 ```

--- a/.changelog/2323.txt
+++ b/.changelog/2323.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_database_user: Supports Workload OIDC database_user
+resource/mongodbatlas_database_user: Supports Workload OIDC `mongodbatlas_database_user`
 ```

--- a/.changelog/2323.txt
+++ b/.changelog/2323.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+mongodbatlas_database_user: Supports Workload OIDC database_user
+```

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -134,7 +134,7 @@ func (r *databaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed: true,
 				Default:  stringdefault.StaticString("NONE"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("NONE", "IDP_GROUP"),
+					stringvalidator.OneOf("NONE", "IDP_GROUP", "USER"),
 				},
 			},
 			"ldap_auth_type": schema.StringAttribute{

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -133,9 +133,6 @@ func (r *databaseUserRS) Schema(ctx context.Context, req resource.SchemaRequest,
 				Optional: true,
 				Computed: true,
 				Default:  stringdefault.StaticString("NONE"),
-				Validators: []validator.String{
-					stringvalidator.OneOf("NONE", "IDP_GROUP", "USER"),
-				},
 			},
 			"ldap_auth_type": schema.StringAttribute{
 				Optional: true,

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -497,9 +497,12 @@ func TestAccConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
 
 func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 	var (
-		projectID = acc.ProjectIDExecution(t)
-		idpID     = os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID")
-		username  = fmt.Sprintf("%s/%s", idpID, "IDP_GROUP")
+		projectID         = acc.ProjectIDExecution(t)
+		idpID             = os.Getenv("MONGODB_ATLAS_FEDERATED_IDP_ID")
+		workforceAuthType = "IDP_GROUP"
+		workloadAuthType  = "USER"
+		usernameWorkforce = fmt.Sprintf("%s/%s", idpID, workforceAuthType)
+		usernameWorkload  = fmt.Sprintf("%s/%s", idpID, workloadAuthType)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -508,12 +511,23 @@ func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigDataBaseUserWithOIDCWorkforceAuthType(projectID, username, "atlasAdmin"),
+				Config: acc.ConfigDataBaseUserWithOIDCAuthType(projectID, usernameWorkforce, workforceAuthType, "admin", "atlasAdmin"),
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkforce),
+					resource.TestCheckResourceAttr(resourceName, "oidc_auth_type", workforceAuthType),
 					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "admin"),
+				),
+			},
+			{
+				Config: acc.ConfigDataBaseUserWithOIDCAuthType(projectID, usernameWorkload, workloadAuthType, "$external", "atlasAdmin"),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkload),
+					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkload),
+					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
 				),
 			},
 			{

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -526,7 +526,7 @@ func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkload),
-					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkload),
+					resource.TestCheckResourceAttr(resourceName, "oidc_auth_type", workloadAuthType),
 					resource.TestCheckResourceAttr(resourceName, "auth_database_name", "$external"),
 				),
 			},

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -96,11 +96,10 @@ func TestAccConfigRSDatabaseUser_withX509TypeCustomer(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -156,11 +155,10 @@ func TestAccConfigRSDatabaseUser_withAWSIAMType(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -485,11 +483,10 @@ func TestAccConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -531,11 +528,10 @@ func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/testutil/acc/database_user.go
+++ b/internal/testutil/acc/database_user.go
@@ -179,3 +179,19 @@ func ConfigDatabaseUserWithLDAPAuthType(projectID, username, roleName, keyLabel,
 		}
 	`, projectID, username, roleName, keyLabel, valueLabel)
 }
+
+func ConfigDataBaseUserWithOIDCWorkforceAuthType(projectID, username, roleName string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_database_user" "test" {
+		project_id         = %[1]q
+		username           = %[2]q
+		oidc_auth_type     = "IDP_GROUP"
+		auth_database_name = "admin"
+
+		roles {
+			role_name     = %[3]q
+			database_name = "admin"
+		}
+	}
+`, projectID, username, roleName)
+}

--- a/internal/testutil/acc/database_user.go
+++ b/internal/testutil/acc/database_user.go
@@ -180,18 +180,18 @@ func ConfigDatabaseUserWithLDAPAuthType(projectID, username, roleName, keyLabel,
 	`, projectID, username, roleName, keyLabel, valueLabel)
 }
 
-func ConfigDataBaseUserWithOIDCWorkforceAuthType(projectID, username, roleName string) string {
+func ConfigDataBaseUserWithOIDCAuthType(projectID, username, authType, databaseName, roleName string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_database_user" "test" {
 		project_id         = %[1]q
 		username           = %[2]q
-		oidc_auth_type     = "IDP_GROUP"
-		auth_database_name = "admin"
+		oidc_auth_type     = %[3]q
+		auth_database_name = %[4]q
 
 		roles {
-			role_name     = %[3]q
+			role_name     = %[5]q
 			database_name = "admin"
 		}
 	}
-`, projectID, username, roleName)
+`, projectID, username, authType, databaseName, roleName)
 }

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -89,7 +89,8 @@ In addition to all arguments above, the following attributes are exported:
 * `ldap_auth_type` - Method by which the provided username is authenticated. Default is `NONE`. Other valid values are: `USER`, `GROUP`.
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
-  * `IDP_GROUP` - Create a OIDC federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `IDP_GROUP` - OIDC Workforce federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `USER` - OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/d/database_user.html.markdown
+++ b/website/docs/d/database_user.html.markdown
@@ -89,7 +89,7 @@ In addition to all arguments above, the following attributes are exported:
 * `ldap_auth_type` - Method by which the provided username is authenticated. Default is `NONE`. Other valid values are: `USER`, `GROUP`.
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
-  * `IDP_GROUP` - OIDC Workforce federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `IDP_GROUP` - OIDC Workforce federated authentication group. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
   * `USER` - OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -99,7 +99,7 @@ Possible values include:
 * `ldap_auth_type` - Method by which the provided username is authenticated. Default is `NONE`. Other valid values are: `USER`, `GROUP`.
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
-  * `IDP_GROUP` - Create a OIDC federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `IDP_GROUP` - OIDC Workforce federated authentication group. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
   * `USER` - OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.

--- a/website/docs/d/database_users.html.markdown
+++ b/website/docs/d/database_users.html.markdown
@@ -100,6 +100,7 @@ Possible values include:
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
   * `IDP_GROUP` - Create a OIDC federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `USER` - OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 * `scopes` - Array of clusters and Atlas Data Lakes that this user has access to.
     * `name` - Name of the cluster or Atlas Data Lake that the user has access to.
     * `type` - Type of resource that the user has access to. Valid values are: `CLUSTER` and `DATA_LAKE`

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -152,8 +152,8 @@ Accepted values include:
 
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
-  * `IDP_GROUP` - Create a OIDC Workforce federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
-  * `USER` - Create a OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `IDP_GROUP` - OIDC Workforce federated authentication group. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `USER` - OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 ### Roles
 
 Block mapping a user's role to a database / collection. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well.

--- a/website/docs/r/database_user.html.markdown
+++ b/website/docs/r/database_user.html.markdown
@@ -152,7 +152,8 @@ Accepted values include:
 
 * `oidc_auth_type` - (Optional) Human-readable label that indicates whether the new database user authenticates with OIDC (OpenID Connect) federated authentication. If no value is given, Atlas uses the default value of `NONE`. The accepted types are:
   * `NONE` -	The user does not use OIDC federated authentication.
-  * `IDP_GROUP` - Create a OIDC federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `IDP_GROUP` - Create a OIDC Workforce federated authentication user. To learn more about OIDC federated authentication, see [Set up Workforce Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
+  * `USER` - Create a OIDC Workload federated authentication user. To learn more about OIDC federated authentication, see [Set up Workload Identity Federation with OIDC](https://www.mongodb.com/docs/atlas/security-oidc/).
 ### Roles
 
 Block mapping a user's role to a database / collection. A role allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well.


### PR DESCRIPTION
## Description

OIDC Workforce was already supported. Only change needed to support workload is to add the enum to the validation. This PR also changes the relevant documentation and adds tests for this functionality

Link to any related issue(s): CLOUDP-250919

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
