### PR TITLE
chore: Uses advanced_cluster instead of cluster in tests

### DIFF
--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -273,41 +273,65 @@ const (
 		replication_specs {
 			zone_name  = "US"
 			num_shards = 1
-			regions_config {
+			region_configs {
+				auto_scaling {
+					disk_gb_enabled = false
+				}
 				region_name     = "US_EAST_1"
-				electable_nodes = 3
+				provider_name	= "AWS"
 				priority        = 7
-				read_only_nodes = 0
+				electable_specs {
+					instance_size = "M10"
+					node_count = 3
+				}
 			}
 		}
 		replication_specs {
 			zone_name  = "EU"
 			num_shards = 1
-			regions_config {
+			region_configs {
+				auto_scaling {
+					disk_gb_enabled = false
+				}
 				region_name     = "EU_WEST_1"
-				electable_nodes = 3
+				provider_name	= "AWS"
 				priority        = 7
-				read_only_nodes = 0
+				electable_specs {
+					instance_size = "M10"
+					node_count = 3
+				}
 			}
 		}
 		replication_specs {
 			zone_name  = "DE"
 			num_shards = 1
-			regions_config {
+			region_configs {
+				auto_scaling {
+					disk_gb_enabled = false
+				}
 				region_name     = "EU_NORTH_1"
-				electable_nodes = 3
+				provider_name	= "AWS"
 				priority        = 7
-				read_only_nodes = 0
+				electable_specs {
+					instance_size = "M10"
+					node_count = 3
+				}
 			}
 		}
 		replication_specs {
 			zone_name  = "JP"
 			num_shards = 1
-			regions_config {
+			region_configs {
+				auto_scaling {
+					disk_gb_enabled = false
+				}
 				region_name     = "AP_NORTHEAST_1"
-				electable_nodes = 3
+				provider_name	= "AWS"
 				priority        = 7
-				read_only_nodes = 0
+				electable_specs {
+					instance_size = "M10"
+					node_count = 3
+				}
 			}
 		}
 	`

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -61,23 +61,27 @@ func GetClusterInfo(tb testing.TB, req *ClusterRequest) ClusterInfo {
 		`, req.ResourceDependencyName)
 	}
 	clusterTerraformStr := fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "test_cluster" {
+		resource "mongodbatlas_advanced_cluster" "test_cluster" {
 			project_id                   = %[1]q
 			name                         = %[2]q
-			cloud_backup                 = %[3]t
-			auto_scaling_disk_gb_enabled = false
-			provider_name                = %[4]q
-			provider_instance_size_name  = "M10"
-		
-			cluster_type = %[5]q
+			backup_enabled               = %[3]t
+			cluster_type 				 = %[5]q
+			
 			replication_specs {
 				num_shards = 1
 				zone_name  = "Zone 1"
-				regions_config {
-					region_name     = "US_WEST_2"
-					electable_nodes = 3
+				region_configs {
+					auto_scaling {
+						disk_gb_enabled = false
+					}
+					provider_name	= %[4]q
+					region_name		= "US_WEST_2"
 					priority        = 7
-					read_only_nodes = 0
+					
+					electable_specs {
+						instance_size	= "M10"
+						node_count 		= 3
+					}
 				}
 			}
 			%[6]s
@@ -88,7 +92,7 @@ func GetClusterInfo(tb testing.TB, req *ClusterRequest) ClusterInfo {
 		ProjectIDStr:        fmt.Sprintf("%q", projectID),
 		ProjectID:           projectID,
 		ClusterName:         clusterName,
-		ClusterNameStr:      "mongodbatlas_cluster.test_cluster.name",
+		ClusterNameStr:      "mongodbatlas_advanced_cluster.test_cluster.name",
 		ClusterTerraformStr: clusterTerraformStr,
 	}
 }


### PR DESCRIPTION
## Description

Uses advanced_cluster instead of cluster in tests

Link to any related issue(s): CLOUDP-260440

### Affected test groups and resources
- backup
  - mongodbatlas_cloud_backup_schedule
  - mongodbatlas_cloud_backup_snapshot
  - mongodbatlas_cloud_backup_snapshot_export_job
- cluster
  - mongodbatlas_global_cluster_config

- Runs for [`backup` group](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/9838937132)
- Cluster group runs already since `resource_global_cluster_config_test.go` was changed


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
