### PR TITLE
test: Refactors resource tests to use GetClusterInfo `cloud_backup_schedule`

### DIFF
--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -259,9 +259,11 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 			},
 			PitEnabled: true, // you cannot copy oplogs when pit is not enabled
 		})
-		clusterName = clusterInfo.ClusterName
-		projectID   = clusterInfo.ProjectID
-		checkMap    = map[string]string{
+		clusterName         = clusterInfo.ClusterName
+		terraformStr        = clusterInfo.ClusterTerraformStr
+		clusterResourceName = clusterInfo.ClusterResourceName
+		projectID           = clusterInfo.ProjectID
+		checkMap            = map[string]string{
 			"cluster_name":                             clusterName,
 			"reference_hour_of_day":                    "3",
 			"reference_minute_of_hour":                 "45",
@@ -307,7 +309,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configCopySettings(clusterInfo.ClusterTerraformStr, projectID, clusterInfo.ClusterResourceName, false, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(terraformStr, projectID, clusterResourceName, false, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
@@ -315,7 +317,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(checksCreate...),
 			},
 			{
-				Config: configCopySettings(clusterInfo.ClusterTerraformStr, projectID, clusterInfo.ClusterResourceName, true, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(terraformStr, projectID, clusterResourceName, true, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -252,8 +252,15 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 
 func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			CloudBackup: true,
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{Region: "US_EAST_2"},
+			},
+			PitEnabled: true, // you cannot copy oplogs when pit is not enabled
+		})
+		clusterName = clusterInfo.ClusterName
+		projectID   = clusterInfo.ProjectID
 		checkMap    = map[string]string{
 			"cluster_name":                             clusterName,
 			"reference_hour_of_day":                    "3",
@@ -300,7 +307,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configCopySettings(projectID, clusterName, false, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(clusterInfo.ClusterTerraformStr, projectID, clusterInfo.ClusterResourceName, false, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
@@ -308,7 +315,7 @@ func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(checksCreate...),
 			},
 			{
-				Config: configCopySettings(projectID, clusterName, true, &admin.DiskBackupSnapshotSchedule{
+				Config: configCopySettings(clusterInfo.ClusterTerraformStr, projectID, clusterInfo.ClusterResourceName, true, &admin.DiskBackupSnapshotSchedule{
 					ReferenceHourOfDay:    conversion.Pointer(3),
 					ReferenceMinuteOfHour: conversion.Pointer(45),
 					RestoreWindowDays:     conversion.Pointer(1),
@@ -525,10 +532,10 @@ func configDefault(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) s
 	`, info.ClusterNameStr, info.ProjectIDStr, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays())
 }
 
-func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p *admin.DiskBackupSnapshotSchedule) string {
+func configCopySettings(terraformStr, projectID, clusterResourceName string, emptyCopySettings bool, p *admin.DiskBackupSnapshotSchedule) string {
 	var copySettings string
 	if !emptyCopySettings {
-		copySettings = `
+		copySettings = fmt.Sprintf(`
 			copy_settings {
 				cloud_provider = "AWS"
 				frequencies = ["HOURLY",
@@ -538,40 +545,19 @@ func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p
 							"YEARLY",
 							"ON_DEMAND"]
 				region_name = "US_EAST_1"
-				replication_spec_id = mongodbatlas_cluster.my_cluster.replication_specs.*.id[0]
+				replication_spec_id = %[1]s.replication_specs.*.id[0]
 				should_copy_oplogs = true
-			}`
+			}`, clusterResourceName)
 	}
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "my_cluster" {
-			project_id   = %[1]q
-			name         = %[2]q
-			
-			cluster_type = "REPLICASET"
-						replication_specs {
-						num_shards = 1
-						regions_config {
-							region_name     = "US_EAST_2"
-							electable_nodes = 3
-							priority        = 7
-							read_only_nodes = 0
-							}
-						}
-			// Provider Settings "block"
-			provider_name               = "AWS"
-			provider_region_name        = "US_EAST_2"
-			provider_instance_size_name = "M10"
-			cloud_backup     = true //enable cloud provider snapshots
-			pit_enabled = true // enable point in time restore. you cannot copy oplogs when pit is not enabled.
-		}
-		
+		%[1]s
 		resource "mongodbatlas_cloud_backup_schedule" "schedule_test" {
-			project_id   = %[1]q
-			cluster_name     = %[2]q
+			project_id       = %[2]q
+			cluster_name     = %[3]s.name
 
-			reference_hour_of_day    = %[3]d
-			reference_minute_of_hour = %[4]d
-			restore_window_days      = %[5]d
+			reference_hour_of_day    = %[4]d
+			reference_minute_of_hour = %[5]d
+			restore_window_days      = %[6]d
 
 			policy_item_hourly {
 				frequency_interval = 1
@@ -598,9 +584,9 @@ func configCopySettings(projectID, clusterName string, emptyCopySettings bool, p
 				retention_unit     = "years"
 				retention_value    = 1
 			}
-			%s
+			%[7]s
 		}
-	`, projectID, clusterName, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), copySettings)
+	`, terraformStr, projectID, clusterResourceName, p.GetReferenceHourOfDay(), p.GetReferenceMinuteOfHour(), p.GetRestoreWindowDays(), copySettings)
 }
 
 func configOnePolicy(info *acc.ClusterInfo, p *admin.DiskBackupSnapshotSchedule) string {

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -17,6 +17,7 @@ type ClusterRequest struct {
 	DiskSizeGb             int
 	CloudBackup            bool
 	Geosharded             bool
+	PitEnabled             bool
 }
 
 type ClusterInfo struct {

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -104,6 +104,7 @@ func ClusterResourceHcl(projectID string, req *ClusterRequest) (configStr, clust
 		"cluster_type":   clusterTypeStr,
 		"name":           clusterName,
 		"backup_enabled": req.CloudBackup,
+		"pit_enabled":    req.PitEnabled,
 	}
 	if req.DiskSizeGb != 0 {
 		clusterRootAttributes["disk_size_gb"] = req.DiskSizeGb

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -314,6 +314,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -112,6 +112,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {
@@ -139,6 +140,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = true
   cluster_type   = "GEOSHARDED"
   name           = "my-name"
+  pit_enabled    = true
   project_id     = "project"
 
   replication_specs {
@@ -167,6 +169,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {
@@ -195,6 +198,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {
@@ -223,6 +227,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {
@@ -267,6 +272,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
   backup_enabled = false
   cluster_type   = "REPLICASET"
   name           = "my-name"
+  pit_enabled    = false
   project_id     = "project"
 
   replication_specs {
@@ -367,7 +373,7 @@ func Test_ClusterResourceHcl(t *testing.T) {
 			},
 			"overrideClusterResource": {
 				overrideClusterResource,
-				acc.ClusterRequest{ClusterNameExplicit: clusterName, Geosharded: true, CloudBackup: true, ReplicationSpecs: []acc.ReplicationSpecRequest{
+				acc.ClusterRequest{ClusterNameExplicit: clusterName, Geosharded: true, PitEnabled: true, CloudBackup: true, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{Region: "MY_REGION_1", ZoneName: "Zone X", InstanceSize: "M30", NodeCount: 30, ProviderName: constant.AZURE},
 				}},
 			},


### PR DESCRIPTION
## Description

Refactors resource tests to use GetClusterInfo `cloud_backup_schedule`

Link to any related issue(s): CLOUDP-261446

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
