### PR TITLE
chore: Fixes invalid cluster name in example

### DIFF
--- a/examples/mongodbatlas_database_user/Readme.md
+++ b/examples/mongodbatlas_database_user/Readme.md
@@ -77,8 +77,8 @@ atlasclusterstring = [
     "aws_private_link_srv" = {}
     "private" = ""
     "private_srv" = ""
-    "standard" = "mongodb://MongoDB_Atlas-shard-00-00.xgpi2.mongodb.net:27017,MongoDB_Atlas-shard-00-01.xgpi2.mongodb.net:27017,MongoDB_Atlas-shard-00-02.xgpi2.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-90b49a-shard-0"
-    "standard_srv" = "mongodb+srv://MongoDB_Atlas.xgpi2.mongodb.net"
+    "standard" = "mongodb://MongoDBAtlas-shard-00-00.xgpi2.mongodb.net:27017,MongoDBAtlas-shard-00-01.xgpi2.mongodb.net:27017,MongoDBAtlas-shard-00-02.xgpi2.mongodb.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-90b49a-shard-0"
+    "standard_srv" = "mongodb+srv://MongoDBAtlas.xgpi2.mongodb.net"
   },
 ]
 project_name = Atlas-DB-Scope

--- a/examples/mongodbatlas_database_user/atlas_cluster.tf
+++ b/examples/mongodbatlas_database_user/atlas_cluster.tf
@@ -1,6 +1,6 @@
 resource "mongodbatlas_advanced_cluster" "cluster" {
   project_id     = mongodbatlas_project.project1.id
-  name           = "MongoDB_Atlas"
+  name           = "MongoDBAtlas"
   cluster_type   = "REPLICASET"
   backup_enabled = true
 


### PR DESCRIPTION
## Description

Fixes invalid cluster name in example.

Getting error:

Error: error creating advanced cluster: ... POST: HTTP 400 Bad Request (Error code: "CLUSTER_NAME_INVALID") Detail: The cluster name MongoDB_Atlas is invalid. The name can only contain ASCII letters, numbers, and hyphens. Reason: Bad Request. Params: [MongoDB_Atlas]


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
