### PR TITLE
doc: Updates development practices for external contributors on merging PRs

### DIFF
--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -51,7 +51,20 @@ For more explained information about plugin override check [Development Override
 - Make sure that the PR title follows [*Conventional Commits*](https://www.conventionalcommits.org/).
 - Add comments around your new code that explain what's happening.
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
-- A repo maintainer will review the your pull request, and may either request additional changes or merge the pull request.
+- A repo maintainer will review the your pull request. 
+
+### Merging a Pull Request
+Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.
+Our GitHub setup does not allow sharing of variables and secrets across forks made by external contributors. This is a necessary security measure to prevent unauthorized access and potential vulnerabilities
+
+As external contributors cannot merge changes from their forks directly nor create branches from the master, the contribution process involves co-authoring. Here's what will happen:
+
+- We will cherry-pick your commit into a new branch in our main repository.
+- We will then create a new pull request from this branch, adding you as a co-author to ensure your contribution is not lost.
+- Our team will carry out any necessary testing and review on the new pull request. You are welcome to participate in this phase by commenting and making further suggestions.
+- Once approved, the pull request will be merged into the main branch.
+- **Exception**: 
+For minor changes that do not affect the core functionality of the project and do not require running tests, exceptions to the above process may be made at the discretion of the project maintainers.
 
 #### PR Title Format
 

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -51,7 +51,7 @@ For more explained information about plugin override check [Development Override
 - Make sure that the PR title follows [*Conventional Commits*](https://www.conventionalcommits.org/).
 - Add comments around your new code that explain what's happening.
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
-- A repo maintainer will review the your pull request. 
+- A repo maintainer will review your pull request. 
 
 ### Merging a Pull Request
 Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -55,7 +55,7 @@ For more explained information about plugin override check [Development Override
 
 ### Merging a Pull Request
 Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.
-Our GitHub setup does not allow sharing of variables and secrets across forks made by external contributors. This is a necessary security measure to prevent unauthorized access and potential vulnerabilities
+Our GitHub setup does not allow sharing of variables and secrets across forks made by external contributors. This is a necessary security measure to prevent unauthorized access and potential vulnerabilities.
 
 As external contributors cannot merge changes from their forks directly nor create branches from the master, the contribution process involves co-authoring. Here's what will happen:
 


### PR DESCRIPTION
## Description

This PR updates our contributing guidelines for external contributors for merging PRs.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-243664 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
