### PR TITLE
feat: Updates plural `mongodbatlas_advanced_clusters` data source to support independent shard scaling

### DIFF
--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -339,7 +339,6 @@ func flattenAdvancedClusters(ctx context.Context, connV220231115 *admin20231115.
 		results = append(results, result)
 	}
 	return results
-
 }
 
 func flattenAdvancedClustersOldSDK(ctx context.Context, connV220231115 *admin20231115.APIClient, connV2 *admin.APIClient, clusters []admin20231115.AdvancedClusterDescription, d *schema.ResourceData) []map[string]any {

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -18,6 +18,10 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
+const (
+	errorListRead = "error reading advanced cluster list for project(%s): %s"
+)
+
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourcePluralRead,
@@ -280,7 +284,7 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
-			return diag.FromErr(fmt.Errorf("error reading advanced cluster list for project(%s): %s", projectID, err))
+			return diag.FromErr(fmt.Errorf(errorListRead, projectID, err))
 		}
 		if err := d.Set("results", flattenAdvancedClustersOldSDK(ctx, connV220231115, connV2, list.GetResults(), d)); err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "results", d.Id(), err))
@@ -291,7 +295,7 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
-			return diag.FromErr(fmt.Errorf("error reading advanced cluster list for project(%s): %s", projectID, err))
+			return diag.FromErr(fmt.Errorf(errorListRead, projectID, err))
 		}
 		if err := d.Set("results", flattenAdvancedClusters(ctx, connV220231115, connV2, list.GetResults(), d)); err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "results", d.Id(), err))

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -584,30 +584,6 @@ func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T
 	})
 }
 
-func TestAccClusterAdvancedClusterConfig_pluralDatasource(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false),
-				Check:  checkGeoShardedOldSchema(clusterName, 1, 1, true, true),
-			},
-			{
-				Config:      configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 2, false),
-				ExpectError: regexp.MustCompile(advancedcluster.ErrorOperationNotPermitted),
-			},
-		},
-	})
-}
-
 func checkAggr(attrsSet []string, attrsMap map[string]string, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{checkExists(resourceName)}
 	checks = acc.AddAttrChecks(resourceName, checks, attrsMap)

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1412,7 +1412,7 @@ func configShardedNewSchema(orgID, projectName, name, instanceSizeSpec1, instanc
 
 func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, diskIopsSpec2 string) resource.TestCheckFunc {
 	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
-		[]string{"results.#", "results.0.replication_specs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
+		[]string{"results.#", "results.0.replication_specs.#", "results.0.replication_specs.0.region_configs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
 	return checkAggr(
 		[]string{"replication_specs.0.external_id", "replication_specs.0.zone_id", "replication_specs.1.external_id", "replication_specs.1.zone_id"},
 		map[string]string{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1402,10 +1402,17 @@ func configShardedNewSchema(orgID, projectName, name, instanceSizeSpec1, instanc
 			name 	     = mongodbatlas_advanced_cluster.test.name
 			use_replication_spec_per_shard = true
 		}
+
+		data "mongodbatlas_advanced_clusters" "test" {
+			project_id = mongodbatlas_advanced_cluster.test.project_id
+			use_replication_spec_per_shard = true
+		}
 	`, orgID, projectName, name, instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, diskIopsSpec2)
 }
 
 func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, diskIopsSpec2 string) resource.TestCheckFunc {
+	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
+		[]string{"results.#", "results.0.replication_specs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
 	return checkAggr(
 		[]string{"replication_specs.0.external_id", "replication_specs.0.zone_id", "replication_specs.1.external_id", "replication_specs.1.zone_id"},
 		map[string]string{
@@ -1419,6 +1426,6 @@ func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, 
 			"replication_specs.0.region_configs.0.analytics_specs.0.disk_size_gb":  "60",
 			"replication_specs.1.region_configs.0.analytics_specs.0.disk_size_gb":  "60",
 			"replication_specs.0.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec1,
-			"replication_specs.1.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec2,
-		})
+			"replication_specs.1.region_configs.0.electable_specs.0.disk_iops":     diskIopsSpec2},
+		pluralChecks...)
 }


### PR DESCRIPTION
## Description

Updates plural `mongodbatlas_advanced_clusters` data source to support independent shard scaling.

Link to any related issue(s): [CLOUDP-258710](https://jira.mongodb.org/browse/CLOUDP-258710)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Testing
Created two clusters with a REPLICASET & other one as asymmetric sharded in a project and fetched using plural data source:
- When `use_replication_spec_per_shard=true`, both clusters are returned by data source
- When`use_replication_spec_per_shard=false` or not set, only REPLICASET is returned (expected)