### PR TITLE
test: Refactors resource tests to use GetClusterInfo `cluster_outage_simulation`

### DIFF
--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
@@ -30,7 +30,7 @@ func Resource() *schema.Resource {
 		UpdateContext: resourceUpdate,
 		DeleteContext: resourceDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(25 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation.go
@@ -30,7 +30,7 @@ func Resource() *schema.Resource {
 		UpdateContext: resourceUpdate,
 		DeleteContext: resourceDelete,
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(25 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_migration_test.go
@@ -3,63 +3,13 @@ package clusteroutagesimulation_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestMigOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		config      = configSingleRegion(projectID, clusterName)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
-		CheckDestroy: checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "start_request_date"),
-					resource.TestCheckResourceAttrSet(resourceName, "simulation_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(config),
-		},
-	})
+	mig.CreateAndRunTest(t, singleRegionTestCase(t))
 }
 
 func TestMigOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		config      = configMultiRegion(projectID, clusterName)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
-		CheckDestroy: checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            config,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "outage_filters.#"),
-					resource.TestCheckResourceAttrSet(resourceName, "start_request_date"),
-					resource.TestCheckResourceAttrSet(resourceName, "simulation_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "state"),
-				),
-			},
-			mig.TestStepCheckEmptyPlan(config),
-		},
-	})
+	mig.CreateAndRunTest(t, multiRegionTestCase(t))
 }

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -16,19 +16,41 @@ const (
 	dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
 )
 
-func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-	)
+var (
+	singleRegionRequest = acc.ClusterRequest{
+		ReplicationSpecs: []acc.ReplicationSpecRequest{
+			{Region: "US_WEST_2", InstanceSize: "M10"},
+		},
+	}
+	multiRegionRequest = acc.ClusterRequest{ReplicationSpecs: []acc.ReplicationSpecRequest{
+		{
+			Region:    "US_EAST_1",
+			NodeCount: 3,
+			ExtraRegionConfigs: []acc.ReplicationSpecRequest{
+				{Region: "US_EAST_2", NodeCount: 2, Priority: 6},
+				{Region: "US_WEST_2", NodeCount: 2, Priority: 5, NodeCountReadOnly: 2},
+			},
+		},
+	}}
+)
 
-	resource.ParallelTest(t, resource.TestCase{
+func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
+	resource.ParallelTest(t, *singleRegionTestCase(t))
+}
+
+func singleRegionTestCase(t *testing.T) *resource.TestCase {
+	t.Helper()
+	var (
+		clusterInfo = acc.GetClusterInfo(t, &singleRegionRequest)
+		clusterName = clusterInfo.ClusterName
+	)
+	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configSingleRegion(projectID, clusterName),
+				Config: configSingleRegion(&clusterInfo),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -46,22 +68,27 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 				),
 			},
 		},
-	})
+	}
 }
 
 func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
+	resource.ParallelTest(t, *multiRegionTestCase(t))
+}
+
+func multiRegionTestCase(t *testing.T) *resource.TestCase {
+	t.Helper()
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		clusterInfo = acc.GetClusterInfo(t, &multiRegionRequest)
+		clusterName = clusterInfo.ClusterName
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configMultiRegion(projectID, clusterName),
+				Config: configMultiRegion(&clusterInfo),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -79,73 +106,36 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 				),
 			},
 		},
-	})
+	}
 }
 
-func configSingleRegion(projectID, clusterName string) string {
+func configSingleRegion(info *acc.ClusterInfo) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "test" {
-				project_id                  = %[1]q
-				name                        = %[2]q
-				provider_name               = "AWS"
-				provider_region_name        = "US_WEST_2"
-				provider_instance_size_name = "M10"
-			}
-
+			%[1]s
 			resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
-				project_id = %[1]q
-				cluster_name = %[2]q
+				project_id = %[2]q
+				cluster_name = %[3]q
 				outage_filters {
 					cloud_provider = "AWS"
 					region_name    = "US_WEST_2"
 				}
-				depends_on = ["mongodbatlas_cluster.test"]
+				depends_on = [%[4]s]
 			}
 
 			data "mongodbatlas_cluster_outage_simulation" "test" {
-				project_id = %[1]q
-				cluster_name = %[2]q
+				project_id = %[2]q
+				cluster_name = %[3]q
 				depends_on = [mongodbatlas_cluster_outage_simulation.test_outage]
 			}		
-	`, projectID, clusterName)
+	`, info.ClusterTerraformStr, info.ProjectID, info.ClusterName, info.ClusterResourceName)
 }
 
-func configMultiRegion(projectID, clusterName string) string {
+func configMultiRegion(info *acc.ClusterInfo) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_cluster" "test" {
-			project_id   = %[1]q
-			name         = %[2]q
-			cluster_type = "REPLICASET"
-			
-			provider_name               = "AWS"
-			provider_instance_size_name = "M10"
-			
-			replication_specs {
-				num_shards = 1
-				regions_config {
-				region_name     = "US_EAST_1"
-				electable_nodes = 3
-				priority        = 7
-				read_only_nodes = 0
-				}
-				regions_config {
-				region_name     = "US_EAST_2"
-				electable_nodes = 2
-				priority        = 6
-				read_only_nodes = 0
-				}
-				regions_config {
-				region_name     = "US_WEST_2"
-				electable_nodes = 2
-				priority        = 5
-				read_only_nodes = 2
-				}
-			}
-		}
-
+		%[1]s
 		resource "mongodbatlas_cluster_outage_simulation" "test_outage" {
-			project_id   = %[1]q
-			cluster_name = %[2]q
+			project_id   = %[2]q
+			cluster_name = %[3]q
 
 			outage_filters {
 				cloud_provider = "AWS"
@@ -155,15 +145,15 @@ func configMultiRegion(projectID, clusterName string) string {
 					cloud_provider = "AWS"
 					region_name    = "US_EAST_2"
 			}
-			depends_on = ["mongodbatlas_cluster.test"]
+			depends_on = [%[4]s]
 		}
 
 		data "mongodbatlas_cluster_outage_simulation" "test" {
-			project_id = %[1]q
-			cluster_name = %[2]q
+			project_id = %[2]q
+			cluster_name = %[3]q
 			depends_on = [mongodbatlas_cluster_outage_simulation.test_outage]
 		}		
-	`, projectID, clusterName)
+	`, info.ClusterTerraformStr, info.ProjectID, info.ClusterName, info.ClusterResourceName)
 }
 
 func checkDestroy(s *terraform.State) error {

--- a/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
+++ b/internal/service/clusteroutagesimulation/resource_cluster_outage_simulation_test.go
@@ -16,24 +16,6 @@ const (
 	dataSourceName = "data.mongodbatlas_cluster_outage_simulation.test"
 )
 
-var (
-	singleRegionRequest = acc.ClusterRequest{
-		ReplicationSpecs: []acc.ReplicationSpecRequest{
-			{Region: "US_WEST_2", InstanceSize: "M10"},
-		},
-	}
-	multiRegionRequest = acc.ClusterRequest{ReplicationSpecs: []acc.ReplicationSpecRequest{
-		{
-			Region:    "US_EAST_1",
-			NodeCount: 3,
-			ExtraRegionConfigs: []acc.ReplicationSpecRequest{
-				{Region: "US_EAST_2", NodeCount: 2, Priority: 6},
-				{Region: "US_WEST_2", NodeCount: 2, Priority: 5, NodeCountReadOnly: 2},
-			},
-		},
-	}}
-)
-
 func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 	resource.ParallelTest(t, *singleRegionTestCase(t))
 }
@@ -41,6 +23,11 @@ func TestAccOutageSimulationCluster_SingleRegion_basic(t *testing.T) {
 func singleRegionTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 	var (
+		singleRegionRequest = acc.ClusterRequest{
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{Region: "US_WEST_2", InstanceSize: "M10"},
+			},
+		}
 		clusterInfo = acc.GetClusterInfo(t, &singleRegionRequest)
 		clusterName = clusterInfo.ClusterName
 	)
@@ -78,6 +65,16 @@ func TestAccOutageSimulationCluster_MultiRegion_basic(t *testing.T) {
 func multiRegionTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 	var (
+		multiRegionRequest = acc.ClusterRequest{ReplicationSpecs: []acc.ReplicationSpecRequest{
+			{
+				Region:    "US_EAST_1",
+				NodeCount: 3,
+				ExtraRegionConfigs: []acc.ReplicationSpecRequest{
+					{Region: "US_EAST_2", NodeCount: 2, Priority: 6},
+					{Region: "US_WEST_2", NodeCount: 2, Priority: 5, NodeCountReadOnly: 2},
+				},
+			},
+		}}
 		clusterInfo = acc.GetClusterInfo(t, &multiRegionRequest)
 		clusterName = clusterInfo.ClusterName
 	)

--- a/internal/testutil/acc/cluster.go
+++ b/internal/testutil/acc/cluster.go
@@ -96,10 +96,15 @@ type ReplicationSpecRequest struct {
 	ProviderName             string
 	ExtraRegionConfigs       []ReplicationSpecRequest
 	NodeCount                int
+	NodeCountReadOnly        int
+	Priority                 int
 	AutoScalingDiskGbEnabled bool
 }
 
 func (r *ReplicationSpecRequest) AddDefaults() {
+	if r.Priority == 0 {
+		r.Priority = 7
+	}
 	if r.NodeCount == 0 {
 		r.NodeCount = 3
 	}
@@ -141,13 +146,23 @@ func ReplicationSpec(req *ReplicationSpecRequest) admin.ReplicationSpec {
 }
 
 func CloudRegionConfig(req ReplicationSpecRequest) admin.CloudRegionConfig {
+	req.AddDefaults()
+	var readOnly admin.DedicatedHardwareSpec
+	if req.NodeCountReadOnly != 0 {
+		readOnly = admin.DedicatedHardwareSpec{
+			NodeCount:    &req.NodeCountReadOnly,
+			InstanceSize: &req.InstanceSize,
+		}
+	}
 	return admin.CloudRegionConfig{
 		RegionName:   &req.Region,
+		Priority:     &req.Priority,
 		ProviderName: &req.ProviderName,
 		ElectableSpecs: &admin.HardwareSpec{
 			InstanceSize: &req.InstanceSize,
 			NodeCount:    &req.NodeCount,
 		},
+		ReadOnlySpecs: &readOnly,
 		AutoScaling: &admin.AdvancedAutoScalingSettings{
 			DiskGB: &admin.DiskGBAutoScaling{Enabled: &req.AutoScalingDiskGbEnabled},
 		},

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -167,6 +167,12 @@ func writeReplicationSpec(cluster *hclwrite.Body, spec admin.ReplicationSpec) er
 		nodeSpec := rc.GetElectableSpecs()
 		nodeSpecBlock := rcBlock.AppendNewBlock("electable_specs", nil).Body()
 		err = addPrimitiveAttributesViaJSON(nodeSpecBlock, nodeSpec)
+
+		readOnlySpecs := rc.GetReadOnlySpecs()
+		if readOnlySpecs.GetNodeCount() != 0 {
+			readOnlyBlock := rcBlock.AppendNewBlock("read_only_specs", nil).Body()
+			err = addPrimitiveAttributesViaJSON(readOnlyBlock, readOnlySpecs)
+		}
 	}
 	return err
 }

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -345,6 +345,38 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
 
 }
 `
+var readOnlyAndPriority = `
+resource "mongodbatlas_advanced_cluster" "cluster_info" {
+  backup_enabled = false
+  cluster_type   = "REPLICASET"
+  name           = "my-name"
+  pit_enabled    = false
+  project_id     = "project"
+
+  replication_specs {
+    num_shards = 1
+    zone_name  = "Zone 1"
+
+    region_configs {
+      priority      = 5
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+      auto_scaling {
+        disk_gb_enabled = false
+      }
+      electable_specs {
+        instance_size = "M10"
+        node_count    = 5
+      }
+      read_only_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+    }
+  }
+
+}
+`
 
 func Test_ClusterResourceHcl(t *testing.T) {
 	var (
@@ -397,6 +429,14 @@ func Test_ClusterResourceHcl(t *testing.T) {
 				}, ReplicationSpecs: []acc.ReplicationSpecRequest{
 					{AutoScalingDiskGbEnabled: true},
 				}},
+			},
+			"readOnlyAndPriority": {
+				readOnlyAndPriority,
+				acc.ClusterRequest{
+					ClusterName: clusterName,
+					ReplicationSpecs: []acc.ReplicationSpecRequest{
+						{Priority: 5, NodeCount: 5, Region: "US_EAST_1", NodeCountReadOnly: 1},
+					}},
 			},
 		}
 	)


### PR DESCRIPTION
## Description

Refactors resource tests to use GetClusterInfo `cluster_outage_simulation`

Link to any related issue(s): CLOUDP-261444

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.


## Further comments
