### PR TITLE
test: Uses ComposeAggregateTestCheckFunc for soft assertions

### DIFF
--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -22,7 +22,7 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configProject(orgID, projectName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", "0"),

--- a/internal/service/accesslistapikey/data_source_accesslist_api_key_test.go
+++ b/internal/service/accesslistapikey/data_source_accesslist_api_key_test.go
@@ -23,7 +23,7 @@ func TestAccConfigDSAccesslistAPIKey_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, description, ipAddress),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),

--- a/internal/service/accesslistapikey/data_source_accesslist_api_keys_test.go
+++ b/internal/service/accesslistapikey/data_source_accesslist_api_keys_test.go
@@ -25,7 +25,7 @@ func TestAccConfigDSAccesslistAPIKeys_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDSPlural(orgID, description, ipAddress),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),

--- a/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_migration_test.go
@@ -26,7 +26,7 @@ func TestMigProjectAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configWithIPAddress(orgID, description, ipAddress),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
@@ -54,7 +54,7 @@ func TestMigProjectAccesslistAPIKey_SettingCIDRBlock(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProviders("1.14.0"),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
@@ -92,7 +92,7 @@ func TestMigProjectAccesslistAPIKey_SettingCIDRBlock_WideCIDR_SDKMigration(t *te
 			{
 				ExternalProviders: acc.ExternalProviders("1.14.0"),
 				Config:            configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),

--- a/internal/service/accesslistapikey/resource_access_list_api_key_test.go
+++ b/internal/service/accesslistapikey/resource_access_list_api_key_test.go
@@ -28,7 +28,7 @@ func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithIPAddress(orgID, description, ipAddress),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", ipAddress),
@@ -36,7 +36,7 @@ func TestAccProjectRSAccesslistAPIKey_SettingIPAddress(t *testing.T) {
 			},
 			{
 				Config: configWithIPAddress(orgID, description, updatedIPAddress),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "ip_address", updatedIPAddress),
@@ -68,7 +68,7 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
@@ -76,7 +76,7 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock(t *testing.T) {
 			},
 			{
 				Config: configWithCIDRBlock(orgID, description, updatedCIDRBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),
@@ -102,7 +102,7 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithCIDRBlock(orgID, description, cidrBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", cidrBlock),
@@ -110,7 +110,7 @@ func TestAccProjectRSAccessListAPIKey_SettingCIDRBlock_WideCIDR(t *testing.T) {
 			},
 			{
 				Config: configWithCIDRBlock(orgID, description, updatedCIDRBlock),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cidr_block", updatedCIDRBlock),

--- a/internal/service/alertconfiguration/data_source_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/data_source_alert_configuration_test.go
@@ -21,7 +21,7 @@ func TestAccConfigDSAlertConfiguration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicDS(projectID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
@@ -47,7 +47,7 @@ func TestAccConfigDSAlertConfiguration_withThreshold(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithThreshold(projectID, true, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
@@ -73,7 +73,7 @@ func TestAccConfigDSAlertConfiguration_withOutput(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithOutputs(projectID, outputLabel),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourceName, "notification.#", "1"),
@@ -102,7 +102,7 @@ func TestAccConfigDSAlertConfiguration_withPagerDuty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithPagerDutyDS(projectID, serviceKey, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
 				),

--- a/internal/service/alertconfiguration/data_source_alert_configurations_test.go
+++ b/internal/service/alertconfiguration/data_source_alert_configurations_test.go
@@ -26,7 +26,7 @@ func TestAccConfigDSAlertConfigurations_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicPluralDS(projectID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkCount(dataSourcePluralName),
 					resource.TestCheckResourceAttr(dataSourcePluralName, "project_id", projectID),
 					resource.TestCheckNoResourceAttr(dataSourcePluralName, "total_count"),
@@ -48,7 +48,7 @@ func TestAccConfigDSAlertConfigurations_withOutputTypes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configOutputType(projectID, outputTypes),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkCount(dataSourcePluralName),
 					resource.TestCheckResourceAttr(dataSourcePluralName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourcePluralName, "results.0.output.#", "2"),
@@ -86,7 +86,7 @@ func TestAccConfigDSAlertConfigurations_totalCount(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configTotalCount(projectID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkCount(dataSourcePluralName),
 					resource.TestCheckResourceAttr(dataSourcePluralName, "project_id", projectID),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "total_count"),

--- a/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
@@ -21,7 +21,7 @@ func TestMigConfigRSAlertConfiguration_withNotificationsMetricThreshold(t *testi
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
@@ -45,7 +45,7 @@ func TestMigConfigRSAlertConfiguration_withThreshold(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
@@ -71,7 +71,7 @@ func TestMigConfigRSAlertConfiguration_withEmptyOptionalBlocks(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
@@ -108,7 +108,7 @@ func TestMigConfigRSAlertConfiguration_withMultipleMatchers(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "matcher.#", "2"),
@@ -132,7 +132,7 @@ func TestMigConfigRSAlertConfiguration_withEmptyOptionalAttributes(t *testing.T)
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -35,7 +35,7 @@ func TestAccConfigRSAlertConfiguration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicRS(projectID, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
@@ -43,7 +43,7 @@ func TestAccConfigRSAlertConfiguration_basic(t *testing.T) {
 			},
 			{
 				Config: configBasicRS(projectID, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "2"),
@@ -93,7 +93,7 @@ func TestAccConfigRSAlertConfiguration_withEmptyMatcherMetricThresholdConfig(t *
 		Steps: []resource.TestStep{
 			{
 				Config: configWithEmptyMatcherMetricThresholdConfig(projectID, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
@@ -116,14 +116,14 @@ func TestAccConfigRSAlertConfiguration_withNotifications(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithNotifications(projectID, true, true, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configWithNotifications(projectID, false, false, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -163,7 +163,7 @@ func TestAccConfigRSAlertConfiguration_withMatchers(t *testing.T) {
 						"operator":  "CONTAINS",
 						"value":     "MONGOS",
 					}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -180,7 +180,7 @@ func TestAccConfigRSAlertConfiguration_withMatchers(t *testing.T) {
 						"operator":  "EQUALS",
 						"value":     "PRIMARY",
 					}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -203,14 +203,14 @@ func TestAccConfigRSAlertConfiguration_withMetricUpdated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithMetricUpdated(projectID, true, 99.0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configWithMetricUpdated(projectID, false, 89.7),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -233,14 +233,14 @@ func TestAccConfigRSAlertConfiguration_withThresholdUpdated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithThresholdUpdated(projectID, true, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configWithThresholdUpdated(projectID, false, 3),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -270,7 +270,7 @@ func TestAccConfigRSAlertConfiguration_withoutRoles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithoutRoles(projectID, true, 99.0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -293,7 +293,7 @@ func TestAccConfigRSAlertConfiguration_withoutOptionalAttributes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithEmptyOptionalAttributes(projectID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -347,7 +347,7 @@ func TestAccConfigRSAlertConfiguration_updatePagerDutyWithNotifierId(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: configWithPagerDutyNotifierID(projectID, notifierID, 10, &serviceKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.0.delay_min", "10"),
@@ -356,7 +356,7 @@ func TestAccConfigRSAlertConfiguration_updatePagerDutyWithNotifierId(t *testing.
 			},
 			{
 				Config: configWithPagerDutyNotifierID(projectID, notifierID, 15, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "notification.0.delay_min", "15"),
@@ -382,7 +382,7 @@ func TestAccConfigRSAlertConfiguration_withDataDog(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithDataDog(projectID, ddAPIKey, ddRegion, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -406,7 +406,7 @@ func TestAccConfigRSAlertConfiguration_withPagerDuty(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithPagerDuty(projectID, serviceKey, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -437,7 +437,7 @@ func TestAccConfigAlertConfiguration_PagerDutyUsingIntegrationID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithPagerDutyIntegrationID(orgID, projectName, serviceKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(nil, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "notification.0.integration_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "notification.0.integration_id"),
@@ -462,7 +462,7 @@ func TestAccConfigRSAlertConfiguration_withOpsGenie(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithOpsGenie(projectID, apiKey, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -486,7 +486,7 @@ func TestAccConfigRSAlertConfiguration_withVictorOps(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithVictorOps(projectID, apiKey, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsUsingProxy(proxyPort, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),

--- a/internal/service/apikey/data_source_api_key_test.go
+++ b/internal/service/apikey/data_source_api_key_test.go
@@ -25,7 +25,7 @@ func TestAccConfigDSAPIKey_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "description", description),

--- a/internal/service/apikey/data_source_api_keys_test.go
+++ b/internal/service/apikey/data_source_api_keys_test.go
@@ -25,7 +25,7 @@ func TestAccConfigDSAPIKeys_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDSPlural(orgID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "description", description),

--- a/internal/service/apikey/resource_api_key_migration_test.go
+++ b/internal/service/apikey/resource_api_key_migration_test.go
@@ -25,7 +25,7 @@ func TestMigConfigAPIKey_basic(t *testing.T) {
 			{
 				Config:            config,
 				ExternalProviders: mig.ExternalProviders(),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "description", description),

--- a/internal/service/apikey/resource_api_key_test.go
+++ b/internal/service/apikey/resource_api_key_test.go
@@ -29,7 +29,7 @@ func TestAccConfigRSAPIKey_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -37,7 +37,7 @@ func TestAccConfigRSAPIKey_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, descriptionUpdate, roleNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "description", descriptionUpdate),

--- a/internal/service/atlasuser/data_source_atlas_user_test.go
+++ b/internal/service/atlasuser/data_source_atlas_user_test.go
@@ -26,7 +26,7 @@ func TestAccConfigDSAtlasUser_ByUserID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUserByUserID(userID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					dataSourceChecksForUser(dataSourceName, "", user)...,
 				),
 			},
@@ -47,7 +47,7 @@ func TestAccConfigDSAtlasUser_ByUsername(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUserByUsername(username),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					dataSourceChecksForUser(dataSourceName, "", user)...,
 				),
 			},

--- a/internal/service/atlasuser/data_source_atlas_users_test.go
+++ b/internal/service/atlasuser/data_source_atlas_users_test.go
@@ -30,7 +30,7 @@ func TestAccConfigDSAtlasUsers_ByOrgID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUsersByOrgID(orgID),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -51,7 +51,7 @@ func TestAccConfigDSAtlasUsers_ByProjectID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUsersByProjectID(projectName, orgID, projectOwnerID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "total_count", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "1"), // we know project will only have the project owner
@@ -82,7 +82,7 @@ func TestAccConfigDSAtlasUsers_ByTeamID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUsersByTeamID(orgID, teamName, username),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(dataSourceName, "total_count", "1"),
@@ -116,7 +116,7 @@ func TestAccConfigDSAtlasUsers_UsingPagination(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDSMongoDBAtlasUsersByTeamWithPagination(orgID, teamName, username, itemsPerPage, pageNum),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(dataSourceName, "total_count", "1"),

--- a/internal/service/auditing/resource_auditing_migration_test.go
+++ b/internal/service/auditing/resource_auditing_migration_test.go
@@ -23,7 +23,7 @@ func TestMigGenericAuditing_basic(t *testing.T) {
 			{
 				Config:            config,
 				ExternalProviders: mig.ExternalProviders(),
-				Check:             resource.ComposeTestCheckFunc(checks(auditFilter, true, true)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(checks(auditFilter, true, true)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/auditing/resource_auditing_test.go
+++ b/internal/service/auditing/resource_auditing_test.go
@@ -30,11 +30,11 @@ func TestAccGenericAuditing_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, auditFilter, true, true),
-				Check:  resource.ComposeTestCheckFunc(checks(auditFilter, true, true)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks(auditFilter, true, true)...),
 			},
 			{
 				Config: configBasic(projectID, "{}", false, false),
-				Check:  resource.ComposeTestCheckFunc(checks("{}", false, false)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks("{}", false, false)...),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -35,7 +35,7 @@ func TestAccBackupCompliancePolicy_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithoutOptionals(projectName, orgID, projectOwnerID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authorized_user_first_name", "First"),
 					resource.TestCheckResourceAttr(resourceName, "authorized_user_last_name", "Last"),
@@ -46,7 +46,7 @@ func TestAccBackupCompliancePolicy_update(t *testing.T) {
 			},
 			{
 				Config: configBasic(projectName, orgID, projectOwnerID, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "authorized_user_first_name", "First"),
 					resource.TestCheckResourceAttr(resourceName, "authorized_user_last_name", "Last"),
@@ -91,7 +91,7 @@ func TestAccBackupCompliancePolicy_withoutRestoreWindowDays(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithoutRestoreDays(projectName, orgID, projectOwnerID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "copy_protection_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_at_rest_enabled", "false"),
@@ -116,7 +116,7 @@ func basicTestCase(tb testing.TB, useYearly bool) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectName, orgID, projectOwnerID, useYearly),
-				Check:  resource.ComposeTestCheckFunc(basicChecks()...),
+				Check:  resource.ComposeAggregateTestCheckFunc(basicChecks()...),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -28,7 +28,7 @@ func TestMigBackupRSCloudBackupSchedule_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -34,7 +34,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
@@ -62,7 +62,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
 				}, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "0"),
@@ -105,7 +105,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "false"),
@@ -165,7 +165,7 @@ func TestAccBackupRSCloudBackupSchedule_export(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configExportPolicies(&clusterInfo, policyName, roleName, bucketName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
@@ -197,7 +197,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
@@ -231,7 +231,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "0"),
@@ -267,7 +267,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
@@ -317,7 +317,7 @@ func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
@@ -371,7 +371,7 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 					RetentionUnit:     "days",
 					RetentionValue:    1,
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
@@ -384,7 +384,7 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 					RetentionUnit:     "days",
 					RetentionValue:    3,
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.ClusterName),
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "2"),

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -23,7 +23,7 @@ func TestMigBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "type", "replicaSet"),
@@ -57,7 +57,7 @@ func TestMigBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "type", "shardedCluster"),

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -32,7 +32,7 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(&clusterInfo, description, retentionInDays),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "type", "replicaSet"),
@@ -81,7 +81,7 @@ func TestAccBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSharded(projectID, clusterName, description, retentionInDays),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "type", "shardedCluster"),

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -40,7 +40,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, bucketName, policyName, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", bucketName),

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -59,7 +59,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, bucketName, roleName, policyName, clusterInfo.ClusterNameStr, clusterInfo.ClusterTerraformStr),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
@@ -38,7 +38,7 @@ func TestAccCloudBackupSnapshotRestoreJob_basicDownload(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDownload(projectID, clusterName, description, retentionInDays, useSnapshotID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.download", "true"),
 				),
@@ -70,7 +70,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, clusterName, description, retentionInDays),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.automated", "true"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_type_config.0.target_cluster_name", clusterName),

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -59,7 +59,7 @@ func basicAuthorizationTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configAuthorizationAWS(projectID, policyName, roleName, federatedDatabaseInstanceName, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
@@ -69,7 +69,7 @@ func basicAuthorizationTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configAuthorizationAWS(projectID, policyName, roleNameUpdated, federatedDatabaseInstanceName, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -33,7 +33,7 @@ func TestAccCloudProviderAccessSetupAzure_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "azure_config.0.atlas_azure_app_id"),
@@ -70,7 +70,7 @@ func basicSetupTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configSetupAWS(projectID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					// same as regular cloud resource
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "aws_config.0.atlas_assumed_role_external_id"),

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -42,7 +42,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWS(projectID, clusterName, true, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -64,7 +64,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configAWS(projectID, clusterName, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -116,7 +116,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 					SampleSizeBIConnector:            conversion.Pointer[int64](110),
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -141,7 +141,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 				Config: configAdvancedConfPartial(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -180,7 +180,7 @@ func TestAccCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 					SampleSizeBIConnector:            conversion.Pointer[int64](110),
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
@@ -196,7 +196,7 @@ func TestAccCluster_basic_DefaultWriteRead_AdvancedConf(t *testing.T) {
 				Config: configAdvancedConfPartialDefault(projectID, clusterName, "false", &matlas.ProcessArgs{
 					MinimumEnabledTLSProtocol: "TLS1_2",
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
@@ -239,7 +239,7 @@ func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 					SampleSizeBIConnector:            conversion.Pointer[int64](110),
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
@@ -276,7 +276,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 					SampleSizeBIConnector:            conversion.Pointer[int64](110),
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](300),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
@@ -299,7 +299,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 					SampleSizeBIConnector:            conversion.Pointer[int64](0),
 					TransactionLifetimeLimitSeconds:  conversion.Pointer[int64](60),
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "false"),
@@ -330,7 +330,7 @@ func TestAccCluster_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAzure(orgID, projectName, clusterName, "true", "M30", true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -341,7 +341,7 @@ func TestAccCluster_basicAzure(t *testing.T) {
 			},
 			{
 				Config: configAzure(orgID, projectName, clusterName, "false", "M30", true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -369,7 +369,7 @@ func TestAccCluster_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCP(orgID, projectName, clusterName, "true"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -381,7 +381,7 @@ func TestAccCluster_basicGCP(t *testing.T) {
 			},
 			{
 				Config: configGCP(orgID, projectName, clusterName, "false"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -410,7 +410,7 @@ func TestAccCluster_WithBiConnectorGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCPWithBiConnector(orgID, projectName, clusterName, "true", false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -423,7 +423,7 @@ func TestAccCluster_WithBiConnectorGCP(t *testing.T) {
 			},
 			{
 				Config: configGCPWithBiConnector(orgID, projectName, clusterName, "false", true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -479,7 +479,7 @@ func TestAccCluster_MultiRegion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiRegion(orgID, projectName, clusterName, "true", createRegionsConfig),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -494,7 +494,7 @@ func TestAccCluster_MultiRegion(t *testing.T) {
 			},
 			{
 				Config: configMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -549,7 +549,7 @@ func TestAccCluster_ProviderRegionName(t *testing.T) {
 			},
 			{
 				Config: configSingleRegionWithProviderRegionName(orgID, projectName, clusterName, "false"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -564,7 +564,7 @@ func TestAccCluster_ProviderRegionName(t *testing.T) {
 			},
 			{
 				Config: configMultiRegion(orgID, projectName, clusterName, "false", updatedRegionsConfig),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -604,7 +604,7 @@ func TestAccCluster_Global(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigClusterGlobal(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -637,7 +637,7 @@ func TestAccCluster_AWSWithLabels(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasClusterAWSConfigdWithLabels(projectID, clusterName, "false", "M10", "US_WEST_2", []matlas.Label{}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -663,7 +663,7 @@ func TestAccCluster_AWSWithLabels(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -685,7 +685,7 @@ func TestAccCluster_AWSWithLabels(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -713,7 +713,7 @@ func TestAccCluster_WithTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithTags(orgID, projectName, clusterName, "false", "M10", "US_WEST_2", []matlas.Tag{}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -736,7 +736,7 @@ func TestAccCluster_WithTags(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -761,7 +761,7 @@ func TestAccCluster_WithTags(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -805,7 +805,7 @@ func TestAccCluster_withPrivateEndpointLink(t *testing.T) {
 			{
 				Config: configWithPrivateEndpointLink(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 				),
@@ -839,7 +839,7 @@ func TestAccCluster_withAzureNetworkPeering(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAzureWithNetworkPeering(projectID, providerName, directoryID, subcrptionID, resourceGroupName, vNetName, clusterName, atlasCidrBlock, region),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -869,7 +869,7 @@ func TestAccCluster_withGCPNetworkPeering(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCPWithNetworkPeering(gcpProjectID, gcpRegion, projectID, providerName, gcpPeeringName, clusterName, gcpClusterRegion),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -904,7 +904,7 @@ func TestAccCluster_withAzureAndContainerID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAzureWithContainerID(projectID, clusterName, providerName, region, directoryID, subcrptionID, resourceGroupName, vNetName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -935,7 +935,7 @@ func TestAccCluster_withAWSAndContainerID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWSWithContainerID(awsAccessKey, awsSecretKey, projectID, clusterName, providerName, awsRegion, vpcCIDRBlock, awsAccountID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -965,7 +965,7 @@ func TestAccCluster_withGCPAndContainerID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCPWithContainerID(gcpProjectID, gcpRegion, projectID, clusterName, providerName, gcpClusterRegion, gcpPeeringName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
@@ -999,7 +999,7 @@ func TestAccCluster_withAutoScalingAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWSWithAutoscaling(projectID, clusterName, "true", "false", "true", "false", minSize, maxSize, instanceSize),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1018,7 +1018,7 @@ func TestAccCluster_withAutoScalingAWS(t *testing.T) {
 			},
 			{
 				Config: configAWSWithAutoscaling(projectID, clusterName, "false", "true", "true", "true", minSizeUpdated, maxSizeUpdated, instanceSizeUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1049,7 +1049,7 @@ func TestAccCluster_tenant(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configTenant(orgID, projectName, clusterName, "M2", "2", dbMajorVersion),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1059,7 +1059,7 @@ func TestAccCluster_tenant(t *testing.T) {
 			},
 			{
 				Config: configTenantUpdated(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1087,7 +1087,7 @@ func TestAccCluster_tenant_m5(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configTenant(orgID, projectName, clusterName, "M5", "5", dbMajorVersion),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1114,7 +1114,7 @@ func TestAccCluster_basicGCPRegionNameWesternUS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCPRegionName(orgID, projectName, clusterName, regionName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
@@ -1139,7 +1139,7 @@ func TestAccCluster_basicGCPRegionNameUSWest2(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCPRegionName(orgID, projectName, clusterName, regionName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "provider_region_name", regionName),
@@ -1238,7 +1238,7 @@ func TestAccCluster_RegionsConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configRegions(orgID, projectName, clusterName, replications),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "3"),
@@ -1246,7 +1246,7 @@ func TestAccCluster_RegionsConfig(t *testing.T) {
 			},
 			{
 				Config: configRegions(orgID, projectName, clusterName, replicationsUpdate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "2"),
@@ -1254,7 +1254,7 @@ func TestAccCluster_RegionsConfig(t *testing.T) {
 			},
 			{
 				Config: configRegions(orgID, projectName, clusterName, replicationsShardsUpdate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.#", "2"),
@@ -1280,7 +1280,7 @@ func TestAccCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWSPaused(projectID, clusterName, true, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1293,7 +1293,7 @@ func TestAccCluster_basicAWS_UnpauseToPaused(t *testing.T) {
 			},
 			{
 				Config: configAWSPaused(projectID, clusterName, false, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1328,7 +1328,7 @@ func TestAccCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWSPaused(projectID, clusterName, true, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
@@ -1341,7 +1341,7 @@ func TestAccCluster_basicAWS_PausedToUnpaused(t *testing.T) {
 			},
 			{
 				Config: configAWSPaused(projectID, clusterName, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
@@ -22,7 +22,7 @@ func TestMigOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
@@ -50,7 +50,7 @@ func TestMigOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -29,7 +29,7 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configSingleRegion(projectID, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
@@ -62,7 +62,7 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiRegion(projectID, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),

--- a/internal/service/controlplaneipaddresses/data_source_test.go
+++ b/internal/service/controlplaneipaddresses/data_source_test.go
@@ -15,7 +15,7 @@ func TestAccControlPlaneIpAddressesDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrWith(dataSourceName, "outbound.aws.us-east-1.0", acc.CIDRBlockExpression()),
 				),
 			},

--- a/internal/service/customdbrole/data_source_custom_db_role_test.go
+++ b/internal/service/customdbrole/data_source_custom_db_role_test.go
@@ -26,7 +26,7 @@ func TestAccConfigDSCustomDBRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, projectName, roleName, "INSERT", databaseName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					// Test for Resource
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),

--- a/internal/service/customdbrole/data_source_custom_db_roles_test.go
+++ b/internal/service/customdbrole/data_source_custom_db_roles_test.go
@@ -26,7 +26,7 @@ func TestAccConfigDSCustomDBRoles_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDSPlural(orgID, projectName, roleName, "INSERT", databaseName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					// Test for Resource
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),

--- a/internal/service/customdbrole/resource_custom_db_role_migration_test.go
+++ b/internal/service/customdbrole/resource_custom_db_role_migration_test.go
@@ -25,7 +25,7 @@ func TestMigConfigCustomDBRoles_Basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),

--- a/internal/service/customdbrole/resource_custom_db_role_test.go
+++ b/internal/service/customdbrole/resource_custom_db_role_test.go
@@ -32,7 +32,7 @@ func TestAccConfigRSCustomDBRoles_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, roleName, "INSERT", databaseName1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
@@ -43,7 +43,7 @@ func TestAccConfigRSCustomDBRoles_Basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, roleName, "UPDATE", databaseName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
@@ -141,7 +141,7 @@ func TestAccConfigRSCustomDBRoles_WithInheritedRoles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithInheritedRoles(orgID, projectName, inheritRole, testRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Roles
 					// inherited Role [0]
@@ -172,7 +172,7 @@ func TestAccConfigRSCustomDBRoles_WithInheritedRoles(t *testing.T) {
 			},
 			{
 				Config: configWithInheritedRoles(orgID, projectName, inheritRoleUpdated, testRoleUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Role
 					// inherited Role [0]
@@ -332,7 +332,7 @@ func TestAccConfigRSCustomDBRoles_MultipleCustomRoles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithMultiple(orgID, projectName, inheritRole, testRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Role
 					checkExists(InheritedRoleResourceName),
@@ -353,7 +353,7 @@ func TestAccConfigRSCustomDBRoles_MultipleCustomRoles(t *testing.T) {
 			},
 			{
 				Config: configWithMultiple(orgID, projectName, inheritRoleUpdated, testRoleUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Role
 					checkExists(InheritedRoleResourceName),
@@ -393,7 +393,7 @@ func TestAccConfigRSCustomDBRoles_MultipleResources(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config: configBasic(orgID, projectName, roleName, "INSERT", acc.RandomClusterName()),
-						Check: resource.ComposeTestCheckFunc(
+						Check: resource.ComposeAggregateTestCheckFunc(
 							checkExists(resourceName),
 							resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 							resource.TestCheckResourceAttr(resourceName, "role_name", roleName),
@@ -494,7 +494,7 @@ func TestAccConfigRSCustomDBRoles_UpdatedInheritRoles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithMultiple(orgID, projectName, inheritRole, testRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Role
 					checkExists(InheritedRoleResourceName),
@@ -514,7 +514,7 @@ func TestAccConfigRSCustomDBRoles_UpdatedInheritRoles(t *testing.T) {
 			},
 			{
 				Config: configWithMultiple(orgID, projectName, inheritRoleUpdated, testRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 
 					// For Inherited Role
 					checkExists(InheritedRoleResourceName),

--- a/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/data_source_custom_dns_configuration_cluster_aws_test.go
@@ -21,7 +21,7 @@ func TestAccConfigDSCustomDNSConfigurationAWS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, projectName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "enabled", "true"),

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_migration_test.go
@@ -23,7 +23,7 @@ func TestMigConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws_test.go
@@ -26,7 +26,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -34,7 +34,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -42,7 +42,7 @@ func TestAccConfigRSCustomDNSConfigurationAWS_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),

--- a/internal/service/databaseuser/data_source_database_user_test.go
+++ b/internal/service/databaseuser/data_source_database_user_test.go
@@ -21,7 +21,7 @@ func TestAccConfigDSDatabaseUser_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(projectID, username, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourceName, "username", username),

--- a/internal/service/databaseuser/data_source_database_users_test.go
+++ b/internal/service/databaseuser/data_source_database_users_test.go
@@ -21,7 +21,7 @@ func TestAccConfigDSDatabaseUsers_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDSPlural(projectID, username, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourcePluralName, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourcePluralName, "results.#", "2"),
 					resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.username"),

--- a/internal/service/databaseuser/resource_database_user_migration_test.go
+++ b/internal/service/databaseuser/resource_database_user_migration_test.go
@@ -24,7 +24,7 @@ func TestMigConfigRSDatabaseUser_Basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
@@ -52,7 +52,7 @@ func TestMigConfigRSDatabaseUser_withX509TypeCustomer(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "x509_type", x509Type),
@@ -77,7 +77,7 @@ func TestMigConfigRSDatabaseUser_withAWSIAMType(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "aws_iam_type", "USER"),
@@ -115,7 +115,7 @@ func TestMigConfigRSDatabaseUser_withLabels(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -142,7 +142,7 @@ func TestMigConfigRSDatabaseUser_withEmptyLabels(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "password", "test-acc-password"),
@@ -182,7 +182,7 @@ func TestMigConfigRSDatabaseUser_withRoles(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
@@ -217,7 +217,7 @@ func TestMigConfigRSDatabaseUser_withScopes(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
@@ -246,7 +246,7 @@ func TestMigConfigRSDatabaseUser_withEmptyScopes(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
@@ -272,7 +272,7 @@ func TestMigConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
 					resource.TestCheckResourceAttr(resourceName, "ldap_auth_type", "USER"),

--- a/internal/service/databaseuser/resource_database_user_test.go
+++ b/internal/service/databaseuser/resource_database_user_test.go
@@ -33,7 +33,7 @@ func TestAccConfigRSDatabaseUser_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserBasic(projectID, username, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -48,7 +48,7 @@ func TestAccConfigRSDatabaseUser_basic(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigDatabaseUserBasic(projectID, username, "read", "Second Key", "Second value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -86,7 +86,7 @@ func TestAccConfigRSDatabaseUser_withX509TypeCustomer(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserWithX509Type(projectID, username, x509Type, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -119,7 +119,7 @@ func TestAccConfigRSDatabaseUser_withX509TypeManaged(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserWithX509Type(projectID, username, x509Type, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -145,7 +145,7 @@ func TestAccConfigRSDatabaseUser_withAWSIAMType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserWithAWSIAMType(projectID, username, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -177,7 +177,7 @@ func TestAccConfigRSDatabaseUser_withLabels(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserWithLabels(projectID, username, "atlasAdmin", nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -199,7 +199,7 @@ func TestAccConfigRSDatabaseUser_withLabels(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -225,7 +225,7 @@ func TestAccConfigRSDatabaseUser_withLabels(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -265,7 +265,7 @@ func TestAccConfigRSDatabaseUser_withRoles(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -285,7 +285,7 @@ func TestAccConfigRSDatabaseUser_withRoles(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -324,7 +324,7 @@ func TestAccConfigRSDatabaseUser_withScopes(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -346,7 +346,7 @@ func TestAccConfigRSDatabaseUser_withScopes(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -387,7 +387,7 @@ func TestAccConfigRSDatabaseUser_updateToEmptyScopes(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -402,7 +402,7 @@ func TestAccConfigRSDatabaseUser_updateToEmptyScopes(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigDatabaseUserWithScopes(projectID, username, password, "atlasAdmin", nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -439,7 +439,7 @@ func TestAccConfigRSDatabaseUser_updateToEmptyLabels(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "labels.#", "2"),
@@ -451,7 +451,7 @@ func TestAccConfigRSDatabaseUser_updateToEmptyLabels(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigDatabaseUserWithLabels(projectID, username, "atlasAdmin", nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "labels.#", "0"),
 				),
@@ -473,7 +473,7 @@ func TestAccConfigRSDatabaseUser_withLDAPAuthType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDatabaseUserWithLDAPAuthType(projectID, username, "atlasAdmin", "First Key", "First value"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -509,7 +509,7 @@ func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigDataBaseUserWithOIDCAuthType(projectID, usernameWorkforce, workforceAuthType, "admin", "atlasAdmin"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkforce),
@@ -519,7 +519,7 @@ func TestAccCOnfigRSDatabaseUser_withOIDCAuthType(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigDataBaseUserWithOIDCAuthType(projectID, usernameWorkload, workloadAuthType, "$external", "atlasAdmin"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "username", usernameWorkload),

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline_run_test.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline_run_test.go
@@ -25,7 +25,7 @@ func TestAccDataLakeRunDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configRunDS(projectID, pipelineName, runID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "pipeline_name", pipelineName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "id"),

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline_runs_test.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline_runs_test.go
@@ -24,7 +24,7 @@ func TestAccDataLakeRunDSPlural_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configRunDSPlural(projectID, pipelineName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "pipeline_name", pipelineName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "results.#"),

--- a/internal/service/datalakepipeline/resource_data_lake_pipeline_migration_test.go
+++ b/internal/service/datalakepipeline/resource_data_lake_pipeline_migration_test.go
@@ -25,7 +25,7 @@ func TestMigcDataLakePipeline_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/internal/service/datalakepipeline/resource_data_lake_pipeline_test.go
+++ b/internal/service/datalakepipeline/resource_data_lake_pipeline_test.go
@@ -31,7 +31,7 @@ func TestAccDataLakePipeline_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicWithPluralDS(orgID, projectName, firstClusterName, secondClusterName, firstPipelineName, secondPipelineName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", firstPipelineName),

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -34,7 +34,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
@@ -86,7 +86,7 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
@@ -131,7 +131,7 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
@@ -175,7 +175,7 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
@@ -219,7 +219,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProvidersWithAWS("1.11.0"),
 				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -131,7 +131,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
@@ -144,7 +144,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKmsUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
@@ -204,7 +204,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
@@ -215,7 +215,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
@@ -263,7 +263,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
@@ -271,7 +271,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKmsUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
@@ -316,7 +316,7 @@ func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, true, &awsKms),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),

--- a/internal/service/eventtrigger/data_source_event_trigger_test.go
+++ b/internal/service/eventtrigger/data_source_event_trigger_test.go
@@ -42,7 +42,7 @@ func TestAccEventTriggerDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasDataSourceEventTriggerConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 				),
 			},

--- a/internal/service/eventtrigger/data_source_event_triggers_test.go
+++ b/internal/service/eventtrigger/data_source_event_triggers_test.go
@@ -43,7 +43,7 @@ func TestAccEventTriggerDSPlural_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, `"INSERT", "UPDATE"`, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 				),
 			},

--- a/internal/service/eventtrigger/resource_event_trigger_test.go
+++ b/internal/service/eventtrigger/resource_event_trigger_test.go
@@ -55,14 +55,14 @@ func TestAccEventTrigger_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDatabaseTrigger(projectID, appID, `"INSERT", "UPDATE"`, &event, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configDatabaseTrigger(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, &eventUpdated, true, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -106,7 +106,7 @@ func TestAccEventTrigger_databaseNoCollection(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDatabaseNoCollectionTrigger(projectID, appID, `"INSERT", "UPDATE"`, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "config_database", event.Config.Database),
@@ -167,14 +167,14 @@ func TestAccEventTrigger_databaseEventProccesor(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDatabaseEPTrigger(projectID, appID, `"INSERT", "UPDATE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configDatabaseEPTrigger(projectID, appID, `"INSERT", "UPDATE", "DELETE"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -226,14 +226,14 @@ func TestAccEventTrigger_authBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAuthenticationTrigger(projectID, appID, `"anon-user", "local-userpass"`, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configAuthenticationTrigger(projectID, appID, `"anon-user", "local-userpass", "api-key"`, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -287,14 +287,14 @@ func TestAccEventTrigger_authEventProcessor(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAuthenticationEPTrigger(projectID, appID, `"anon-user", "local-userpass"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configAuthenticationEPTrigger(projectID, appID, `"anon-user", "local-userpass", "api-key"`, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -343,14 +343,14 @@ func TestAccEventTrigger_scheduleBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configScheduleTrigger(projectID, appID, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleTrigger(projectID, appID, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -401,14 +401,14 @@ func TestAccEventTrigger_scheduleEventProcessor(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configScheduleEPTrigger(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleEPTrigger(projectID, appID, eventBridgeAwsAccountID, eventBridgeAwsRegion, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
@@ -457,14 +457,14 @@ func TestAccEventTrigger_functionBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configScheduleTrigger(projectID, appID, &event),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),
 			},
 			{
 				Config: configScheduleTrigger(projectID, appID, &eventUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 				),

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance_test.go
@@ -34,7 +34,7 @@ func TestAccFederatedDatabaseInstanceDS_s3Bucket(t *testing.T) {
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configDSWithS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName, &federatedInstance),
 					checkAttributes(&federatedInstance, name),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances_test.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances_test.go
@@ -29,7 +29,7 @@ func TestAccFederatedDatabaseInstanceDSPlural_basic(t *testing.T) {
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configDSPlural(policyName, roleName, projectName, orgID, firstName, secondName, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
 				),

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_migration_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_migration_test.go
@@ -25,7 +25,7 @@ func TestMigFederatedDatabaseInstance_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configFirstSteps(name, projectName, orgID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "storage_stores.0.read_preference.0.tag_sets.#"),

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -42,11 +42,11 @@ func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configFirstSteps(name, projectName, orgID),
-				Check:  resource.ComposeTestCheckFunc(firstStepChecks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(firstStepChecks...),
 			},
 			{
 				Config: configFirstStepsUpdate(name, projectName, orgID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "storage_stores.0.read_preference.0.tag_sets.#"),
@@ -95,7 +95,7 @@ func TestAccFederatedDatabaseInstance_s3bucket(t *testing.T) {
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configWithS3Bucket(policyName, roleName, projectName, orgID, name, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 				),
@@ -128,7 +128,7 @@ func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configWithCluster(orgID, projectName, clusterName1, clusterName2, name),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "storage_stores.0.read_preference.0.tag_sets.#"),

--- a/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
+++ b/internal/service/federatedquerylimit/resource_federated_query_limit_test.go
@@ -44,7 +44,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configBasic(policyName, roleName, projectName, orgID, tenantName, testS3Bucket),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "tenant_name"),
 					resource.TestCheckResourceAttr(resourceName, "limit_name", limitName),

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_provider_test.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_provider_test.go
@@ -21,7 +21,7 @@ func TestAccFederatedSettingsIdentityProviderDS_samlBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicDS(federatedSettingsID, idpID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "associated_orgs.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "acs_url"),

--- a/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers_test.go
+++ b/internal/service/federatedsettingsidentityprovider/data_source_federated_settings_identity_providers_test.go
@@ -23,14 +23,14 @@ func TestAccFederatedSettingsIdentityProvidersDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configPluralDS(federatedSettingsID, conversion.StringPtr(federatedsettingsidentityprovider.WORKFORCE), []string{oidcProtocol, samlProtocol}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "2"),
 				),
 			},
 			{
 				Config: configPluralDS(federatedSettingsID, conversion.StringPtr(federatedsettingsidentityprovider.WORKFORCE), []string{samlProtocol}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.display_name", "SAML-test"),
@@ -38,7 +38,7 @@ func TestAccFederatedSettingsIdentityProvidersDS_basic(t *testing.T) {
 			},
 			{
 				Config: configPluralDS(federatedSettingsID, conversion.StringPtr(federatedsettingsidentityprovider.WORKFORCE), []string{oidcProtocol}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.display_name", "OIDC-test"),
@@ -46,7 +46,7 @@ func TestAccFederatedSettingsIdentityProvidersDS_basic(t *testing.T) {
 			},
 			{
 				Config: configPluralDS(federatedSettingsID, conversion.StringPtr(federatedsettingsidentityprovider.WORKFORCE), []string{}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.0.display_name", "SAML-test"), // if no protocol is specified, it defaults to SAML
@@ -54,7 +54,7 @@ func TestAccFederatedSettingsIdentityProvidersDS_basic(t *testing.T) {
 			},
 			{
 				Config: configPluralDS(federatedSettingsID, conversion.StringPtr(federatedsettingsidentityprovider.WORKLOAD), []string{}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "results.#", "0"),
 				),

--- a/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
+++ b/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider_test.go
@@ -73,7 +73,7 @@ func basicSAMLTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName, idpID),
 					resource.TestCheckResourceAttr(resourceName, "federation_settings_id", federationSettingsID),
 					resource.TestCheckResourceAttr(resourceName, "name", "SAML-test"),
@@ -125,11 +125,11 @@ func basicOIDCWorkforceTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configOIDCWorkforceBasic(federationSettingsID, associatedDomain, description1, audience1),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config: configOIDCWorkforceBasic(federationSettingsID, associatedDomain, description2, audience2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsManaged(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", description2),
 					resource.TestCheckResourceAttr(resourceName, "audience", audience2),

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_org_test.go
@@ -22,7 +22,7 @@ func TestAccFederatedSettingsOrgDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicDS(federatedSettingsID, orgID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "role_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "data_access_identity_provider_ids.#"),

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs_test.go
@@ -21,7 +21,7 @@ func TestAccFederatedSettingsOrgDSPlural_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicPluralDS(federatedSettingsID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "federation_settings_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "results.0.identity_provider_id"),

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_test.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_test.go
@@ -25,7 +25,7 @@ func TestAccFederatedSettingsDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasDataSourceFederatedSettingsConfig(orgID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasFederatedSettingsExists(resourceName),
 
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org_test.go
@@ -60,7 +60,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configWithIdps,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "federation_settings_id", federationSettingsID),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -72,7 +72,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configDetachedIdps,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_access_identity_provider_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "identity_provider_id", ""),
@@ -80,7 +80,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configWithDomainRestriction,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "domain_restriction_enabled", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "user_conflicts.#"),

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping_test.go
@@ -52,11 +52,11 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(federationSettingsID, orgID, groupID, extGroupName1),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config: configBasic(federationSettingsID, orgID, groupID, extGroupName2),
-				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr(resourceName, "external_group_name", extGroupName2)),
+				Check:  resource.ComposeAggregateTestCheckFunc(resource.TestCheckResourceAttr(resourceName, "external_group_name", extGroupName2)),
 			},
 			{
 				Config:            configBasic(federationSettingsID, orgID, groupID, extGroupName2),

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config_test.go
@@ -19,7 +19,7 @@ func TestAccClusterRSGlobalClusterDS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(&clusterInfo, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "cluster_name"),
 				),

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
@@ -21,7 +21,7 @@ func TestMigClusterRSGlobalCluster_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -25,7 +25,7 @@ func TestAccClusterRSGlobalCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(&clusterInfo, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mapping.%"),
@@ -57,7 +57,7 @@ func TestAccClusterRSGlobalCluster_withAWSAndBackup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(&clusterInfo, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),
@@ -90,7 +90,7 @@ func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithDBConfig(&clusterInfo, customZone),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "managed_namespaces.#", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_zone_mappings.#"),

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -40,7 +40,7 @@ func TestAccLDAPConfiguration_withVerify_CACertificateComplete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithVerify(projectID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "hostname", hostname),
@@ -83,7 +83,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, hostname, username, password, authEnabled, cast.ToInt(port)),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "hostname", hostname),

--- a/internal/service/ldapverify/resource_ldap_verify_test.go
+++ b/internal/service/ldapverify/resource_ldap_verify_test.go
@@ -38,7 +38,7 @@ func TestAccLDAPVerify_withConfiguration_CACertificate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithConfiguration(projectID, hostname, username, password, caCertificate, cast.ToInt(port), true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
@@ -74,7 +74,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, hostname, username, password, cast.ToInt(port)),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "request_id"),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/internal/service/maintenancewindow/data_source_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/data_source_maintenance_window_test.go
@@ -26,7 +26,7 @@ func TestAccConfigDSMaintenanceWindow_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, projectName, dayOfWeek, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "day_of_week", cast.ToString(dayOfWeek)),

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -25,7 +25,7 @@ func TestMigConfigMaintenanceWindow_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -31,7 +31,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
@@ -41,7 +41,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDayUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
@@ -51,7 +51,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeekUpdated, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeekUpdated)),
@@ -61,7 +61,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
@@ -93,7 +93,7 @@ func TestAccConfigRSMaintenanceWindow_autoDeferActivated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithAutoDeferEnabled(orgID, projectName, dayOfWeek, hourOfDay),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),

--- a/internal/service/networkcontainer/resource_network_container_migration_test.go
+++ b/internal/service/networkcontainer/resource_network_container_migration_test.go
@@ -27,7 +27,7 @@ func TestMigNetworkContainer_basicAWS(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -50,7 +50,7 @@ func TestMigNetworkContainer_basicAzure(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -73,7 +73,7 @@ func TestMigNetworkContainer_basicGCP(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/networkcontainer/resource_network_container_test.go
+++ b/internal/service/networkcontainer/resource_network_container_test.go
@@ -35,11 +35,11 @@ func TestAccNetworkContainer_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AWS, "US_EAST_1"),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, "US_EAST_2"),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				ResourceName:            resourceName,
@@ -68,11 +68,11 @@ func TestAccNetworkContainer_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AZURE, "US_EAST_2"),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AZURE, "US_EAST_2"),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AZURE)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AZURE)...),
 			},
 		},
 	})
@@ -94,11 +94,11 @@ func TestAccNetworkContainer_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, gcpCidrBlock, constant.GCP, ""),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.GCP, ""),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 		},
 	})
@@ -119,7 +119,7 @@ func TestAccNetworkContainer_withRegionsGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, gcpWithRegionsCidrBlock, constant.GCP, regions),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.GCP)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.GCP)...),
 			},
 		},
 	})
@@ -144,15 +144,15 @@ func TestAccNetworkContainer_updateIndividualFields(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, cidrBlock, constant.AWS, region),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, region),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 			{
 				Config: configBasic(projectID, cidrBlockUpdated, constant.AWS, regionUpdated),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(constant.AWS)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(constant.AWS)...),
 			},
 		},
 	})

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -43,7 +43,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -54,7 +54,7 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 			},
 			{
 				Config: configAzure(projectID, providerName, directoryID, subscriptionID, resourceGroupName, updatedvNetName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -92,7 +92,7 @@ func TestAccNetworkRSNetworkPeering_GCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGCP(projectID, providerName, gcpProjectID, networkName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -109,7 +109,7 @@ func TestAccNetworkRSNetworkPeering_GCP(t *testing.T) {
 			},
 			{
 				Config: configGCP(projectID, providerName, gcpProjectID, updatedNetworkName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "container_id"),
@@ -169,7 +169,7 @@ func TestAccNetworkRSNetworkPeering_AWSDifferentRegionName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWS(orgID, projectName, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -196,7 +196,7 @@ func basicAWSTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configAWS(orgID, projectName, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/onlinearchive/resource_online_archive_migration_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_migration_test.go
@@ -34,14 +34,14 @@ func TestMigBackupRSOnlineArchiveWithNoChangeBetweenVersions(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configFirstStep(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					populateWithSampleData(resourceName, &cluster),
 				),
 			},
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
 				),
 			},

--- a/internal/service/onlinearchive/resource_online_archive_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_test.go
@@ -38,13 +38,13 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				// We need this step to pupulate the cluster with Sample Data
 				// The online archive won't work if the cluster does not have data
 				Config: configFirstStep(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					populateWithSampleData(resourceName, &cluster),
 				),
 			},
 			{
 				Config: configWithDailySchedule(orgID, projectName, clusterName, 1, 7),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -60,7 +60,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 			},
 			{
 				Config: configWithDailySchedule(orgID, projectName, clusterName, 2, 8),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -76,7 +76,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 			},
 			{
 				Config: testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -89,7 +89,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 			},
 			{
 				Config: testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -102,7 +102,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 			},
 			{
 				Config: configWithoutSchedule(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -111,7 +111,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 			},
 			{
 				Config: configWithoutSchedule(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
 				),
 			},
@@ -138,13 +138,13 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 				// We need this step to pupulate the cluster with Sample Data
 				// The online archive won't work if the cluster does not have data
 				Config: configFirstStep(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					populateWithSampleData(resourceName, &cluster),
 				),
 			},
 			{
 				Config: configWithoutSchedule(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -152,7 +152,7 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 			},
 			{
 				Config: configWithDailySchedule(orgID, projectName, clusterName, 1, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "collection_type"),
@@ -189,13 +189,13 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 				// We need this step to pupulate the cluster with Sample Data
 				// The online archive won't work if the cluster does not have data
 				Config: configFirstStep(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					populateWithSampleData(resourceName, &cluster),
 				),
 			},
 			{
 				Config: configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider, processRegion),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
 					resource.TestCheckResourceAttr(onlineArchiveDataSourceName, "data_process_region.0.cloud_provider", cloudProvider),
@@ -208,7 +208,7 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 			},
 			{
 				Config: configWithoutSchedule(orgID, projectName, clusterName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
 				),

--- a/internal/service/organization/data_source_organization_test.go
+++ b/internal/service/organization/data_source_organization_test.go
@@ -20,7 +20,7 @@ func TestAccConfigDSOrganization_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigWithDS(orgID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "restrict_employee_access"),

--- a/internal/service/organization/data_source_organizations_test.go
+++ b/internal/service/organization/data_source_organizations_test.go
@@ -18,7 +18,7 @@ func TestAccConfigDSOrganizations_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasOrganizationsConfigWithDS(),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.id"),
@@ -40,7 +40,7 @@ func TestAccConfigDSOrganizations_withPagination(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasOrganizationsConfigWithPagination(2, 5),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
 				),
 			},

--- a/internal/service/organization/resource_organization_migration_test.go
+++ b/internal/service/organization/resource_organization_migration_test.go
@@ -27,7 +27,7 @@ func TestMigConfigRSOrganization_Basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -37,7 +37,7 @@ func TestAccConfigRSOrganization_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -48,7 +48,7 @@ func TestAccConfigRSOrganization_Basic(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, updatedName, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -110,7 +110,7 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigWithSettings(orgOwnerID, name, description, roleName, settingsConfig),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -121,7 +121,7 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigWithSettings(orgOwnerID, name, description, roleName, settingsConfigUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -132,7 +132,7 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 			},
 			{
 				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, "org-name-updated", description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "description"),

--- a/internal/service/orginvitation/data_source_org_invitation_test.go
+++ b/internal/service/orginvitation/data_source_org_invitation_test.go
@@ -25,7 +25,7 @@ func TestAccConfigDSOrgInvitation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(orgID, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "invitation_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(dataSourceName, "username", name),

--- a/internal/service/orginvitation/resource_org_invitation_migration_test.go
+++ b/internal/service/orginvitation/resource_org_invitation_migration_test.go
@@ -25,7 +25,7 @@ func TestMigConfigOrgInvitation_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),

--- a/internal/service/orginvitation/resource_org_invitation_test.go
+++ b/internal/service/orginvitation/resource_org_invitation_test.go
@@ -29,7 +29,7 @@ func TestAccConfigRSOrgInvitation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -40,7 +40,7 @@ func TestAccConfigRSOrgInvitation_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, name, updateRoles),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -48,7 +48,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithDependencies(resourceSuffix, projectID, false, dependencies),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					checkModeClustersUpToDate(projectID, clusterName, clusterResourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -58,7 +58,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 			},
 			{
 				Config: configWithDependencies(resourceSuffix, projectID, true, dependencies),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					checkModeClustersUpToDate(projectID, clusterName, clusterResourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -87,7 +87,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -98,7 +98,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configBasic(orgID, projectName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),

--- a/internal/service/privatelinkendpoint/data_source_privatelink_endpoint_test.go
+++ b/internal/service/privatelinkendpoint/data_source_privatelink_endpoint_test.go
@@ -23,7 +23,7 @@ func TestAccNetworkDSPrivateLinkEndpoint_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDS(projectID, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_link_id"),

--- a/internal/service/privatelinkendpoint/resource_privatelink_endpoint_migration_test.go
+++ b/internal/service/privatelinkendpoint/resource_privatelink_endpoint_migration_test.go
@@ -26,7 +26,7 @@ func TestMigNetworkPrivateLinkEndpoint_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),

--- a/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
+++ b/internal/service/privatelinkendpoint/resource_privatelink_endpoint_test.go
@@ -28,7 +28,7 @@ func TestAccNetworkRSPrivateLinkEndpointAWS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
@@ -63,7 +63,7 @@ func TestAccNetworkRSPrivateLinkEndpointAzure_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),
@@ -98,7 +98,7 @@ func TestAccNetworkRSPrivateLinkEndpointGCP_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, providerName, region),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "provider_name"),

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless_test.go
@@ -34,7 +34,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, instanceName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
 				),

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -50,7 +50,7 @@ func basicAWSTestCase(tb testing.TB) *resource.TestCase {
 				Config: configCompleteAWS(
 					awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix,
 				),
-				Check: resource.ComposeTestCheckFunc(checks...),
+				Check: resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -27,7 +27,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchiveDS_basic
 		Steps: []resource.TestStep{
 			{
 				Config: dataSourcesConfigBasic(projectID, endpointID, customerEndpointDNSName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "project_id", projectID),
 					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchive, "endpoint_id", endpointID),

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archives_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/data_source_privatelink_endpoint_service_data_federation_online_archives_test.go
@@ -26,7 +26,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchivesDSPlura
 		Steps: []resource.TestStep{
 			{
 				Config: dataSourceConfigBasic(projectID, endpointID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchives, "project_id", projectID),
 					resource.TestCheckResourceAttrSet(dataSourcePrivatelinkEndpointServiceDataFederetionDataArchives, "results.#"),

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_migration_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_migration_test.go
@@ -23,7 +23,7 @@ func TestMigNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),

--- a/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
+++ b/internal/service/privatelinkendpointservicedatafederationonlinearchive/resource_privatelink_endpoint_service_data_federation_online_archive_test.go
@@ -31,7 +31,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basic(t
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConfigBasic(projectID, endpointID, comment),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
@@ -63,7 +63,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_updateC
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConfigBasic(projectID, endpointID, comment),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
@@ -74,7 +74,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_updateC
 			},
 			{
 				Config: resourceConfigBasic(projectID, endpointID, commentUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
@@ -85,7 +85,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_updateC
 			},
 			{
 				Config: resourceConfigBasic(projectID, endpointID, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),
@@ -110,7 +110,7 @@ func TestAccNetworkPrivatelinkEndpointServiceDataFederationOnlineArchive_basicWi
 		Steps: []resource.TestStep{
 			{
 				Config: resourceConfigBasicWithRegionDNSName(projectID, endpointID, comment, customerEndpointDNSName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_id", endpointID),

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_migration_test.go
@@ -27,7 +27,7 @@ func TestMigServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
@@ -57,7 +57,7 @@ func TestMigServerlessPrivateLinkEndpointService_AWSVPC(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProvidersWithAWS(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 				),

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless_test.go
@@ -31,7 +31,7 @@ func TestAccServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, instanceName, commentOrigin),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentOrigin),
@@ -43,7 +43,7 @@ func TestAccServerlessPrivateLinkEndpointService_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(projectID, instanceName, commentUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentUpdated),
@@ -83,7 +83,7 @@ func TestAccServerlessPrivateLinkEndpointService_AWSEndpointCommentUpdate(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: configAWSEndpoint(projectID, instanceName, awsAccessKey, awsSecretKey, false, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttrSet(datasourceEndpointsName, "project_id"),
@@ -93,7 +93,7 @@ func TestAccServerlessPrivateLinkEndpointService_AWSEndpointCommentUpdate(t *tes
 			},
 			{
 				Config: configAWSEndpoint(projectID, instanceName, awsAccessKey, awsSecretKey, true, commentUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "comment", commentUpdated),

--- a/internal/service/project/resource_project_migration_test.go
+++ b/internal/service/project/resource_project_migration_test.go
@@ -28,7 +28,7 @@ func TestMigProject_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 				),
 			},
@@ -67,7 +67,7 @@ func TestMigProject_withTeams(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -94,7 +94,7 @@ func TestMigProject_withFalseDefaultSettings(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -128,7 +128,7 @@ func TestMigProject_withLimits(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.clusters"),
@@ -156,14 +156,14 @@ func TestMigGovProject_regionUsageRestrictionsDefault(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProviders("1.15.3"),
 				Config:            configGovSimple(orgID, projectName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsGov(resourceName),
 				),
 			},
 			{
 				ExternalProviders: acc.ExternalProviders("1.16.0"),
 				Config:            configGovSimple(orgID, projectName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsGov(resourceName),
 				),
 				ExpectError: regexp.MustCompile("Provider produced inconsistent result after apply"),

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -551,7 +551,7 @@ func TestAccProject_basic(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(checks...),
+				Check: resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config: configBasic(orgID, projectName, projectOwnerID, false,
@@ -570,7 +570,7 @@ func TestAccProject_basic(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -592,7 +592,7 @@ func TestAccProject_basic(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -625,7 +625,7 @@ func TestAccGovProject_withProjectOwner(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGovWithOwner(orgID, projectName, projectOwnerID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExistsGov(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -651,7 +651,7 @@ func TestAccProject_withFalseDefaultSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithFalseDefaultSettings(orgID, projectName, projectOwnerID),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -675,7 +675,7 @@ func TestAccProject_withUpdatedSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
@@ -691,7 +691,7 @@ func TestAccProject_withUpdatedSettings(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "with_default_alerts_settings", "true"),
 					resource.TestCheckResourceAttr(resourceName, "is_collect_database_specifics_statistics_enabled", "true"),
@@ -704,7 +704,7 @@ func TestAccProject_withUpdatedSettings(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "with_default_alerts_settings", "false"),
 					resource.TestCheckResourceAttr(resourceName, "is_collect_database_specifics_statistics_enabled", "false"),
@@ -734,7 +734,7 @@ func TestAccProject_withUpdatedRole(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithUpdatedRole(orgID, projectName, acc.GetProjectTeamsIDsWithPos(0), roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
@@ -742,7 +742,7 @@ func TestAccProject_withUpdatedRole(t *testing.T) {
 			},
 			{
 				Config: configWithUpdatedRole(orgID, projectName, acc.GetProjectTeamsIDsWithPos(0), roleNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "cluster_count", clusterCount),
@@ -771,7 +771,7 @@ func TestAccProject_updatedToEmptyRoles(t *testing.T) {
 						},
 					},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "teams.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "teams.0.team_id", acc.GetProjectTeamsIDsWithPos(0)),
@@ -782,7 +782,7 @@ func TestAccProject_updatedToEmptyRoles(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, "", false, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "teams.#", "0"),
 				),
@@ -829,7 +829,7 @@ func TestAccProject_withUpdatedLimits(t *testing.T) {
 						Value: 1,
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(checks...),
+				Check: resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config: configWithLimits(orgID, projectName, []*admin.DataFederationLimit{
@@ -838,7 +838,7 @@ func TestAccProject_withUpdatedLimits(t *testing.T) {
 						Value: 2,
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.nodesPerPrivateLinkRegion"),
@@ -860,7 +860,7 @@ func TestAccProject_withUpdatedLimits(t *testing.T) {
 						Value: 30,
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckTypeSetElemNestedAttrs(
@@ -910,7 +910,7 @@ func TestAccProject_updatedToEmptyLimits(t *testing.T) {
 						Value: 1,
 					},
 				}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "limits.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "limits.0.name", "atlas.project.deployment.clusters"),
 					resource.TestCheckResourceAttr(resourceName, "limits.0.value", "1"),
@@ -918,7 +918,7 @@ func TestAccProject_updatedToEmptyLimits(t *testing.T) {
 			},
 			{
 				Config: configWithLimits(orgID, projectName, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "limits.#", "0"),
 				),
 			},
@@ -963,7 +963,7 @@ func TestAccProject_withInvalidLimitNameOnUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithLimits(orgID, projectName, []*admin.DataFederationLimit{}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 				),
@@ -1011,7 +1011,7 @@ func TestAccProject_withTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithTags(orgID, projectName, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", projectName),
 					resource.TestCheckResourceAttr(resourceName, "org_id", orgID),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
@@ -1028,7 +1028,7 @@ func TestAccProject_withTags(t *testing.T) {
 			},
 			{
 				Config: configWithTags(orgID, projectName, tagsEmpty),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceNameByID, "tags.#", "0"),
 				),

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -39,7 +39,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
@@ -70,7 +70,7 @@ func TestAccProjectAPIKey_changingSingleProject(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configChangingProject(orgID, projectName2, description, fmt.Sprintf("%q", projectID1)),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
@@ -78,7 +78,7 @@ func TestAccProjectAPIKey_changingSingleProject(t *testing.T) {
 			},
 			{
 				Config: configChangingProject(orgID, projectName2, description, "mongodbatlas_project.proj2.id"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "public_key"),
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
@@ -103,7 +103,7 @@ func TestAccProjectAPIKey_multiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configMultiple(projectID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
@@ -134,14 +134,14 @@ func TestAccProjectAPIKey_updateDescription(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, description, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 				),
 			},
 			{
 				Config: configBasic(projectID, updatedDescription, roleName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
 				),
@@ -167,7 +167,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: projectAPIKeyConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 				),
 			},
@@ -200,14 +200,14 @@ func TestAccProjectAPIKey_deleteProjectAndAssignment(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.1.project_id"),
 				),
 			},
 			{
 				Config: configDeletedProjectAndAssignment(orgID, projectID1, projectName2, description, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project_assignment.0.project_id"),
 				),
 			},

--- a/internal/service/projectinvitation/data_source_project_invitation_test.go
+++ b/internal/service/projectinvitation/data_source_project_invitation_test.go
@@ -26,7 +26,7 @@ func TestAccProjectDSProjectInvitation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMongoDBAtlasProjectInvitationConfig(orgID, projectName, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "username"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "invitation_id"),

--- a/internal/service/projectinvitation/resource_project_invitation_migration_test.go
+++ b/internal/service/projectinvitation/resource_project_invitation_migration_test.go
@@ -26,7 +26,7 @@ func TestMigProjectInvitation_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            configBasic(orgID, projectName, name, roles),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),

--- a/internal/service/projectinvitation/resource_project_invitation_test.go
+++ b/internal/service/projectinvitation/resource_project_invitation_test.go
@@ -30,7 +30,7 @@ func TestAccProjectRSProjectInvitation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, name, initialRole),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),
@@ -41,7 +41,7 @@ func TestAccProjectRSProjectInvitation_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, projectName, name, updateRoles),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "invitation_id"),

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_migration_test.go
@@ -25,7 +25,7 @@ func TestMigProjectIPAccessList_settingIPAddress(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks(ipAddress, "", "", comment)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks(ipAddress, "", "", comment)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -47,7 +47,7 @@ func TestMigProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks("", cidrBlock, "", comment)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks("", cidrBlock, "", comment)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},
@@ -75,7 +75,7 @@ func TestMigProjectIPAccessList_settingAWSSecurityGroup(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(commonChecks("", "", awsSGroup, comment)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(commonChecks("", "", awsSGroup, comment)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list_test.go
@@ -35,11 +35,11 @@ func TestAccProjectIPAccesslist_settingIPAddress(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithIPAddress(projectID, ipAddress, comment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(ipAddress, "", "", comment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(ipAddress, "", "", comment)...),
 			},
 			{
 				Config: configWithIPAddress(projectID, updatedIPAddress, updatedComment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(updatedIPAddress, "", "", updatedComment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(updatedIPAddress, "", "", updatedComment)...),
 			},
 			{
 				ResourceName:      resourceName,
@@ -67,11 +67,11 @@ func TestAccProjectIPAccessList_settingCIDRBlock(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithCIDRBlock(projectID, cidrBlock, comment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks("", cidrBlock, "", comment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", cidrBlock, "", comment)...),
 			},
 			{
 				Config: configWithCIDRBlock(projectID, updatedCIDRBlock, updatedComment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks("", updatedCIDRBlock, "", updatedComment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", updatedCIDRBlock, "", updatedComment)...),
 			},
 		},
 	})
@@ -98,11 +98,11 @@ func TestAccProjectIPAccessList_settingAWSSecurityGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, awsSGroup, comment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks("", "", awsSGroup, comment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", "", awsSGroup, comment)...),
 			},
 			{
 				Config: configWithAWSSecurityGroup(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, awsRegion, updatedAWSSgroup, updatedComment),
-				Check:  resource.ComposeTestCheckFunc(commonChecks("", "", updatedAWSSgroup, updatedComment)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks("", "", updatedAWSSgroup, updatedComment)...),
 			},
 		},
 	})
@@ -144,11 +144,11 @@ func TestAccProjectIPAccessList_settingMultiple(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithMultiple(projectID, accessList, false),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config: configWithMultiple(projectID, accessList, true),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -45,11 +45,11 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, nonEmptyPrefixPath, true),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(s3BucketName1, nonEmptyPrefixPath)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(s3BucketName1, nonEmptyPrefixPath)...),
 			},
 			{
 				Config: configBasicUpdated(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, nonEmptyPrefixPath, true),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(s3BucketName2, nonEmptyPrefixPath)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(s3BucketName2, nonEmptyPrefixPath)...),
 			},
 			{
 				Config:                               configBasicUpdated(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, nonEmptyPrefixPath, true),
@@ -87,7 +87,7 @@ func noPrefixPathTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, s3BucketName1, s3BucketName2, s3BucketPolicyName, awsIAMRoleName, awsIAMRolePolicyName, defaultPrefixPath, false),
-				Check:  resource.ComposeTestCheckFunc(commonChecks(s3BucketName1, defaultPrefixPath)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(commonChecks(s3BucketName1, defaultPrefixPath)...),
 			},
 		},
 	}

--- a/internal/service/searchdeployment/resource_search_deployment_migration_test.go
+++ b/internal/service/searchdeployment/resource_search_deployment_migration_test.go
@@ -27,7 +27,7 @@ func TestMigSearchDeployment_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             resource.ComposeTestCheckFunc(searchNodeChecks(resourceName, clusterName, instanceSize, searchNodeCount)...),
+				Check:             resource.ComposeAggregateTestCheckFunc(searchNodeChecks(resourceName, clusterName, instanceSize, searchNodeCount)...),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/searchdeployment/resource_search_deployment_test.go
+++ b/internal/service/searchdeployment/resource_search_deployment_test.go
@@ -41,7 +41,7 @@ func newSearchNodeTestStep(resourceName, orgID, projectName, clusterName, instan
 	dataSourceChecks := searchNodeChecks(fmt.Sprintf("data.%s", resourceName), clusterName, instanceSize, searchNodeCount)
 	return resource.TestStep{
 		Config: configBasic(orgID, projectName, clusterName, instanceSize, searchNodeCount),
-		Check:  resource.ComposeTestCheckFunc(append(resourceChecks, dataSourceChecks...)...),
+		Check:  resource.ComposeAggregateTestCheckFunc(append(resourceChecks, dataSourceChecks...)...),
 	}
 }
 

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -31,7 +31,7 @@ func TestAccSearchIndex_withSearchType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, indexName, databaseName, clusterName, true),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -54,7 +54,7 @@ func TestAccSearchIndex_withMapping(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithMapping(projectID, indexName, databaseName, clusterName),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -84,7 +84,7 @@ func TestAccSearchIndex_withSynonyms(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithSynonyms(projectID, indexName, databaseName, clusterName, with),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -113,11 +113,11 @@ func TestAccSearchIndex_updatedToEmptySynonyms(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithSynonyms(projectID, indexName, databaseName, clusterName, with),
-				Check:  resource.ComposeTestCheckFunc(checks1...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks1...),
 			},
 			{
 				Config: configWithSynonyms(projectID, indexName, databaseName, clusterName, without),
-				Check:  resource.ComposeTestCheckFunc(checks2...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks2...),
 			},
 		},
 	})
@@ -136,14 +136,14 @@ func TestAccSearchIndex_updatedToEmptyAnalyzers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdditional(projectID, indexName, databaseName, clusterName, analyzersTF),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrWith(resourceName, "analyzers", acc.JSONEquals(analyzersJSON)),
 				),
 			},
 			{
 				Config: configAdditional(projectID, indexName, databaseName, clusterName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "analyzers", ""),
 				),
@@ -165,14 +165,14 @@ func TestAccSearchIndex_updatedToEmptyMappingsFields(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdditional(projectID, indexName, databaseName, clusterName, mappingsFieldsTF),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrWith(resourceName, "mappings_fields", acc.JSONEquals(mappingsFieldsJSON)),
 				),
 			},
 			{
 				Config: configAdditional(projectID, indexName, databaseName, clusterName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "mappings_fields", ""),
 				),
@@ -203,7 +203,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, indexName, databaseName, clusterName, false),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
 				Config:            configBasic(projectID, indexName, databaseName, clusterName, false),
@@ -243,7 +243,7 @@ func basicVectorTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configVector(projectID, indexName, databaseName, clusterName),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	}

--- a/internal/service/serverlessinstance/resource_serverless_instance_test.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance_test.go
@@ -34,7 +34,7 @@ func TestAccServerlessInstance_withTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigServerlessInstance(projectID, instanceName, false, nil, nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
@@ -54,7 +54,7 @@ func TestAccServerlessInstance_withTags(t *testing.T) {
 					},
 				},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
@@ -76,7 +76,7 @@ func TestAccServerlessInstance_withTags(t *testing.T) {
 					},
 				},
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
@@ -103,7 +103,7 @@ func TestAccServerlessInstance_autoIndexing(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigServerlessInstance(projectID, instanceName, false, conversion.Pointer(false), nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_indexing", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "auto_indexing", "false"),
@@ -112,7 +112,7 @@ func TestAccServerlessInstance_autoIndexing(t *testing.T) {
 			},
 			{
 				Config: acc.ConfigServerlessInstance(projectID, instanceName, false, conversion.Pointer(true), nil),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_indexing", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "auto_indexing", "true"),
@@ -137,7 +137,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigServerlessInstance(projectID, instanceName, true, nil, nil),
-				Check:  resource.ComposeTestCheckFunc(basicChecks(projectID, instanceName)...),
+				Check:  resource.ComposeAggregateTestCheckFunc(basicChecks(projectID, instanceName)...),
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/streamconnection/data_source_stream_connections_test.go
+++ b/internal/service/streamconnection/data_source_stream_connections_test.go
@@ -84,5 +84,5 @@ func streamConnectionsAttributeChecks(resourceName string, pageNum, itemsPerPage
 	if itemsPerPage != nil {
 		resourceChecks = append(resourceChecks, resource.TestCheckResourceAttr(resourceName, "items_per_page", fmt.Sprint(*itemsPerPage)))
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -182,7 +182,7 @@ func sampleStreamConnectionAttributeChecks(
 		resource.TestCheckResourceAttr(resourceName, "connection_name", sampleName),
 		resource.TestCheckResourceAttr(resourceName, "type", "Sample"),
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
 func kafkaStreamConnectionAttributeChecks(
@@ -209,7 +209,7 @@ func kafkaStreamConnectionAttributeChecks(
 			resource.TestCheckResourceAttrSet(resourceName, "security.broker_public_certificate"),
 		)
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
 func clusterStreamConnectionConfig(projectID, instanceName, clusterName string) string {
@@ -248,7 +248,7 @@ func clusterStreamConnectionAttributeChecks(resourceName, clusterName string) re
 		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.role", "atlasAdmin"),
 		resource.TestCheckResourceAttr(resourceName, "db_role_to_execute.type", "BUILT_IN"),
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
 func checkStreamConnectionImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/service/streaminstance/data_source_stream_instance_test.go
+++ b/internal/service/streaminstance/data_source_stream_instance_test.go
@@ -22,7 +22,7 @@ func TestAccStreamDSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstanceDataSourceConfig(projectID, instanceName, region, cloudProvider),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					streamInstanceAttributeChecks(dataSourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(dataSourceName, "stream_config.tier", "SP30"),
 				),

--- a/internal/service/streaminstance/data_source_stream_instances_test.go
+++ b/internal/service/streaminstance/data_source_stream_instances_test.go
@@ -30,7 +30,7 @@ func TestAccStreamDSStreamInstances_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstancesDataSourceConfig(projectID, instanceName, region, cloudProvider),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -54,7 +54,7 @@ func TestAccStreamDSStreamInstances_withPageConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: streamInstancesWithPageAttrDataSourceConfig(projectID, instanceName, region, cloudProvider, pageNumber),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 		},
 	})

--- a/internal/service/streaminstance/resource_stream_instance_test.go
+++ b/internal/service/streaminstance/resource_stream_instance_test.go
@@ -23,7 +23,7 @@ func TestAccStreamRSStreamInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.StreamInstanceConfig(projectID, instanceName, region, cloudProvider), // as of now there are no values that can be updated because only one region is supported
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
 				),
@@ -51,7 +51,7 @@ func TestAccStreamRSStreamInstance_withStreamConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.StreamInstanceWithStreamConfigConfig(projectID, instanceName, region, cloudProvider, "SP10"), // as of now there are no values that can be updated because only one region is supported
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProvider),
 					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
 				),
@@ -76,7 +76,7 @@ func streamInstanceAttributeChecks(resourceName, instanceName, region, cloudProv
 		resource.TestCheckResourceAttr(resourceName, "data_process_region.cloud_provider", cloudProvider),
 		resource.TestCheckResourceAttr(resourceName, "hostnames.#", "1"),
 	}
-	return resource.ComposeTestCheckFunc(resourceChecks...)
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
 func checkStreamInstanceImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/service/team/data_source_team_test.go
+++ b/internal/service/team/data_source_team_test.go
@@ -24,7 +24,7 @@ func TestAccConfigDSTeam_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: dataSourceConfigBasic(orgID, name, username),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
@@ -50,7 +50,7 @@ func TestAccConfigDSTeamByName_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: dataSourceConfigBasicByName(orgID, name, username),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),

--- a/internal/service/team/resource_team_migration_test.go
+++ b/internal/service/team/resource_team_migration_test.go
@@ -25,7 +25,7 @@ func TestMigConfigTeams_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/internal/service/team/resource_team_test.go
+++ b/internal/service/team/resource_team_test.go
@@ -30,7 +30,7 @@ func TestAccConfigRSTeam_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, name, usernames),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -39,7 +39,7 @@ func TestAccConfigRSTeam_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, updatedName, usernames),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
@@ -48,7 +48,7 @@ func TestAccConfigRSTeam_basic(t *testing.T) {
 			},
 			{
 				Config: configBasic(orgID, updatedName, usernames),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
@@ -81,7 +81,7 @@ func TestAccConfigRSTeam_legacyName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicLegacyNames(orgID, name, usernames),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
@@ -64,7 +64,7 @@ func basicPagerDutyTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasicPagerDuty(projectID, serviceKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "service_key", serviceKey),
@@ -77,7 +77,7 @@ func basicPagerDutyTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configBasicPagerDuty(projectID, updatedServiceKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "service_key", updatedServiceKey),
@@ -103,7 +103,7 @@ func opsGenieTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configOpsGenie(projectID, apiKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
@@ -114,7 +114,7 @@ func opsGenieTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configOpsGenie(projectID, updatedAPIKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", updatedAPIKey),
@@ -141,7 +141,7 @@ func victorOpsTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configVictorOps(projectID, apiKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
@@ -152,7 +152,7 @@ func victorOpsTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configVictorOps(projectID, updatedAPIKey),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", updatedAPIKey),
@@ -179,7 +179,7 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configDatadog(projectID, apiKey, "US"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
@@ -190,7 +190,7 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configDatadog(projectID, updatedAPIKey, "US"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", updatedAPIKey),
@@ -220,7 +220,7 @@ func prometheusTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configPrometheus(projectID, username, password, serviceDiscovery, scheme),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "user_name", username),
@@ -234,7 +234,7 @@ func prometheusTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configPrometheus(projectID, updatedUsername, password, serviceDiscovery, scheme),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "user_name", updatedUsername),
@@ -266,7 +266,7 @@ func microsoftTeamsTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configMicrosoftTeams(projectID, url),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "microsoft_teams_webhook_url", url),
@@ -275,7 +275,7 @@ func microsoftTeamsTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configMicrosoftTeams(projectID, updatedURL),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "microsoft_teams_webhook_url", updatedURL),
@@ -301,7 +301,7 @@ func webhookTest(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configWebhook(projectID, url),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "url", url),
@@ -310,7 +310,7 @@ func webhookTest(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configWebhook(projectID, updatedURL),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "url", updatedURL),

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_migration_test.go
@@ -24,7 +24,7 @@ func TestMigGenericX509AuthDBUser_basic(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -51,7 +51,7 @@ func TestMigGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),

--- a/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
+++ b/internal/service/x509authenticationdatabaseuser/resource_x509_authentication_database_user_test.go
@@ -33,7 +33,7 @@ func TestAccGenericX509AuthDBUser_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(projectID, username),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -64,7 +64,7 @@ func TestAccGenericX509AuthDBUser_withCustomerX509(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithCustomerX509(orgID, projectName, cas),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "customer_x509_cas"),
@@ -94,7 +94,7 @@ func TestAccGenericX509AuthDBUser_withDatabaseUser(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithDatabaseUser(projectID, username, months),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "username"),


### PR DESCRIPTION
## Description

Uses ComposeAggregateTestCheckFunc for soft assertions

Link to any related issue(s): CLOUDP-256881

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
