### PR TITLE
fix: Returns error if the analyzers attribute contains unknown fields.

### DIFF
--- a/.changelog/2394.txt
+++ b/.changelog/2394.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_search_index: Returns error if the `analyzers` attribute contains unknown fields.
+resource/mongodbatlas_search_index: Returns error if the `analyzers` attribute contains unknown fields
 ```

--- a/.changelog/2394.txt
+++ b/.changelog/2394.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_search_index: Returns error if the `analyzers` attribute contains unknown fields.
+```

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -1,6 +1,7 @@
 package searchindex
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -387,8 +388,8 @@ func flattenSearchIndexSynonyms(synonyms []admin.SearchSynonymMappingDefinition)
 }
 
 func marshalSearchIndex(fields any) (string, error) {
-	bytes, err := json.Marshal(fields)
-	return string(bytes), err
+	respBytes, err := json.Marshal(fields)
+	return string(respBytes), err
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -566,7 +567,10 @@ func unmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyze
 	if str == "" {
 		return fields, nil
 	}
-	if err := json.Unmarshal([]byte(str), &fields); err != nil {
+	dec := json.NewDecoder(bytes.NewReader([]byte(str)))
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(&fields); err != nil {
 		return nil, diag.Errorf("cannot unmarshal search index attribute `analyzers` because it has an incorrect format")
 	}
 	return fields, nil

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -3,6 +3,7 @@ package searchindex_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -113,6 +114,10 @@ func TestAccSearchIndex_updatedToEmptyAnalyzers(t *testing.T) {
 			{
 				Config: configAdditional(projectID, indexName, databaseName, clusterName, ""),
 				Check:  checkAdditionalAnalyzers(projectID, indexName, databaseName, clusterName, false),
+			},
+			{
+				Config:      configAdditional(projectID, indexName, databaseName, clusterName, incorrectFormatAnalyzersTF),
+				ExpectError: regexp.MustCompile("cannot unmarshal search index attribute `analyzers` because it has an incorrect format"),
 			},
 		},
 	})
@@ -437,8 +442,9 @@ const (
 	with           = true
 	without        = false
 
-	analyzersTF      = "\nanalyzers = <<-EOF\n" + analyzersJSON + "\nEOF\n"
-	mappingsFieldsTF = "\nmappings_fields = <<-EOF\n" + mappingsFieldsJSON + "\nEOF\n"
+	analyzersTF                = "\nanalyzers = <<-EOF\n" + analyzersJSON + "\nEOF\n"
+	incorrectFormatAnalyzersTF = "\nanalyzers = <<-EOF\n" + incorrectFormatAnalyzersJSON + "\nEOF\n"
+	mappingsFieldsTF           = "\nmappings_fields = <<-EOF\n" + mappingsFieldsJSON + "\nEOF\n"
 
 	analyzersJSON = `
 		[
@@ -508,5 +514,19 @@ const (
 			"numDimensions": 1536,
 			"similarity": "euclidean"
 		}]	
+	`
+
+	incorrectFormatAnalyzersJSON = `
+		[
+			{
+				"wrongField":[
+					{
+							"type":"length",
+							"min":20,
+							"max":33
+					}
+				]
+			}
+		]
 	`
 )


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): CLOUDP-260704

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
