### PR TITLE
Update x509_authentication_database_user.md

### DIFF
--- a/docs/data-sources/x509_authentication_database_user.md
+++ b/docs/data-sources/x509_authentication_database_user.md
@@ -10,7 +10,7 @@
 ```terraform
 resource "mongodbatlas_database_user" "user" {
   project_id    = "<PROJECT-ID>"
-  username      = "myUsername"
+  username      = "CN=xxxx.domain.com"
   x509_type     = "MANAGED"
   database_name = "$external"
 
@@ -69,7 +69,7 @@ data "mongodbatlas_x509_authentication_database_user" "test" {
 ## Argument Reference
 
 * `project_id` - (Required) Identifier for the Atlas project associated with the X.509 configuration.
-* `username` - (Optional) Username of the database user to create a certificate for.
+* `username` - (Optional) Username of the database user to create a certificate for. e.g. CN=xxx.domain.com, OU=ORGANIZATION
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
username value is confusing in documentation

## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Username field is confusing in documentation. It should follow RFC 2253.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
