### PR TITLE
test: Uses hclwrite to generate the cluster for GetClusterInfo

### DIFF
--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -374,7 +374,8 @@ func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
 
 func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 	var (
-		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ProviderName: constant.AZURE})
+		spec        = acc.ReplicationSpec(&acc.ReplicationSpecRequest{ProviderName: constant.AZURE})
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true}, spec)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -80,7 +80,11 @@ func TestAccClusterRSGlobalCluster_withAWSAndBackup(t *testing.T) {
 
 func TestAccClusterRSGlobalCluster_database(t *testing.T) {
 	var (
-		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, ExtraConfig: zonesStr})
+		specUS      = acc.ReplicationSpec(&acc.ReplicationSpecRequest{ZoneName: "US", Region: "US_EAST_1"})
+		specEU      = acc.ReplicationSpec(&acc.ReplicationSpecRequest{ZoneName: "EU", Region: "EU_WEST_1"})
+		specDE      = acc.ReplicationSpec(&acc.ReplicationSpecRequest{ZoneName: "DE", Region: "EU_NORTH_1"})
+		specJP      = acc.ReplicationSpec(&acc.ReplicationSpecRequest{ZoneName: "JP", Region: "AP_NORTHEAST_1"})
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true}, specUS, specEU, specDE, specJP)
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -266,73 +270,6 @@ const (
 		custom_zone_mappings {
 			location = "JP"
 			zone     = "JP"
-		}
-	`
-
-	zonesStr = `
-		replication_specs {
-			zone_name  = "US"
-			num_shards = 1
-			region_configs {
-				auto_scaling {
-					disk_gb_enabled = false
-				}
-				region_name     = "US_EAST_1"
-				provider_name	= "AWS"
-				priority        = 7
-				electable_specs {
-					instance_size = "M10"
-					node_count = 3
-				}
-			}
-		}
-		replication_specs {
-			zone_name  = "EU"
-			num_shards = 1
-			region_configs {
-				auto_scaling {
-					disk_gb_enabled = false
-				}
-				region_name     = "EU_WEST_1"
-				provider_name	= "AWS"
-				priority        = 7
-				electable_specs {
-					instance_size = "M10"
-					node_count = 3
-				}
-			}
-		}
-		replication_specs {
-			zone_name  = "DE"
-			num_shards = 1
-			region_configs {
-				auto_scaling {
-					disk_gb_enabled = false
-				}
-				region_name     = "EU_NORTH_1"
-				provider_name	= "AWS"
-				priority        = 7
-				electable_specs {
-					instance_size = "M10"
-					node_count = 3
-				}
-			}
-		}
-		replication_specs {
-			zone_name  = "JP"
-			num_shards = 1
-			region_configs {
-				auto_scaling {
-					disk_gb_enabled = false
-				}
-				region_name     = "AP_NORTHEAST_1"
-				provider_name	= "AWS"
-				priority        = 7
-				electable_specs {
-					instance_size = "M10"
-					node_count = 3
-				}
-			}
 		}
 	`
 )

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -79,7 +79,7 @@ func (r *ReplicationSpecRequest) AddDefaults() {
 		r.ZoneName = "Zone 1"
 	}
 	if r.Region == "" {
-		r.Region = "US_WEST_1"
+		r.Region = "US_WEST_2"
 	}
 	if r.InstanceSize == "" {
 		r.InstanceSize = "M10"

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -68,14 +68,10 @@ type ReplicationSpecRequest struct {
 	Region       string
 	InstanceSize string
 	ProviderName string
-	NumShards    int
 	NodeCount    int
 }
 
 func (r *ReplicationSpecRequest) AddDefaults() {
-	if r.NumShards == 0 {
-		r.NumShards = 1
-	}
 	if r.NodeCount == 0 {
 		r.NodeCount = 3
 	}
@@ -98,8 +94,9 @@ func ReplicationSpec(req *ReplicationSpecRequest) admin.ReplicationSpec {
 		req = new(ReplicationSpecRequest)
 	}
 	req.AddDefaults()
+	defaultNumShards := 1
 	spec := admin.ReplicationSpec{
-		NumShards: &req.NumShards,
+		NumShards: &defaultNumShards,
 		ZoneName:  &req.ZoneName,
 		RegionConfigs: &[]admin.CloudRegionConfig{
 			{

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 type ClusterRequest struct {
-	ProviderName           string
 	ResourceDependencyName string
 	ClusterNameExplicit    string
 	CloudBackup            bool
@@ -67,35 +67,44 @@ type ReplicationSpecRequest struct {
 	ZoneName     string
 	Region       string
 	InstanceSize string
+	ProviderName string
 	NumShards    int
 	NodeCount    int
+}
+
+func (r *ReplicationSpecRequest) AddDefaults() {
+	if r.NumShards == 0 {
+		r.NumShards = 1
+	}
+	if r.NodeCount == 0 {
+		r.NodeCount = 3
+	}
+	if r.ZoneName == "" {
+		r.ZoneName = "zone1"
+	}
+	if r.Region == "" {
+		r.Region = "US_WEST_1"
+	}
+	if r.InstanceSize == "" {
+		r.InstanceSize = "M10"
+	}
+	if r.ProviderName == "" {
+		r.ProviderName = constant.AWS
+	}
 }
 
 func ReplicationSpec(req *ReplicationSpecRequest) admin.ReplicationSpec {
 	if req == nil {
 		req = new(ReplicationSpecRequest)
 	}
-	if req.NumShards == 0 {
-		req.NumShards = 1
-	}
-	if req.NodeCount == 0 {
-		req.NodeCount = 3
-	}
-	if req.ZoneName == "" {
-		req.ZoneName = "zone1"
-	}
-	if req.Region == "" {
-		req.Region = "US_WEST_1"
-	}
-	if req.InstanceSize == "" {
-		req.InstanceSize = "M10"
-	}
+	req.AddDefaults()
 	spec := admin.ReplicationSpec{
 		NumShards: &req.NumShards,
 		ZoneName:  &req.ZoneName,
 		RegionConfigs: &[]admin.CloudRegionConfig{
 			{
-				RegionName: &req.Region,
+				RegionName:   &req.Region,
+				ProviderName: &req.ProviderName,
 				ElectableSpecs: &admin.HardwareSpec{
 					InstanceSize: &req.InstanceSize,
 					NodeCount:    &req.NodeCount,

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -80,7 +80,7 @@ func (r *ReplicationSpecRequest) AddDefaults() {
 		r.NodeCount = 3
 	}
 	if r.ZoneName == "" {
-		r.ZoneName = "zone1"
+		r.ZoneName = "Zone 1"
 	}
 	if r.Region == "" {
 		r.Region = "US_WEST_1"

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ClusterRequest struct {
-	ResourceDependencyName string
+	ResourceDependencyName string // use "," to separate resources
 	ClusterNameExplicit    string
+	DiskSizeGb             int
 	CloudBackup            bool
 	Geosharded             bool
 }

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -1,9 +1,18 @@
 package acc
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+	"github.com/zclconf/go-cty/cty"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func FormatToHCLMap(m map[string]string, indent, varName string) string {
@@ -41,7 +50,6 @@ func FormatToHCLLifecycleIgnore(keys ...string) string {
 	return strings.Join(lines, "\n")
 }
 
-// make test deterministic
 func sortStringMapKeys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -49,4 +57,167 @@ func sortStringMapKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+func sortStringMapKeysAny(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func AddNonZeroAttributes(b *hclwrite.Body, obj any) error {
+	var objMap map[string]interface{}
+	inrec, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(inrec, &objMap)
+	if err != nil {
+		return err
+	}
+	addNonEmptyAttributes(b, objMap)
+	return nil
+}
+
+func addNonEmptyAttributes(b *hclwrite.Body, values map[string]any) {
+	for _, keyCamel := range sortStringMapKeysAny(values) {
+		key := ToSnakeCase(keyCamel)
+		value := values[keyCamel]
+		switch value := value.(type) {
+		case bool:
+			b.SetAttributeValue(key, cty.BoolVal(value))
+		case string:
+			if value == "" {
+				continue
+			}
+			b.SetAttributeValue(key, cty.StringVal(value))
+		case int:
+			if value == 0 {
+				continue
+			}
+			b.SetAttributeValue(key, cty.NumberIntVal(int64(value)))
+		case float64:
+			b.SetAttributeValue(key, cty.NumberIntVal(int64(value)))
+		default:
+			continue
+		}
+	}
+}
+
+func ClusterResourceHcl(projectID string, req *ClusterRequest, specs []admin.ReplicationSpec) (configStr, clusterName string, err error) {
+	if len(specs) == 0 {
+		specs = append(specs, ReplicationSpec(nil))
+	}
+	if req == nil {
+		req = new(ClusterRequest)
+	}
+	if req.ProviderName == "" {
+		req.ProviderName = constant.AWS
+	}
+	clusterName = req.ClusterNameExplicit
+	if clusterName == "" {
+		clusterName = RandomClusterName()
+	}
+	clusterTypeStr := "REPLICASET"
+	if req.Geosharded {
+		clusterTypeStr = "GEOSHARDED"
+	}
+
+	f := hclwrite.NewEmptyFile()
+	root := f.Body()
+	cluster := root.AppendNewBlock("resource", []string{"mongodbatlas_advanced_cluster", "cluster_info"}).Body()
+	addNonEmptyAttributes(cluster, map[string]any{
+		"project_id":     projectID,
+		"clusterType":    clusterTypeStr,
+		"name":           clusterName,
+		"backup_enabled": req.CloudBackup,
+	})
+	cluster.AppendNewline()
+	for i, spec := range specs {
+		err = writeReplicationSpec(cluster, spec, req.ProviderName)
+		if err != nil {
+			return "", "", fmt.Errorf("error writing hcl for replication spec %d: %w", i, err)
+		}
+	}
+	cluster.AppendNewline()
+	if req.ResourceDependencyName != "" {
+		if !strings.Contains(req.ResourceDependencyName, ".") {
+			return "", "", fmt.Errorf("req.ResourceDependencyName must have a '.'")
+		}
+		dependsOnAttr, err := extractValueTokens(fmt.Sprintf("dummy = [%s]", req.ResourceDependencyName))
+		if err != nil {
+			return "", "", err
+		}
+		cluster.SetAttributeRaw("depends_on", dependsOnAttr)
+	}
+	return "\n" + string(f.Bytes()), clusterName, err
+}
+
+func writeReplicationSpec(cluster *hclwrite.Body, spec admin.ReplicationSpec, providerName string) error {
+	replicationBlock := cluster.AppendNewBlock("replication_specs", nil).Body()
+	err := AddNonZeroAttributes(replicationBlock, spec)
+	if err != nil {
+		return err
+	}
+	for _, rc := range spec.GetRegionConfigs() {
+		if rc.ProviderName == nil {
+			rc.SetProviderName(providerName)
+		}
+		if rc.Priority == nil {
+			rc.SetPriority(7)
+		}
+		replicationBlock.AppendNewline()
+		rcBlock := replicationBlock.AppendNewBlock("region_configs", nil).Body()
+		err = AddNonZeroAttributes(rcBlock, rc)
+		if err != nil {
+			return err
+		}
+		autoScalingBlock := rcBlock.AppendNewBlock("auto_scaling", nil).Body()
+		if rc.AutoScaling == nil {
+			autoScalingBlock.SetAttributeValue("disk_gb_enabled", cty.BoolVal(false))
+		} else {
+			autoScaling := rc.GetAutoScaling()
+			return fmt.Errorf("auto_scaling on replication spec is not supportd yet %v", autoScaling)
+		}
+		nodeSpec := rc.GetElectableSpecs()
+		nodeSpecBlock := rcBlock.AppendNewBlock("electable_specs", nil).Body()
+		err = AddNonZeroAttributes(nodeSpecBlock, nodeSpec)
+	}
+	return err
+}
+
+func extractValueTokens(tfExpression string) ([]*hclwrite.Token, error) {
+	src := []byte(tfExpression)
+
+	f, diags := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("extract attribute error %s\nparsing %s", diags, tfExpression)
+	}
+	for _, attr := range f.Body().Attributes() {
+		tokens := hclwrite.Tokens{}
+		tokens = attr.BuildTokens(tokens)
+		equalFound := false
+		returnTokens := []*hclwrite.Token{}
+		for _, token := range tokens {
+			if equalFound {
+				returnTokens = append(returnTokens, token)
+			}
+			if token.Type == hclsyntax.TokenEqual {
+				equalFound = true
+			}
+		}
+		return returnTokens, nil
+	}
+	return nil, fmt.Errorf("extract attribute error parsing %s", tfExpression)
 }

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -94,12 +94,16 @@ func ClusterResourceHcl(projectID string, req *ClusterRequest, specs []admin.Rep
 	f := hclwrite.NewEmptyFile()
 	root := f.Body()
 	cluster := root.AppendNewBlock("resource", []string{"mongodbatlas_advanced_cluster", "cluster_info"}).Body()
-	addPrimitiveAttributes(cluster, map[string]any{
+	clusterRootAttributes := map[string]any{
 		"project_id":     projectID,
-		"clusterType":    clusterTypeStr,
+		"cluster_type":   clusterTypeStr,
 		"name":           clusterName,
 		"backup_enabled": req.CloudBackup,
-	})
+	}
+	if req.DiskSizeGb != 0 {
+		clusterRootAttributes["disk_size_gb"] = req.DiskSizeGb
+	}
+	addPrimitiveAttributes(cluster, clusterRootAttributes)
 	cluster.AppendNewline()
 	for i, spec := range specs {
 		err = writeReplicationSpec(cluster, spec)

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func projectTemplateWithExtra(extra string) string {
@@ -133,6 +134,33 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
 }
 `
+var overrideClusterResource = `
+resource "mongodbatlas_advanced_cluster" "cluster_info" {
+  backup_enabled = true
+  cluster_type   = "GEOSHARDED"
+  name           = "my-name"
+  project_id     = "project"
+
+  replication_specs {
+    num_shards = 1
+    zone_name  = "Zone X"
+
+    region_configs {
+      priority      = 7
+      provider_name = "AZURE"
+      region_name   = "MY_REGION_1"
+      auto_scaling {
+        disk_gb_enabled = false
+      }
+      electable_specs {
+        instance_size = "M30"
+        node_count    = 30
+      }
+    }
+  }
+
+}
+`
 
 var dependsOnClusterResource = `
 resource "mongodbatlas_advanced_cluster" "cluster_info" {
@@ -162,6 +190,50 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   depends_on = [mongodbatlas_project.project_execution]
 }
 `
+var twoReplicationSpecs = `
+resource "mongodbatlas_advanced_cluster" "cluster_info" {
+  backup_enabled = false
+  cluster_type   = "REPLICASET"
+  name           = "my-name"
+  project_id     = "project"
+
+  replication_specs {
+    num_shards = 1
+    zone_name  = "Zone 1"
+
+    region_configs {
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_WEST_1"
+      auto_scaling {
+        disk_gb_enabled = false
+      }
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }
+  }
+  replication_specs {
+    num_shards = 1
+    zone_name  = "Zone 2"
+
+    region_configs {
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "EU_WEST_2"
+      auto_scaling {
+        disk_gb_enabled = false
+      }
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }
+  }
+
+}
+`
 
 func Test_ClusterResourceHcl(t *testing.T) {
 	var (
@@ -169,20 +241,46 @@ func Test_ClusterResourceHcl(t *testing.T) {
 		testCases   = map[string]struct {
 			expected string
 			req      acc.ClusterRequest
+			specs    []acc.ReplicationSpecRequest
 		}{
 			"defaults": {
 				standardClusterResource,
 				acc.ClusterRequest{ClusterNameExplicit: clusterName},
+				nil,
 			},
 			"dependsOn": {
 				dependsOnClusterResource,
 				acc.ClusterRequest{ClusterNameExplicit: clusterName, ResourceDependencyName: "mongodbatlas_project.project_execution"},
+				nil,
+			},
+			"twoReplicationSpecs": {
+				twoReplicationSpecs,
+				acc.ClusterRequest{ClusterNameExplicit: clusterName},
+				[]acc.ReplicationSpecRequest{
+					{Region: "US_WEST_1", ZoneName: "Zone 1"},
+					{Region: "EU_WEST_2", ZoneName: "Zone 2"},
+				},
+			},
+			"overrideClusterResource": {
+				overrideClusterResource,
+				acc.ClusterRequest{ClusterNameExplicit: clusterName, Geosharded: true, CloudBackup: true},
+				[]acc.ReplicationSpecRequest{
+					{Region: "MY_REGION_1", ZoneName: "Zone X", InstanceSize: "M30", NodeCount: 30, ProviderName: "AZURE"},
+				},
 			},
 		}
 	)
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			config, actualClusterName, err := acc.ClusterResourceHcl("project", &tc.req, nil)
+			specs := make([]admin.ReplicationSpec, len(tc.specs))
+			if len(tc.specs) == 0 {
+				specs = []admin.ReplicationSpec{acc.ReplicationSpec(nil)}
+			} else {
+				for i, req := range tc.specs {
+					specs[i] = acc.ReplicationSpec(&req)
+				}
+			}
+			config, actualClusterName, err := acc.ClusterResourceHcl("project", &tc.req, specs)
 			require.NoError(t, err)
 			assert.Equal(t, clusterName, actualClusterName)
 			assert.Equal(t, tc.expected, config)

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -121,7 +121,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
     region_configs {
       priority      = 7
       provider_name = "AWS"
-      region_name   = "US_WEST_1"
+      region_name   = "US_WEST_2"
       auto_scaling {
         disk_gb_enabled = false
       }
@@ -176,7 +176,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
     region_configs {
       priority      = 7
       provider_name = "AWS"
-      region_name   = "US_WEST_1"
+      region_name   = "US_WEST_2"
       auto_scaling {
         disk_gb_enabled = false
       }

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -115,7 +115,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
   replication_specs {
     num_shards = 1
-    zone_name  = "zone1"
+    zone_name  = "Zone 1"
 
     region_configs {
       priority      = 7
@@ -143,7 +143,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
   replication_specs {
     num_shards = 1
-    zone_name  = "zone1"
+    zone_name  = "Zone 1"
 
     region_configs {
       priority      = 7

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -115,7 +115,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
   replication_specs {
     num_shards = 1
-    zone_name  = "z1"
+    zone_name  = "zone1"
 
     region_configs {
       priority      = 7
@@ -143,7 +143,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
   replication_specs {
     num_shards = 1
-    zone_name  = "z1"
+    zone_name  = "zone1"
 
     region_configs {
       priority      = 7


### PR DESCRIPTION
## Description

Uses hclwrite to generate the cluster for GetClusterInfo

Link to any related issue(s): CLOUDP-260447

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
