### PR TITLE
fix: Allows `oplog_size_mb` to be 0 for default value

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -420,8 +420,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	// Validate oplog_size_mb to show the error before the cluster is created.
 	if oplogSizeMB, ok := d.GetOkExists("advanced_configuration.0.oplog_size_mb"); ok {
-		if cast.ToInt64(oplogSizeMB) <= 0 {
-			return diag.FromErr(fmt.Errorf("`advanced_configuration.oplog_size_mb` cannot be <= 0"))
+		if cast.ToInt64(oplogSizeMB) < 0 {
+			return diag.FromErr(fmt.Errorf("`advanced_configuration.oplog_size_mb` cannot be < 0"))
 		}
 	}
 


### PR DESCRIPTION
## Description

Allows `oplog_size_mb`to be 0 for default value.

Command `terraform plan -generate-config-out=<FILE>` for `mongodbatlas_advanced_cluster` resource generates `oplog_size_mb = 0` when it has the default value.  

We need to allow that.


Link to any related issue(s): CLOUDP-263178

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
