### PR TITLE
chore: Send Slack runs on schedule or if `inputs.send_notification` is `true`

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -81,7 +81,7 @@ jobs:
   
   slack-notification:
     needs: [tests, clean-after]
-    if: ${{ !cancelled() && needs.tests.result == 'failure' && (inputs.send_notification == true || inputs.send_notification == 'true') }}
+    if: ${{ !cancelled() && needs.tests.result == 'failure' && !contains(inputs.send_notification, 'false') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -81,7 +81,7 @@ jobs:
   
   slack-notification:
     needs: [tests, clean-after]
-    if: ${{ !cancelled() && needs.tests.result == 'failure' && !contains(inputs.send_notification, 'false') }}
+    if: ${{ !cancelled() && needs.tests.result == 'failure' && !contains(github.event.inputs.send_notification, 'false') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
## Description

Send Slack runs on schedule or if `inputs.send_notification` is `true` when the test result is `failure`

the job always runs on schedule and when triggered manually or called by another job it only runs if inputs.send_notification is checked. That's because:
- If the workflow is run on schedule, then inputs.should_run is null.
- The contains function converts its argument to a string: null is converted to ''.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
