### PR TITLE
test: Unifies Azure and GCP networking tests

### DIFF
--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -32,6 +32,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
 		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
 		vNetName          = os.Getenv("AZURE_VNET_NAME")
+		updatedvNetName   = os.Getenv("AZURE_VNET_NAME_UPDATED")
 		providerName      = "AZURE"
 	)
 
@@ -48,6 +49,17 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
+					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+				),
+			},
+			{
+				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, updatedvNetName),
+				Check: resource.ComposeTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
+					resource.TestCheckResourceAttr(resourceName, "vnet_name", updatedvNetName),
 					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
 				),
 			},

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -36,7 +36,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 		providerName      = "AZURE"
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
@@ -85,7 +85,7 @@ func TestAccNetworkRSNetworkPeering_GCP(t *testing.T) {
 		updatedNetworkName = acc.RandomName()
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvGCP(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -25,44 +25,7 @@ func TestAccNetworkNetworkPeering_basicAWS(t *testing.T) {
 	resource.ParallelTest(t, *basicAWSTestCase(t))
 }
 
-func TestAccNetworkRSNetworkPeering_basicAzure(t *testing.T) {
-	var (
-		projectID         = acc.ProjectIDExecution(t)
-		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
-		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
-		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
-		vNetName          = os.Getenv("AZURE_VNET_NAME")
-		providerName      = "AZURE"
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyNetworkPeering,
-		Steps: []resource.TestStep{
-			{
-				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
-					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
-					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"container_id"},
-			},
-		},
-	})
-}
-
-func TestAccNetworkRSNetworkPeering_updateBasicAzure(t *testing.T) {
+func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 	var (
 		projectID         = acc.ProjectIDExecution(t)
 		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
@@ -100,52 +63,18 @@ func TestAccNetworkRSNetworkPeering_updateBasicAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
 				),
 			},
-		},
-	})
-}
-
-func TestAccNetworkRSNetworkPeering_basicGCP(t *testing.T) {
-	acc.SkipTestForCI(t) // needs GCP configuration
-
-	var (
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		providerName = "GCP"
-		gcpProjectID = os.Getenv("GCP_PROJECT_ID")
-		networkName  = acc.RandomName()
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckPeeringEnvGCP(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyNetworkPeering,
-		Steps: []resource.TestStep{
 			{
-				Config: configGCP(projectID, providerName, gcpProjectID, networkName),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
-
-					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
-					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
-					resource.TestCheckResourceAttr(resourceName, "network_name", networkName),
-
-					// computed values that are obtain from associated container, checks for existing prefix convention to ensure they are gcp related values
-					resource.TestCheckResourceAttrWith(resourceName, "atlas_gcp_project_id", acc.MatchesExpression("p-.*")),
-					resource.TestCheckResourceAttrWith(resourceName, "atlas_vpc_name", acc.MatchesExpression("nt-.*")),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"container_id"},
 			},
 		},
 	})
 }
 
-func TestAccNetworkRSNetworkPeering_updateBasicGCP(t *testing.T) {
+func TestAccNetworkRSNetworkPeering_GCP(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
 	var (
@@ -172,6 +101,10 @@ func TestAccNetworkRSNetworkPeering_updateBasicGCP(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
 					resource.TestCheckResourceAttr(resourceName, "network_name", networkName),
+
+					// computed values that are obtain from associated container, checks for existing prefix convention to ensure they are gcp related values
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_gcp_project_id", acc.MatchesExpression("p-.*")),
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_vpc_name", acc.MatchesExpression("nt-.*")),
 				),
 			},
 			{
@@ -185,7 +118,17 @@ func TestAccNetworkRSNetworkPeering_updateBasicGCP(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "gcp_project_id", gcpProjectID),
 					resource.TestCheckResourceAttr(resourceName, "network_name", updatedNetworkName),
+
+					// computed values that are obtain from associated container, checks for existing prefix convention to ensure they are gcp related values
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_gcp_project_id", acc.MatchesExpression("p-.*")),
+					resource.TestCheckResourceAttrWith(resourceName, "atlas_vpc_name", acc.MatchesExpression("nt-.*")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -32,7 +32,6 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
 		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
 		vNetName          = os.Getenv("AZURE_VNET_NAME")
-		updatedvNetName   = os.Getenv("AZURE_VNET_NAME_UPDATED")
 		providerName      = "AZURE"
 	)
 
@@ -49,17 +48,6 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
-					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
-				),
-			},
-			{
-				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, updatedvNetName),
-				Check: resource.ComposeTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
-					resource.TestCheckResourceAttr(resourceName, "vnet_name", updatedvNetName),
 					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
 				),
 			},


### PR DESCRIPTION
## Description

Unifies Azure and GCP networking tests. 

This PR is focused on fixing flaky test TestAccNetworkRSNetworkPeering_updateBasicAzure. 
So for instance no test check refactors are done.

Azure and GCP basic and update tests are joined in one Azure and GCP tests because the basic tests are basically the first step in the update ones, so they don't add a lot of value. 

This will also eliminate flakiness as tests were sharing project execution and now there will be only one Azure test.



Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
