### PR TITLE
test: Refactors resource tests to use GetClusterInfo `online_archive`

### DIFF
--- a/internal/service/onlinearchive/resource_online_archive_migration_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_migration_test.go
@@ -12,19 +12,12 @@ import (
 func TestMigBackupRSOnlineArchiveWithNoChangeBetweenVersions(t *testing.T) {
 	var (
 		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
-		clusterInfo               = acc.GetClusterInfo(t, &acc.ClusterRequest{
-			ReplicationSpecs: []acc.ReplicationSpecRequest{
-				{AutoScalingDiskGbEnabled: true},
-			},
-			Tags: map[string]string{
-				"ArchiveTest": "true", "Owner": "test",
-			},
-		})
-		clusterName          = clusterInfo.ClusterName
-		projectID            = clusterInfo.ProjectID
-		clusterTerraformStr  = clusterInfo.ClusterTerraformStr
-		clusterResourceName  = clusterInfo.ClusterResourceName
-		deleteExpirationDays = 0
+		clusterInfo               = acc.GetClusterInfo(t, &clusterRequest)
+		clusterName               = clusterInfo.ClusterName
+		projectID                 = clusterInfo.ProjectID
+		clusterTerraformStr       = clusterInfo.ClusterTerraformStr
+		clusterResourceName       = clusterInfo.ClusterResourceName
+		deleteExpirationDays      = 0
 	)
 	if mig.IsProviderVersionAtLeast("1.12.2") {
 		deleteExpirationDays = 7

--- a/internal/service/onlinearchive/resource_online_archive_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_test.go
@@ -4,29 +4,32 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"testing"
 	"time"
 
-	matlas "go.mongodb.org/atlas/mongodbatlas"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
 func TestAccBackupRSOnlineArchive(t *testing.T) {
 	var (
-		cluster                      matlas.Cluster
-		resourceName                 = "mongodbatlas_cluster.online_archive_test"
 		onlineArchiveResourceName    = "mongodbatlas_online_archive.users_archive"
 		onlineArchiveDataSourceName  = "data.mongodbatlas_online_archive.read_archive"
 		onlineArchivesDataSourceName = "data.mongodbatlas_online_archives.all"
-		orgID                        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName                  = acc.RandomProjectName()
-		clusterName                  = acc.RandomClusterName()
+		clusterInfo                  = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{AutoScalingDiskGbEnabled: true},
+			},
+			Tags: map[string]string{
+				"ArchiveTest": "true", "Owner": "test",
+			},
+		})
+		clusterName         = clusterInfo.ClusterName
+		projectID           = clusterInfo.ProjectID
+		clusterTerraformStr = clusterInfo.ClusterTerraformStr
+		clusterResourceName = clusterInfo.ClusterResourceName
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -35,15 +38,13 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				// We need this step to pupulate the cluster with Sample Data
-				// The online archive won't work if the cluster does not have data
-				Config: configFirstStep(orgID, projectName, clusterName),
+				Config: clusterTerraformStr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					populateWithSampleData(resourceName, &cluster),
+					populateWithSampleData(clusterResourceName, projectID, clusterName),
 				),
 			},
 			{
-				Config: configWithDailySchedule(orgID, projectName, clusterName, 1, 7),
+				Config: configWithDailySchedule(clusterTerraformStr, clusterResourceName, 1, 7),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -59,7 +60,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithDailySchedule(orgID, projectName, clusterName, 2, 8),
+				Config: configWithDailySchedule(clusterTerraformStr, clusterResourceName, 2, 8),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -75,7 +76,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName, 2),
+				Config: testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(clusterTerraformStr, clusterResourceName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -88,7 +89,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName, 2),
+				Config: testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(clusterTerraformStr, clusterResourceName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -101,7 +102,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithoutSchedule(orgID, projectName, clusterName),
+				Config: configWithoutSchedule(clusterTerraformStr, clusterResourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -110,7 +111,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithoutSchedule(orgID, projectName, clusterName),
+				Config: configWithoutSchedule(clusterTerraformStr, clusterResourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "partition_fields.0.field_name", "last_review"),
 				),
@@ -121,12 +122,19 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 
 func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 	var (
-		cluster                   matlas.Cluster
-		resourceName              = "mongodbatlas_cluster.online_archive_test"
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{AutoScalingDiskGbEnabled: true},
+			},
+			Tags: map[string]string{
+				"ArchiveTest": "true", "Owner": "test",
+			},
+		})
+		clusterResourceName       = clusterInfo.ClusterResourceName
+		clusterName               = clusterInfo.ClusterName
+		projectID                 = clusterInfo.ProjectID
 		onlineArchiveResourceName = "mongodbatlas_online_archive.users_archive"
-		orgID                     = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName               = acc.RandomProjectName()
-		clusterName               = acc.RandomClusterName()
+		clusterTerraformStr       = clusterInfo.ClusterTerraformStr
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -135,15 +143,13 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				// We need this step to pupulate the cluster with Sample Data
-				// The online archive won't work if the cluster does not have data
-				Config: configFirstStep(orgID, projectName, clusterName),
+				Config: clusterTerraformStr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					populateWithSampleData(resourceName, &cluster),
+					populateWithSampleData(clusterResourceName, projectID, clusterName),
 				),
 			},
 			{
-				Config: configWithoutSchedule(orgID, projectName, clusterName),
+				Config: configWithoutSchedule(clusterTerraformStr, clusterResourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -151,7 +157,7 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithDailySchedule(orgID, projectName, clusterName, 1, 1),
+				Config: configWithDailySchedule(clusterTerraformStr, clusterResourceName, 1, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -169,15 +175,22 @@ func TestAccBackupRSOnlineArchiveBasic(t *testing.T) {
 
 func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 	var (
-		cluster                     matlas.Cluster
-		resourceName                = "mongodbatlas_cluster.online_archive_test"
 		onlineArchiveResourceName   = "mongodbatlas_online_archive.users_archive"
 		onlineArchiveDataSourceName = "data.mongodbatlas_online_archive.read_archive"
-		orgID                       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName                 = acc.RandomProjectName()
-		clusterName                 = acc.RandomClusterName()
-		cloudProvider               = "AWS"
-		processRegion               = "US_EAST_1"
+		clusterInfo                 = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{AutoScalingDiskGbEnabled: true},
+			},
+			Tags: map[string]string{
+				"ArchiveTest": "true", "Owner": "test",
+			},
+		})
+		clusterResourceName = clusterInfo.ClusterResourceName
+		clusterName         = clusterInfo.ClusterName
+		projectID           = clusterInfo.ProjectID
+		clusterTerraformStr = clusterInfo.ClusterTerraformStr
+		cloudProvider       = "AWS"
+		processRegion       = "US_EAST_1"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -186,15 +199,13 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				// We need this step to pupulate the cluster with Sample Data
-				// The online archive won't work if the cluster does not have data
-				Config: configFirstStep(orgID, projectName, clusterName),
+				Config: clusterTerraformStr,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					populateWithSampleData(resourceName, &cluster),
+					populateWithSampleData(clusterResourceName, projectID, clusterName),
 				),
 			},
 			{
-				Config: configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider, processRegion),
+				Config: configWithDataProcessRegion(clusterTerraformStr, clusterResourceName, cloudProvider, processRegion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
@@ -203,11 +214,11 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 				),
 			},
 			{
-				Config:      configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider, "AP_SOUTH_1"),
+				Config:      configWithDataProcessRegion(clusterTerraformStr, clusterResourceName, cloudProvider, "AP_SOUTH_1"),
 				ExpectError: regexp.MustCompile("data_process_region can't be modified"),
 			},
 			{
-				Config: configWithoutSchedule(orgID, projectName, clusterName),
+				Config: configWithoutSchedule(clusterTerraformStr, clusterResourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.cloud_provider", cloudProvider),
 					resource.TestCheckResourceAttr(onlineArchiveResourceName, "data_process_region.0.region", processRegion),
@@ -219,10 +230,17 @@ func TestAccBackupRSOnlineArchiveWithProcessRegion(t *testing.T) {
 
 func TestAccBackupRSOnlineArchiveInvalidProcessRegion(t *testing.T) {
 	var (
-		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName   = acc.RandomProjectName()
-		clusterName   = acc.RandomClusterName()
-		cloudProvider = "AWS"
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{AutoScalingDiskGbEnabled: true},
+			},
+			Tags: map[string]string{
+				"ArchiveTest": "true", "Owner": "test",
+			},
+		})
+		clusterTerraformStr = clusterInfo.ClusterTerraformStr
+		cloudProvider       = "AWS"
+		clusterResourceName = clusterInfo.ClusterResourceName
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -231,14 +249,15 @@ func TestAccBackupRSOnlineArchiveInvalidProcessRegion(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider, "UNKNOWN"),
+				Config:      configWithDataProcessRegion(clusterTerraformStr, clusterResourceName, cloudProvider, "UNKNOWN"),
 				ExpectError: regexp.MustCompile("INVALID_ATTRIBUTE"),
 			},
 		},
 	})
 }
 
-func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resource.TestCheckFunc {
+// populateWithSampleData adds Sample Data to the cluster otherwise online archive won't work
+func populateWithSampleData(resourceName, projectID, clusterName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -247,18 +266,18 @@ func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resour
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-		ids := conversion.DecodeStateID(rs.Primary.ID)
-		log.Printf("[DEBUG] projectID: %s, name %s", ids["project_id"], ids["cluster_name"])
-		clusterResp, _, err := acc.Conn().Clusters.Get(context.Background(), ids["project_id"], ids["cluster_name"])
+		conn := acc.ConnV2()
+		ctx := context.Background()
+		_, _, err := conn.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
 		if err != nil {
-			return fmt.Errorf("cluster(%s:%s) does not exist %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
+			return fmt.Errorf("cluster(%s:%s) does not exist %s", projectID, clusterName, err)
 		}
-		*cluster = *clusterResp
-
-		job, _, err := acc.Conn().Clusters.LoadSampleDataset(context.Background(), ids["project_id"], ids["cluster_name"])
-
+		job, _, err := conn.ClustersApi.LoadSampleDataset(context.Background(), projectID, clusterName).Execute()
 		if err != nil {
-			return fmt.Errorf("cluster(%s:%s) loading sample data set error %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
+			return fmt.Errorf("cluster(%s:%s) loading sample data set error %s", projectID, clusterName, err)
+		}
+		if job == nil {
+			return fmt.Errorf("cluster(%s:%s) loading sample data set error, no job found", projectID, clusterName)
 		}
 		ticker := time.NewTicker(30 * time.Second)
 
@@ -268,26 +287,28 @@ func populateWithSampleData(resourceName string, cluster *matlas.Cluster) resour
 			case <-time.After(20 * time.Second):
 				log.Println("timeout elapsed ....")
 			case <-ticker.C:
-				job, _, err = acc.Conn().Clusters.GetSampleDatasetStatus(context.Background(), ids["project_id"], job.ID)
+				job, _, err = conn.ClustersApi.GetSampleDatasetLoadStatus(ctx, projectID, job.GetId()).Execute()
 				fmt.Println("querying for job ")
-				if job.State != "WORKING" {
+				if err != nil {
+					return fmt.Errorf("cluster(%s:%s) failed to query for job, %s", projectID, clusterName, err)
+				}
+				if job == nil {
+					return fmt.Errorf("cluster(%s:%s) failed to query for job, no job found", projectID, clusterName)
+				}
+				if job.GetState() != "WORKING" {
 					break JOB
 				}
 			}
 		}
 
-		if err != nil {
-			return fmt.Errorf("cluster(%s:%s) loading sample data set error %s", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
-		}
-
-		if job.State != "COMPLETED" {
-			return fmt.Errorf("cluster(%s:%s) working sample data set error %s", rs.Primary.Attributes["project_id"], job.ID, job.State)
+		if job.GetState() != "COMPLETED" {
+			return fmt.Errorf("cluster(%s:%s) working sample data set error %s", projectID, job.GetId(), job.GetState())
 		}
 		return nil
 	}
 }
 
-func configWithDailySchedule(orgID, projectName, clusterName string, startHour, deleteExpirationDays int) string {
+func configWithDailySchedule(clusterTerraformStr, clusterResourceName string, startHour, deleteExpirationDays int) string {
 	var dataExpirationRuleBlock string
 	if deleteExpirationDays > 0 {
 		dataExpirationRuleBlock = fmt.Sprintf(`
@@ -300,8 +321,8 @@ func configWithDailySchedule(orgID, projectName, clusterName string, startHour, 
 	return fmt.Sprintf(`
 	%[1]s
 	resource "mongodbatlas_online_archive" "users_archive" {
-		project_id = mongodbatlas_cluster.online_archive_test.project_id
-		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		project_id = %[4]s.project_id
+		cluster_name = %[4]s.name
 		coll_name = "listingsAndReviews"
 		collection_type = "STANDARD"
 		db_name = "sample_airbnb"
@@ -351,15 +372,15 @@ func configWithDailySchedule(orgID, projectName, clusterName string, startHour, 
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, configFirstStep(orgID, projectName, clusterName), startHour, dataExpirationRuleBlock)
+	`, clusterTerraformStr, startHour, dataExpirationRuleBlock, clusterResourceName)
 }
 
-func configWithoutSchedule(orgID, projectName, clusterName string) string {
+func configWithoutSchedule(clusterTerraformStr, clusterResourceName string) string {
 	return fmt.Sprintf(`
 	%s
 	resource "mongodbatlas_online_archive" "users_archive" {
-		project_id = mongodbatlas_cluster.online_archive_test.project_id
-		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		project_id = %[2]s.project_id
+		cluster_name = %[2]s.name
 		coll_name = "listingsAndReviews"
 		collection_type = "STANDARD"
 		db_name = "sample_airbnb"
@@ -399,15 +420,15 @@ func configWithoutSchedule(orgID, projectName, clusterName string) string {
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, configFirstStep(orgID, projectName, clusterName))
+	`, clusterTerraformStr, clusterResourceName)
 }
 
-func configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider, region string) string {
+func configWithDataProcessRegion(clusterTerraformStr, clusterResourceName, cloudProvider, region string) string {
 	return fmt.Sprintf(`
-	%s
+	%[1]s
 	resource "mongodbatlas_online_archive" "users_archive" {
-		project_id = mongodbatlas_cluster.online_archive_test.project_id
-		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		project_id = %[4]s.project_id
+		cluster_name = %[4]s.name
 		coll_name = "listingsAndReviews"
 		collection_type = "STANDARD"
 		db_name = "sample_airbnb"
@@ -452,58 +473,15 @@ func configWithDataProcessRegion(orgID, projectName, clusterName, cloudProvider,
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, configFirstStep(orgID, projectName, clusterName), cloudProvider, region)
+	`, clusterTerraformStr, cloudProvider, region, clusterResourceName)
 }
 
-func configFirstStep(orgID, projectName, clusterName string) string {
+func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(clusterTerraformStr, clusterResourceName string, startHour int) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_project" "cluster_project" {
-		name   = %[2]q
-		org_id = %[1]q
-	}
-	resource "mongodbatlas_cluster" "online_archive_test" {
-		project_id   = mongodbatlas_project.cluster_project.id
-		name         = %[3]q
-		disk_size_gb = 10
-
-		cluster_type = "REPLICASET"
-		replication_specs {
-		  num_shards = 1
-		  regions_config {
-			 region_name     = "US_EAST_1"
-			 electable_nodes = 3
-			 priority        = 7
-			 read_only_nodes = 0
-		   }
-		}
-
-		cloud_backup                 = false
-		auto_scaling_disk_gb_enabled = true
-
-		// Provider Settings "block"
-		provider_name               = "AWS"
-		provider_instance_size_name = "M10"
-
-		labels {
-			key   = "ArchiveTest"
-			value = "true"
-		}
-		labels {
-			key   = "Owner"
-			value = "test"
-		}
-	}
-
-	
-	`, orgID, projectName, clusterName)
-}
-
-func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, clusterName string, startHour int) string {
-	return fmt.Sprintf(`
-	%s
+	%[1]s
 	resource "mongodbatlas_online_archive" "users_archive" {
-		project_id = mongodbatlas_cluster.online_archive_test.project_id
-		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		project_id = %[3]s.project_id
+		cluster_name = %[3]s.name
 		coll_name = "listingsAndReviews"
 		collection_type = "STANDARD"
 		db_name = "sample_airbnb"
@@ -520,7 +498,7 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 			day_of_week = 1
 			end_hour = 1
 			end_minute = 1
-			start_hour = %d
+			start_hour = %[2]d
 			start_minute = 1
 		}
 
@@ -552,15 +530,15 @@ func testAccBackupRSOnlineArchiveConfigWithWeeklySchedule(orgID, projectName, cl
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, configFirstStep(orgID, projectName, clusterName), startHour)
+	`, clusterTerraformStr, startHour, clusterResourceName)
 }
 
-func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, clusterName string, startHour int) string {
+func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(clusterTerraformStr, clusterResourceName string, startHour int) string {
 	return fmt.Sprintf(`
-	%s
+	%[1]s
 	resource "mongodbatlas_online_archive" "users_archive" {
-		project_id = mongodbatlas_cluster.online_archive_test.project_id
-		cluster_name = mongodbatlas_cluster.online_archive_test.name
+		project_id = %[3]s.project_id
+		cluster_name = %[3]s.name
 		coll_name = "listingsAndReviews"
 		collection_type = "STANDARD"
 		db_name = "sample_airbnb"
@@ -577,7 +555,7 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 			day_of_month = 1
 			end_hour = 1
 			end_minute = 1
-			start_hour = %d
+			start_hour = %[2]d
 			start_minute = 1
 		}
 
@@ -611,5 +589,5 @@ func testAccBackupRSOnlineArchiveConfigWithMonthlySchedule(orgID, projectName, c
 		project_id =  mongodbatlas_online_archive.users_archive.project_id
 		cluster_name = mongodbatlas_online_archive.users_archive.cluster_name
 	}
-	`, configFirstStep(orgID, projectName, clusterName), startHour)
+	`, clusterTerraformStr, startHour, clusterResourceName)
 }

--- a/internal/service/onlinearchive/resource_online_archive_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_test.go
@@ -17,7 +17,7 @@ import (
 var (
 	clusterRequest = acc.ClusterRequest{
 		ReplicationSpecs: []acc.ReplicationSpecRequest{
-			// Must US_EAST_1 in dev for online_archive to work
+			// Must use US_EAST_1 in dev for online_archive to work
 			{AutoScalingDiskGbEnabled: true, Region: "US_EAST_1"},
 		},
 		Tags: map[string]string{

--- a/internal/service/onlinearchive/resource_online_archive_test.go
+++ b/internal/service/onlinearchive/resource_online_archive_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -38,12 +37,6 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 		clusterResourceName          = clusterInfo.ClusterResourceName
 	)
 
-	config1 := clusterTerraformStr
-	config2 := configWithDailySchedule(clusterTerraformStr, clusterResourceName, 1, 7)
-	config3 := configWithDailySchedule(clusterTerraformStr, clusterResourceName, 2, 8)
-	if config1 != config2 {
-		t.Fatal(strings.Join([]string{config1, "\n#CONFIG2\n", config2, "\n#CONFIG3\n", config3}, "\n"))
-	}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -56,7 +49,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: config2,
+				Config: configWithDailySchedule(clusterTerraformStr, clusterResourceName, 1, 7),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),
@@ -72,7 +65,7 @@ func TestAccBackupRSOnlineArchive(t *testing.T) {
 				),
 			},
 			{
-				Config: config3,
+				Config: configWithDailySchedule(clusterTerraformStr, clusterResourceName, 2, 8),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "state"),
 					resource.TestCheckResourceAttrSet(onlineArchiveResourceName, "archive_id"),

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -10,6 +10,7 @@ import (
 )
 
 type ClusterRequest struct {
+	Tags                   map[string]string
 	ResourceDependencyName string
 	ClusterNameExplicit    string
 	ReplicationSpecs       []ReplicationSpecRequest
@@ -69,12 +70,13 @@ func ExistingClusterUsed() bool {
 }
 
 type ReplicationSpecRequest struct {
-	ZoneName           string
-	Region             string
-	InstanceSize       string
-	ProviderName       string
-	ExtraRegionConfigs []ReplicationSpecRequest
-	NodeCount          int
+	ZoneName                 string
+	Region                   string
+	InstanceSize             string
+	ProviderName             string
+	ExtraRegionConfigs       []ReplicationSpecRequest
+	NodeCount                int
+	AutoScalingDiskGbEnabled bool
 }
 
 func (r *ReplicationSpecRequest) AddDefaults() {
@@ -125,6 +127,9 @@ func CloudRegionConfig(req ReplicationSpecRequest) admin.CloudRegionConfig {
 		ElectableSpecs: &admin.HardwareSpec{
 			InstanceSize: &req.InstanceSize,
 			NodeCount:    &req.NodeCount,
+		},
+		AutoScaling: &admin.AdvancedAutoScalingSettings{
+			DiskGB: &admin.DiskGBAutoScaling{Enabled: &req.AutoScalingDiskGbEnabled},
 		},
 	}
 }

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -117,7 +117,8 @@ func ClusterResourceHcl(projectID string, req *ClusterRequest) (configStr, clust
 		}
 	}
 	if len(req.Tags) > 0 {
-		for key, value := range req.Tags {
+		for _, key := range sortStringMapKeys(req.Tags) {
+			value := req.Tags[key]
 			tagBlock := cluster.AppendNewBlock("tags", nil).Body()
 			tagBlock.SetAttributeValue("key", cty.StringVal(key))
 			tagBlock.SetAttributeValue("value", cty.StringVal(value))

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -343,7 +343,7 @@ func Test_ClusterResourceHcl(t *testing.T) {
 	var (
 		clusterName = "my-name"
 		testCases   = map[string]struct {
-      expected string
+			expected string
 			req      acc.ClusterRequest
 		}{
 			"defaults": {

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -303,11 +303,47 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 }
 `
 
+var autoScalingDiskEnabled = `
+resource "mongodbatlas_advanced_cluster" "cluster_info" {
+  backup_enabled = false
+  cluster_type   = "REPLICASET"
+  name           = "my-name"
+  project_id     = "project"
+
+  replication_specs {
+    num_shards = 1
+    zone_name  = "Zone 1"
+
+    region_configs {
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_WEST_2"
+      auto_scaling {
+        disk_gb_enabled = true
+      }
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 3
+      }
+    }
+  }
+  tags {
+    key   = "ArchiveTest"
+    value = "true"
+  }
+  tags {
+    key   = "Owner"
+    value = "test"
+  }
+
+}
+`
+
 func Test_ClusterResourceHcl(t *testing.T) {
 	var (
 		clusterName = "my-name"
 		testCases   = map[string]struct {
-			expected string
+      expected string
 			req      acc.ClusterRequest
 		}{
 			"defaults": {
@@ -346,6 +382,14 @@ func Test_ClusterResourceHcl(t *testing.T) {
 					},
 				},
 				},
+			},
+			"autoScalingDiskEnabled": {
+				autoScalingDiskEnabled,
+				acc.ClusterRequest{ClusterNameExplicit: clusterName, Tags: map[string]string{
+					"ArchiveTest": "true", "Owner": "test",
+				}, ReplicationSpecs: []acc.ReplicationSpecRequest{
+					{AutoScalingDiskGbEnabled: true},
+				}},
 			},
 		}
 	)


### PR DESCRIPTION
## Description

Refactors resource tests to use GetClusterInfo `online_archive`

Link to any related issue(s): CLOUDP-261220

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
