### PR TITLE
fix: Fixes nil pointer dereference in `mongodbatlas_alert_configuration`

### DIFF
--- a/.changelog/2436.txt
+++ b/.changelog/2436.txt
@@ -1,11 +1,11 @@
 ```release-note:note
-resource/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute.
+resource/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute
 ```
 
 ```release-note:note
-data-source/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute.
+data-source/mongodbatlas_cloud_backup_snapshot_export_job: Deprecates the `err_msg` attribute
 ```
 
 ```release-note:note
-data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Deprecates the `err_msg` attribute.
+data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Deprecates the `err_msg` attribute
 ```

--- a/.changelog/2462.txt
+++ b/.changelog/2462.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_organization: Fixes a bug in organization resource creation where the provider crashed.
+resource/mongodbatlas_organization: Fixes a bug in organization resource creation where the provider crashed
 ```

--- a/.changelog/2463.txt
+++ b/.changelog/2463.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_alert_configuration: Fixes nil pointer dereference when alert is modified outside Terraform
+```

--- a/.changelog/2463.txt
+++ b/.changelog/2463.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_alert_configuration: Fixes an issue where the `terraform apply` command crashes if you attempt to edit an existing `mongodbatlas_alert_configuration` by adding a value to `threshold_config`.
+resource/mongodbatlas_alert_configuration: Fixes an issue where the `terraform apply` command crashes if you attempt to edit an existing `mongodbatlas_alert_configuration` by adding a value to `threshold_config`
 ```

--- a/.changelog/2463.txt
+++ b/.changelog/2463.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_alert_configuration: Fixes nil pointer dereference when alert is modified outside Terraform
+resource/mongodbatlas_alert_configuration: Fixes an issue where the `terraform apply` command crashes if you attempt to edit an existing `mongodbatlas_alert_configuration` by adding a value to `threshold_config`.
 ```

--- a/internal/service/alertconfiguration/model_alert_configuration.go
+++ b/internal/service/alertconfiguration/model_alert_configuration.go
@@ -200,28 +200,28 @@ func NewTFMetricThresholdConfigModel(t *admin.ServerlessMetricThreshold, currSta
 		return []TfMetricThresholdConfigModel{
 			{
 				MetricName: conversion.StringNullIfEmpty(t.MetricName),
-				Operator:   conversion.StringNullIfEmpty(*t.Operator),
-				Threshold:  types.Float64Value(*t.Threshold),
-				Units:      conversion.StringNullIfEmpty(*t.Units),
-				Mode:       conversion.StringNullIfEmpty(*t.Mode),
+				Operator:   conversion.StringNullIfEmpty(t.GetOperator()),
+				Threshold:  types.Float64Value(t.GetThreshold()),
+				Units:      conversion.StringNullIfEmpty(t.GetUnits()),
+				Mode:       conversion.StringNullIfEmpty(t.GetMode()),
 			},
 		}
 	}
 	currState := currStateSlice[0]
 	newState := TfMetricThresholdConfigModel{
-		Threshold: types.Float64Value(*t.Threshold),
+		Threshold: types.Float64Value(t.GetThreshold()),
 	}
 	if !currState.MetricName.IsNull() {
 		newState.MetricName = conversion.StringNullIfEmpty(t.MetricName)
 	}
 	if !currState.Operator.IsNull() {
-		newState.Operator = conversion.StringNullIfEmpty(*t.Operator)
+		newState.Operator = conversion.StringNullIfEmpty(t.GetOperator())
 	}
 	if !currState.Units.IsNull() {
-		newState.Units = conversion.StringNullIfEmpty(*t.Units)
+		newState.Units = conversion.StringNullIfEmpty(t.GetUnits())
 	}
 	if !currState.Mode.IsNull() {
-		newState.Mode = conversion.StringNullIfEmpty(*t.Mode)
+		newState.Mode = conversion.StringNullIfEmpty(t.GetMode())
 	}
 	return []TfMetricThresholdConfigModel{newState}
 }

--- a/internal/service/alertconfiguration/model_alert_configuration.go
+++ b/internal/service/alertconfiguration/model_alert_configuration.go
@@ -234,21 +234,21 @@ func NewTFThresholdConfigModel(t *admin.GreaterThanRawThreshold, currStateSlice 
 	if len(currStateSlice) == 0 { // threshold was created elsewhere from terraform, or import statement is being called
 		return []TfThresholdConfigModel{
 			{
-				Operator:  conversion.StringNullIfEmpty(*t.Operator),
-				Threshold: types.Float64Value(float64(*t.Threshold)), // int in new SDK but keeping float64 for backward compatibility
-				Units:     conversion.StringNullIfEmpty(*t.Units),
+				Operator:  conversion.StringNullIfEmpty(t.GetOperator()),
+				Threshold: types.Float64Value(float64(t.GetThreshold())), // int in new SDK but keeping float64 for backward compatibility
+				Units:     conversion.StringNullIfEmpty(t.GetUnits()),
 			},
 		}
 	}
 	currState := currStateSlice[0]
 	newState := TfThresholdConfigModel{}
 	if !currState.Operator.IsNull() {
-		newState.Operator = conversion.StringNullIfEmpty(*t.Operator)
+		newState.Operator = conversion.StringNullIfEmpty(t.GetOperator())
 	}
 	if !currState.Units.IsNull() {
-		newState.Units = conversion.StringNullIfEmpty(*t.Units)
+		newState.Units = conversion.StringNullIfEmpty(t.GetUnits())
 	}
-	newState.Threshold = types.Float64Value(float64(*t.Threshold))
+	newState.Threshold = types.Float64Value(float64(t.GetThreshold()))
 
 	return []TfThresholdConfigModel{newState}
 }


### PR DESCRIPTION
## Description

Fixes nil pointer dereference in `mongodbatlas_alert_configuration` when the alert has been modified through the MongoDB Atlas UI

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2458

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
