### PR TITLE
chore: Continue populating `replications_specs.*.id` value even when calling new API

### DIFF
--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -309,7 +309,12 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
 		}
 
-		replicationSpecs, err = flattenAdvancedReplicationSpecsDS(ctx, clusterDescLatest.GetReplicationSpecs(), d, connV2)
+		zoneNameToOldReplicationSpecIDs, err := getReplicationSpecIDsFromOldAPI(ctx, projectID, clusterName, connV220231115)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		replicationSpecs, err = flattenAdvancedReplicationSpecsDS(ctx, clusterDescLatest.GetReplicationSpecs(), zoneNameToOldReplicationSpecIDs, d, connV2)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 		}

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -1036,7 +1036,7 @@ func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.Replic
 	tfMap["external_id"] = apiObject.GetId()
 
 	if oldID, ok := zoneNameToOldReplicationSpecIDs[apiObject.GetZoneName()]; ok {
-		tfMap["id"] = oldID // id stores replicationSpecs.*.id value associated to old cluster API (2023-02-01)
+		tfMap["id"] = oldID // replicationSpecs.*.id stores value associated to old cluster API (2023-02-01)
 	}
 
 	// define num_shards for backwards compatibility as this attribute has default value of 1.

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -15,7 +15,6 @@ import (
 	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
 	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -590,11 +589,10 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 func getReplicationSpecIDsFromOldAPI(ctx context.Context, projectID, clusterName string, connV220231115 *admin20231115.APIClient) (map[string]string, error) {
 	clusterOldAPI, _, err := connV220231115.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
 	if apiError, ok := admin20231115.AsError(err); ok {
-		readErrorMsg := "error reading  advanced cluster with 2023-02-01 API (%s): %s"
 		if apiError.GetErrorCode() == "ASYMMETRIC_SHARD_UNSUPPORTED" {
-			tflog.Info(ctx, fmt.Sprintf(readErrorMsg, clusterName, err))
 			return nil, nil // if its the case of an asymmetric shard an error is expected in old API, replication_specs.*.id attribute will not be populated
 		}
+		readErrorMsg := "error reading  advanced cluster with 2023-02-01 API (%s): %s"
 		return nil, fmt.Errorf(readErrorMsg, clusterName, err)
 	}
 	specs := clusterOldAPI.GetReplicationSpecs()

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -15,6 +15,7 @@ import (
 	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
 	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -550,7 +551,12 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
 		}
 
-		replicationSpecs, err = flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), d.Get("replication_specs").([]any), d, connV2)
+		zoneNameToOldReplicationSpecIDs, err := getReplicationSpecIDsFromOldAPI(ctx, projectID, clusterName, connV220231115)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		replicationSpecs, err = flattenAdvancedReplicationSpecs(ctx, cluster.GetReplicationSpecs(), zoneNameToOldReplicationSpecIDs, d.Get("replication_specs").([]any), d, connV2)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 		}
@@ -577,6 +583,26 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 
 	return nil
+}
+
+// getReplicationSpecIDsFromOldAPI returns the id values of replication specs coming from old API. This is used to populate old replication_specs.*.id attribute avoiding breaking changes.
+// In the old API each replications spec has a 1:1 relation with each zone, so ids are returned in a map from zoneName to id.
+func getReplicationSpecIDsFromOldAPI(ctx context.Context, projectID, clusterName string, connV220231115 *admin20231115.APIClient) (map[string]string, error) {
+	clusterOldAPI, _, err := connV220231115.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
+	if apiError, ok := admin20231115.AsError(err); ok {
+		readErrorMsg := "error reading  advanced cluster with 2023-02-01 API (%s): %s"
+		if apiError.GetErrorCode() == "ASYMMETRIC_SHARD_UNSUPPORTED" {
+			tflog.Info(ctx, fmt.Sprintf(readErrorMsg, clusterName, err))
+			return nil, nil // if its the case of an asymmetric shard an error is expected in old API, replication_specs.*.id attribute will not be populated
+		}
+		return nil, fmt.Errorf(readErrorMsg, clusterName, err)
+	}
+	specs := clusterOldAPI.GetReplicationSpecs()
+	result := make(map[string]string, len(specs))
+	for _, spec := range specs {
+		result[spec.GetZoneName()] = spec.GetId()
+	}
+	return result, nil
 }
 
 func setRootFields(d *schema.ResourceData, cluster *admin.ClusterDescription20250101, isResourceSchema bool) diag.Diagnostics {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -558,7 +558,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchema(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: configShardedNewSchema(orgID, projectName, clusterName, "M30", "M30", 3000, 3000),
-				Check:  checkShardedNewSchema("M30", "M30", "3000", "3000", true),
+				Check:  checkShardedNewSchema("M30", "M30", "3000", "3000", false),
 			},
 		},
 	})
@@ -578,7 +578,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: configShardedNewSchema(orgID, projectName, clusterName, "M30", "M40", 3000, 3000), // TODO: disk iops is failing if value is different
-				Check:  checkShardedNewSchema("M30", "M40", "3000", "3000", false),                        // replication spec old ids not populated for asymmetric cluster
+				Check:  checkShardedNewSchema("M30", "M40", "3000", "3000", true),                         // replication spec old ids not populated for asymmetric cluster
 			},
 		},
 	})
@@ -1435,10 +1435,10 @@ func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, 
 			"replication_specs.0.id": "",
 			"replication_specs.1.id": "",
 		}))
-		acc.AddNoAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
+		additionalChecks = acc.AddNoAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
 	} else {
 		additionalChecks = append(additionalChecks, checkAggr([]string{"replication_specs.0.id", "replication_specs.1.id"}, map[string]string{}))
-		acc.AddAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
+		additionalChecks = acc.AddAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
 	}
 
 	return checkAggr(

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -644,9 +644,9 @@ func configTenant(projectID, name string) string {
 
 func checkTenant(projectID, name string) resource.TestCheckFunc {
 	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
-		[]string{"results.#", "results.0.replication_specs.#", "replication_specs.0.id", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
+		[]string{"results.#", "results.0.replication_specs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
 	return checkAggr(
-		[]string{"replication_specs.#", "replication_specs.0.region_configs.#"},
+		[]string{"replication_specs.#", "replication_specs.0.id", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"project_id":                           projectID,
 			"name":                                 name,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1435,7 +1435,10 @@ func checkShardedNewSchema(instanceSizeSpec1, instanceSizeSpec2, diskIopsSpec1, 
 			"replication_specs.0.id": "",
 			"replication_specs.1.id": "",
 		}))
-		additionalChecks = acc.AddNoAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
+		additionalChecks = acc.AddAttrChecks(dataSourcePluralName, additionalChecks, map[string]string{
+			"results.0.replication_specs.0.id": "",
+			"results.0.replication_specs.1.id": "",
+		})
 	} else {
 		additionalChecks = append(additionalChecks, checkAggr([]string{"replication_specs.0.id", "replication_specs.1.id"}, map[string]string{}))
 		additionalChecks = acc.AddAttrSetChecks(dataSourcePluralName, additionalChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -58,7 +58,6 @@ func TestAccBackupCompliancePolicy_update(t *testing.T) {
 }
 
 func TestAccBackupCompliancePolicy_overwriteBackupPolicies(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-262014 for ensuring replicationSpec.id is being populated for replica set and symmetric sharded clusters
 	var (
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName    = acc.RandomProjectName() // No ProjectIDExecution to avoid conflicts with backup compliance policy

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -251,7 +251,6 @@ func TestAccBackupRSCloudBackupSchedule_onePolicy(t *testing.T) {
 }
 
 func TestAccBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-262014 for ensuring replicationSpec.id is being populated for replica set and symmetric sharded clusters
 	var (
 		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{
 			CloudBackup: true,


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-262014

Populating existing `replication_spec.*.id` for replica set and symmetric sharded clusters is relevant to avoid breaking the use case of cloud backup schedule with currently uses this value ([example](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_backup_schedule#example-usage---create-a-cluster-with-cloud-backup-enabled-with-snapshot-distribution)).
As part of this PR existing tests related to cloud backup schedule are now unskipped and working.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
