### PR TITLE
test: Adds unit test to understand replication ID matching

### DIFF
--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -302,7 +302,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "pit_enabled", clusterName, err))
 	}
 
-	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
+	replicationSpecs, err := FlattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -271,7 +271,7 @@ func flattenAdvancedClusters(ctx context.Context, connV2 *admin.APIClient, clust
 		if err != nil {
 			log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", cluster.GetId(), err)
 		}
-		replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), nil, d, connV2)
+		replicationSpecs, err := FlattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), nil, d, connV2)
 		if err != nil {
 			log.Printf("[WARN] Error setting `replication_specs` for the cluster(%s): %s", cluster.GetId(), err)
 		}

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -434,7 +434,7 @@ func flattenProcessArgs(p *admin.ClusterDescriptionProcessArgs) []map[string]any
 	}
 }
 
-func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.ReplicationSpec, tfMapObjects []any,
+func FlattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.ReplicationSpec, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
 	if len(apiObjects) == 0 {
 		return nil, nil
@@ -451,11 +451,7 @@ func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.Rep
 		}
 
 		for j := 0; j < len(apiObjects); j++ {
-			if wasAPIObjectUsed[j] {
-				continue
-			}
-
-			if !doesAdvancedReplicationSpecMatchAPI(tfMapObject, &apiObjects[j]) {
+			if wasAPIObjectUsed[j] || !doesAdvancedReplicationSpecMatchAPI(tfMapObject, &apiObjects[j]) {
 				continue
 			}
 

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -135,12 +135,11 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 
 			tfOutputSpecs, err := advancedcluster.FlattenAdvancedReplicationSpecs(context.Background(), tc.adminSpecs, tc.tfInputSpecs, resourceData, client)
 
-			asserter := assert.New(t)
 			require.NoError(t, err)
-			asserter.Len(tfOutputSpecs, tc.expectedLen)
+			assert.Len(t, tfOutputSpecs, tc.expectedLen)
 			if tc.expectedLen != 0 {
-				asserter.Equal(expectedID, tfOutputSpecs[0]["id"])
-				asserter.Equal(expectedZoneName, tfOutputSpecs[0]["zone_name"])
+				assert.Equal(t, expectedID, tfOutputSpecs[0]["id"])
+				assert.Equal(t, expectedZoneName, tfOutputSpecs[0]["zone_name"])
 			}
 		})
 	}

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -35,15 +35,15 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 			ProviderName: &providerName,
 			RegionName:   &regionName,
 		}}
-		regionConfigsTfSameZone = []map[string]any{{
+		regionConfigTfSameZone = map[string]any{
 			"provider_name": "AWS",
 			"region_name":   regionName,
-		}}
-		regionConfigsTfDiffZone = []map[string]any{{
+		}
+		regionConfigTfDiffZone = map[string]any{
 			"provider_name": "AWS",
 			"region_name":   regionName,
 			"zone_name":     unexpectedZoneName,
-		}}
+		}
 		apiSpecExpected  = admin.ReplicationSpec{Id: &expectedID, ZoneName: &expectedZoneName, RegionConfigs: &regionConfigAdmin}
 		apiSpecDifferent = admin.ReplicationSpec{Id: &unexpectedID, ZoneName: &unexpectedZoneName, RegionConfigs: &regionConfigAdmin}
 		testSchema       = map[string]*schema.Schema{
@@ -52,25 +52,25 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 		tfSameIDSameZone = map[string]any{
 			"id":             expectedID,
 			"num_shards":     1,
-			"region_configs": regionConfigsTfSameZone,
+			"region_configs": []any{regionConfigTfSameZone},
 			"zone_name":      expectedZoneName,
 		}
 		tfNoIDSameZone = map[string]any{
 			"id":             nil,
 			"num_shards":     1,
-			"region_configs": regionConfigsTfSameZone,
+			"region_configs": []any{regionConfigTfSameZone},
 			"zone_name":      expectedZoneName,
 		}
 		tfNoIDDiffZone = map[string]any{
 			"id":             nil,
 			"num_shards":     1,
-			"region_configs": regionConfigsTfDiffZone,
+			"region_configs": []any{regionConfigTfDiffZone},
 			"zone_name":      unexpectedZoneName,
 		}
 		tfdiffIDDiffZone = map[string]any{
 			"id":             "unique",
 			"num_shards":     1,
-			"region_configs": regionConfigsTfDiffZone,
+			"region_configs": []any{regionConfigTfDiffZone},
 			"zone_name":      unexpectedZoneName,
 		}
 	)

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115014/admin"
 	"go.mongodb.org/atlas-sdk/v20231115014/mockadmin"
 )
@@ -20,6 +22,154 @@ var (
 	errGeneric       = errors.New("generic")
 	advancedClusters = []admin.AdvancedClusterDescription{{StateName: conversion.StringPtr("NOT IDLE")}}
 )
+
+func TestFlattenReplicationSpecs(t *testing.T) {
+	var (
+		regionName         = "EU_WEST_1"
+		providerName       = "AWS"
+		expectedID         = "id1"
+		unexpectedID       = "id2"
+		zoneName           = "z1"
+		unexpectedZoneName = "z2"
+		admin1             = admin.ReplicationSpec{Id: &expectedID, ZoneName: &zoneName, RegionConfigs: &[]admin.CloudRegionConfig{{
+			ProviderName: &providerName,
+			RegionName:   conversion.StringPtr(regionName),
+		}}}
+		admin2 = admin.ReplicationSpec{Id: &unexpectedID, ZoneName: &unexpectedZoneName, RegionConfigs: &[]admin.CloudRegionConfig{{
+			ProviderName: &providerName,
+			RegionName:   conversion.StringPtr(regionName),
+		}}}
+		testSchema = map[string]*schema.Schema{
+			"project_id": {Type: schema.TypeString},
+		}
+		tf1SameIDSameZone = map[string]any{
+			"id":         expectedID,
+			"num_shards": 1,
+			"region_configs": []any{
+				map[string]any{
+					"provider_name": "AWS",
+					"region_name":   regionName,
+					"zone_name":     zoneName,
+				},
+			},
+		}
+		tf2NoIDSameZone = map[string]any{
+			"id":         nil,
+			"num_shards": 1,
+			"region_configs": []any{
+				map[string]any{
+					"provider_name": "AWS",
+					"region_name":   regionName,
+					"zone_name":     zoneName,
+				},
+			},
+		}
+		tf3NoIDDiffZone = map[string]any{
+			"id":         nil,
+			"num_shards": 1,
+			"region_configs": []any{
+				map[string]any{
+					"provider_name": "AWS",
+					"region_name":   regionName,
+					"zone_name":     "differentZone",
+				},
+			},
+		}
+		tf4diffIDDiffZone = map[string]any{
+			"id":         "unique",
+			"num_shards": 1,
+			"region_configs": []any{
+				map[string]any{
+					"provider_name": "AWS",
+					"region_name":   regionName,
+					"zone_name":     "uniqueZone",
+				},
+			},
+		}
+	)
+	type expectFlags struct {
+		expectedLen int
+		differentID bool
+	}
+	testCases := map[string]struct {
+		adminSpecs   []admin.ReplicationSpec
+		tfInputSpecs []any
+		expectFlags  expectFlags
+	}{
+		"existing id, should match admin": {
+			[]admin.ReplicationSpec{admin1},
+			[]any{tf1SameIDSameZone},
+			expectFlags{},
+		},
+		"missing id, should be set when zone_name matches": {
+			[]admin.ReplicationSpec{admin1},
+			[]any{tf2NoIDSameZone},
+			expectFlags{},
+		},
+		"missing id, should be set when there is one admin spec": {
+			[]admin.ReplicationSpec{admin1},
+			[]any{tf3NoIDDiffZone},
+			expectFlags{},
+		},
+		"existing different id, should change to the admin spec 1": {
+			[]admin.ReplicationSpec{admin1},
+			[]any{tf4diffIDDiffZone},
+			expectFlags{},
+		},
+		"existing different id, should change to the admin spec 2": {
+			[]admin.ReplicationSpec{admin2},
+			[]any{tf1SameIDSameZone},
+			expectFlags{
+				differentID: true,
+			},
+		},
+		"existing id, should match correct api spec and extra api spec added": {
+			[]admin.ReplicationSpec{admin2, admin1},
+			[]any{tf1SameIDSameZone},
+			expectFlags{
+				expectedLen: 2,
+			},
+		},
+		"existing different id and existing same id, only api spec kept": {
+			[]admin.ReplicationSpec{admin1},
+			[]any{tf4diffIDDiffZone, tf1SameIDSameZone},
+			expectFlags{
+				expectedLen: 1,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			peeringAPI := mockadmin.NetworkPeeringApi{}
+
+			peeringAPI.EXPECT().ListPeeringContainerByCloudProviderWithParams(mock.Anything, mock.Anything).Return(admin.ListPeeringContainerByCloudProviderApiRequest{ApiService: &peeringAPI})
+			peeringAPI.EXPECT().ListPeeringContainerByCloudProviderExecute(mock.Anything).Return(&admin.PaginatedCloudProviderContainer{Results: &[]admin.CloudProviderContainer{{Id: conversion.StringPtr("c1"), RegionName: &regionName, ProviderName: &providerName}}}, nil, nil)
+
+			client := &admin.APIClient{
+				NetworkPeeringApi: &peeringAPI,
+			}
+			resourceData := schema.TestResourceDataRaw(t, testSchema, map[string]any{"project_id": "p1"})
+
+			tfOutputSpecs, err := advancedcluster.FlattenAdvancedReplicationSpecs(context.Background(), tc.adminSpecs, tc.tfInputSpecs, resourceData, client)
+
+			asserter := assert.New(t)
+			require.NoError(t, err)
+			flags := tc.expectFlags
+			var expectedLen int
+			if flags.expectedLen == 0 {
+				expectedLen = 1
+			} else {
+				expectedLen = flags.expectedLen
+			}
+			asserter.Len(tfOutputSpecs, expectedLen)
+			if flags.differentID {
+				asserter.NotEqual(expectedID, tfOutputSpecs[0]["id"])
+			} else {
+				asserter.Equal(expectedID, tfOutputSpecs[0]["id"])
+			}
+		})
+	}
+}
 
 type Result struct {
 	response any

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -552,7 +552,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "pit_enabled", clusterName, err))
 	}
 
-	replicationSpecs, err := flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
+	replicationSpecs, err := FlattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}


### PR DESCRIPTION
## Description

Adds unit test to understand replication ID matching.

Context:
During investigation to fix related issue I wanted to understand the Terraform behavior.
Although we cannot re-use the code in CFN, the implementation will be simlar.

Link to any related issue(s): CLOUDP-256534

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
