### PR TITLE
chore: Migrates `mongodbatlas_cloud_backup_snapshot_export_job` to new auto-generated SDK

### DIFF
--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,0 +1,11 @@
+```release-note:note
+resource/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+```
+
+```release-note:note
+data-source/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+```
+
+```release-note:note
+data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+```

--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,11 +1,11 @@
 ```release-note:note
-resource/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+resource/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute.
 ```
 
 ```release-note:note
-data-source/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+data-source/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute.
 ```
 
 ```release-note:note
-data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Deprecates the `err_msg` attribute. The attribute is no longer returned from the backend and was considered low value for customers
+data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Deprecates the `err_msg` attribute.
 ```

--- a/docs/data-sources/cloud_backup_snapshot_export_job.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_job.md
@@ -49,7 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 * `custom_data` - Custom data to include in the metadata file named `.complete` that Atlas uploads to the bucket when the export job finishes. Custom data can be specified as key and value pairs.
 * `components` - _Returned for sharded clusters only._ Export job details for each replica set in the sharded cluster.
 * `created_at` - Timestamp in ISO 8601 date and time format in UTC when the export job was created.
-* `err_msg` - Error message, only if the export job failed.
+* `err_msg` - Error message, only if the export job failed. **Note:** This attribute is deprecated as it is not being used.
 * `export_status` - _Returned for replica set only._ Status of the export job.
 * `finished_at` - Timestamp in ISO 8601 date and time format in UTC when the export job completes.
 * `export_job_id` - Unique identifier of the export job.

--- a/docs/data-sources/cloud_backup_snapshot_export_jobs.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_jobs.md
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 * `custom_data` - Custom data to include in the metadata file named `.complete` that Atlas uploads to the bucket when the export job finishes. Custom data can be specified as key and value pairs.
 * `components` - _Returned for sharded clusters only._ Export job details for each replica set in the sharded cluster.
 * `created_at` - Timestamp in ISO 8601 date and time format in UTC when the export job was created.
-* `err_msg` - Error message, only if the export job failed.
+* `err_msg` - Error message, only if the export job failed. **Note:** This attribute is deprecated as it is not being used.
 * `export_status` - _Returned for replica set only._ Status of the export job.
 * `finished_at` - Timestamp in ISO 8601 date and time format in UTC when the export job completes.
 * `export_job_id` - Unique identifier of the export job.

--- a/docs/resources/cloud_backup_snapshot_export_job.md
+++ b/docs/resources/cloud_backup_snapshot_export_job.md
@@ -101,7 +101,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `components` - _Returned for sharded clusters only._ Export job details for each replica set in the sharded cluster.
 * `created_at` - Timestamp in ISO 8601 date and time format in UTC when the export job was created.
-* `err_msg` - Error message, only if the export job failed.
+* `err_msg` - Error message, only if the export job failed. **Note:** This attribute is deprecated as it is not being used.
 * `export_status` - _Returned for replica set only._ Status of the export job.
 * `finished_at` - Timestamp in ISO 8601 date and time format in UTC when the export job completes.
 * `export_job_id` - Unique identifier of the export job.

--- a/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
@@ -70,9 +70,10 @@ func DataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"err_msg": { //TODO: this is no longer returned by the API, could be removed
-				Type:     schema.TypeString,
-				Computed: true,
+			"err_msg": {
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
 			},
 			"export_bucket_id": {
 				Type:     schema.TypeString,

--- a/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
@@ -73,7 +73,7 @@ func DataSource() *schema.Resource {
 			"err_msg": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.20.0"),
 			},
 			"export_bucket_id": {
 				Type:     schema.TypeString,

--- a/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_job.go
@@ -70,7 +70,7 @@ func DataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"err_msg": {
+			"err_msg": { //TODO: this is no longer returned by the API, could be removed
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_jobs.go
+++ b/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_jobs.go
@@ -84,7 +84,7 @@ func PluralDataSource() *schema.Resource {
 						"err_msg": {
 							Type:       schema.TypeString,
 							Computed:   true,
-							Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
+							Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.20.0"),
 						},
 						"export_bucket_id": {
 							Type:     schema.TypeString,

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func Resource() *schema.Resource {
@@ -93,7 +93,7 @@ func returnCloudBackupSnapshotExportJobSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"err_msg": {
+		"err_msg": { //TODO: this is no longer returned by the API, could be removed
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -135,8 +135,8 @@ func resourceMongoDBAtlasCloudBackupSnapshotExportJobRead(ctx context.Context, d
 	return setExportJobFields(d, exportJob)
 }
 
-func readExportJob(ctx context.Context, meta any, d *schema.ResourceData) (*matlas.CloudProviderSnapshotExportJob, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+func readExportJob(ctx context.Context, meta any, d *schema.ResourceData) (*admin.DiskBackupExportJob, error) {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID, clusterName, exportID := getRequiredFields(d)
 	if d.Id() != "" && (projectID == "" || clusterName == "" || exportID == "") {
 		ids := conversion.DecodeStateID(d.Id())
@@ -144,12 +144,12 @@ func readExportJob(ctx context.Context, meta any, d *schema.ResourceData) (*matl
 		clusterName = ids["cluster_name"]
 		exportID = ids["export_job_id"]
 	}
-	exportJob, _, err := conn.CloudProviderSnapshotExportJobs.Get(ctx, projectID, clusterName, exportID)
+	exportJob, _, err := connV2.CloudBackupsApi.GetBackupExportJob(ctx, projectID, clusterName, exportID).Execute()
 	if err == nil {
 		d.SetId(conversion.EncodeStateID(map[string]string{
 			"project_id":    projectID,
 			"cluster_name":  clusterName,
-			"export_job_id": exportJob.ID,
+			"export_job_id": exportJob.GetId(),
 		}))
 	}
 	return exportJob, err
@@ -162,12 +162,12 @@ func getRequiredFields(d *schema.ResourceData) (projectID, clusterName, exportID
 	return projectID, clusterName, exportID
 }
 
-func setExportJobFields(d *schema.ResourceData, exportJob *matlas.CloudProviderSnapshotExportJob) diag.Diagnostics {
-	if err := d.Set("export_job_id", exportJob.ID); err != nil {
+func setExportJobFields(d *schema.ResourceData, exportJob *admin.DiskBackupExportJob) diag.Diagnostics {
+	if err := d.Set("export_job_id", exportJob.Id); err != nil {
 		return diag.Errorf("error setting `export_job_id` for snapshot export job (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("snapshot_id", exportJob.SnapshotID); err != nil {
+	if err := d.Set("snapshot_id", exportJob.SnapshotId); err != nil {
 		return diag.Errorf("error setting `snapshot_id` for snapshot export job (%s): %s", d.Id(), err)
 	}
 
@@ -183,11 +183,7 @@ func setExportJobFields(d *schema.ResourceData, exportJob *matlas.CloudProviderS
 		return diag.Errorf("error setting `created_at` for snapshot export job (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("err_msg", exportJob.ErrMsg); err != nil {
-		return diag.Errorf("error setting `created_at` for snapshot export job (%s): %s", d.Id(), err)
-	}
-
-	if err := d.Set("export_bucket_id", exportJob.ExportBucketID); err != nil {
+	if err := d.Set("export_bucket_id", exportJob.ExportBucketId); err != nil {
 		return diag.Errorf("error setting `created_at` for snapshot export job (%s): %s", d.Id(), err)
 	}
 
@@ -216,34 +212,34 @@ func setExportJobFields(d *schema.ResourceData, exportJob *matlas.CloudProviderS
 	return nil
 }
 
-func flattenExportJobsComponents(components []*matlas.CloudProviderSnapshotExportJobComponent) []map[string]any {
-	if len(components) == 0 {
+func flattenExportJobsComponents(components *[]admin.DiskBackupExportMember) []map[string]any {
+	if len(*components) == 0 {
 		return nil
 	}
 
 	customData := make([]map[string]any, 0)
 
-	for i := range components {
+	for i := range *components {
 		customData = append(customData, map[string]any{
-			"export_id":        components[i].ExportID,
-			"replica_set_name": components[i].ReplicaSetName,
+			"export_id":        (*components)[i].ExportId,
+			"replica_set_name": (*components)[i].ReplicaSetName,
 		})
 	}
 
 	return customData
 }
 
-func flattenExportJobsCustomData(data []*matlas.CloudProviderSnapshotExportJobCustomData) []map[string]any {
-	if len(data) == 0 {
+func flattenExportJobsCustomData(data *[]admin.BackupLabel) []map[string]any {
+	if len(*data) == 0 {
 		return nil
 	}
 
 	customData := make([]map[string]any, 0)
 
-	for i := range data {
+	for i := range *data {
 		customData = append(customData, map[string]any{
-			"key":   data[i].Key,
-			"value": data[i].Value,
+			"key":   (*data)[i].Key,
+			"value": (*data)[i].Value,
 		})
 	}
 
@@ -251,40 +247,40 @@ func flattenExportJobsCustomData(data []*matlas.CloudProviderSnapshotExportJobCu
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotExportJobCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
-	request := &matlas.CloudProviderSnapshotExportJob{
-		SnapshotID:     d.Get("snapshot_id").(string),
-		ExportBucketID: d.Get("export_bucket_id").(string),
+	request := &admin.DiskBackupExportJobRequest{
+		SnapshotId:     d.Get("snapshot_id").(string),
+		ExportBucketId: d.Get("export_bucket_id").(string),
 		CustomData:     expandExportJobCustomData(d),
 	}
 
-	jobResponse, _, err := conn.CloudProviderSnapshotExportJobs.Create(ctx, projectID, clusterName, request)
+	jobResponse, _, err := connV2.CloudBackupsApi.CreateBackupExportJob(ctx, projectID, clusterName, request).Execute()
 	if err != nil {
 		return diag.Errorf("error creating snapshot export job: %s", err)
 	}
 
-	if err := d.Set("export_job_id", jobResponse.ID); err != nil {
-		return diag.Errorf("error setting `export_job_id` for snapshot export job (%s): %s", jobResponse.ID, err)
+	if err := d.Set("export_job_id", jobResponse.Id); err != nil {
+		return diag.Errorf("error setting `export_job_id` for snapshot export job (%s): %s", *jobResponse.Id, err)
 	}
 	return resourceMongoDBAtlasCloudBackupSnapshotExportJobRead(ctx, d, meta)
 }
 
-func expandExportJobCustomData(d *schema.ResourceData) []*matlas.CloudProviderSnapshotExportJobCustomData {
+func expandExportJobCustomData(d *schema.ResourceData) *[]admin.BackupLabel {
 	customData := d.Get("custom_data").(*schema.Set)
-	res := make([]*matlas.CloudProviderSnapshotExportJobCustomData, customData.Len())
+	res := make([]admin.BackupLabel, customData.Len())
 
 	for i, val := range customData.List() {
 		v := val.(map[string]any)
-		res[i] = &matlas.CloudProviderSnapshotExportJobCustomData{
-			Key:   v["key"].(string),
-			Value: v["value"].(string),
+		res[i] = admin.BackupLabel{
+			Key:   conversion.Pointer(v["key"].(string)),
+			Value: conversion.Pointer(v["value"].(string)),
 		}
 	}
 
-	return res
+	return &res
 }
 
 func resourceMongoDBAtlasCloudBackupSnapshotExportJobImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
@@ -97,7 +97,7 @@ func returnCloudBackupSnapshotExportJobSchema() map[string]*schema.Schema {
 		"err_msg": {
 			Type:       schema.TypeString,
 			Computed:   true,
-			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.18.0"),
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.20.0"),
 		},
 		"export_status_exported_collections": {
 			Type:     schema.TypeInt,

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -41,8 +41,9 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			"project_id": projectID,
 		}
 		attrsPluralDS = map[string]string{
-			"project_id":                  projectID,
-			"results.0.custom_data.0.key": "exported by",
+			"project_id":                    projectID,
+			"results.0.custom_data.0.key":   "exported by",
+			"results.0.custom_data.0.value": "tf-acc-test",
 		}
 	)
 	checks := []resource.TestCheckFunc{checkExists(resourceName)}


### PR DESCRIPTION
## Description

Migrates `cloud_bakcup_snapshot_export_job` to new auto-generated SDK

Link to any related issue(s): CLOUDP-246318

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
