### PR TITLE
fix: Fixes creation of organization 

### DIFF
--- a/.changelog/2462.txt
+++ b/.changelog/2462.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_organization: Fixes organization creation
+```

--- a/.changelog/2462.txt
+++ b/.changelog/2462.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_organization: Fixes organization creation
+resource/mongodbatlas_organization: Fixes a bug in organization resource creation where the provider crashed.
 ```

--- a/internal/service/organization/data_source_organization.go
+++ b/internal/service/organization/data_source_organization.go
@@ -13,7 +13,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasOrganizationRead,
+		ReadContext: dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"org_id": {
 				Type:     schema.TypeString,
@@ -59,8 +59,7 @@ func DataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).AtlasV2
 	orgID := d.Get("org_id").(string)
 

--- a/internal/service/organization/data_source_organization_test.go
+++ b/internal/service/organization/data_source_organization_test.go
@@ -19,7 +19,7 @@ func TestAccConfigDSOrganization_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigWithDS(orgID),
+				Config: configWithDS(orgID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "name"),
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
@@ -31,7 +31,7 @@ func TestAccConfigDSOrganization_basic(t *testing.T) {
 		},
 	})
 }
-func testAccMongoDBAtlasOrganizationConfigWithDS(orgID string) string {
+func configWithDS(orgID string) string {
 	config := fmt.Sprintf(`
 		
 		data "mongodbatlas_organization" "test" {

--- a/internal/service/organization/data_source_organizations.go
+++ b/internal/service/organization/data_source_organizations.go
@@ -16,7 +16,7 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasOrganizationsRead,
+		ReadContext: pluralDataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -86,8 +86,7 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasOrganizationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get client connection.
+func pluralDataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	organizationOptions := &admin.ListOrganizationsApiParams{

--- a/internal/service/organization/data_source_organizations_test.go
+++ b/internal/service/organization/data_source_organizations_test.go
@@ -17,7 +17,7 @@ func TestAccConfigDSOrganizations_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasOrganizationsConfigWithDS(),
+				Config: configWithPluralDS(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "results.0.name"),
@@ -39,7 +39,7 @@ func TestAccConfigDSOrganizations_withPagination(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasOrganizationsConfigWithPagination(2, 5),
+				Config: configWithPagination(2, 5),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "results.#"),
 				),
@@ -48,14 +48,14 @@ func TestAccConfigDSOrganizations_withPagination(t *testing.T) {
 	})
 }
 
-func testAccMongoDBAtlasOrganizationsConfigWithDS() string {
+func configWithPluralDS() string {
 	return `	
 		data "mongodbatlas_organizations" "test" {
 		}
 	`
 }
 
-func testAccMongoDBAtlasOrganizationsConfigWithPagination(pageNum, itemPage int) string {
+func configWithPagination(pageNum, itemPage int) string {
 	return fmt.Sprintf(`
 		data "mongodbatlas_organizations" "test" {
 			page_num = %d

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -18,10 +18,10 @@ import (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceMongoDBAtlasOrganizationCreate,
-		ReadContext:   resourceMongoDBAtlasOrganizationRead,
-		UpdateContext: resourceMongoDBAtlasOrganizationUpdate,
-		DeleteContext: resourceMongoDBAtlasOrganizationDelete,
+		CreateContext: resourceCreate,
+		ReadContext:   resourceRead,
+		UpdateContext: resourceUpdate,
+		DeleteContext: resourceDelete,
 		Importer:      nil, // import is not supported. See CLOUDP-215155
 		Schema: map[string]*schema.Schema{
 			"org_owner_id": {
@@ -80,7 +80,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceMongoDBAtlasOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	if err := ValidateAPIKeyIsOrgOwner(conversion.ExpandStringList(d.Get("role_names").(*schema.Set).List())); err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,7 +104,7 @@ func resourceMongoDBAtlasOrganizationCreate(ctx context.Context, d *schema.Resou
 		PublicKey:        *organization.ApiKey.PublicKey,
 		PrivateKey:       *organization.ApiKey.PrivateKey,
 		BaseURL:          meta.(*config.MongoDBClient).Config.BaseURL,
-		TerraformVersion: meta.(*config.Config).TerraformVersion,
+		TerraformVersion: meta.(*config.MongoDBClient).Config.TerraformVersion,
 	}
 
 	clients, _ := cfg.NewClient(ctx)
@@ -136,16 +136,16 @@ func resourceMongoDBAtlasOrganizationCreate(ctx context.Context, d *schema.Resou
 		"org_id": organization.Organization.GetId(),
 	}))
 
-	return resourceMongoDBAtlasOrganizationRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	cfg := config.Config{
 		PublicKey:        d.Get("public_key").(string),
 		PrivateKey:       d.Get("private_key").(string),
 		BaseURL:          meta.(*config.MongoDBClient).Config.BaseURL,
-		TerraformVersion: meta.(*config.Config).TerraformVersion,
+		TerraformVersion: meta.(*config.MongoDBClient).Config.TerraformVersion,
 	}
 
 	clients, _ := cfg.NewClient(ctx)
@@ -189,13 +189,13 @@ func resourceMongoDBAtlasOrganizationRead(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceMongoDBAtlasOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	cfg := config.Config{
 		PublicKey:        d.Get("public_key").(string),
 		PrivateKey:       d.Get("private_key").(string),
 		BaseURL:          meta.(*config.MongoDBClient).Config.BaseURL,
-		TerraformVersion: meta.(*config.Config).TerraformVersion,
+		TerraformVersion: meta.(*config.MongoDBClient).Config.TerraformVersion,
 	}
 
 	clients, _ := cfg.NewClient(ctx)
@@ -218,16 +218,16 @@ func resourceMongoDBAtlasOrganizationUpdate(ctx context.Context, d *schema.Resou
 		}
 	}
 
-	return resourceMongoDBAtlasOrganizationRead(ctx, d, meta)
+	return resourceRead(ctx, d, meta)
 }
 
-func resourceMongoDBAtlasOrganizationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
 	cfg := config.Config{
 		PublicKey:        d.Get("public_key").(string),
 		PrivateKey:       d.Get("private_key").(string),
 		BaseURL:          meta.(*config.MongoDBClient).Config.BaseURL,
-		TerraformVersion: meta.(*config.Config).TerraformVersion,
+		TerraformVersion: meta.(*config.MongoDBClient).Config.TerraformVersion,
 	}
 
 	clients, _ := cfg.NewClient(ctx)

--- a/internal/service/organization/resource_organization_migration_test.go
+++ b/internal/service/organization/resource_organization_migration_test.go
@@ -26,7 +26,7 @@ func TestMigConfigRSOrganization_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+				Config:            configBasic(orgOwnerID, name, description, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
@@ -35,7 +35,7 @@ func TestMigConfigRSOrganization_Basic(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+				Config:                   configBasic(orgOwnerID, name, description, roleName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -33,12 +33,12 @@ func TestAccConfigRSOrganization_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+				Config: configBasic(orgOwnerID, name, description, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "api_access_list_required", "false"),
@@ -47,9 +47,9 @@ func TestAccConfigRSOrganization_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, updatedName, description, roleName),
+				Config: configBasic(orgOwnerID, updatedName, description, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "api_access_list_required", "false"),
@@ -74,10 +74,10 @@ func TestAccConfigRSOrganization_BasicAccess(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleName),
+				Config:      configBasic(orgOwnerID, name, description, roleName),
 				ExpectError: regexp.MustCompile("API Key must have the ORG_OWNER role"),
 			},
 		},
@@ -106,12 +106,12 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             testAccCheckMongoDBAtlasOrganizationDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigWithSettings(orgOwnerID, name, description, roleName, settingsConfig),
+				Config: configWithSettings(orgOwnerID, name, description, roleName, settingsConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "api_access_list_required", "false"),
@@ -120,9 +120,9 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigWithSettings(orgOwnerID, name, description, roleName, settingsConfigUpdated),
+				Config: configWithSettings(orgOwnerID, name, description, roleName, settingsConfigUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "api_access_list_required", "false"),
@@ -131,9 +131,9 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, "org-name-updated", description, roleName),
+				Config: configBasic(orgOwnerID, "org-name-updated", description, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasOrganizationExists(resourceName),
+					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -143,7 +143,7 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 	})
 }
 
-func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.TestCheckFunc {
+func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -174,7 +174,7 @@ func testAccCheckMongoDBAtlasOrganizationExists(resourceName string) resource.Te
 	}
 }
 
-func testAccCheckMongoDBAtlasOrganizationDestroy(s *terraform.State) error {
+func checkDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_organization" {
 			continue
@@ -200,7 +200,7 @@ func testAccCheckMongoDBAtlasOrganizationDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, roleNames string) string {
+func configBasic(orgOwnerID, name, description, roleNames string) string {
 	return fmt.Sprintf(`
 	  resource "mongodbatlas_organization" "test" {
 		org_owner_id = "%s"
@@ -211,7 +211,7 @@ func testAccMongoDBAtlasOrganizationConfigBasic(orgOwnerID, name, description, r
 	`, orgOwnerID, name, description, roleNames)
 }
 
-func testAccMongoDBAtlasOrganizationConfigWithSettings(orgOwnerID, name, description, roleNames, settingsConfig string) string {
+func configWithSettings(orgOwnerID, name, description, roleNames, settingsConfig string) string {
 	return fmt.Sprintf(`
 	  resource "mongodbatlas_organization" "test" {
 		org_owner_id = "%s"


### PR DESCRIPTION
## Description

- Refactor of organization resource simplifying method names
- Fixes creation of organization. 
- Tests can't be enabled in CI, but have run tests locally and built the provider from this branch and used it locally to create an organization

**Issue:**
```
panic: interface conversion: interface {} is *config.MongoDBClient, not *config.Config
```
**Terraform configuration:**
```
data "mongodbatlas_atlas_user" "my_user" {
  username = <email>
}

resource "mongodbatlas_organization" "test" {
  org_owner_id = data.mongodbatlas_atlas_user.my_user.user_id
  name         = "HELP-62459"
  description  = "test org creation for HELP-62459"
  role_names   = ["ORG_OWNER"]
}
```
**Output:**
```
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - mongodb/mongodbatlas in ../terraform-provider-mongodbatlas/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.mongodbatlas_atlas_user.my_user: Reading...
data.mongodbatlas_atlas_user.my_user: Read complete after 1s [id=654a5cec4fa15f542aa0d620]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # mongodbatlas_organization.test will be created
  + resource "mongodbatlas_organization" "test" {
      + api_access_list_required   = (known after apply)
      + description                = "test org creation for HELP-62459"
      + id                         = (known after apply)
      + multi_factor_auth_required = (known after apply)
      + name                       = "HELP-62459"
      + org_id                     = (known after apply)
      + org_owner_id               = <org_owner_id>
      + private_key                = (sensitive value)
      + public_key                 = (sensitive value)
      + restrict_employee_access   = (known after apply)
      + role_names                 = [
          + "ORG_OWNER",
        ]
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mongodbatlas_organization.test: Creating...
mongodbatlas_organization.test: Creation complete after 2s [id=b3JnX2lk:NjZhMzUyMWE2MzBhYmUwMGY4NjkyMzA4]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Link to any related issue(s): HELP-62459

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
