### PR TITLE
test: Refactors resource tests to use GetClusterInfo `federated_database_instance`

### DIFF
--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -113,16 +113,22 @@ func TestAccFederatedDatabaseInstance_s3bucket(t *testing.T) {
 
 func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 	var (
-		clusterRequest = acc.ClusterRequest{
-			ReplicationSpecs: []acc.ReplicationSpecRequest{
-				{Region: "EU_WEST_2"},
-			},
+		specs = []acc.ReplicationSpecRequest{
+			{Region: "EU_WEST_2"},
 		}
-		resourceName        = "mongodbatlas_federated_database_instance.test"
-		name                = acc.RandomName()
-		clusterInfo         = acc.GetClusterInfo(t, &clusterRequest)
-		projectID           = clusterInfo.ProjectID
-		cluster2Info        = acc.GetClusterInfoWithProject(t, &clusterRequest, projectID, "cluster2")
+		clusterRequest = acc.ClusterRequest{
+			ReplicationSpecs: specs,
+		}
+		resourceName    = "mongodbatlas_federated_database_instance.test"
+		name            = acc.RandomName()
+		clusterInfo     = acc.GetClusterInfo(t, &clusterRequest)
+		projectID       = clusterInfo.ProjectID
+		clusterRequest2 = acc.ClusterRequest{
+			ProjectID:        projectID,
+			ReplicationSpecs: specs,
+			ResourceSuffix:   "cluster2",
+		}
+		cluster2Info        = acc.GetClusterInfo(t, &clusterRequest2)
 		dependencyTerraform = fmt.Sprintf("%s\n%s", clusterInfo.ClusterTerraformStr, cluster2Info.ClusterTerraformStr)
 	)
 

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -28,6 +28,8 @@ type ClusterInfo struct {
 	ClusterTerraformStr string
 }
 
+const DefaultClusterResourceSuffix = "cluster_info"
+
 // GetClusterInfo is used to obtain a project and cluster configuration resource.
 // When `MONGODB_ATLAS_CLUSTER_NAME` and `MONGODB_ATLAS_PROJECT_ID` are defined, creation of resources is avoided. This is useful for local execution but not intended for CI executions.
 // Clusters will be created in project ProjectIDExecution.
@@ -48,11 +50,15 @@ func GetClusterInfo(tb testing.TB, req *ClusterRequest) ClusterInfo {
 		}
 	}
 	projectID = ProjectIDExecution(tb)
-	clusterTerraformStr, clusterName, err := ClusterResourceHcl(projectID, req)
+	return GetClusterInfoWithProject(tb, req, projectID, DefaultClusterResourceSuffix)
+}
+
+func GetClusterInfoWithProject(tb testing.TB, req *ClusterRequest, projectID, resourceSuffix string) ClusterInfo {
+	tb.Helper()
+	clusterTerraformStr, clusterName, clusterResourceName, err := ClusterResourceHcl(projectID, req, resourceSuffix)
 	if err != nil {
 		tb.Error(err)
 	}
-	clusterResourceName := "mongodbatlas_advanced_cluster.cluster_info"
 	return ClusterInfo{
 		ProjectIDStr:        fmt.Sprintf("%q", projectID),
 		ProjectID:           projectID,

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -348,32 +348,32 @@ func Test_ClusterResourceHcl(t *testing.T) {
 		}{
 			"defaults": {
 				standardClusterResource,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName},
+				acc.ClusterRequest{ClusterName: clusterName},
 			},
 			"dependsOn": {
 				dependsOnClusterResource,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, ResourceDependencyName: "mongodbatlas_project.project_execution"},
+				acc.ClusterRequest{ClusterName: clusterName, ResourceDependencyName: "mongodbatlas_project.project_execution"},
 			},
 			"dependsOnMulti": {
 				dependsOnMultiResource,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, ResourceDependencyName: "mongodbatlas_private_endpoint_regional_mode.atlasrm, mongodbatlas_privatelink_endpoint_service.atlasple"},
+				acc.ClusterRequest{ClusterName: clusterName, ResourceDependencyName: "mongodbatlas_private_endpoint_regional_mode.atlasrm, mongodbatlas_privatelink_endpoint_service.atlasple"},
 			},
 			"twoReplicationSpecs": {
 				twoReplicationSpecs,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, ReplicationSpecs: []acc.ReplicationSpecRequest{
+				acc.ClusterRequest{ClusterName: clusterName, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{Region: "US_WEST_1", ZoneName: "Zone 1"},
 					{Region: "EU_WEST_2", ZoneName: "Zone 2"},
 				}},
 			},
 			"overrideClusterResource": {
 				overrideClusterResource,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, Geosharded: true, CloudBackup: true, ReplicationSpecs: []acc.ReplicationSpecRequest{
+				acc.ClusterRequest{ClusterName: clusterName, Geosharded: true, CloudBackup: true, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{Region: "MY_REGION_1", ZoneName: "Zone X", InstanceSize: "M30", NodeCount: 30, ProviderName: constant.AZURE},
 				}},
 			},
 			"twoRegionConfigs": {
 				twoRegionConfigs,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, ReplicationSpecs: []acc.ReplicationSpecRequest{
+				acc.ClusterRequest{ClusterName: clusterName, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{
 						Region:             "US_WEST_1",
 						InstanceSize:       "M10",
@@ -395,7 +395,9 @@ func Test_ClusterResourceHcl(t *testing.T) {
 	)
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			config, actualClusterName, actualResourceName, err := acc.ClusterResourceHcl("project", &tc.req, acc.DefaultClusterResourceSuffix)
+			req := tc.req
+			req.ProjectID = "project"
+			config, actualClusterName, actualResourceName, err := acc.ClusterResourceHcl(&req)
 			require.NoError(t, err)
 			assert.Equal(t, "mongodbatlas_advanced_cluster.cluster_info", actualResourceName)
 			assert.Equal(t, clusterName, actualClusterName)

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -385,7 +385,7 @@ func Test_ClusterResourceHcl(t *testing.T) {
 			},
 			"autoScalingDiskEnabled": {
 				autoScalingDiskEnabled,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, Tags: map[string]string{
+				acc.ClusterRequest{ClusterName: clusterName, Tags: map[string]string{
 					"ArchiveTest": "true", "Owner": "test",
 				}, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{AutoScalingDiskGbEnabled: true},

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -395,8 +395,9 @@ func Test_ClusterResourceHcl(t *testing.T) {
 	)
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			config, actualClusterName, err := acc.ClusterResourceHcl("project", &tc.req)
+			config, actualClusterName, actualResourceName, err := acc.ClusterResourceHcl("project", &tc.req, acc.DefaultClusterResourceSuffix)
 			require.NoError(t, err)
+			assert.Equal(t, "mongodbatlas_advanced_cluster.cluster_info", actualResourceName)
 			assert.Equal(t, clusterName, actualClusterName)
 			assert.Equal(t, tc.expected, config)
 		})


### PR DESCRIPTION
## Description

- Adds support for `GetClusterInfoWithProject` needed to have multiple clusters
- Refactors resource tests to use GetClusterInfo `federated_database_instance`

Link to any related issue(s): CLOUDP-261434

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:
- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
