### PR TITLE
feat: Calling new API version when creating clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/zclconf/go-cty v1.14.4
 	go.mongodb.org/atlas v0.36.0
 	go.mongodb.org/atlas-sdk/v20231115014 v20231115014.0.0
-	go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240619083352-d423f3e4cbe1
+	go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea
 	go.mongodb.org/realm v0.1.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/zclconf/go-cty v1.14.4
 	go.mongodb.org/atlas v0.36.0
 	go.mongodb.org/atlas-sdk/v20231115014 v20231115014.0.0
-	go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea
+	go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240624083419-fb05c1937b8a
 	go.mongodb.org/realm v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -787,6 +787,8 @@ go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240614083321-69cb517e
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240614083321-69cb517ed2e5/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240619083352-d423f3e4cbe1 h1:q7r+JFie1lLZ1+ndlswVxpvWmo9/Bd62fdT2hezWMNk=
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240619083352-d423f3e4cbe1/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
+go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea h1:0RjNbmuy5swpaV7nFIEd6h6LsAaauPeVBSTaN2xcdzA=
+go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -789,6 +789,8 @@ go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240619083352-d423f3e4
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240619083352-d423f3e4cbe1/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea h1:0RjNbmuy5swpaV7nFIEd6h6LsAaauPeVBSTaN2xcdzA=
 go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240621083407-1908ed1f83ea/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
+go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240624083419-fb05c1937b8a h1:9HlqteDe9q+S5A222pfnyHJiYNOBDsXBA1UdESHkhz4=
+go.mongodb.org/atlas-sdk/v20240530001 v20240530001.0.1-0.20240624083419-fb05c1937b8a/go.mod h1:xfvOKGvcdJ12uduvUSIIfcHQvEpPXc9UQT+DYUCrmlA=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -787,6 +787,12 @@ func expandAdvancedReplicationSpecs(tfList []any, rootDiskSizeGB *float64) *[]ad
 		}
 		apiObject := expandAdvancedReplicationSpec(tfMap, rootDiskSizeGB)
 		apiObjects = append(apiObjects, *apiObject)
+
+		// handles adding additional replication spec objects if legacy num_shards attribute is being used and greater than 1
+		numShards := tfMap["num_shards"].(int)
+		for range numShards - 1 {
+			apiObjects = append(apiObjects, *apiObject)
+		}
 	}
 	return &apiObjects
 }

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -818,7 +818,7 @@ func expandAdvancedReplicationSpec(tfMap map[string]any, rootDiskSizeGB *float64
 		ZoneName:      conversion.StringPtr(tfMap["zone_name"].(string)),
 		RegionConfigs: expandRegionConfigs(tfMap["region_configs"].([]any), rootDiskSizeGB),
 	}
-	// here we will populate id value using external_id value
+	// here we will populate id value using external_id value (relevant for update)
 	return apiObject
 }
 
@@ -898,7 +898,7 @@ func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *f
 		apiObject.NodeCount = conversion.Pointer(v.(int))
 	}
 
-	// Once disk_size_gb is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be reomved)
+	// Once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be reomved)
 	apiObject.DiskSizeGB = rootDiskSizeGB
 
 	return apiObject

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -898,7 +898,7 @@ func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *f
 		apiObject.NodeCount = conversion.Pointer(v.(int))
 	}
 
-	// Once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be reomved)
+	// Once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be removed)
 	apiObject.DiskSizeGB = rootDiskSizeGB
 
 	return apiObject

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -818,7 +818,7 @@ func expandAdvancedReplicationSpec(tfMap map[string]any, rootDiskSizeGB *float64
 		ZoneName:      conversion.StringPtr(tfMap["zone_name"].(string)),
 		RegionConfigs: expandRegionConfigs(tfMap["region_configs"].([]any), rootDiskSizeGB),
 	}
-	// here we will populate id value using external_id value (relevant for update)
+	// TODO: here we will populate id value using external_id value from the state (relevant for update request)
 	return apiObject
 }
 
@@ -898,7 +898,7 @@ func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *f
 		apiObject.NodeCount = conversion.Pointer(v.(int))
 	}
 
-	// Once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be removed)
+	// TODO: once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be removed)
 	apiObject.DiskSizeGB = rootDiskSizeGB
 
 	return apiObject

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -776,9 +776,6 @@ func expandLabelSliceFromSetSchema(d *schema.ResourceData) ([]admin.ComponentLab
 }
 
 func expandAdvancedReplicationSpecs(tfList []any, rootDiskSizeGB *float64) *[]admin.ReplicationSpec20240710 {
-	if len(tfList) == 0 {
-		return nil
-	}
 	var apiObjects []admin.ReplicationSpec20240710
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
@@ -794,13 +791,13 @@ func expandAdvancedReplicationSpecs(tfList []any, rootDiskSizeGB *float64) *[]ad
 			apiObjects = append(apiObjects, *apiObject)
 		}
 	}
+	if apiObjects == nil {
+		return nil
+	}
 	return &apiObjects
 }
 
 func expandAdvancedReplicationSpecsOldSDK(tfList []any) *[]admin20231115.ReplicationSpec {
-	if len(tfList) == 0 {
-		return nil
-	}
 	var apiObjects []admin20231115.ReplicationSpec
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
@@ -809,6 +806,9 @@ func expandAdvancedReplicationSpecsOldSDK(tfList []any) *[]admin20231115.Replica
 		}
 		apiObject := expandAdvancedReplicationSpecOldSDK(tfMap)
 		apiObjects = append(apiObjects, *apiObject)
+	}
+	if apiObjects == nil {
+		return nil
 	}
 	return &apiObjects
 }
@@ -835,9 +835,6 @@ func expandAdvancedReplicationSpecOldSDK(tfMap map[string]any) *admin20231115.Re
 }
 
 func expandRegionConfigs(tfList []any, rootDiskSizeGB *float64) *[]admin.CloudRegionConfig {
-	if len(tfList) == 0 {
-		return nil
-	}
 	var apiObjects []admin.CloudRegionConfig
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
@@ -847,7 +844,9 @@ func expandRegionConfigs(tfList []any, rootDiskSizeGB *float64) *[]admin.CloudRe
 		apiObject := expandRegionConfig(tfMap, rootDiskSizeGB)
 		apiObjects = append(apiObjects, *apiObject)
 	}
-
+	if apiObjects == nil {
+		return nil
+	}
 	return &apiObjects
 }
 

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -15,7 +15,8 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/spf13/cast"
-	"go.mongodb.org/atlas-sdk/v20231115014/admin"
+	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
+	"go.mongodb.org/atlas-sdk/v20240530001/admin"
 )
 
 var (
@@ -275,7 +276,7 @@ func IsSharedTier(instanceSize string) bool {
 	return instanceSize == "M0" || instanceSize == "M2" || instanceSize == "M5"
 }
 
-func UpgradeRefreshFunc(ctx context.Context, name, projectID string, client admin.ClustersApi) retry.StateRefreshFunc {
+func UpgradeRefreshFunc(ctx context.Context, name, projectID string, client admin20231115.ClustersApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		cluster, resp, err := client.GetCluster(ctx, projectID, name).Execute()
 
@@ -300,7 +301,7 @@ func UpgradeRefreshFunc(ctx context.Context, name, projectID string, client admi
 	}
 }
 
-func ResourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, clustersAPI admin.ClustersApi) retry.StateRefreshFunc {
+func ResourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, clustersAPI admin20231115.ClustersApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		clusters, resp, err := clustersAPI.ListClusters(ctx, projectID).Execute()
 
@@ -339,7 +340,7 @@ func FormatMongoDBMajorVersion(val any) string {
 	return fmt.Sprintf("%.1f", cast.ToFloat32(val))
 }
 
-func flattenLabels(l []admin.ComponentLabel) []map[string]string {
+func flattenLabels(l []admin20231115.ComponentLabel) []map[string]string {
 	labels := make([]map[string]string, 0, len(l))
 	for _, item := range l {
 		if item.GetKey() == ignoreLabel {
@@ -353,7 +354,7 @@ func flattenLabels(l []admin.ComponentLabel) []map[string]string {
 	return labels
 }
 
-func flattenConnectionStrings(str admin.ClusterConnectionStrings) []map[string]any {
+func flattenConnectionStrings(str admin20231115.ClusterConnectionStrings) []map[string]any {
 	return []map[string]any{
 		{
 			"standard":         str.GetStandard(),
@@ -365,7 +366,7 @@ func flattenConnectionStrings(str admin.ClusterConnectionStrings) []map[string]a
 	}
 }
 
-func flattenPrivateEndpoint(privateEndpoints []admin.ClusterDescriptionConnectionStringsPrivateEndpoint) []map[string]any {
+func flattenPrivateEndpoint(privateEndpoints []admin20231115.ClusterDescriptionConnectionStringsPrivateEndpoint) []map[string]any {
 	endpoints := make([]map[string]any, 0, len(privateEndpoints))
 	for _, endpoint := range privateEndpoints {
 		endpoints = append(endpoints, map[string]any{
@@ -379,7 +380,7 @@ func flattenPrivateEndpoint(privateEndpoints []admin.ClusterDescriptionConnectio
 	return endpoints
 }
 
-func flattenEndpoints(listEndpoints []admin.ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) []map[string]any {
+func flattenEndpoints(listEndpoints []admin20231115.ClusterDescriptionConnectionStringsPrivateEndpointEndpoint) []map[string]any {
 	endpoints := make([]map[string]any, 0, len(listEndpoints))
 	for _, endpoint := range listEndpoints {
 		endpoints = append(endpoints, map[string]any{
@@ -391,7 +392,7 @@ func flattenEndpoints(listEndpoints []admin.ClusterDescriptionConnectionStringsP
 	return endpoints
 }
 
-func flattenBiConnectorConfig(biConnector admin.BiConnector) []map[string]any {
+func flattenBiConnectorConfig(biConnector admin20231115.BiConnector) []map[string]any {
 	return []map[string]any{
 		{
 			"enabled":         biConnector.GetEnabled(),
@@ -413,7 +414,7 @@ func expandBiConnectorConfig(d *schema.ResourceData) *admin.BiConnector {
 	return nil
 }
 
-func flattenProcessArgs(p *admin.ClusterDescriptionProcessArgs) []map[string]any {
+func flattenProcessArgs(p *admin20231115.ClusterDescriptionProcessArgs) []map[string]any {
 	if p == nil {
 		return nil
 	}
@@ -434,8 +435,8 @@ func flattenProcessArgs(p *admin.ClusterDescriptionProcessArgs) []map[string]any
 	}
 }
 
-func FlattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.ReplicationSpec, tfMapObjects []any,
-	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
+func FlattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin20231115.ReplicationSpec, tfMapObjects []any,
+	d *schema.ResourceData, connV2 *admin20231115.APIClient) ([]map[string]any, error) {
 	if len(apiObjects) == 0 {
 		return nil, nil
 	}
@@ -492,12 +493,12 @@ func FlattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.Rep
 	return tfList, nil
 }
 
-func doesAdvancedReplicationSpecMatchAPI(tfObject map[string]any, apiObject *admin.ReplicationSpec) bool {
+func doesAdvancedReplicationSpecMatchAPI(tfObject map[string]any, apiObject *admin20231115.ReplicationSpec) bool {
 	return tfObject["id"] == apiObject.GetId() || (tfObject["id"] == nil && tfObject["zone_name"] == apiObject.GetZoneName())
 }
 
-func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.ReplicationSpec, tfMapObject map[string]any,
-	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
+func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin20231115.ReplicationSpec, tfMapObject map[string]any,
+	d *schema.ResourceData, connV2 *admin20231115.APIClient) (map[string]any, error) {
 	if apiObject == nil {
 		return nil, nil
 	}
@@ -525,8 +526,8 @@ func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.Replic
 	return tfMap, nil
 }
 
-func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects []admin.CloudRegionConfig, tfMapObjects []any,
-	d *schema.ResourceData, connV2 *admin.APIClient) (tfResult []map[string]any, containersIDs map[string]string, err error) {
+func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects []admin20231115.CloudRegionConfig, tfMapObjects []any,
+	d *schema.ResourceData, connV2 *admin20231115.APIClient) (tfResult []map[string]any, containersIDs map[string]string, err error) {
 	if len(apiObjects) == 0 {
 		return nil, nil, nil
 	}
@@ -544,7 +545,7 @@ func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects
 		}
 
 		if apiObject.GetProviderName() != "TENANT" {
-			params := &admin.ListPeeringContainerByCloudProviderApiParams{
+			params := &admin20231115.ListPeeringContainerByCloudProviderApiParams{
 				GroupId:      d.Get("project_id").(string),
 				ProviderName: apiObject.ProviderName,
 			}
@@ -561,7 +562,7 @@ func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects
 	return tfList, containerIDs, nil
 }
 
-func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin.CloudRegionConfig, tfMapObject map[string]any) map[string]any {
+func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin20231115.CloudRegionConfig, tfMapObject map[string]any) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -599,11 +600,11 @@ func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin.CloudRegionConf
 	return tfMap
 }
 
-func hwSpecToDedicatedHwSpec(apiObject *admin.HardwareSpec) *admin.DedicatedHardwareSpec {
+func hwSpecToDedicatedHwSpec(apiObject *admin20231115.HardwareSpec) *admin20231115.DedicatedHardwareSpec {
 	if apiObject == nil {
 		return nil
 	}
-	return &admin.DedicatedHardwareSpec{
+	return &admin20231115.DedicatedHardwareSpec{
 		NodeCount:     apiObject.NodeCount,
 		DiskIOPS:      apiObject.DiskIOPS,
 		EbsVolumeType: apiObject.EbsVolumeType,
@@ -623,7 +624,7 @@ func dedicatedHwSpecToHwSpec(apiObject *admin.DedicatedHardwareSpec) *admin.Hard
 	}
 }
 
-func flattenAdvancedReplicationSpecRegionConfigSpec(apiObject *admin.DedicatedHardwareSpec, providerName string, tfMapObjects []any) []map[string]any {
+func flattenAdvancedReplicationSpecRegionConfigSpec(apiObject *admin20231115.DedicatedHardwareSpec, providerName string, tfMapObjects []any) []map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -659,7 +660,7 @@ func flattenAdvancedReplicationSpecRegionConfigSpec(apiObject *admin.DedicatedHa
 	return tfList
 }
 
-func flattenAdvancedReplicationSpecAutoScaling(apiObject *admin.AdvancedAutoScalingSettings) []map[string]any {
+func flattenAdvancedReplicationSpecAutoScaling(apiObject *admin20231115.AdvancedAutoScalingSettings) []map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -678,7 +679,7 @@ func flattenAdvancedReplicationSpecAutoScaling(apiObject *admin.AdvancedAutoScal
 	return tfList
 }
 
-func getAdvancedClusterContainerID(containers []admin.CloudProviderContainer, cluster *admin.CloudRegionConfig) string {
+func getAdvancedClusterContainerID(containers []admin20231115.CloudProviderContainer, cluster *admin20231115.CloudRegionConfig) string {
 	if len(containers) == 0 {
 		return ""
 	}
@@ -695,8 +696,8 @@ func getAdvancedClusterContainerID(containers []admin.CloudProviderContainer, cl
 	return ""
 }
 
-func expandProcessArgs(d *schema.ResourceData, p map[string]any) admin.ClusterDescriptionProcessArgs {
-	res := admin.ClusterDescriptionProcessArgs{}
+func expandProcessArgs(d *schema.ResourceData, p map[string]any) admin20231115.ClusterDescriptionProcessArgs {
+	res := admin20231115.ClusterDescriptionProcessArgs{}
 
 	if _, ok := d.GetOkExists("advanced_configuration.0.default_read_concern"); ok {
 		res.DefaultReadConcern = conversion.StringPtr(cast.ToString(p["default_read_concern"]))
@@ -773,11 +774,11 @@ func expandLabelSliceFromSetSchema(d *schema.ResourceData) ([]admin.ComponentLab
 	return res, nil
 }
 
-func expandAdvancedReplicationSpecs(tfList []any) *[]admin.ReplicationSpec {
+func expandAdvancedReplicationSpecs(tfList []any) *[]admin.ReplicationSpec20240710 {
 	if len(tfList) == 0 {
 		return nil
 	}
-	var apiObjects []admin.ReplicationSpec
+	var apiObjects []admin.ReplicationSpec20240710
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok || tfMap == nil {
@@ -789,11 +790,36 @@ func expandAdvancedReplicationSpecs(tfList []any) *[]admin.ReplicationSpec {
 	return &apiObjects
 }
 
-func expandAdvancedReplicationSpec(tfMap map[string]any) *admin.ReplicationSpec {
-	apiObject := &admin.ReplicationSpec{
-		NumShards:     conversion.Pointer(tfMap["num_shards"].(int)),
+func expandAdvancedReplicationSpecsOldSDK(tfList []any) *[]admin20231115.ReplicationSpec {
+	if len(tfList) == 0 {
+		return nil
+	}
+	var apiObjects []admin20231115.ReplicationSpec
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok || tfMap == nil {
+			continue
+		}
+		apiObject := expandAdvancedReplicationSpecOldSDK(tfMap)
+		apiObjects = append(apiObjects, *apiObject)
+	}
+	return &apiObjects
+}
+
+func expandAdvancedReplicationSpec(tfMap map[string]any) *admin.ReplicationSpec20240710 {
+	apiObject := &admin.ReplicationSpec20240710{
 		ZoneName:      conversion.StringPtr(tfMap["zone_name"].(string)),
 		RegionConfigs: expandRegionConfigs(tfMap["region_configs"].([]any)),
+	}
+	// here we will populate id value using external_id value
+	return apiObject
+}
+
+func expandAdvancedReplicationSpecOldSDK(tfMap map[string]any) *admin20231115.ReplicationSpec {
+	apiObject := &admin20231115.ReplicationSpec{
+		NumShards:     conversion.Pointer(tfMap["num_shards"].(int)),
+		ZoneName:      conversion.StringPtr(tfMap["zone_name"].(string)),
+		RegionConfigs: convertRegionConfigSliceToOldSDK(expandRegionConfigs(tfMap["region_configs"].([]any))),
 	}
 	if tfMap["id"].(string) != "" {
 		apiObject.Id = conversion.StringPtr(tfMap["id"].(string))

--- a/internal/service/advancedcluster/model_sdk_version_conversion.go
+++ b/internal/service/advancedcluster/model_sdk_version_conversion.go
@@ -1,0 +1,130 @@
+package advancedcluster
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
+	"go.mongodb.org/atlas-sdk/v20240530001/admin"
+)
+
+// Conversions from one SDK model version to another are used to avoid duplicating our flatten/expand conversion functions.
+// - These functions must not contain any business logic.
+// - All will be removed once we rely on a single API version.
+
+func convertTagsToLatest(tags *[]admin20231115.ResourceTag) *[]admin.ResourceTag {
+	if tags == nil {
+		return nil
+	}
+	tagSlice := *tags
+	results := make([]admin.ResourceTag, len(tagSlice))
+	for i := range len(tagSlice) {
+		tag := tagSlice[i]
+		results[i] = admin.ResourceTag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		}
+	}
+	return &results
+}
+
+func convertBiConnectToOldSDK(biconnector *admin.BiConnector) *admin20231115.BiConnector {
+	if biconnector == nil {
+		return nil
+	}
+	return &admin20231115.BiConnector{
+		Enabled:        biconnector.Enabled,
+		ReadPreference: biconnector.ReadPreference,
+	}
+}
+
+func convertLabelSliceToOldSDK(slice []admin.ComponentLabel, err diag.Diagnostics) ([]admin20231115.ComponentLabel, diag.Diagnostics) {
+	if err != nil {
+		return nil, err
+	}
+	results := make([]admin20231115.ComponentLabel, len(slice))
+	for i := range len(slice) {
+		label := slice[i]
+		results[i] = admin20231115.ComponentLabel{
+			Key:   label.Key,
+			Value: label.Value,
+		}
+	}
+	return results, nil
+}
+
+func convertRegionConfigSliceToOldSDK(slice *[]admin.CloudRegionConfig) *[]admin20231115.CloudRegionConfig {
+	if slice == nil {
+		return nil
+	}
+	cloudRegionSlice := *slice
+	results := make([]admin20231115.CloudRegionConfig, len(cloudRegionSlice))
+	for i := range len(cloudRegionSlice) {
+		cloudRegion := cloudRegionSlice[i]
+		results[i] = admin20231115.CloudRegionConfig{
+			ElectableSpecs:       convertHardwareSpecToOldSDK(cloudRegion.ElectableSpecs),
+			Priority:             cloudRegion.Priority,
+			ProviderName:         cloudRegion.ProviderName,
+			RegionName:           cloudRegion.RegionName,
+			AnalyticsAutoScaling: convertAdvancedAutoScalingSettingsToOldSDK(cloudRegion.AnalyticsAutoScaling),
+			AnalyticsSpecs:       convertDedicatedHardwareSpecToOldSDK(cloudRegion.AnalyticsSpecs),
+			AutoScaling:          convertAdvancedAutoScalingSettingsToOldSDK(cloudRegion.AutoScaling),
+			ReadOnlySpecs:        convertDedicatedHardwareSpecToOldSDK(cloudRegion.ReadOnlySpecs),
+			BackingProviderName:  cloudRegion.BackingProviderName,
+		}
+	}
+	return &results
+}
+
+func convertHardwareSpecToOldSDK(hwspec *admin.HardwareSpec) *admin20231115.HardwareSpec {
+	if hwspec == nil {
+		return nil
+	}
+	return &admin20231115.HardwareSpec{
+		DiskIOPS:      hwspec.DiskIOPS,
+		EbsVolumeType: hwspec.EbsVolumeType,
+		InstanceSize:  hwspec.InstanceSize,
+		NodeCount:     hwspec.NodeCount,
+	}
+}
+
+func convertAdvancedAutoScalingSettingsToOldSDK(settings *admin.AdvancedAutoScalingSettings) *admin20231115.AdvancedAutoScalingSettings {
+	if settings == nil {
+		return nil
+	}
+	return &admin20231115.AdvancedAutoScalingSettings{
+		Compute: convertAdvancedComputeAutoScalingToOldSDK(settings.Compute),
+		DiskGB:  convertDiskGBAutoScalingToOldSDK(settings.DiskGB),
+	}
+}
+
+func convertAdvancedComputeAutoScalingToOldSDK(settings *admin.AdvancedComputeAutoScaling) *admin20231115.AdvancedComputeAutoScaling {
+	if settings == nil {
+		return nil
+	}
+	return &admin20231115.AdvancedComputeAutoScaling{
+		Enabled:          settings.Enabled,
+		MaxInstanceSize:  settings.MaxInstanceSize,
+		MinInstanceSize:  settings.MinInstanceSize,
+		ScaleDownEnabled: settings.ScaleDownEnabled,
+	}
+}
+
+func convertDiskGBAutoScalingToOldSDK(settings *admin.DiskGBAutoScaling) *admin20231115.DiskGBAutoScaling {
+	if settings == nil {
+		return nil
+	}
+	return &admin20231115.DiskGBAutoScaling{
+		Enabled: settings.Enabled,
+	}
+}
+
+func convertDedicatedHardwareSpecToOldSDK(spec *admin.DedicatedHardwareSpec) *admin20231115.DedicatedHardwareSpec {
+	if spec == nil {
+		return nil
+	}
+	return &admin20231115.DedicatedHardwareSpec{
+		NodeCount:     spec.NodeCount,
+		DiskIOPS:      spec.DiskIOPS,
+		EbsVolumeType: spec.EbsVolumeType,
+		InstanceSize:  spec.InstanceSize,
+	}
+}

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -418,9 +418,9 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if v, ok := d.GetOk("version_release_system"); ok {
 		params.VersionReleaseSystem = conversion.StringPtr(v.(string))
 	}
-	// if v, ok := d.GetOk("global_cluster_self_managed_sharding"); ok {
-	// 	params.GlobalClusterSelfManagedSharding = conversion.Pointer(v.(bool)) // TODO: fix when property is exposed.
-	// }
+	if v, ok := d.GetOk("global_cluster_self_managed_sharding"); ok {
+		params.GlobalClusterSelfManagedSharding = conversion.Pointer(v.(bool))
+	}
 
 	// Validate oplog_size_mb to show the error before the cluster is created.
 	if oplogSizeMB, ok := d.GetOkExists("advanced_configuration.0.oplog_size_mb"); ok {


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-257162

This PR adjusts the create operation to start using the new API exclusively, but still preserving the possibility of creating clusters defined in the old schema structure.
- If numShards is > 1 additional replication spec object are added in the request.
- If disk size gb is defined at the root level, it is propagated to the hardware spec level.
- New expand functions supporting new API model. Existing expand functions are preserved as they are currently being used for the update operation which was not modified.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
