### PR TITLE
fix: Removes error diagnostic if `mongodbatlas_project_ip_access_list` resource doesn't exist

### DIFF
--- a/.changelog/2349.txt
+++ b/.changelog/2349.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixes resource removal in Read() if resource doesn't exist after creation
+```

--- a/.changelog/2349.txt
+++ b/.changelog/2349.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fixes resource removal in Read() if resource doesn't exist after creation
+resource/mongodbatlas_project_ip_access_list: Fixes resource removal in Read() if resource doesn't exist after creation
 ```

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"go.mongodb.org/atlas-sdk/v20231115014/admin"
+
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,10 +19,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20231115014/admin"
 )
 
 const (
@@ -234,7 +236,6 @@ func (r *projectIPAccessListRS) Read(ctx context.Context, req resource.ReadReque
 			// deleted in the backend case
 			if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
 				resp.State.RemoveResource(ctx)
-				resp.Diagnostics.AddError("resource not found", err.Error())
 				return nil
 			}
 


### PR DESCRIPTION
## Description

If the `mongodbatlas_project_ip_access_list` resource is deleted from the UI after creation, the provider should plan to recreate it and remove it from the state. Currently, this doesn't happen because when calling resp.State.RemoveResource(ctx) in the provider in `Read(`), we add an error to the response diagnostic, interfering with resource removal. 
As a result, users only see a 404 error and must manually remove the resource from the state. 
This PR removes the error diagnostic to ensure `resp.State.RemoveResource(ctx)` functions correctly.

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2343

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
