### PR TITLE
test: Refactors resource tests to use GetClusterInfo `cloud_backup_snapshot_restore_job`

### DIFF
--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job_test.go
@@ -152,11 +152,11 @@ func configBasic(terraformStr, clusterResourceName, description, retentionInDays
 	return fmt.Sprintf(`
 		%[1]s
 		resource "mongodbatlas_cloud_backup_snapshot" "test" {
-			project_id        = %[1]s.project_id
-			cluster_name      = %[1]s.name
+			project_id        = %[2]s.project_id
+			cluster_name      = %[2]s.name
 			description       = %[3]q
 			retention_in_days = %[4]q
-			depends_on = [%[1]s]
+			depends_on = [%[2]s]
 		}
 
 		resource "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {


### PR DESCRIPTION
## Description

Refactors resource tests to use GetClusterInfo `cloud_backup_snapshot_restore_job`

Link to any related issue(s): CLOUDP-261445

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
