### PR TITLE
chore: Clean up usages of old SDK

### DIFF
--- a/internal/service/alertconfiguration/resource_alert_configuration.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration.go
@@ -520,7 +520,7 @@ func (r *alertConfigurationRS) Update(ctx context.Context, req resource.UpdateRe
 }
 
 func (r *alertConfigurationRS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.Client.Atlas
+	connV2 := r.Client.AtlasV2
 
 	var alertConfigState TfAlertConfigurationRSModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &alertConfigState)...)
@@ -530,7 +530,7 @@ func (r *alertConfigurationRS) Delete(ctx context.Context, req resource.DeleteRe
 
 	ids := conversion.DecodeStateID(alertConfigState.ID.ValueString())
 
-	_, err := conn.AlertConfigurations.Delete(ctx, ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID])
+	_, err := connV2.AlertConfigurationsApi.DeleteAlertConfiguration(ctx, ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID]).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(errorReadAlertConf, err.Error())
 	}

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -162,14 +162,14 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID, id, err := splitImportID(d.Id())
 	if err != nil {
 		return nil, err
 	}
 
-	_, _, err = conn.CloudProviderSnapshotExportBuckets.Get(ctx, *projectID, *id)
+	_, _, err = conn.CloudBackupsApi.GetExportBucket(ctx, *projectID, *id).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import snapshot export bucket %s in project %s, error: %s", *id, *projectID, err)
 	}

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job.go
@@ -290,7 +290,7 @@ func expandExportJobCustomData(d *schema.ResourceData) *[]admin.BackupLabel {
 }
 
 func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	conn := meta.(*config.MongoDBClient).Atlas
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	parts := strings.SplitN(d.Id(), "--", 3)
 	if len(parts) != 3 {
@@ -301,7 +301,7 @@ func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) 
 	clusterName := parts[1]
 	exportID := parts[2]
 
-	_, _, err := conn.CloudProviderSnapshotExportJobs.Get(ctx, projectID, clusterName, exportID)
+	_, _, err := connV2.CloudBackupsApi.GetBackupExportJob(ctx, projectID, clusterName, exportID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import snapshot export job %s in project %s and cluster %s, error: %s", exportID, projectID, clusterName, err)
 	}

--- a/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
+++ b/internal/service/cloudbackupsnapshotexportjob/resource_cloud_backup_snapshot_export_job_test.go
@@ -82,7 +82,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		_, _, err = acc.Conn().CloudProviderSnapshotExportJobs.Get(context.Background(), projectID, clusterName, exportJobID)
+		_, _, err = acc.ConnV2().CloudBackupsApi.GetBackupExportJob(context.Background(), projectID, clusterName, exportJobID).Execute()
 		if err == nil {
 			return nil
 		}

--- a/internal/service/onlinearchive/resource_online_archive.go
+++ b/internal/service/onlinearchive/resource_online_archive.go
@@ -633,8 +633,6 @@ func mapCriteria(d *schema.ResourceData) admin.Criteria {
 }
 
 func mapSchedule(d *schema.ResourceData) *admin.OnlineArchiveSchedule {
-	// scheduleInput := &matlas.OnlineArchiveSchedule{
-
 	// We have to provide schedule.type="DEFAULT" when the schedule block is not provided or removed
 	scheduleInput := &admin.OnlineArchiveSchedule{
 		Type: scheduleTypeDefault,

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -205,7 +205,7 @@ func testConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName,
 			vpc_id             = aws_vpc.primary.id
 			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
 			vpc_endpoint_type  = "Interface"
-			subnet_ids         = [aws_subnet.primary-az1.id, aws_subnet.primary-az2.id]
+			subnet_ids         = [aws_subnet.primary-az1.id]
 			security_group_ids = [aws_security_group.primary_default.id]
 			
 		}

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -168,7 +168,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 		projectID := rs.Primary.ID
-		_, _, err := acc.Conn().PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID)
+		_, _, err := acc.ConnV2().PrivateEndpointServicesApi.GetRegionalizedPrivateEndpointSetting(context.Background(), projectID).Execute()
 		if err == nil {
 			return nil
 		}
@@ -181,7 +181,7 @@ func checkDestroy(s *terraform.State) error {
 		if rs.Type != "mongodbatlas_private_endpoint_regional_mode" {
 			continue
 		}
-		setting, _, _ := acc.Conn().PrivateEndpoints.GetRegionalizedPrivateEndpointSetting(context.Background(), rs.Primary.ID)
+		setting, _, _ := acc.ConnV2().PrivateEndpointServicesApi.GetRegionalizedPrivateEndpointSetting(context.Background(), rs.Primary.ID).Execute()
 		if setting != nil && setting.Enabled != false {
 			return fmt.Errorf("Regionalized private endpoint setting for project %q was not properly disabled", rs.Primary.ID)
 		}

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -205,7 +205,7 @@ func testConfigUnmanagedAWS(awsAccessKey, awsSecretKey, projectID, providerName,
 			vpc_id             = aws_vpc.primary.id
 			service_name       = mongodbatlas_privatelink_endpoint.test.endpoint_service_name
 			vpc_endpoint_type  = "Interface"
-			subnet_ids         = [aws_subnet.primary-az1.id]
+			subnet_ids         = [aws_subnet.primary-az1.id, aws_subnet.primary-az2.id]
 			security_group_ids = [aws_security_group.primary_default.id]
 			
 		}

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -17,6 +17,7 @@ func TestAccPrivateEndpointRegionalMode_basic(t *testing.T) {
 }
 
 func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
+	acc.SkipTestForCI(t) // needs AWS configuration
 	var (
 		endpointResourceSuffix                 = "atlasple"
 		resourceSuffix                         = "atlasrm"

--- a/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
@@ -342,7 +342,7 @@ func checkDestroy(s *terraform.State) error {
 		if attrs["type"] == "" {
 			return fmt.Errorf("no type is set")
 		}
-		_, _, err := acc.Conn().Integrations.Get(context.Background(), attrs["project_id"], attrs["type"])
+		_, _, err := acc.ConnV2().ThirdPartyIntegrationsApi.GetThirdPartyIntegration(context.Background(), attrs["project_id"], attrs["type"]).Execute()
 		if err == nil {
 			return fmt.Errorf("third party integration service (%s) still exists", attrs["type"])
 		}
@@ -496,7 +496,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if attrs["type"] == "" {
 			return fmt.Errorf("no type is set")
 		}
-		if _, _, err := acc.Conn().Integrations.Get(context.Background(), attrs["project_id"], attrs["type"]); err == nil {
+		if _, _, err := acc.ConnV2().ThirdPartyIntegrationsApi.GetThirdPartyIntegration(context.Background(), attrs["project_id"], attrs["type"]).Execute(); err == nil {
 			return nil
 		}
 		return fmt.Errorf("third party integration (%s) does not exist", attrs["project_id"])


### PR DESCRIPTION
## Description

Final clean up of old SDK. `mongodbatlas_cluster` resource still uses it

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
