### PR TITLE
test: Moves disk_size_gb to replication spec for GetClusterInfo

### DIFF
--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -70,10 +70,9 @@ func TestAccBackupCompliancePolicy_overwriteBackupPolicies(t *testing.T) {
 			ProjectID:            projectIDTerraform,
 			MongoDBMajorVersion:  "6.0",
 			CloudBackup:          true,
-			DiskSizeGb:           12,
 			RetainBackupsEnabled: true,
 			ReplicationSpecs: []acc.ReplicationSpecRequest{
-				{EbsVolumeType: "STANDARD", AutoScalingDiskGbEnabled: true, NodeCount: 3},
+				{EbsVolumeType: "STANDARD", AutoScalingDiskGbEnabled: true, NodeCount: 3, DiskSizeGb: 12},
 			},
 		}
 		clusterInfo = acc.GetClusterInfo(t, &req)

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode_test.go
@@ -26,9 +26,9 @@ func TestAccPrivateEndpointRegionalMode_conn(t *testing.T) {
 		providerName                           = "AWS"
 		region                                 = os.Getenv("AWS_REGION_LOWERCASE")
 		privatelinkEndpointServiceResourceName = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", endpointResourceSuffix)
-		spec1                                  = acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1"}
-		spec2                                  = acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2"}
-		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, DiskSizeGb: 80, ReplicationSpecs: []acc.ReplicationSpecRequest{spec1, spec2}})
+		spec1                                  = acc.ReplicationSpecRequest{Region: os.Getenv("AWS_REGION_UPPERCASE"), ProviderName: providerName, ZoneName: "Zone 1", DiskSizeGb: 80}
+		spec2                                  = acc.ReplicationSpecRequest{Region: "US_WEST_2", ProviderName: providerName, ZoneName: "Zone 2", DiskSizeGb: 80}
+		clusterInfo                            = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, ReplicationSpecs: []acc.ReplicationSpecRequest{spec1, spec2}})
 		projectID                              = clusterInfo.ProjectID
 		clusterResourceName                    = clusterInfo.ResourceName
 		clusterDataName                        = "data.mongodbatlas_advanced_cluster.test"

--- a/internal/testutil/acc/config_cluster.go
+++ b/internal/testutil/acc/config_cluster.go
@@ -73,9 +73,6 @@ func ClusterResourceHcl(req *ClusterRequest) (configStr, clusterName, resourceNa
 	} else {
 		clusterRootAttributes["project_id"] = projectID
 	}
-	if req.DiskSizeGb != 0 {
-		clusterRootAttributes["disk_size_gb"] = req.DiskSizeGb
-	}
 	if req.RetainBackupsEnabled {
 		clusterRootAttributes["retain_backups_enabled"] = req.RetainBackupsEnabled
 	}

--- a/internal/testutil/acc/config_cluster_test.go
+++ b/internal/testutil/acc/config_cluster_test.go
@@ -61,6 +61,7 @@ resource "mongodbatlas_advanced_cluster" "cluster_info" {
         disk_gb_enabled = false
       }
       electable_specs {
+        disk_size_gb    = 16
         ebs_volume_type = "STANDARD"
         instance_size   = "M30"
         node_count      = 30
@@ -314,7 +315,15 @@ func Test_ClusterResourceHcl(t *testing.T) {
 					MongoDBMajorVersion:  "6.0",
 					RetainBackupsEnabled: true,
 					ReplicationSpecs: []acc.ReplicationSpecRequest{
-						{Region: "MY_REGION_1", ZoneName: "Zone X", InstanceSize: "M30", NodeCount: 30, ProviderName: constant.AZURE, EbsVolumeType: "STANDARD"},
+						{
+							Region:        "MY_REGION_1",
+							ZoneName:      "Zone X",
+							InstanceSize:  "M30",
+							NodeCount:     30,
+							ProviderName:  constant.AZURE,
+							EbsVolumeType: "STANDARD",
+							DiskSizeGb:    16,
+						},
 					},
 					PitEnabled: true,
 					AdvancedConfiguration: map[string]any{


### PR DESCRIPTION
## Description

Moves disk_size_gb to replication spec for GetClusterInfo

Link to any related issue(s): CLOUDP-261482

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
