### PR TITLE
chore: Enables GitHub Action linter errors in GitHub

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,18 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "actionlint",
+			"severity": "warning",
+			"pattern": [
+				{
+					"regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"message": 4,
+					"code": 5
+				}
+			]
+		}
+	]
+}

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -23,6 +23,8 @@ jobs:
         go-version-file: 'go.mod'
     - name: Build
       run: make build
+    - name: Set the user terminal
+      run: export GPG_TTY=$(tty)
   unit-test:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -53,7 +53,10 @@ jobs:
         with:
           version: v1.59.0 # Also update GOLANGCI_VERSION variable in GNUmakefile when updating this version
       - name: actionlint
-        run: make tools && actionlint -verbose -color
+        run: |
+          make tools
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          actionlint -color
         shell: bash  
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -23,8 +23,6 @@ jobs:
         go-version-file: 'go.mod'
     - name: Build
       run: make build
-    - name: Set the user terminal
-      run: export GPG_TTY=$(tty)
   unit-test:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Enables GitHub Action linter errors in GitHub.

Follow same idea as in: https://github.com/mongodb/mongodb-atlas-cli/pull/2704


Link to any related issue(s): CLOUDP-262444

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Example of linter errors:
<img width="972" alt="linter_error" src="https://github.com/user-attachments/assets/680f8e88-9ef3-4315-b04b-fbf117a44875">
