### PR TITLE
test: Refactors `mongodb_advanced_cluster` tests 

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -47,14 +47,7 @@ func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-				),
+				Check:             checkMultiCloud(clusterName),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -25,14 +25,7 @@ func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-				),
+				Check:             checkSingleProvider(projectID, clusterName),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -47,7 +47,7 @@ func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             checkMultiCloud(clusterName),
+				Check:             checkMultiCloud(clusterName, 3),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -25,7 +25,7 @@ func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -54,7 +54,7 @@ func TestMigAdvancedCluster_multiCloud(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -110,7 +110,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -123,7 +123,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configUpdated,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -33,11 +33,11 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configTenant(projectID, clusterName),
-				Check:  resource.ComposeTestCheckFunc(checkTenant(clusterName)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checkTenant(clusterName)...),
 			},
 			{
 				Config: configTenant(projectID, clusterNameUpdated),
-				Check:  resource.ComposeTestCheckFunc(checkTenant(clusterNameUpdated)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checkTenant(clusterNameUpdated)...),
 			},
 			{
 				ResourceName:      resourceName,
@@ -63,7 +63,7 @@ func TestAccClusterAdvancedCluster_singleProvider(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSingleProvider(projectID, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -100,7 +100,7 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiCloud(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -117,7 +117,7 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 			},
 			{
 				Config: configMultiCloud(orgID, projectName, clusterNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -156,7 +156,7 @@ func TestAccClusterAdvancedCluster_multicloudSharded(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiCloudSharded(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -166,7 +166,7 @@ func TestAccClusterAdvancedCluster_multicloudSharded(t *testing.T) {
 			},
 			{
 				Config: configMultiCloudSharded(orgID, projectName, clusterNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
@@ -200,7 +200,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSingleProviderPaused(projectID, clusterName, false, instanceSize),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -211,7 +211,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 			},
 			{
 				Config: configSingleProviderPaused(projectID, clusterName, true, instanceSize),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -249,7 +249,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSingleProviderPaused(projectID, clusterName, true, instanceSize),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -260,7 +260,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 			},
 			{
 				Config: configSingleProviderPaused(projectID, clusterName, false, instanceSize),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -325,7 +325,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvanced(projectID, clusterName, processArgs),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
@@ -344,7 +344,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 			},
 			{
 				Config: configAdvanced(projectID, clusterNameUpdated, processArgsUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
@@ -400,7 +400,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvancedDefaultWrite(projectID, clusterName, processArgs),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
@@ -416,7 +416,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 			},
 			{
 				Config: configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
@@ -456,7 +456,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
@@ -465,7 +465,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 			},
 			{
 				Config: configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
@@ -498,7 +498,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 		Steps: []resource.TestStep{
 			{
 				Config: configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
@@ -507,7 +507,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 			},
 			{
 				Config: configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
@@ -532,7 +532,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiZoneWithShards(orgID, projectName, clusterName, 1, 1, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "1"),
@@ -544,7 +544,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *tes
 			},
 			{
 				Config: configMultiZoneWithShards(orgID, projectName, clusterName, 2, 1, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "2"),
@@ -572,7 +572,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithTags(orgID, projectName, clusterName, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -593,7 +593,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 						Value: "value 2",
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -616,7 +616,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 						Value: "value 3",
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -647,7 +647,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiZoneWithShards(orgID, projectName, clusterName, 1, 1, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_self_managed_sharding", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "global_cluster_self_managed_sharding", "true"),

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -252,41 +252,11 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvanced(projectID, clusterName, processArgs),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
-				),
+				Check:  checkAdvanced(clusterName, "TLS1_1"),
 			},
 			{
 				Config: configAdvanced(projectID, clusterNameUpdated, processArgsUpdated),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.transaction_lifetime_limit_seconds", "300"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterNameUpdated),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
-				),
+				Check:  checkAdvanced(clusterName, "TLS1_2"),
 			},
 		},
 	})
@@ -983,6 +953,25 @@ func configAdvanced(projectID, clusterName string, p *admin.ClusterDescriptionPr
 	`, projectID, clusterName,
 		p.GetFailIndexKeyTooLong(), p.GetJavascriptEnabled(), p.GetMinimumEnabledTlsProtocol(), p.GetNoTableScan(),
 		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetTransactionLifetimeLimitSeconds())
+}
+
+func checkAdvanced(name, tls string) resource.TestCheckFunc {
+	return checkAggr(
+		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
+		map[string]string{
+			"name": name,
+			"advanced_configuration.0.minimum_enabled_tls_protocol":         tls,
+			"advanced_configuration.0.fail_index_key_too_long":              "false",
+			"advanced_configuration.0.javascript_enabled":                   "true",
+			"advanced_configuration.0.no_table_scan":                        "false",
+			"advanced_configuration.0.oplog_size_mb":                        "1000",
+			"advanced_configuration.0.sample_refresh_interval_bi_connector": "310",
+			"advanced_configuration.0.sample_size_bi_connector":             "110",
+			"advanced_configuration.0.transaction_lifetime_limit_seconds":   "300"},
+		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"))
 }
 
 func configAdvancedDefaultWrite(projectID, clusterName string, p *admin.ClusterDescriptionProcessArgs) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -830,8 +830,7 @@ func checkMultiCloudSharded(name string) resource.TestCheckFunc {
 	return checkAggr(
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{
-			"name":                   name,
-			"retain_backups_enabled": "false"})
+			"name": name})
 }
 
 func configSingleProviderPaused(projectID, clusterName string, paused bool, instanceSize string) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -405,27 +405,11 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAndShardUpdating(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiZoneWithShards(orgID, projectName, clusterName, 1, 1, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.1.num_shards", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(dataSourceName, "replication_specs.0.num_shards", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "replication_specs.1.num_shards", "1"),
-				),
+				Check:  checkMultiZoneWithShards(clusterName, 1, 1),
 			},
 			{
 				Config: configMultiZoneWithShards(orgID, projectName, clusterName, 2, 1, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.num_shards", "2"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.1.num_shards", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(dataSourceName, "replication_specs.0.num_shards", "2"),
-					resource.TestCheckResourceAttr(dataSourceName, "replication_specs.1.num_shards", "1"),
-				),
+				Check:  checkMultiZoneWithShards(clusterName, 2, 1),
 			},
 		},
 	})
@@ -1128,4 +1112,14 @@ func configMultiZoneWithShards(orgID, projectName, name string, numShardsFirstZo
 			name 	     = mongodbatlas_advanced_cluster.test.name
 		}
 	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding)
+}
+
+func checkMultiZoneWithShards(name string, numShardsFirstZone, numShardsSecondZone int) resource.TestCheckFunc {
+	return checkAggr(
+		[]string{"project_id"},
+		map[string]string{
+			"name":                           name,
+			"replication_specs.0.num_shards": strconv.Itoa(numShardsFirstZone),
+			"replication_specs.1.num_shards": strconv.Itoa(numShardsSecondZone),
+		})
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -830,9 +830,9 @@ func checkSingleProvider(projectID, name string) resource.TestCheckFunc {
 	return checkAggr(
 		[]string{"replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{
-			"project_id":             projectID,
-			"name":                   name,
-			"retain_backups_enabled": "true"},
+			"project_id": projectID,
+			"name":       name},
+		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
 		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
 		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)))
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -91,35 +91,11 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiCloud(orgID, projectName, clusterName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals("3")),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterName),
-					resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals("3")),
-				),
+				Check:  checkMultiCloud(clusterName),
 			},
 			{
 				Config: configMultiCloud(orgID, projectName, clusterNameUpdated),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
-					resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
-					resource.TestCheckResourceAttr(dataSourceName, "name", clusterNameUpdated),
-				),
+				Check:  checkMultiCloud(clusterNameUpdated),
 			},
 			{
 				ResourceName:            resourceName,
@@ -897,6 +873,19 @@ func configMultiCloud(orgID, projectName, name string) string {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
 	`, orgID, projectName, name)
+}
+
+func checkMultiCloud(name string) resource.TestCheckFunc {
+	return checkAggr(
+		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
+		map[string]string{
+			"name":                   name,
+			"retain_backups_enabled": "false"},
+		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#"),
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"))
 }
 
 func configMultiCloudSharded(orgID, projectName, name string) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -91,11 +91,11 @@ func TestAccClusterAdvancedCluster_multicloud(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiCloud(orgID, projectName, clusterName),
-				Check:  checkMultiCloud(clusterName),
+				Check:  checkMultiCloud(clusterName, 3),
 			},
 			{
 				Config: configMultiCloud(orgID, projectName, clusterNameUpdated),
-				Check:  checkMultiCloud(clusterNameUpdated),
+				Check:  checkMultiCloud(clusterNameUpdated, 3),
 			},
 			{
 				ResourceName:            resourceName,
@@ -765,17 +765,20 @@ func configMultiCloud(orgID, projectName, name string) string {
 	`, orgID, projectName, name)
 }
 
-func checkMultiCloud(name string) resource.TestCheckFunc {
+func checkMultiCloud(name string, regionConfigs int) resource.TestCheckFunc {
 	return checkAggr(
-		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
+		[]string{"project_id", "replication_specs.#"},
 		map[string]string{
 			"name":                   name,
 			"retain_backups_enabled": "false"},
 		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
+		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
+		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
+		resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"))
+		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
+	)
 }
 
 func configMultiCloudSharded(orgID, projectName, name string) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -730,11 +730,7 @@ func configTenant(projectID, name string) string {
 
 func checkTenant(projectID, name string) resource.TestCheckFunc {
 	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
-		[]string{"results.#",
-			"results.0.replication_specs.#",
-			"results.0.name",
-			"results.0.termination_protection_enabled",
-			"results.0.global_cluster_self_managed_sharding"}...)
+		[]string{"results.#", "results.0.replication_specs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
 	return checkAggr(
 		[]string{"replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{

--- a/internal/testutil/acc/attribute_checks.go
+++ b/internal/testutil/acc/attribute_checks.go
@@ -104,7 +104,7 @@ func AddAttrChecksPrefix(targetName string, checks []resource.TestCheckFunc, map
 
 // copyChecks helps to prevent the accidental modification of the existing slice
 func copyChecks[T map[string]string | []string](checks []resource.TestCheckFunc, additionalChecks T) []resource.TestCheckFunc {
-	newChecks := make([]resource.TestCheckFunc, len(checks)+len(additionalChecks))
+	newChecks := make([]resource.TestCheckFunc, len(checks), len(checks)+len(additionalChecks))
 	copy(newChecks, checks)
 	return newChecks
 }

--- a/internal/testutil/acc/attribute_checks.go
+++ b/internal/testutil/acc/attribute_checks.go
@@ -66,9 +66,7 @@ func JSONEquals(expected string) resource.CheckResourceAttrWithFunc {
 }
 
 func AddAttrSetChecks(targetName string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
-	// avoids accidentally modifying existing slice
-	newChecks := make([]resource.TestCheckFunc, len(checks), len(checks)+len(attrNames))
-	copy(newChecks, checks)
+	newChecks := copyChecks(checks, attrNames)
 	for _, attrName := range attrNames {
 		newChecks = append(newChecks, resource.TestCheckResourceAttrSet(targetName, attrName))
 	}
@@ -76,9 +74,7 @@ func AddAttrSetChecks(targetName string, checks []resource.TestCheckFunc, attrNa
 }
 
 func AddNoAttrSetChecks(targetName string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
-	// avoids accidentally modifying existing slice
-	newChecks := make([]resource.TestCheckFunc, len(checks), len(checks)+len(attrNames))
-	copy(newChecks, checks)
+	newChecks := copyChecks(checks, attrNames)
 	for _, attrName := range attrNames {
 		newChecks = append(newChecks, resource.TestCheckNoResourceAttr(targetName, attrName))
 	}
@@ -86,9 +82,7 @@ func AddNoAttrSetChecks(targetName string, checks []resource.TestCheckFunc, attr
 }
 
 func AddAttrChecks(targetName string, checks []resource.TestCheckFunc, mapChecks map[string]string) []resource.TestCheckFunc {
-	// avoids accidentally modifying existing slice
-	newChecks := make([]resource.TestCheckFunc, len(checks), len(checks)+len(mapChecks))
-	copy(newChecks, checks)
+	newChecks := copyChecks(checks, mapChecks)
 	for key, value := range mapChecks {
 		newChecks = append(newChecks, resource.TestCheckResourceAttr(targetName, key, value))
 	}
@@ -96,9 +90,7 @@ func AddAttrChecks(targetName string, checks []resource.TestCheckFunc, mapChecks
 }
 
 func AddAttrChecksPrefix(targetName string, checks []resource.TestCheckFunc, mapChecks map[string]string, prefix string, skipNames ...string) []resource.TestCheckFunc {
-	// avoids accidentally modifying existing slice
-	newChecks := make([]resource.TestCheckFunc, len(checks), len(checks)+len(mapChecks))
-	copy(newChecks, checks)
+	newChecks := copyChecks(checks, mapChecks)
 	prefix, _ = strings.CutSuffix(prefix, ".")
 	for key, value := range mapChecks {
 		if slices.Contains(skipNames, key) {
@@ -107,5 +99,12 @@ func AddAttrChecksPrefix(targetName string, checks []resource.TestCheckFunc, map
 		keyWithPrefix := fmt.Sprintf("%s.%s", prefix, key)
 		newChecks = append(newChecks, resource.TestCheckResourceAttr(targetName, keyWithPrefix, value))
 	}
+	return newChecks
+}
+
+// copyChecks helps to prevent the accidental modification of the existing slice
+func copyChecks[T map[string]string | []string](checks []resource.TestCheckFunc, additionalChecks T) []resource.TestCheckFunc {
+	newChecks := make([]resource.TestCheckFunc, len(checks)+len(additionalChecks))
+	copy(newChecks, checks)
 	return newChecks
 }


### PR DESCRIPTION
## Description

Refactors `mongodb_advanced_cluster` tests.

Also adding aggregate checks (soft assertions) as in CLOUDP-256881 so no need to run `mongodb_advanced_cluster` tests again in another PR.

(although it was not the goal, the file has now 100 fewer lines)

Link to any related issue(s): CLOUDP-256561

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Example of aggregate check fails:
```
=== CONT  TestAccClusterAdvancedCluster_basicTenant
    resource_advanced_cluster_test.go:29: Step 1/3 error: Check failed: Check 3/20 error: mongodbatlas_advanced_cluster.test: Attribute 'global_cluster_self_managed_sharding' expected "false678", got "false"
        Check 5/20 error: mongodbatlas_advanced_cluster.test: Attribute 'name' expected "test-acc-tf-c-793928882496728491490", got "test-acc-tf-c-7939288824967284914"
        Check 7/20 error: data.mongodbatlas_advanced_cluster.test: Attribute 'name' expected "test-acc-tf-c-793928882496728491490", got "test-acc-tf-c-7939288824967284914"
        Check 9/20 error: data.mongodbatlas_advanced_cluster.test: Attribute 'global_cluster_self_managed_sharding' expected "false678", got "false"
        Check 10/20 error: mongodbatlas_advanced_cluster.test: Attribute 'project_id123' expected to be set
        Check 12/20 error: mongodbatlas_advanced_cluster.test: Attribute 'replication_specs.0.region_configs456.#' expected to be set
        Check 13/20 error: data.mongodbatlas_advanced_cluster.test: Attribute 'project_id123' expected to be set
        Check 15/20 error: data.mongodbatlas_advanced_cluster.test: Attribute 'replication_specs.0.region_configs456.#' expected to be set
--- FAIL: TestAccClusterAdvancedCluster_basicTenant (248.79s)
```
