### PR TITLE
chore: Updates delete logic for `mongodbatlas_search_deployment`

### DIFF
--- a/internal/service/searchdeployment/state_transition_search_deployment.go
+++ b/internal/service/searchdeployment/state_transition_search_deployment.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
-const SearchDeploymentDoesNotExistsError = "ATLAS_FTS_DEPLOYMENT_DOES_NOT_EXIST"
+const SearchDeploymentDoesNotExistsError = "ATLAS_SEARCH_DEPLOYMENT_DOES_NOT_EXIST"
 
 func WaitSearchNodeStateTransition(ctx context.Context, projectID, clusterName string, client admin.AtlasSearchApi,
 	timeConfig retrystrategy.TimeConfig) (*admin.ApiSearchDeploymentResponse, error) {
@@ -56,7 +56,7 @@ func searchDeploymentRefreshFunc(ctx context.Context, projectID, clusterName str
 			return nil, "", err
 		}
 		if err != nil {
-			if resp.StatusCode == 400 && strings.Contains(err.Error(), SearchDeploymentDoesNotExistsError) {
+			if resp.StatusCode == 404 && strings.Contains(err.Error(), SearchDeploymentDoesNotExistsError) {
 				return "", retrystrategy.RetryStrategyDeletedState, nil
 			}
 			if resp.StatusCode == 503 {

--- a/internal/service/searchdeployment/state_transition_search_deployment_test.go
+++ b/internal/service/searchdeployment/state_transition_search_deployment_test.go
@@ -20,7 +20,7 @@ var (
 	updating = "UPDATING"
 	idle     = "IDLE"
 	unknown  = ""
-	sc400    = conversion.IntPtr(400)
+	sc404    = conversion.IntPtr(404)
 	sc500    = conversion.IntPtr(500)
 	sc503    = conversion.IntPtr(503)
 )
@@ -94,7 +94,7 @@ func TestSearchDeploymentStateTransitionForDelete(t *testing.T) {
 			name: "Regular transition to DELETED",
 			mockResponses: []response{
 				{state: &updating},
-				{statusCode: sc400, err: errors.New(searchdeployment.SearchDeploymentDoesNotExistsError)},
+				{statusCode: sc404, err: errors.New(searchdeployment.SearchDeploymentDoesNotExistsError)},
 			},
 			expectedError: false,
 		},


### PR DESCRIPTION
## Description

Updates delete logic for `mongodbatlas_search_deployment` following the new Atlas API update.

This PR fixes `mongodbatlas_search_deployment` tests.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
