### PR TITLE
test: Refactors resource tests to use GetClusterInfo `ldap_configuration`

### DIFF
--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -46,7 +46,7 @@ func TestAccLDAPConfiguration_withVerify_CACertificateComplete(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithVerify(clusterTerraformStr, projectID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
+				Config: configWithVerify(clusterTerraformStr, clusterInfo.ClusterResourceName, projectID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -162,7 +162,7 @@ func configBasic(projectID, hostname, username, password string, authEnabled boo
 	`, projectID, hostname, username, password, authEnabled, port)
 }
 
-func configWithVerify(clusterTerraformStr, projectID, clusterName, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
+func configWithVerify(clusterTerraformStr, clusterResourceName, projectID, clusterName, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
 	return fmt.Sprintf(`
 %[9]s
 
@@ -176,7 +176,7 @@ func configWithVerify(clusterTerraformStr, projectID, clusterName, hostname, use
 %[8]s
 			EOF
 			authz_query_template = "{USER}?memberOf?base"
-			depends_on = [mongodbatlas_cluster.test]
+			depends_on = [%[10]s]
 		}
 
 		resource "mongodbatlas_ldap_configuration" "test" {
@@ -196,5 +196,5 @@ func configWithVerify(clusterTerraformStr, projectID, clusterName, hostname, use
 				ldap_query = "DC=example,DC=com??sub?(userPrincipalName={0})"
 			}
 			depends_on = [mongodbatlas_ldap_verify.test]
-		}`, projectID, clusterName, hostname, username, password, port, authEnabled, caCertificate, clusterTerraformStr)
+		}`, projectID, clusterName, hostname, username, password, port, authEnabled, caCertificate, clusterTerraformStr, clusterResourceName)
 }

--- a/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration_test.go
@@ -37,7 +37,6 @@ func TestAccLDAPConfiguration_withVerify_CACertificateComplete(t *testing.T) {
 			},
 		})
 		projectID           = clusterInfo.ProjectID
-		clusterName         = clusterInfo.ClusterName
 		clusterTerraformStr = clusterInfo.ClusterTerraformStr
 	)
 
@@ -46,7 +45,7 @@ func TestAccLDAPConfiguration_withVerify_CACertificateComplete(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithVerify(clusterTerraformStr, clusterInfo.ClusterResourceName, projectID, clusterName, hostname, username, password, caCertificate, cast.ToInt(port), true),
+				Config: configWithVerify(clusterTerraformStr, clusterInfo.ClusterResourceName, projectID, hostname, username, password, caCertificate, cast.ToInt(port), true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -162,33 +161,33 @@ func configBasic(projectID, hostname, username, password string, authEnabled boo
 	`, projectID, hostname, username, password, authEnabled, port)
 }
 
-func configWithVerify(clusterTerraformStr, clusterResourceName, projectID, clusterName, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
+func configWithVerify(clusterTerraformStr, clusterResourceName, projectID, hostname, username, password, caCertificate string, port int, authEnabled bool) string {
 	return fmt.Sprintf(`
-%[9]s
+%[8]s
 
 		resource "mongodbatlas_ldap_verify" "test" {
-			project_id                  = %[1]q
-			hostname = %[3]q
-			bind_username                     = %[4]q
-			bind_password                     = %[5]q
-			port                     = %[6]d
+			project_id    = %[1]q
+			hostname      = %[2]q
+			bind_username = %[3]q
+			bind_password = %[4]q
+			port          = %[5]d
 			ca_certificate = <<-EOF
-%[8]s
+%[7]s
 			EOF
 			authz_query_template = "{USER}?memberOf?base"
-			depends_on = [%[10]s]
+			depends_on = [%[9]s]
 		}
 
 		resource "mongodbatlas_ldap_configuration" "test" {
-			project_id                  = %[1]q
-			authorization_enabled                = false
-			hostname = %[3]q
-			bind_username                     = %[4]q
-			bind_password                     = %[5]q
-			port                     = %[6]d
-			authentication_enabled                = %[7]t
+			project_id             = %[1]q
+			authorization_enabled  = false
+			hostname               = %[2]q
+			bind_username          = %[3]q
+			bind_password          = %[4]q
+			port                   = %[5]d
+			authentication_enabled = %[6]t
 			ca_certificate = <<-EOF
-%[8]s
+%[7]s
 			EOF
 			authz_query_template = "{USER}?memberOf?base"
 			user_to_dn_mapping{
@@ -196,5 +195,5 @@ func configWithVerify(clusterTerraformStr, clusterResourceName, projectID, clust
 				ldap_query = "DC=example,DC=com??sub?(userPrincipalName={0})"
 			}
 			depends_on = [mongodbatlas_ldap_verify.test]
-		}`, projectID, clusterName, hostname, username, password, port, authEnabled, caCertificate, clusterTerraformStr, clusterResourceName)
+		}`, projectID, hostname, username, password, port, authEnabled, caCertificate, clusterTerraformStr, clusterResourceName)
 }


### PR DESCRIPTION
## Description

Refactors resource tests to use GetClusterInfo `ldap_configuration`

Link to any related issue(s): CLOUDP-261433

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
