### PR TITLE
remove!: Removes `items_per_page` and `page_num` from `data_source_privatelink_endpoints_service_serverless`

### DIFF
--- a/.changelog/2336.txt
+++ b/.changelog/2336.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-data-source/mongodbatlas_privatelink_endpoints_service_serverless: Removes page_num and items_per_page arguments
+data-source/mongodbatlas_privatelink_endpoints_service_serverless: Removes `page_num` and `items_per_page` arguments
 ```

--- a/.changelog/2336.txt
+++ b/.changelog/2336.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+mongodbatlas_privatelink_endpoints_service_serverless: Removes page_num and items_per_page arguments
+```

--- a/.changelog/2336.txt
+++ b/.changelog/2336.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-mongodbatlas_privatelink_endpoints_service_serverless: Removes page_num and items_per_page arguments
+data-source/mongodbatlas_privatelink_endpoints_service_serverless: Removes page_num and items_per_page arguments
 ```

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -2,12 +2,10 @@ package privatelinkendpointserviceserverless
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20231115014/admin"
 )
@@ -24,16 +22,6 @@ func PluralDataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"page_num": {
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.17.0"),
-				Type:       schema.TypeInt,
-				Optional:   true,
-			},
-			"items_per_page": {
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.17.0"),
-				Type:       schema.TypeInt,
-				Optional:   true,
 			},
 			"results": {
 				Type:     schema.TypeList,

--- a/website/docs/guides/1.17.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.17.0-upgrade-guide.html.markdown
@@ -25,7 +25,7 @@ The Terraform MongoDB Atlas Provider version 1.17.0 has a number of new and exci
 			`terraform import mongodbatlas_federated_settings_identity_provider.identity_provider  <federation_settings_id>-<idp_id>`
         3. Run `terraform plan`.
         4. Run `terraform apply`.
-- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_data_source_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless)
+- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless)
 
 ### Helpful Links
 

--- a/website/docs/guides/1.17.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.17.0-upgrade-guide.html.markdown
@@ -25,7 +25,7 @@ The Terraform MongoDB Atlas Provider version 1.17.0 has a number of new and exci
 			`terraform import mongodbatlas_federated_settings_identity_provider.identity_provider  <federation_settings_id>-<idp_id>`
         3. Run `terraform plan`.
         4. Run `terraform apply`.
-- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless) data source
+- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless) data source.
 
 ### Helpful Links
 

--- a/website/docs/guides/1.17.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.17.0-upgrade-guide.html.markdown
@@ -25,6 +25,7 @@ The Terraform MongoDB Atlas Provider version 1.17.0 has a number of new and exci
 			`terraform import mongodbatlas_federated_settings_identity_provider.identity_provider  <federation_settings_id>-<idp_id>`
         3. Run `terraform plan`.
         4. Run `terraform apply`.
+- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_data_source_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless)
 
 ### Helpful Links
 

--- a/website/docs/guides/1.17.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/1.17.0-upgrade-guide.html.markdown
@@ -25,7 +25,7 @@ The Terraform MongoDB Atlas Provider version 1.17.0 has a number of new and exci
 			`terraform import mongodbatlas_federated_settings_identity_provider.identity_provider  <federation_settings_id>-<idp_id>`
         3. Run `terraform plan`.
         4. Run `terraform apply`.
-- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless)
+- Attributes `page_num` and `items_per_page` removed from [`mongodbatlas_privatelink_endpoints_service_serverless`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/privatelink_endpoints_service_serverless) data source
 
 ### Helpful Links
 


### PR DESCRIPTION
## Description

Removes `items_per_page` and `page_num` from `data_source_privatelink_endpoints_service_serverless`
Link to any related issue(s): CLOUDP-253079

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
