### PR TITLE
chore: Uses PAT instead of GITHUB_TOKEN for issues.yml

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,16 +5,13 @@
   on:
     issues:
       types: [opened, reopened, closed]
-  permissions: 
-    issues: write
-    contents: read
   jobs:
     jira_task:
       name: Create Jira issue
       if: github.event.action == 'opened'
       runs-on: ubuntu-latest
-      permissions:
-        issues: write
+      env:
+        GITHUB_TOKEN: ${{ secrets.APIX_BOT_PAT }}
       steps:
       - name: Create JIRA ticket
         id: create
@@ -74,7 +71,8 @@
       name: Reopen JIRA ticket
       if: github.event.action == 'reopened'
       runs-on: ubuntu-latest
-      permissions: {}
+      env:
+        GITHUB_TOKEN: ${{ secrets.APIX_BOT_PAT }}
       steps:
         - name: Reopened JIRA ticket if exists
           run: |
@@ -123,6 +121,8 @@
       name: Close JIRA ticket
       if: github.event.action == 'closed'
       runs-on: ubuntu-latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.APIX_BOT_PAT }}
       steps:
         - name: Close JIRA ticket if exists
           run: |


### PR DESCRIPTION
## Description

use PAT instead of GITHUB_TOKEN for issues.yml

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
