### PR TITLE
feat: Support `disk_size_gb` at region config level while also preserving backwards compatibility with root level value

### DIFF
--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -304,7 +304,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		clusterID = clusterDescLatest.GetId()
 
 		// root disk_size_gb defined for backwards compatibility avoiding breaking changes
-		if err := d.Set("disk_size_gb", getDiskSizeGBFromReplicationSpec(clusterDescLatest)); err != nil {
+		if err := d.Set("disk_size_gb", GetDiskSizeGBFromReplicationSpec(clusterDescLatest)); err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
 		}
 

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -303,6 +303,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 		clusterID = clusterDescLatest.GetId()
 
+		// root disk_size_gb defined for backwards compatibility avoiding breaking changes
+		if err := d.Set("disk_size_gb", getDiskSizeGBFromReplicationSpec(clusterDescLatest)); err != nil {
+			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
+		}
+
 		replicationSpecs, err = flattenAdvancedReplicationSpecsDS(ctx, clusterDescLatest.GetReplicationSpecs(), d, connV2)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -280,7 +280,7 @@ func IsSharedTier(instanceSize string) bool {
 
 // GetDiskSizeGBFromReplicationSpec obtains the diskSizeGB value by looking into the electable spec of the first replication spec.
 // Independent storage size scaling is not supported (CLOUDP-201331), meaning all electable/analytics/readOnly configs in all replication specs are the same.
-func GetDiskSizeGBFromReplicationSpec(cluster *admin.ClusterDescription20240710) float64 {
+func GetDiskSizeGBFromReplicationSpec(cluster *admin.ClusterDescription20250101) float64 {
 	specs := cluster.GetReplicationSpecs()
 	if len(specs) < 1 {
 		return 0

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -958,7 +958,7 @@ func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *f
 
 	apiObject.DiskSizeGB = rootDiskSizeGB
 	// disk size gb defined in inner level will take precedence over root level.
-	if v, ok := tfMap["disk_size_gb"]; ok {
+	if v, ok := tfMap["disk_size_gb"]; ok && v.(float64) != 0 {
 		apiObject.DiskSizeGB = conversion.Pointer(v.(float64))
 	}
 

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -278,9 +278,9 @@ func IsSharedTier(instanceSize string) bool {
 	return instanceSize == "M0" || instanceSize == "M2" || instanceSize == "M5"
 }
 
-// getDiskSizeGBFromReplicationSpec obtains the diskSizeGB value by looking into the electable spec of the first replication spec.
-// Independent storage size scaling is not supported (CLOUDP-201331), meaning all electable/analytics/read only configs in all replication specs are the same.
-func getDiskSizeGBFromReplicationSpec(cluster *admin.ClusterDescription20240710) float64 {
+// GetDiskSizeGBFromReplicationSpec obtains the diskSizeGB value by looking into the electable spec of the first replication spec.
+// Independent storage size scaling is not supported (CLOUDP-201331), meaning all electable/analytics/readOnly configs in all replication specs are the same.
+func GetDiskSizeGBFromReplicationSpec(cluster *admin.ClusterDescription20240710) float64 {
 	specs := cluster.GetReplicationSpecs()
 	if len(specs) < 1 {
 		return 0

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -942,8 +942,11 @@ func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *f
 		apiObject.NodeCount = conversion.Pointer(v.(int))
 	}
 
-	// TODO: CLOUDP-258270 once disk_size_gb schema attribute is added at this level, we will check if defined in config and prioritize over value defined at root level (deprecated and to be removed)
 	apiObject.DiskSizeGB = rootDiskSizeGB
+	// disk size gb defined in inner level will take precedence over root level.
+	if v, ok := tfMap["disk_size_gb"]; ok {
+		apiObject.DiskSizeGB = conversion.Pointer(v.(float64))
+	}
 
 	return apiObject
 }

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -278,6 +278,20 @@ func IsSharedTier(instanceSize string) bool {
 	return instanceSize == "M0" || instanceSize == "M2" || instanceSize == "M5"
 }
 
+// getDiskSizeGBFromReplicationSpec obtains the diskSizeGB value by looking into the electable spec of the first replication spec.
+// Independent storage size scaling is not supported (CLOUDP-201331), meaning all electable/analytics/read only configs in all replication specs are the same.
+func getDiskSizeGBFromReplicationSpec(cluster *admin.ClusterDescription20240710) float64 {
+	specs := cluster.GetReplicationSpecs()
+	if len(specs) < 1 {
+		return 0
+	}
+	configs := specs[0].GetRegionConfigs()
+	if len(configs) < 1 {
+		return 0
+	}
+	return configs[0].ElectableSpecs.GetDiskSizeGB()
+}
+
 func UpgradeRefreshFunc(ctx context.Context, name, projectID string, client admin20231115.ClustersApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		cluster, resp, err := client.GetCluster(ctx, projectID, name).Execute()

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -153,16 +153,6 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 
 func TestGetDiskSizeGBFromReplicationSpec(t *testing.T) {
 	diskSizeGBValue := 40.0
-	hardwareSpec := admin.HardwareSpec20250101{
-		DiskSizeGB: admin.PtrFloat64(diskSizeGBValue),
-	}
-	regionConfig := []admin.CloudRegionConfig20250101{{
-		ElectableSpecs: &hardwareSpec,
-	}}
-	replicationSpecsWithValue := []admin.ReplicationSpec20250101{{RegionConfigs: &regionConfig}}
-
-	emptyRegionConfig := []admin.CloudRegionConfig20250101{{}}
-	replicationSpecsEmptyElectable := []admin.ReplicationSpec20250101{{RegionConfigs: &emptyRegionConfig}}
 
 	testCases := map[string]struct {
 		clusterDescription     admin.ClusterDescription20250101
@@ -170,13 +160,21 @@ func TestGetDiskSizeGBFromReplicationSpec(t *testing.T) {
 	}{
 		"cluster description with disk size gb value at electable spec": {
 			clusterDescription: admin.ClusterDescription20250101{
-				ReplicationSpecs: &replicationSpecsWithValue,
+				ReplicationSpecs: &[]admin.ReplicationSpec20250101{{
+					RegionConfigs: &[]admin.CloudRegionConfig20250101{{
+						ElectableSpecs: &admin.HardwareSpec20250101{
+							DiskSizeGB: admin.PtrFloat64(diskSizeGBValue),
+						},
+					}},
+				}},
 			},
 			expectedDiskSizeResult: diskSizeGBValue,
 		},
 		"cluster description with no electable spec": {
 			clusterDescription: admin.ClusterDescription20250101{
-				ReplicationSpecs: &replicationSpecsEmptyElectable,
+				ReplicationSpecs: &[]admin.ReplicationSpec20250101{
+					{RegionConfigs: &[]admin.CloudRegionConfig20250101{{}}},
+				},
 			},
 			expectedDiskSizeResult: 0,
 		},

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -3,6 +3,7 @@ package advancedcluster_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -187,7 +188,7 @@ func TestGetDiskSizeGBFromReplicationSpec(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			result := advancedcluster.GetDiskSizeGBFromReplicationSpec(&tc.clusterDescription)
-			assert.InEpsilon(t, tc.expectedDiskSizeResult, result, 0.001) // using InEpsilon as type is float64
+			assert.Equal(t, fmt.Sprintf("%.f", tc.expectedDiskSizeResult), fmt.Sprintf("%.f", result)) // formatting to string to avoid float comparison
 		})
 	}
 }

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -153,35 +153,35 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 
 func TestGetDiskSizeGBFromReplicationSpec(t *testing.T) {
 	diskSizeGBValue := 40.0
-	hardwareSpec := admin.HardwareSpec20240710{
+	hardwareSpec := admin.HardwareSpec20250101{
 		DiskSizeGB: admin.PtrFloat64(diskSizeGBValue),
 	}
-	regionConfig := []admin.CloudRegionConfig20240710{{
+	regionConfig := []admin.CloudRegionConfig20250101{{
 		ElectableSpecs: &hardwareSpec,
 	}}
-	replicationSpecsWithValue := []admin.ReplicationSpec20240710{{RegionConfigs: &regionConfig}}
+	replicationSpecsWithValue := []admin.ReplicationSpec20250101{{RegionConfigs: &regionConfig}}
 
-	emptyRegionConfig := []admin.CloudRegionConfig20240710{{}}
-	replicationSpecsEmptyElectable := []admin.ReplicationSpec20240710{{RegionConfigs: &emptyRegionConfig}}
+	emptyRegionConfig := []admin.CloudRegionConfig20250101{{}}
+	replicationSpecsEmptyElectable := []admin.ReplicationSpec20250101{{RegionConfigs: &emptyRegionConfig}}
 
 	testCases := map[string]struct {
-		clusterDescription     admin.ClusterDescription20240710
+		clusterDescription     admin.ClusterDescription20250101
 		expectedDiskSizeResult float64
 	}{
 		"cluster description with disk size gb value at electable spec": {
-			clusterDescription: admin.ClusterDescription20240710{
+			clusterDescription: admin.ClusterDescription20250101{
 				ReplicationSpecs: &replicationSpecsWithValue,
 			},
 			expectedDiskSizeResult: diskSizeGBValue,
 		},
 		"cluster description with no electable spec": {
-			clusterDescription: admin.ClusterDescription20240710{
+			clusterDescription: admin.ClusterDescription20250101{
 				ReplicationSpecs: &replicationSpecsEmptyElectable,
 			},
 			expectedDiskSizeResult: 0,
 		},
 		"cluster description with no replication spec": {
-			clusterDescription:     admin.ClusterDescription20240710{},
+			clusterDescription:     admin.ClusterDescription20250101{},
 			expectedDiskSizeResult: 0,
 		},
 	}

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -539,7 +539,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		}
 
 		// root disk_size_gb defined for backwards compatibility avoiding breaking changes
-		if err := d.Set("disk_size_gb", getDiskSizeGBFromReplicationSpec(cluster)); err != nil {
+		if err := d.Set("disk_size_gb", GetDiskSizeGBFromReplicationSpec(cluster)); err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
 		}
 

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -538,7 +538,10 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			return diag.FromErr(fmt.Errorf(errorRead, clusterName, err))
 		}
 
-		// TODO: CLOUDP-258270 set disk size gb at root level
+		// root disk_size_gb defined for backwards compatibility avoiding breaking changes
+		if err := d.Set("disk_size_gb", getDiskSizeGBFromReplicationSpec(cluster)); err != nil {
+			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
+		}
 
 		replicationSpecs, err = flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
 		if err != nil {

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -25,7 +25,7 @@ func TestMigAdvancedCluster_singleAWSProvider(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             checkSingleProvider(projectID, clusterName),
+				Check:             checkSingleProvider(projectID, clusterName, false),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -705,6 +705,7 @@ func configSingleProvider(projectID, name string) string {
 			name         = %[2]q
 			cluster_type = "REPLICASET"
 			retain_backups_enabled = "true"
+			disk_size_gb = 60
 
 			replication_specs {
 				region_configs {
@@ -734,8 +735,9 @@ func checkSingleProvider(projectID, name string) resource.TestCheckFunc {
 	return checkAggr(
 		[]string{"replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{
-			"project_id": projectID,
-			"name":       name},
+			"project_id":   projectID,
+			"disk_size_gb": "60",
+			"name":         name},
 		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
 		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
 		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)))
@@ -1210,6 +1212,7 @@ func configShardedNewSchema(orgID, projectName, name, instanceSizeSpec1, instanc
 						instance_size = %[4]q
 						disk_iops = %[6]d
 						node_count    = 3
+						disk_size_gb  = 60
 					}
 					analytics_specs {
 						instance_size = %[4]q
@@ -1227,6 +1230,7 @@ func configShardedNewSchema(orgID, projectName, name, instanceSizeSpec1, instanc
 						instance_size = %[5]q
 						disk_iops = %[7]d
 						node_count    = 3
+						disk_size_gb  = 60
 					}
 					analytics_specs {
 						instance_size = %[5]q
@@ -1255,6 +1259,10 @@ func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, 
 			"replication_specs.0.id": "",
 			"replication_specs.0.region_configs.0.electable_specs.0.instance_size": instanceSizeSpec1,
 			"replication_specs.1.region_configs.0.electable_specs.0.instance_size": instanceSizeSpec2,
+			"replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb":  "60",
+			"replication_specs.1.region_configs.0.electable_specs.0.disk_size_gb":  "60",
+			"replication_specs.0.region_configs.0.analytics_specs.0.disk_size_gb":  "60",
+			"replication_specs.0.region_configs.0.read_only_specs.0.disk_size_gb":  "60",
 			"replication_specs.0.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec1,
 			"replication_specs.1.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec2,
 		})

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1354,7 +1354,7 @@ func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, 
 			"replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb":  "60",
 			"replication_specs.1.region_configs.0.electable_specs.0.disk_size_gb":  "60",
 			"replication_specs.0.region_configs.0.analytics_specs.0.disk_size_gb":  "60",
-			"replication_specs.0.region_configs.0.read_only_specs.0.disk_size_gb":  "60",
+			"replication_specs.1.region_configs.0.analytics_specs.0.disk_size_gb":  "60",
 			"replication_specs.0.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec1,
 			"replication_specs.1.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec2,
 		})


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-258270

Includes changes so that `disk_size_gb` attribute is configurable and populated  in both the new location (withing `electableSpecs`/`anayticsSpecs`/`readOnlySpecs`) as well as the existing root location.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
