### PR TITLE
fix: Emptying cloud_back_schedule "copy_settings"

### DIFF
--- a/.changelog/2387.txt
+++ b/.changelog/2387.txt
@@ -1,3 +1,3 @@
-```release-note:bug,
+```release-note:bug
 resource/mongodbatlas_cloud_backup_schedule: Updates `copy_settings` on changes (even when empty)
 ```

--- a/.changelog/2387.txt
+++ b/.changelog/2387.txt
@@ -1,0 +1,3 @@
+```release-note:bug,
+resource/mongodbatlas_cloud_backup_schedule: Updates `copy_settings` on changes (even when empty)
+```

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -493,7 +493,7 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 
 	req := &admin.DiskBackupSnapshotSchedule{}
 	copySettings := d.Get("copy_settings")
-	if len(copySettings.([]any)) > 0 || d.HasChange("copy_settings") {
+	if copySettings != nil && (conversion.HasElementsSliceOrMap(copySettings) || d.HasChange("copy_settings")) {
 		req.CopySettings = expandCopySettings(copySettings.([]any))
 	}
 
@@ -642,11 +642,7 @@ func expandCopySetting(tfMap map[string]any) *admin.DiskBackupCopySetting {
 }
 
 func expandCopySettings(tfList []any) *[]admin.DiskBackupCopySetting {
-	if len(tfList) == 0 {
-		return &[]admin.DiskBackupCopySetting{}
-	}
-
-	var copySettings []admin.DiskBackupCopySetting
+	copySettings := make([]admin.DiskBackupCopySetting, 0)
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -492,9 +492,9 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 	}
 
 	req := &admin.DiskBackupSnapshotSchedule{}
-
-	if v, ok := d.GetOk("copy_settings"); ok && len(v.([]any)) > 0 {
-		req.CopySettings = expandCopySettings(v.([]any))
+	copySettings := d.Get("copy_settings")
+	if len(copySettings.([]any)) > 0 || d.HasChange("copy_settings") {
+		req.CopySettings = expandCopySettings(copySettings.([]any))
 	}
 
 	var policiesItem []admin.DiskBackupApiPolicyItem
@@ -643,7 +643,7 @@ func expandCopySetting(tfMap map[string]any) *admin.DiskBackupCopySetting {
 
 func expandCopySettings(tfList []any) *[]admin.DiskBackupCopySetting {
 	if len(tfList) == 0 {
-		return nil
+		return &[]admin.DiskBackupCopySetting{}
 	}
 
 	var copySettings []admin.DiskBackupCopySetting

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -526,9 +526,7 @@ func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) s
 
 func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p *admin.DiskBackupSnapshotSchedule) string {
 	var copySettings string
-	if emptyCopySettings {
-		copySettings = ""
-	} else {
+	if !emptyCopySettings {
 		copySettings = `
 			copy_settings {
 				cloud_provider = "AWS"

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -254,7 +254,45 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
+		checkMap    = map[string]string{
+			"cluster_name":                             clusterName,
+			"reference_hour_of_day":                    "3",
+			"reference_minute_of_hour":                 "45",
+			"restore_window_days":                      "1",
+			"policy_item_hourly.#":                     "1",
+			"policy_item_daily.#":                      "1",
+			"policy_item_weekly.#":                     "1",
+			"policy_item_monthly.#":                    "1",
+			"policy_item_yearly.#":                     "1",
+			"policy_item_hourly.0.frequency_interval":  "1",
+			"policy_item_hourly.0.retention_unit":      "days",
+			"policy_item_hourly.0.retention_value":     "1",
+			"policy_item_daily.0.frequency_interval":   "1",
+			"policy_item_daily.0.retention_unit":       "days",
+			"policy_item_daily.0.retention_value":      "2",
+			"policy_item_weekly.0.frequency_interval":  "4",
+			"policy_item_weekly.0.retention_unit":      "weeks",
+			"policy_item_weekly.0.retention_value":     "3",
+			"policy_item_monthly.0.frequency_interval": "5",
+			"policy_item_monthly.0.retention_unit":     "months",
+			"policy_item_monthly.0.retention_value":    "4",
+			"policy_item_yearly.0.frequency_interval":  "1",
+			"policy_item_yearly.0.retention_unit":      "years",
+			"policy_item_yearly.0.retention_value":     "1",
+		}
+		copySettingsChecks = map[string]string{
+			"copy_settings.#":                    "1",
+			"copy_settings.0.cloud_provider":     "AWS",
+			"copy_settings.0.region_name":        "US_EAST_1",
+			"copy_settings.0.should_copy_oplogs": "true",
+		}
+		emptyCopySettingsChecks = map[string]string{
+			"copy_settings.#": "0",
+		}
 	)
+	checksDefault := acc.AddAttrChecks(resourceName, []resource.TestCheckFunc{checkExists(resourceName)}, checkMap)
+	checksCreate := acc.AddAttrChecks(resourceName, checksDefault, copySettingsChecks)
+	checksUpdate := acc.AddAttrChecks(resourceName, checksDefault, emptyCopySettingsChecks)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -262,41 +300,20 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configCopySettings(projectID, clusterName, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(projectID, clusterName, false, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
 				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "reference_hour_of_day", "3"),
-					resource.TestCheckResourceAttr(resourceName, "reference_minute_of_hour", "45"),
-					resource.TestCheckResourceAttr(resourceName, "restore_window_days", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.frequency_interval", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_unit", "days"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.frequency_interval", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_unit", "days"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_daily.0.retention_value", "2"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.frequency_interval", "4"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_unit", "weeks"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_weekly.0.retention_value", "3"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.frequency_interval", "5"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_unit", "months"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_monthly.0.retention_value", "4"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.frequency_interval", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_unit", "years"),
-					resource.TestCheckResourceAttr(resourceName, "policy_item_yearly.0.retention_value", "1"),
-					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.cloud_provider", "AWS"),
-					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.region_name", "US_EAST_1"),
-					resource.TestCheckResourceAttr(resourceName, "copy_settings.0.should_copy_oplogs", "true"),
-				),
+				Check: resource.ComposeAggregateTestCheckFunc(checksCreate...),
+			},
+			{
+				Config: configCopySettings(projectID, clusterName, true, &admin.DiskBackupSnapshotSchedule{
+					ReferenceHourOfDay:    conversion.Pointer(3),
+					ReferenceMinuteOfHour: conversion.Pointer(45),
+					RestoreWindowDays:     conversion.Pointer(1),
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(checksUpdate...),
 			},
 		},
 	})
@@ -507,7 +524,25 @@ func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) s
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configCopySettings(projectID, clusterName string, p *admin.DiskBackupSnapshotSchedule) string {
+func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p *admin.DiskBackupSnapshotSchedule) string {
+	var copySettings string
+	if emptyCopySettings {
+		copySettings = ""
+	} else {
+		copySettings = `
+			copy_settings {
+				cloud_provider = "AWS"
+				frequencies = ["HOURLY",
+							"DAILY",
+							"WEEKLY",
+							"MONTHLY",
+							"YEARLY",
+							"ON_DEMAND"]
+				region_name = "US_EAST_1"
+				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
+				should_copy_oplogs = true
+			}`
+	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "my_cluster" {
 			project_id   = %[1]q
@@ -564,20 +599,9 @@ func configCopySettings(projectID, clusterName string, p *admin.DiskBackupSnapsh
 				retention_unit     = "years"
 				retention_value    = 1
 			}
-			copy_settings {
-				cloud_provider = "AWS"
-				frequencies = ["HOURLY",
-							"DAILY",
-							"WEEKLY",
-							"MONTHLY",
-							"YEARLY",
-							"ON_DEMAND"]
-				region_name = "US_EAST_1"
-				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
-				should_copy_oplogs = true
-			}
+			%s
 		}
-	`, projectID, clusterName, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
+	`, projectID, clusterName, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), copySettings)
 }
 
 func configOnePolicy(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {


### PR DESCRIPTION
## Description

Emptying cloud_back_schedule "copy_settings"

Link to any related issue(s): CLOUDP-259879 #2385 

Failing test in [b087584](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2387/commits/b08758415797063bfd44f7765420637df05e6106): [test action output](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/9779589036/job/26999406027#step:5:70)

Fixed test in 98a8fdece2aa2712db31e515f97bf2b045fcad0b: [test action output](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/9780536848/job/27002616007?pr=2387#step:5:71)


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
