### PR TITLE
chore: Migrates `mongodbatlas_project_api_key` to new auto-generated SDK

### DIFF
--- a/internal/service/projectapikey/data_source_project_api_keys.go
+++ b/internal/service/projectapikey/data_source_project_api_keys.go
@@ -8,13 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-
-	matlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasProjectAPIKeysRead,
+		ReadContext: pluralDataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -75,22 +74,19 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasProjectAPIKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
-	conn := meta.(*config.MongoDBClient).Atlas
-	options := &matlas.ListOptions{
-		PageNum:      d.Get("page_num").(int),
-		ItemsPerPage: d.Get("items_per_page").(int),
-	}
+func pluralDataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	pageNum := d.Get("page_num").(int)
+	itemsPerPage := d.Get("items_per_page").(int)
 
 	projectID := d.Get("project_id").(string)
 
-	apiKeys, _, err := conn.ProjectAPIKeys.List(ctx, projectID, options)
+	apiKeys, _, err := connV2.ProgrammaticAPIKeysApi.ListProjectApiKeys(ctx, projectID).PageNum(pageNum).ItemsPerPage(itemsPerPage).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting api keys information: %s", err))
 	}
 
-	results, err := flattenProjectAPIKeys(ctx, conn, projectID, apiKeys)
+	results, err := flattenProjectAPIKeys(ctx, connV2, apiKeys.GetResults())
 	if err != nil {
 		diag.FromErr(fmt.Errorf("error setting `results`: %s", err))
 	}
@@ -104,7 +100,7 @@ func dataSourceMongoDBAtlasProjectAPIKeysRead(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func flattenProjectAPIKeys(ctx context.Context, conn *matlas.Client, projectID string, apiKeys []matlas.APIKey) ([]map[string]any, error) {
+func flattenProjectAPIKeys(ctx context.Context, connV2 *admin.APIClient, apiKeys []admin.ApiKeyUserDetails) ([]map[string]any, error) {
 	var results []map[string]any
 
 	if len(apiKeys) == 0 {
@@ -114,13 +110,13 @@ func flattenProjectAPIKeys(ctx context.Context, conn *matlas.Client, projectID s
 	results = make([]map[string]any, len(apiKeys))
 	for k, apiKey := range apiKeys {
 		results[k] = map[string]any{
-			"api_key_id":  apiKey.ID,
-			"description": apiKey.Desc,
-			"public_key":  apiKey.PublicKey,
-			"private_key": apiKey.PrivateKey,
+			"api_key_id":  apiKey.GetId(),
+			"description": apiKey.GetDesc(),
+			"public_key":  apiKey.GetPublicKey(),
+			"private_key": apiKey.GetPrivateKey(),
 		}
 
-		projectAssignment, err := newProjectAssignment(ctx, conn, apiKey.ID)
+		projectAssignment, err := newProjectAssignment(ctx, connV2, apiKey.GetId())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -106,8 +106,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		for _, apiKeyList := range projectAssignmentList[1:] {
 			assignment := []admin.UserAccessRoleAssignment{
 				{
-					ApiUserId: apiKey.Id,
-					Roles:     &apiKeyList.RoleNames,
+					Roles: &apiKeyList.RoleNames,
 				},
 			}
 			_, _, err := connV2.ProgrammaticAPIKeysApi.AddProjectApiKey(ctx, apiKeyList.ProjectID, apiKey.GetId(), &assignment).Execute()
@@ -200,8 +199,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 				roles := conversion.ExpandStringList(apiKey.(map[string]any)["role_names"].(*schema.Set).List())
 				assignment := []admin.UserAccessRoleAssignment{
 					{
-						ApiUserId: &apiKeyID,
-						Roles:     &roles,
+						Roles: &roles,
 					},
 				}
 				_, _, err := connV2.ProgrammaticAPIKeysApi.AddProjectApiKey(ctx, projectID, apiKeyID, &assignment).Execute()
@@ -229,8 +227,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			roles := conversion.ExpandStringList(apiKey.(map[string]any)["role_names"].(*schema.Set).List())
 			assignment := []admin.UserAccessRoleAssignment{
 				{
-					ApiUserId: &apiKeyID,
-					Roles:     &roles,
+					Roles: &roles,
 				},
 			}
 			_, _, err := connV2.ProgrammaticAPIKeysApi.AddProjectApiKey(ctx, projectID, apiKeyID, &assignment).Execute()


### PR DESCRIPTION
## Description

 Migrates `mongodbatlas_project_api_key` to new auto-generated SDK

Link to any related issue(s): CLOUDP-259357

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
