### PR TITLE
refactor: cluster_outage_simulation increase delete timeout to avoid failing test

### DIFF
--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
@@ -30,7 +30,7 @@ func Resource() *schema.Resource {
 		UpdateContext: resourceUpdate,
 		DeleteContext: resourceDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(25 * time.Minute),
+			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {


### PR DESCRIPTION
## Description

cluster_outage_simulation increase default delete timeout to avoid failing test

Link to any related issue(s): CLOUDP-260210

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
