### PR TITLE
chore: Update dev preview to use latest version of cluster API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/zclconf/go-cty v1.14.4
 	go.mongodb.org/atlas v0.36.0
 	go.mongodb.org/atlas-sdk/v20231115014 v20231115014.0.0
-	go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240703083409-9e77f6cad45f
+	go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240710142852-8a1b5dd5d8f3
 	go.mongodb.org/realm v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.0 h1:D+e3bpRwa9WH3HHs8bLjOd
 go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.0/go.mod h1:seuG5HpfG20/8FhJGyWi4yL7hqAcmq7pf/G0gipNOyM=
 go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240703083409-9e77f6cad45f h1:p4oDdUBXj4hW/QUwQ6R3Uqx8tMJw1Z8g4b6/hfZBHfk=
 go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240703083409-9e77f6cad45f/go.mod h1:seuG5HpfG20/8FhJGyWi4yL7hqAcmq7pf/G0gipNOyM=
+go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240710142852-8a1b5dd5d8f3 h1:Y2OD2wNisDWY/am92KmGGftOZxLOXSzr9+WyACRQ1Zw=
+go.mongodb.org/atlas-sdk/v20240530002 v20240530002.0.1-0.20240710142852-8a1b5dd5d8f3/go.mod h1:seuG5HpfG20/8FhJGyWi4yL7hqAcmq7pf/G0gipNOyM=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -332,7 +332,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	return nil
 }
 
-func setRootFields(d *schema.ResourceData, cluster *admin.ClusterDescription20240710) diag.Diagnostics {
+func setRootFields(d *schema.ResourceData, cluster *admin.ClusterDescription20250101) diag.Diagnostics {
 	clusterName := *cluster.Name
 
 	if err := d.Set("backup_enabled", cluster.GetBackupEnabled()); err != nil {

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -458,14 +458,14 @@ func FlattenAdvancedReplicationSpecsOldSDK(ctx context.Context, apiObjects []adm
 		doesAdvancedReplicationSpecMatchAPIOldSDK, replicationSpecFlattener, connV2)
 }
 
-func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.ReplicationSpec20240710, tfMapObjects []any,
+func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.ReplicationSpec20250101, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
-	return flattenAdvancedReplicationSpecsLogic[admin.ReplicationSpec20240710](ctx, apiObjects, tfMapObjects, d,
+	return flattenAdvancedReplicationSpecsLogic[admin.ReplicationSpec20250101](ctx, apiObjects, tfMapObjects, d,
 		doesAdvancedReplicationSpecMatchAPI, flattenAdvancedReplicationSpec, connV2)
 }
 
 type ReplicationSpecSDKModel interface {
-	admin20231115.ReplicationSpec | admin.ReplicationSpec20240710
+	admin20231115.ReplicationSpec | admin.ReplicationSpec20250101
 }
 
 func flattenAdvancedReplicationSpecsLogic[T ReplicationSpecSDKModel](
@@ -533,7 +533,7 @@ func doesAdvancedReplicationSpecMatchAPIOldSDK(tfObject map[string]any, apiObjec
 	return tfObject["id"] == apiObject.GetId() || (tfObject["id"] == nil && tfObject["zone_name"] == apiObject.GetZoneName())
 }
 
-func doesAdvancedReplicationSpecMatchAPI(tfObject map[string]any, apiObject *admin.ReplicationSpec20240710) bool {
+func doesAdvancedReplicationSpecMatchAPI(tfObject map[string]any, apiObject *admin.ReplicationSpec20250101) bool {
 	return tfObject["external_id"] == apiObject.GetId()
 }
 
@@ -566,7 +566,7 @@ func flattenAdvancedReplicationSpecOldSDK(ctx context.Context, apiObject *admin2
 	return tfMap, nil
 }
 
-func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects []admin.CloudRegionConfig20240710, tfMapObjects []any,
+func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects []admin.CloudRegionConfig20250101, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (tfResult []map[string]any, containersIDs map[string]string, err error) {
 	if len(apiObjects) == 0 {
 		return nil, nil, nil
@@ -602,7 +602,7 @@ func flattenAdvancedReplicationSpecRegionConfigs(ctx context.Context, apiObjects
 	return tfList, containerIDs, nil
 }
 
-func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin.CloudRegionConfig20240710, tfMapObject map[string]any) map[string]any {
+func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin.CloudRegionConfig20250101, tfMapObject map[string]any) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -640,11 +640,11 @@ func flattenAdvancedReplicationSpecRegionConfig(apiObject *admin.CloudRegionConf
 	return tfMap
 }
 
-func hwSpecToDedicatedHwSpec(apiObject *admin.HardwareSpec20240710) *admin.DedicatedHardwareSpec20240710 {
+func hwSpecToDedicatedHwSpec(apiObject *admin.HardwareSpec20250101) *admin.DedicatedHardwareSpec20250101 {
 	if apiObject == nil {
 		return nil
 	}
-	return &admin.DedicatedHardwareSpec20240710{
+	return &admin.DedicatedHardwareSpec20250101{
 		NodeCount:     apiObject.NodeCount,
 		DiskIOPS:      apiObject.DiskIOPS,
 		EbsVolumeType: apiObject.EbsVolumeType,
@@ -653,11 +653,11 @@ func hwSpecToDedicatedHwSpec(apiObject *admin.HardwareSpec20240710) *admin.Dedic
 	}
 }
 
-func dedicatedHwSpecToHwSpec(apiObject *admin.DedicatedHardwareSpec20240710) *admin.HardwareSpec20240710 {
+func dedicatedHwSpecToHwSpec(apiObject *admin.DedicatedHardwareSpec20250101) *admin.HardwareSpec20250101 {
 	if apiObject == nil {
 		return nil
 	}
-	return &admin.HardwareSpec20240710{
+	return &admin.HardwareSpec20250101{
 		DiskSizeGB:    apiObject.DiskSizeGB,
 		NodeCount:     apiObject.NodeCount,
 		DiskIOPS:      apiObject.DiskIOPS,
@@ -666,7 +666,7 @@ func dedicatedHwSpecToHwSpec(apiObject *admin.DedicatedHardwareSpec20240710) *ad
 	}
 }
 
-func flattenAdvancedReplicationSpecRegionConfigSpec(apiObject *admin.DedicatedHardwareSpec20240710, providerName string, tfMapObjects []any) []map[string]any {
+func flattenAdvancedReplicationSpecRegionConfigSpec(apiObject *admin.DedicatedHardwareSpec20250101, providerName string, tfMapObjects []any) []map[string]any {
 	if apiObject == nil {
 		return nil
 	}
@@ -725,7 +725,7 @@ func flattenAdvancedReplicationSpecAutoScaling(apiObject *admin.AdvancedAutoScal
 	return tfList
 }
 
-func getAdvancedClusterContainerID(containers []admin.CloudProviderContainer, cluster *admin.CloudRegionConfig20240710) string {
+func getAdvancedClusterContainerID(containers []admin.CloudProviderContainer, cluster *admin.CloudRegionConfig20250101) string {
 	if len(containers) == 0 {
 		return ""
 	}
@@ -820,8 +820,8 @@ func expandLabelSliceFromSetSchema(d *schema.ResourceData) ([]admin.ComponentLab
 	return res, nil
 }
 
-func expandAdvancedReplicationSpecs(tfList []any, rootDiskSizeGB *float64) *[]admin.ReplicationSpec20240710 {
-	var apiObjects []admin.ReplicationSpec20240710
+func expandAdvancedReplicationSpecs(tfList []any, rootDiskSizeGB *float64) *[]admin.ReplicationSpec20250101 {
+	var apiObjects []admin.ReplicationSpec20250101
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok || tfMap == nil {
@@ -858,8 +858,8 @@ func expandAdvancedReplicationSpecsOldSDK(tfList []any) *[]admin20231115.Replica
 	return &apiObjects
 }
 
-func expandAdvancedReplicationSpec(tfMap map[string]any, rootDiskSizeGB *float64) *admin.ReplicationSpec20240710 {
-	apiObject := &admin.ReplicationSpec20240710{
+func expandAdvancedReplicationSpec(tfMap map[string]any, rootDiskSizeGB *float64) *admin.ReplicationSpec20250101 {
+	apiObject := &admin.ReplicationSpec20250101{
 		ZoneName:      conversion.StringPtr(tfMap["zone_name"].(string)),
 		RegionConfigs: expandRegionConfigs(tfMap["region_configs"].([]any), rootDiskSizeGB),
 	}
@@ -879,8 +879,8 @@ func expandAdvancedReplicationSpecOldSDK(tfMap map[string]any) *admin20231115.Re
 	return apiObject
 }
 
-func expandRegionConfigs(tfList []any, rootDiskSizeGB *float64) *[]admin.CloudRegionConfig20240710 {
-	var apiObjects []admin.CloudRegionConfig20240710
+func expandRegionConfigs(tfList []any, rootDiskSizeGB *float64) *[]admin.CloudRegionConfig20250101 {
+	var apiObjects []admin.CloudRegionConfig20250101
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok || tfMap == nil {
@@ -895,9 +895,9 @@ func expandRegionConfigs(tfList []any, rootDiskSizeGB *float64) *[]admin.CloudRe
 	return &apiObjects
 }
 
-func expandRegionConfig(tfMap map[string]any, rootDiskSizeGB *float64) *admin.CloudRegionConfig20240710 {
+func expandRegionConfig(tfMap map[string]any, rootDiskSizeGB *float64) *admin.CloudRegionConfig20250101 {
 	providerName := tfMap["provider_name"].(string)
-	apiObject := &admin.CloudRegionConfig20240710{
+	apiObject := &admin.CloudRegionConfig20250101{
 		Priority:     conversion.Pointer(cast.ToInt(tfMap["priority"])),
 		ProviderName: conversion.StringPtr(providerName),
 		RegionName:   conversion.StringPtr(tfMap["region_name"].(string)),
@@ -924,9 +924,9 @@ func expandRegionConfig(tfMap map[string]any, rootDiskSizeGB *float64) *admin.Cl
 	return apiObject
 }
 
-func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *float64) *admin.DedicatedHardwareSpec20240710 {
+func expandRegionConfigSpec(tfList []any, providerName string, rootDiskSizeGB *float64) *admin.DedicatedHardwareSpec20250101 {
 	tfMap, _ := tfList[0].(map[string]any)
-	apiObject := new(admin.DedicatedHardwareSpec20240710)
+	apiObject := new(admin.DedicatedHardwareSpec20250101)
 	if providerName == "AWS" {
 		if v, ok := tfMap["disk_iops"]; ok && v.(int) > 0 {
 			apiObject.DiskIOPS = conversion.Pointer(v.(int))
@@ -979,7 +979,7 @@ func expandRegionConfigAutoScaling(tfList []any) *admin.AdvancedAutoScalingSetti
 	return &settings
 }
 
-func flattenAdvancedReplicationSpecsDS(ctx context.Context, apiRepSpecs []admin.ReplicationSpec20240710, d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
+func flattenAdvancedReplicationSpecsDS(ctx context.Context, apiRepSpecs []admin.ReplicationSpec20250101, d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
 	if len(apiRepSpecs) == 0 {
 		return nil, nil
 	}
@@ -996,7 +996,7 @@ func flattenAdvancedReplicationSpecsDS(ctx context.Context, apiRepSpecs []admin.
 	return tfList, nil
 }
 
-func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.ReplicationSpec20240710, tfMapObject map[string]any,
+func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.ReplicationSpec20250101, tfMapObject map[string]any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
 	if apiObject == nil {
 		return nil, nil

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -25,7 +25,7 @@ var (
 	dummyClusterName = "clusterName"
 	dummyProjectID   = "projectId"
 	errGeneric       = errors.New("generic")
-	advancedClusters = []admin.ClusterDescription20240710{{StateName: conversion.StringPtr("NOT IDLE")}}
+	advancedClusters = []admin.ClusterDescription20250101{{StateName: conversion.StringPtr("NOT IDLE")}}
 )
 
 func TestFlattenReplicationSpecs(t *testing.T) {
@@ -252,7 +252,7 @@ func TestUpgradeRefreshFunc(t *testing.T) {
 
 func TestResourceListAdvancedRefreshFunc(t *testing.T) {
 	testCases := []struct {
-		mockCluster    *admin.PaginatedClusterDescription20240710
+		mockCluster    *admin.PaginatedClusterDescription20250101
 		mockResponse   *http.Response
 		expectedResult Result
 		mockError      error
@@ -314,7 +314,7 @@ func TestResourceListAdvancedRefreshFunc(t *testing.T) {
 		},
 		{
 			name:          "Successful but with at least one cluster not idle",
-			mockCluster:   &admin.PaginatedClusterDescription20240710{Results: &advancedClusters},
+			mockCluster:   &admin.PaginatedClusterDescription20250101{Results: &advancedClusters},
 			mockResponse:  &http.Response{StatusCode: 200},
 			expectedError: false,
 			expectedResult: Result{
@@ -325,11 +325,11 @@ func TestResourceListAdvancedRefreshFunc(t *testing.T) {
 		},
 		{
 			name:          "Successful",
-			mockCluster:   &admin.PaginatedClusterDescription20240710{},
+			mockCluster:   &admin.PaginatedClusterDescription20250101{},
 			mockResponse:  &http.Response{StatusCode: 200},
 			expectedError: false,
 			expectedResult: Result{
-				response: &admin.PaginatedClusterDescription20240710{},
+				response: &admin.PaginatedClusterDescription20250101{},
 				state:    "IDLE",
 				error:    nil,
 			},

--- a/internal/service/advancedcluster/model_sdk_version_conversion.go
+++ b/internal/service/advancedcluster/model_sdk_version_conversion.go
@@ -140,7 +140,7 @@ func convertLabelSliceToOldSDK(slice []admin.ComponentLabel, err diag.Diagnostic
 	return results, nil
 }
 
-func convertRegionConfigSliceToOldSDK(slice *[]admin.CloudRegionConfig20240710) *[]admin20231115.CloudRegionConfig {
+func convertRegionConfigSliceToOldSDK(slice *[]admin.CloudRegionConfig20250101) *[]admin20231115.CloudRegionConfig {
 	if slice == nil {
 		return nil
 	}
@@ -163,7 +163,7 @@ func convertRegionConfigSliceToOldSDK(slice *[]admin.CloudRegionConfig20240710) 
 	return &results
 }
 
-func convertHardwareSpecToOldSDK(hwspec *admin.HardwareSpec20240710) *admin20231115.HardwareSpec {
+func convertHardwareSpecToOldSDK(hwspec *admin.HardwareSpec20250101) *admin20231115.HardwareSpec {
 	if hwspec == nil {
 		return nil
 	}
@@ -206,7 +206,7 @@ func convertDiskGBAutoScalingToOldSDK(settings *admin.DiskGBAutoScaling) *admin2
 	}
 }
 
-func convertDedicatedHardwareSpecToOldSDK(spec *admin.DedicatedHardwareSpec20240710) *admin20231115.DedicatedHardwareSpec {
+func convertDedicatedHardwareSpecToOldSDK(spec *admin.DedicatedHardwareSpec20250101) *admin20231115.DedicatedHardwareSpec {
 	if spec == nil {
 		return nil
 	}
@@ -218,11 +218,11 @@ func convertDedicatedHardwareSpecToOldSDK(spec *admin.DedicatedHardwareSpec20240
 	}
 }
 
-func convertDedicatedHwSpecToLatest(spec *admin20231115.DedicatedHardwareSpec, rootDiskSizeGB float64) *admin.DedicatedHardwareSpec20240710 {
+func convertDedicatedHwSpecToLatest(spec *admin20231115.DedicatedHardwareSpec, rootDiskSizeGB float64) *admin.DedicatedHardwareSpec20250101 {
 	if spec == nil {
 		return nil
 	}
-	return &admin.DedicatedHardwareSpec20240710{
+	return &admin.DedicatedHardwareSpec20250101{
 		NodeCount:     spec.NodeCount,
 		DiskIOPS:      spec.DiskIOPS,
 		EbsVolumeType: spec.EbsVolumeType,
@@ -262,11 +262,11 @@ func convertDiskGBAutoScalingToLatest(settings *admin20231115.DiskGBAutoScaling)
 	}
 }
 
-func convertHardwareSpecToLatest(hwspec *admin20231115.HardwareSpec, rootDiskSizeGB float64) *admin.HardwareSpec20240710 {
+func convertHardwareSpecToLatest(hwspec *admin20231115.HardwareSpec, rootDiskSizeGB float64) *admin.HardwareSpec20250101 {
 	if hwspec == nil {
 		return nil
 	}
-	return &admin.HardwareSpec20240710{
+	return &admin.HardwareSpec20250101{
 		DiskIOPS:      hwspec.DiskIOPS,
 		EbsVolumeType: hwspec.EbsVolumeType,
 		InstanceSize:  hwspec.InstanceSize,
@@ -275,15 +275,15 @@ func convertHardwareSpecToLatest(hwspec *admin20231115.HardwareSpec, rootDiskSiz
 	}
 }
 
-func convertRegionConfigSliceToLatest(slice *[]admin20231115.CloudRegionConfig, rootDiskSizeGB float64) *[]admin.CloudRegionConfig20240710 {
+func convertRegionConfigSliceToLatest(slice *[]admin20231115.CloudRegionConfig, rootDiskSizeGB float64) *[]admin.CloudRegionConfig20250101 {
 	if slice == nil {
 		return nil
 	}
 	cloudRegionSlice := *slice
-	results := make([]admin.CloudRegionConfig20240710, len(cloudRegionSlice))
+	results := make([]admin.CloudRegionConfig20250101, len(cloudRegionSlice))
 	for i := range len(cloudRegionSlice) {
 		cloudRegion := cloudRegionSlice[i]
-		results[i] = admin.CloudRegionConfig20240710{
+		results[i] = admin.CloudRegionConfig20250101{
 			ElectableSpecs:       convertHardwareSpecToLatest(cloudRegion.ElectableSpecs, rootDiskSizeGB),
 			Priority:             cloudRegion.Priority,
 			ProviderName:         cloudRegion.ProviderName,
@@ -298,8 +298,8 @@ func convertRegionConfigSliceToLatest(slice *[]admin20231115.CloudRegionConfig, 
 	return &results
 }
 
-func convertClusterDescToLatestExcludeRepSpecs(oldClusterDesc *admin20231115.AdvancedClusterDescription) *admin.ClusterDescription20240710 {
-	return &admin.ClusterDescription20240710{
+func convertClusterDescToLatestExcludeRepSpecs(oldClusterDesc *admin20231115.AdvancedClusterDescription) *admin.ClusterDescription20250101 {
+	return &admin.ClusterDescription20250101{
 		BackupEnabled: oldClusterDesc.BackupEnabled,
 		AcceptDataRisksAndForceReplicaSetReconfig: oldClusterDesc.AcceptDataRisksAndForceReplicaSetReconfig,
 		ClusterType:                      oldClusterDesc.ClusterType,

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -392,7 +392,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		rootDiskSizeGB = conversion.Pointer(v.(float64))
 	}
 
-	params := &admin.ClusterDescription20240710{
+	params := &admin.ClusterDescription20250101{
 		Name:             conversion.StringPtr(cast.ToString(d.Get("name"))),
 		ClusterType:      conversion.StringPtr(cast.ToString(d.Get("cluster_type"))),
 		ReplicationSpecs: expandAdvancedReplicationSpecs(d.Get("replication_specs").([]any), rootDiskSizeGB),
@@ -505,7 +505,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	var clusterResp *admin.ClusterDescription20240710
+	var clusterResp *admin.ClusterDescription20250101
 
 	var replicationSpecs []map[string]any
 	if isUsingOldAPISchemaStructure(d) {
@@ -570,7 +570,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 // TODO: CLOUDP-259838 this can likely be unified with data source function setRootFields
-func setResourceRootFields(d *schema.ResourceData, cluster *admin.ClusterDescription20240710) diag.Diagnostics {
+func setResourceRootFields(d *schema.ResourceData, cluster *admin.ClusterDescription20250101) diag.Diagnostics {
 	clusterName := *cluster.Name
 
 	if err := d.Set("cluster_id", cluster.GetId()); err != nil {

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -246,12 +246,12 @@ func DataSource() *schema.Resource {
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV220231115 := meta.(*config.MongoDBClient).AtlasV220231115
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	backupPolicy, _, err := connV2.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
+	backupPolicy, _, err := connV220231115.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return diag.Errorf(cluster.ErrorSnapshotBackupPolicyRead, clusterName, err)
 	}

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
-	"go.mongodb.org/atlas-sdk/v20240530002/admin"
+	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
 )
 
 func TestMigBackupRSCloudBackupSchedule_basic(t *testing.T) {
 	var (
 		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true})
 		useYearly   = mig.IsProviderVersionAtLeast("1.16.0") // attribute introduced in this version
-		config      = configNewPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+		config      = configNewPolicies(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 			ReferenceHourOfDay:    conversion.Pointer(0),
 			ReferenceMinuteOfHour: conversion.Pointer(0),
 			RestoreWindowDays:     conversion.Pointer(7),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	"go.mongodb.org/atlas-sdk/v20240530002/admin"
+	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
 )
 
 var (
@@ -29,7 +29,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configNoPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configNoPolicies(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
@@ -57,7 +57,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: configNewPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configNewPolicies(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(0),
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
@@ -100,7 +100,7 @@ func TestAccBackupRSCloudBackupSchedule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: configAdvancedPolicies(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configAdvancedPolicies(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(0),
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
@@ -192,7 +192,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configDefault(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configDefault(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
@@ -226,7 +226,7 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 				),
 			},
 			{
-				Config: configOnePolicy(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configOnePolicy(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(0),
 					ReferenceMinuteOfHour: conversion.Pointer(0),
 					RestoreWindowDays:     conversion.Pointer(7),
@@ -300,7 +300,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configCopySettings(projectID, clusterName, false, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(projectID, clusterName, false, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
@@ -308,7 +308,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(checksCreate...),
 			},
 			{
-				Config: configCopySettings(projectID, clusterName, true, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(projectID, clusterName, true, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
@@ -329,7 +329,7 @@ func TestAccBackupRSCloudBackupScheduleImport_basic(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configDefault(&clusterInfo, &admin.DiskBackupSnapshotSchedule{
+				Config: configDefault(&clusterInfo, &admin20231115.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(4),
@@ -383,7 +383,7 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configAzure(&clusterInfo, &admin.DiskBackupApiPolicyItem{
+				Config: configAzure(&clusterInfo, &admin20231115.DiskBackupApiPolicyItem{
 					FrequencyInterval: 1,
 					RetentionUnit:     "days",
 					RetentionValue:    1,
@@ -396,7 +396,7 @@ func TestAccBackupRSCloudBackupSchedule_azure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_item_hourly.0.retention_value", "1")),
 			},
 			{
-				Config: configAzure(&clusterInfo, &admin.DiskBackupApiPolicyItem{
+				Config: configAzure(&clusterInfo, &admin20231115.DiskBackupApiPolicyItem{
 					FrequencyInterval: 2,
 					RetentionUnit:     "days",
 					RetentionValue:    3,
@@ -462,7 +462,7 @@ func checkDestroy(s *terraform.State) error {
 	return nil
 }
 
-func configNoPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {
+func configNoPolicies(info *acc.ClusterInfo, p *admin20231115.DiskBackupSnapshotSchedule) string {
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
@@ -480,7 +480,7 @@ func configNoPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {
+func configDefault(info *acc.ClusterInfo, p *admin20231115.DiskBackupSnapshotSchedule) string {
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
@@ -524,7 +524,7 @@ func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) s
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p *admin.DiskBackupSnapshotSchedule) string {
+func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p *admin20231115.DiskBackupSnapshotSchedule) string {
 	var copySettings string
 	if !emptyCopySettings {
 		copySettings = `
@@ -602,7 +602,7 @@ func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p
 	`, projectID, clusterName, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), copySettings)
 }
 
-func configOnePolicy(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {
+func configOnePolicy(info *acc.ClusterInfo, p *admin20231115.DiskBackupSnapshotSchedule) string {
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
@@ -621,7 +621,7 @@ func configOnePolicy(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule)
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configNewPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule, useYearly bool) string {
+func configNewPolicies(info *acc.ClusterInfo, p *admin20231115.DiskBackupSnapshotSchedule, useYearly bool) string {
 	var strYearly string
 	if useYearly {
 		strYearly = `
@@ -672,7 +672,7 @@ func configNewPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedul
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), strYearly)
 }
 
-func configAzure(info *acc.ClusterInfo, policy *admin.DiskBackupApiPolicyItem) string {
+func configAzure(info *acc.ClusterInfo, policy *admin20231115.DiskBackupApiPolicyItem) string {
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s
@@ -692,7 +692,7 @@ func configAzure(info *acc.ClusterInfo, policy *admin.DiskBackupApiPolicyItem) s
 	`, info.ClusterNameStr, info.ProjectIDStr, policy.GetFrequencyInterval(), policy.GetRetentionUnit(), policy.GetRetentionValue())
 }
 
-func configAdvancedPolicies(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {
+func configAdvancedPolicies(info *acc.ClusterInfo, p *admin20231115.DiskBackupSnapshotSchedule) string {
 	return info.ClusterTerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 			cluster_name     = %[1]s

--- a/internal/service/project/resource_project.go
+++ b/internal/service/project/resource_project.go
@@ -130,7 +130,7 @@ var TfLimitObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 
 // Resources that need to be cleaned up before a project can be deleted
 type AtlasProjectDependants struct {
-	AdvancedClusters *admin.PaginatedClusterDescription20240710
+	AdvancedClusters *admin.PaginatedClusterDescription20250101
 }
 
 func (r *projectRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -451,7 +451,7 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 		{
 			name: "Error not from the API",
 			mockResponses: AdvancedClusterDescriptionResponse{
-				AdvancedClusterDescription: &admin.PaginatedClusterDescription20240710{},
+				AdvancedClusterDescription: &admin.PaginatedClusterDescription20250101{},
 				Err:                        errors.New("Non-API error"),
 			},
 			expectedError: true,
@@ -459,7 +459,7 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 		{
 			name: "Error from the API",
 			mockResponses: AdvancedClusterDescriptionResponse{
-				AdvancedClusterDescription: &admin.PaginatedClusterDescription20240710{},
+				AdvancedClusterDescription: &admin.PaginatedClusterDescription20250101{},
 				Err:                        &admin.GenericOpenAPIError{},
 			},
 			expectedError: true,
@@ -467,9 +467,9 @@ func TestResourceProjectDependentsDeletingRefreshFunc(t *testing.T) {
 		{
 			name: "Successful API call",
 			mockResponses: AdvancedClusterDescriptionResponse{
-				AdvancedClusterDescription: &admin.PaginatedClusterDescription20240710{
+				AdvancedClusterDescription: &admin.PaginatedClusterDescription20250101{
 					TotalCount: conversion.IntPtr(2),
-					Results: &[]admin.ClusterDescription20240710{
+					Results: &[]admin.ClusterDescription20250101{
 						{StateName: conversion.StringPtr("IDLE")},
 						{StateName: conversion.StringPtr("DELETING")},
 					},
@@ -1259,7 +1259,7 @@ type DeleteProjectLimitResponse struct {
 	Err                error
 }
 type AdvancedClusterDescriptionResponse struct {
-	AdvancedClusterDescription *admin.PaginatedClusterDescription20240710
+	AdvancedClusterDescription *admin.PaginatedClusterDescription20250101
 	HTTPResponse               *http.Response
 	Err                        error
 }

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -57,19 +57,19 @@ func deleteCluster(projectID, name string) {
 	}
 }
 
-func clusterReq(name, projectID string) admin.ClusterDescription20240710 {
-	return admin.ClusterDescription20240710{
+func clusterReq(name, projectID string) admin.ClusterDescription20250101 {
+	return admin.ClusterDescription20250101{
 		Name:        admin.PtrString(name),
 		GroupId:     admin.PtrString(projectID),
 		ClusterType: admin.PtrString("REPLICASET"),
-		ReplicationSpecs: &[]admin.ReplicationSpec20240710{
+		ReplicationSpecs: &[]admin.ReplicationSpec20250101{
 			{
-				RegionConfigs: &[]admin.CloudRegionConfig20240710{
+				RegionConfigs: &[]admin.CloudRegionConfig20250101{
 					{
 						ProviderName: admin.PtrString(constant.AWS),
 						RegionName:   admin.PtrString(constant.UsWest2),
 						Priority:     admin.PtrInt(7),
-						ElectableSpecs: &admin.HardwareSpec20240710{
+						ElectableSpecs: &admin.HardwareSpec20250101{
 							InstanceSize: admin.PtrString(constant.M10),
 							NodeCount:    admin.PtrInt(3),
 						},


### PR DESCRIPTION
## Description

Update dev sdk preview to be able to consume latest cluster API version defined as `2025-01-01` (date is not accurate to when actual release will be).

This also adjusts cloud backup schedule to avoid use latest dev preview version as this contains breaking changes which we have to see how we will handle as part of CLOUDP-260714 when this new API is released.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
