### PR TITLE
test: Refactors `mongodbatlas_private_endpoint_regional_mode` to use cluster info

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -648,6 +648,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_REGION_UPPERCASE: ${{ vars.AWS_REGION_UPPERCASE }}
+          AWS_REGION_LOWERCASE: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_SECURITY_GROUP_1: ${{ vars.AWS_SECURITY_GROUP_1 }}
           AWS_SECURITY_GROUP_2: ${{ vars.AWS_SECURITY_GROUP_2 }}
           AWS_VPC_CIDR_BLOCK: ${{ vars.AWS_VPC_CIDR_BLOCK }}

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -21,33 +21,37 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
-		endpointResourceSuffix = "atlasple"
-		resourceSuffix         = "atlasrm"
-		resourceName           = fmt.Sprintf("mongodbatlas_private_endpoint_regional_mode.%s", resourceSuffix)
-		awsAccessKey           = os.Getenv("AWS_ACCESS_KEY_ID")
-		awsSecretKey           = os.Getenv("AWS_SECRET_ACCESS_KEY")
-		providerName           = "AWS"
-		region                 = os.Getenv("AWS_REGION")
-		projectID              = acc.ProjectIDExecution(t)
-		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName            = acc.RandomProjectName()
-		clusterName            = acc.RandomClusterName()
-		clusterResourceName    = "test"
-		clusterResource        = acc.ConfigClusterGlobal(orgID, projectName, clusterName)
-		clusterDataSource      = modeClusterData(clusterResourceName, resourceSuffix, endpointResourceSuffix)
-		endpointResources      = testConfigUnmanagedAWS(
+		endpointResourceSuffix                 = "atlasple"
+		resourceSuffix                         = "atlasrm"
+		resourceName                           = fmt.Sprintf("mongodbatlas_private_endpoint_regional_mode.%s", resourceSuffix)
+		awsAccessKey                           = os.Getenv("AWS_ACCESS_KEY_ID")
+		awsSecretKey                           = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		providerName                           = "AWS"
+		region                                 = os.Getenv("AWS_REGION")
+		privatelinkEndpointServiceResourceName = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", endpointResourceSuffix)
+		clusterDependsOn                       = fmt.Sprintf("%s, %s", resourceName, privatelinkEndpointServiceResourceName)
+		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_EAST_1", ProviderName: providerName})
+		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName})
+		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn}, spec1, spec2)
+		clusterName                            = clusterInfo.ClusterName
+		projectID                              = clusterInfo.ProjectID
+		clusterResourceName                    = clusterInfo.ClusterNameStr
+		endpointResources                      = testConfigUnmanagedAWS(
 			awsAccessKey, awsSecretKey, projectID, providerName, region, endpointResourceSuffix,
 		)
-		dependencies = []string{clusterResource, clusterDataSource, endpointResources}
+		dependencies = []string{clusterInfo.ClusterTerraformStr, endpointResources}
 	)
 
+	configBefore := configWithDependencies(resourceSuffix, projectID, false, dependencies)
+	configAfter := configWithDependencies(resourceSuffix, projectID, true, dependencies)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithDependencies(resourceSuffix, projectID, false, dependencies),
+				Config: configBefore,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					checkModeClustersUpToDate(projectID, clusterName, clusterResourceName),
@@ -57,7 +61,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithDependencies(resourceSuffix, projectID, true, dependencies),
+				Config: configAfter,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					checkModeClustersUpToDate(projectID, clusterName, clusterResourceName),
@@ -109,19 +113,6 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			},
 		},
 	}
-}
-
-func modeClusterData(clusterResourceName, regionalModeResourceName, privateLinkResourceName string) string {
-	return fmt.Sprintf(`
-		data "mongodbatlas_cluster" %[1]q {
-			project_id = mongodbatlas_cluster.%[1]s.project_id
-			name       = mongodbatlas_cluster.%[1]s.name
-			depends_on = [
-				mongodbatlas_privatelink_endpoint_service.%[3]s,
-				mongodbatlas_private_endpoint_regional_mode.%[2]s
-			]
-		}
-	`, clusterResourceName, regionalModeResourceName, privateLinkResourceName)
 }
 
 func configWithDependencies(resourceName, projectID string, enabled bool, dependencies []string) string {
@@ -180,9 +171,8 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 }
 
 func checkModeClustersUpToDate(projectID, clusterName, clusterResourceName string) resource.TestCheckFunc {
-	resourceName := strings.Join([]string{"data", "mongodbatlas_cluster", clusterResourceName}, ".")
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[clusterResourceName]
 		if !ok {
 			return fmt.Errorf("Could not find resource state for cluster (%s) on project (%s)", clusterName, projectID)
 		}
@@ -221,14 +211,14 @@ func checkDestroy(s *terraform.State) error {
 func testConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, serviceResourceName string) string {
 	return fmt.Sprintf(`
 		provider "aws" {
-			region     = "%[5]s"
-			access_key = "%[1]s"
-			secret_key = "%[2]s"
+			region     = %[5]q
+			access_key = %[1]q
+			secret_key = %[2]q
 		}
 		resource "mongodbatlas_privatelink_endpoint" "test" {
-			project_id    = "%[3]s"
-			provider_name = "%[4]s"
-			region        = "%[5]s"
+			project_id    = %[3]q
+			provider_name = %[4]q
+			region        = %[5]q
 		}
 		resource "aws_vpc_endpoint" "ptfe_service" {
 			vpc_id             = aws_vpc.primary.id

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
@@ -19,6 +18,7 @@ func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
 }
 
 func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
+	acc.SkipTestForCI(t) // slow test ~90min vs ~15min of the 2nd slowest test in the network group
 	var (
 		endpointResourceSuffix                 = "atlasple"
 		resourceSuffix                         = "atlasrm"
@@ -29,9 +29,9 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		region                                 = os.Getenv("AWS_REGION_LOWERCASE")
 		privatelinkEndpointServiceResourceName = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", endpointResourceSuffix)
 		clusterDependsOn                       = fmt.Sprintf("%s, %s", resourceName, privatelinkEndpointServiceResourceName)
-		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1"})
-		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"})
-		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn, ReplicationSpecs: []admin.ReplicationSpec{spec1, spec2}})
+		spec1                                  = acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1"}
+		spec2                                  = acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"}
+		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn, ReplicationSpecs: []acc.ReplicationSpecRequest{spec1, spec2}})
 		clusterName                            = clusterInfo.ClusterName
 		projectID                              = clusterInfo.ProjectID
 		clusterResourceName                    = clusterInfo.ClusterResourceName

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -25,10 +25,10 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		awsAccessKey                           = os.Getenv("AWS_ACCESS_KEY_ID")
 		awsSecretKey                           = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		providerName                           = "AWS"
-		region                                 = os.Getenv("AWS_REGION")
+		region                                 = os.Getenv("AWS_REGION_LOWERCASE")
 		privatelinkEndpointServiceResourceName = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", endpointResourceSuffix)
 		clusterDependsOn                       = fmt.Sprintf("%s, %s", resourceName, privatelinkEndpointServiceResourceName)
-		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_EAST_1", ProviderName: providerName, ZoneName: "Zone 1"})
+		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1"})
 		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"})
 		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn}, spec1, spec2)
 		clusterName                            = clusterInfo.ClusterName
@@ -43,7 +43,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 	configBefore := configWithDependencies(resourceSuffix, projectID, false, dependencies)
 	configAfter := configWithDependencies(resourceSuffix, projectID, true, dependencies)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t) },
+		PreCheck:                 func() { acc.PreCheckAwsEnv(t); acc.PreCheckAwsRegionCases(t) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -17,7 +17,6 @@ func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
 }
 
 func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
-	acc.SkipTestForCI(t) // slow test ~90min vs ~15min of the 2nd slowest test in the network group
 	var (
 		endpointResourceSuffix                 = "atlasple"
 		resourceSuffix                         = "atlasrm"

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -42,7 +42,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAwsEnv(t); acc.PreCheckAwsRegionCases(t) },
+		PreCheck:                 func() { acc.PreCheckAwsEnvBasic(t); acc.PreCheckAwsRegionCases(t) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
@@ -30,7 +31,7 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		clusterDependsOn                       = fmt.Sprintf("%s, %s", resourceName, privatelinkEndpointServiceResourceName)
 		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1"})
 		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"})
-		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn}, spec1, spec2)
+		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn, ReplicationSpecs: []admin.ReplicationSpec{spec1, spec2}})
 		clusterName                            = clusterInfo.ClusterName
 		projectID                              = clusterInfo.ProjectID
 		clusterResourceName                    = clusterInfo.ClusterResourceName

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -18,8 +18,6 @@ func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
 }
 
 func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
-	acc.SkipTestForCI(t) // needs AWS configuration
-
 	var (
 		endpointResourceSuffix                 = "atlasple"
 		resourceSuffix                         = "atlasrm"
@@ -30,8 +28,8 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		region                                 = os.Getenv("AWS_REGION")
 		privatelinkEndpointServiceResourceName = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", endpointResourceSuffix)
 		clusterDependsOn                       = fmt.Sprintf("%s, %s", resourceName, privatelinkEndpointServiceResourceName)
-		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_EAST_1", ProviderName: providerName})
-		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName})
+		spec1                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_EAST_1", ProviderName: providerName, ZoneName: "Zone 1"})
+		spec2                                  = acc.ReplicationSpec(&acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"})
 		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ResourceDependencyName: clusterDependsOn}, spec1, spec2)
 		clusterName                            = clusterInfo.ClusterName
 		projectID                              = clusterInfo.ProjectID

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -180,6 +180,14 @@ func PreCheckAwsEnv(tb testing.TB) {
 	}
 }
 
+func PreCheckAwsRegionCases(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("AWS_REGION_UPPERCASE") == "" ||
+		os.Getenv("AWS_REGION_LOWERCASE") == "" {
+		tb.Fatal("`AWS_REGION_UPPERCASE`, `AWS_REGION_LOWERCASE` must be set for acceptance testing")
+	}
+}
+
 func PreCheckAwsEnvPrivateLinkEndpointService(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||


### PR DESCRIPTION
## Description

- Refactors mongodbatlas_private_endpoint_regional_mode tests to use cluster info
- Enables the TestAccPrivateEndpointRegionalMode_conn test in CI

Link to any related issue(s): CLOUDP-260920

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
