### PR TITLE
chore: Sends only one notification when Terraform Compatibility Matrix fails

### DIFF
--- a/.github/workflows/terraform-compatibility-matrix.yml
+++ b/.github/workflows/terraform-compatibility-matrix.yml
@@ -48,6 +48,7 @@ jobs:
     with:
       terraform_matrix: '["${{ matrix.terraform_version }}"]'
       atlas_cloud_env: ${{ inputs.atlas_cloud_env }}
+      send_notification: false
   
   slack-notification:
     needs: ["run-test-supported-versions"]

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ on:
       send_notification:
         description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
-        default: true
+        default: false
   workflow_call:
     inputs:
       terraform_matrix:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -81,7 +81,7 @@ jobs:
   
   slack-notification:
     needs: [tests, clean-after]
-    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure' && inputs.send_notification == true}}
+    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure' && inputs.send_notification == 'true' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -11,7 +11,7 @@ on:
         description: 'Previous MongoDB Atlas Provider version matrix for migration tests (JSON array)'
         default: '[""]' # "" for latest version
       send_notification:
-        description: 'Send the Slack notification if any of the tests fail. Can be either `true` or `false`.'
+        description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
         default: true
   workflow_call:
@@ -28,7 +28,7 @@ on:
         type: string
         required: false
       send_notification:
-        description: 'Send the Slack notification if any of the tests fail. Can be either `true` or `false`.'
+        description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
         default: true
 
@@ -81,7 +81,7 @@ jobs:
   
   slack-notification:
     needs: [tests, clean-after]
-    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure' && inputs.send_notification == 'true' }}
+    if: ${{ !cancelled() && needs.tests.result == 'failure' && inputs.send_notification == true }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,6 +10,10 @@ on:
       provider_matrix:
         description: 'Previous MongoDB Atlas Provider version matrix for migration tests (JSON array)'
         default: '[""]' # "" for latest version
+      send_notification:
+        description: 'Send the Slack notification if any of the tests fail. Can be either `true` or `false`.'
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       terraform_matrix:
@@ -24,7 +28,7 @@ on:
         type: string
         required: false
       send_notification:
-        description: 
+        description: 'Send the Slack notification if any of the tests fail. Can be either `true` or `false`.'
         type: boolean
         default: true
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,6 +23,10 @@ on:
         description: 'Atlas cloud environment used, can be either `dev` or `qa`, empty for `dev`'     
         type: string
         required: false
+      send_notification:
+        description: 
+        type: boolean
+        default: true
 
   schedule:
     - cron: "0 0 2-31 * *" # workflow runs every day at midnight UTC except on the first day of the month
@@ -73,7 +77,7 @@ jobs:
   
   slack-notification:
     needs: [tests, clean-after]
-    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure'}}
+    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.tests.result == 'failure' && inputs.send_notification == true}}
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
## Description

Sends only one notification when Terraform Compatibility Matrix fails
- Add boolean input `send_notification` in Test suite workflow, defaults to true
- Test suite sends notification only if `send_notification == true`
- terraform compatibility matrix sets the value of `send_notification` to `false` when calling test suite

Link to any related issue(s): CLOUDP-248667

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
