### PR TITLE
feat: Updates `mongodbatlas_cloud_backup_schedule` data source to support independent shard scaling API changes

### DIFF
--- a/.changelog/2464.txt
+++ b/.changelog/2464.txt
@@ -1,4 +1,4 @@
 
 ```release-note:enhancement
-data-source/mongodbatlas_cloud_backup_schedule: Adds new `use_zone_id_for_copy_settings` and `copy_settings.#.zone_id` attributes and deprecates `copy_settings.#.replication_spec_id`. These new attributes enable you to reference cluster zones using independent shard scaling, which no longer supports `replication_spec.*.id`.
+data-source/mongodbatlas_cloud_backup_schedule: Adds new `use_zone_id_for_copy_settings` and `copy_settings.#.zone_id` attributes and deprecates `copy_settings.#.replication_spec_id`. These new attributes enable you to reference cluster zones using independent shard scaling, which no longer supports `replication_spec.*.id`
 ```

--- a/.changelog/2464.txt
+++ b/.changelog/2464.txt
@@ -1,0 +1,4 @@
+
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_schedule: Adds new attributes `use_zone_id_for_copy_settings` and `copy_settings.#.zone_id` and deprecates `copy_settings.#.replication_spec_id`. These new attributes enable referencing zones of clusters using independent shard scaling which no longer support `replication_spec.*.id`.
+```

--- a/.changelog/2464.txt
+++ b/.changelog/2464.txt
@@ -1,4 +1,4 @@
 
 ```release-note:enhancement
-data-source/mongodbatlas_cloud_backup_schedule: Adds new attributes `use_zone_id_for_copy_settings` and `copy_settings.#.zone_id` and deprecates `copy_settings.#.replication_spec_id`. These new attributes enable referencing zones of clusters using independent shard scaling which no longer support `replication_spec.*.id`.
+data-source/mongodbatlas_cloud_backup_schedule: Adds new `use_zone_id_for_copy_settings` and `copy_settings.#.zone_id` attributes and deprecates `copy_settings.#.replication_spec_id`. These new attributes enable you to reference cluster zones using independent shard scaling, which no longer supports `replication_spec.*.id`.
 ```

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	AsymmetricShardsUnsupportedActionDS = "Ensure to use copy_settings.#.zone_id instead of copy_settings.#.replication_spec_id for asymmetric sharded clusters by setting `use_zone_id_for_copy_settings = true`. Please refer to our examples, documentation, and 1.18.0 migration guide for more details at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
+	AsymmetricShardsUnsupportedActionDS = "Ensure you use copy_settings.#.zone_id instead of copy_settings.#.replication_spec_id for asymmetric sharded clusters by setting `use_zone_id_for_copy_settings = true`. To learn more, see our examples, documentation, and 1.18.0 migration guide at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
 )
 
 func DataSource() *schema.Resource {

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -7,7 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
+	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
+)
+
+const (
+	AsymmetricShardsUnsupportedActionDS = "Ensure to use copy_settings.#.zone_id instead of copy_settings.#.replication_spec_id for asymmetric sharded clusters by setting `use_zone_id_for_copy_settings = true`. Please refer to our examples, documentation, and 1.18.0 migration guide for more details at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
 )
 
 func DataSource() *schema.Resource {
@@ -21,6 +26,10 @@ func DataSource() *schema.Resource {
 			"cluster_name": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"use_zone_id_for_copy_settings": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"cluster_id": {
 				Type:     schema.TypeString,
@@ -47,6 +56,11 @@ func DataSource() *schema.Resource {
 							Computed: true,
 						},
 						"replication_spec_id": {
+							Type:       schema.TypeString,
+							Computed:   true,
+							Deprecated: DeprecationMsgOldSchema,
+						},
+						"zone_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -247,67 +261,46 @@ func DataSource() *schema.Resource {
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV220231115 := meta.(*config.MongoDBClient).AtlasV220231115
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
+	useZoneIDForCopySettings := false
 
-	backupPolicy, _, err := connV220231115.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
-	if err != nil {
-		return diag.Errorf(cluster.ErrorSnapshotBackupPolicyRead, clusterName, err)
-	}
+	var backupSchedule *admin.DiskBackupSnapshotSchedule20250101
+	var backupScheduleOldSDK *admin20231115.DiskBackupSnapshotSchedule
+	var copySettings []map[string]any
+	var err error
 
-	if err := d.Set("cluster_id", backupPolicy.GetClusterId()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "cluster_id", clusterName, err)
-	}
-
-	if err := d.Set("reference_hour_of_day", backupPolicy.GetReferenceHourOfDay()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "reference_hour_of_day", clusterName, err)
+	if v, ok := d.GetOk("use_zone_id_for_copy_settings"); ok {
+		useZoneIDForCopySettings = v.(bool)
 	}
 
-	if err := d.Set("reference_minute_of_hour", backupPolicy.GetReferenceMinuteOfHour()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "reference_minute_of_hour", clusterName, err)
+	if !useZoneIDForCopySettings {
+		backupScheduleOldSDK, _, err = connV220231115.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
+		if err != nil {
+			if apiError, ok := admin20231115.AsError(err); ok && apiError.GetErrorCode() == AsymmetricShardsUnsupportedAPIError {
+				return diag.Errorf("%s : %s : %s", errorSnapshotBackupScheduleRead, ErrorOperationNotPermitted, AsymmetricShardsUnsupportedActionDS)
+			}
+			return diag.Errorf(errorSnapshotBackupScheduleRead, clusterName, err)
+		}
+
+		copySettings = flattenCopySettingsOldSDK(backupScheduleOldSDK.GetCopySettings())
+		backupSchedule = convertBackupScheduleToLatestExcludeCopySettings(backupScheduleOldSDK)
+	} else {
+		backupSchedule, _, err = connV2.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusterName).Execute()
+		if err != nil {
+			return diag.Errorf(errorSnapshotBackupScheduleRead, clusterName, err)
+		}
+		copySettings = FlattenCopySettings(backupSchedule.GetCopySettings())
 	}
 
-	if err := d.Set("restore_window_days", backupPolicy.GetRestoreWindowDays()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "restore_window_days", clusterName, err)
+	diags := setSchemaFieldsExceptCopySettings(d, backupSchedule)
+	if diags.HasError() {
+		return diags
 	}
 
-	if err := d.Set("next_snapshot", conversion.TimePtrToStringPtr(backupPolicy.NextSnapshot)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "next_snapshot", clusterName, err)
-	}
-	if err := d.Set("use_org_and_group_names_in_export_prefix", backupPolicy.GetUseOrgAndGroupNamesInExportPrefix()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "use_org_and_group_names_in_export_prefix", clusterName, err)
-	}
-	if err := d.Set("auto_export_enabled", backupPolicy.GetAutoExportEnabled()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "auto_export_enabled", clusterName, err)
-	}
-	if err := d.Set("id_policy", backupPolicy.GetPolicies()[0].GetId()); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "id_policy", clusterName, err)
-	}
-	if err := d.Set("export", FlattenExport(convertBackupScheduleToLatestExcludeCopySettings(backupPolicy))); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "export", clusterName, err)
-	}
-	if err := d.Set("policy_item_hourly", FlattenPolicyItem(*convertPolicyItemsToLatest(backupPolicy.GetPolicies()[0].PolicyItems), Hourly)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_hourly", clusterName, err)
-	}
-
-	if err := d.Set("policy_item_daily", FlattenPolicyItem(*convertPolicyItemsToLatest(backupPolicy.GetPolicies()[0].PolicyItems), Daily)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_daily", clusterName, err)
-	}
-
-	if err := d.Set("policy_item_weekly", FlattenPolicyItem(*convertPolicyItemsToLatest(backupPolicy.GetPolicies()[0].PolicyItems), Weekly)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_weekly", clusterName, err)
-	}
-
-	if err := d.Set("policy_item_monthly", FlattenPolicyItem(*convertPolicyItemsToLatest(backupPolicy.GetPolicies()[0].PolicyItems), Monthly)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_monthly", clusterName, err)
-	}
-
-	if err := d.Set("policy_item_yearly", FlattenPolicyItem(*convertPolicyItemsToLatest(backupPolicy.GetPolicies()[0].PolicyItems), Yearly)); err != nil {
-		return diag.Errorf(errorSnapshotBackupScheduleSetting, "policy_item_yearly", clusterName, err)
-	}
-
-	if err := d.Set("copy_settings", flattenCopySettingsOldSDK(backupPolicy.GetCopySettings())); err != nil {
+	if err := d.Set("copy_settings", copySettings); err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleSetting, "copy_settings", clusterName, err)
 	}
 

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -1055,15 +1055,3 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 		return fmt.Sprintf("%s-%s", ids["project_id"], ids["cluster_name"]), nil
 	}
 }
-
-// func checkAggr(attrsSet []string, attrsMap map[string]string, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
-// 	checks := []resource.TestCheckFunc{checkExists(resourceName)}
-// 	checks = acc.AddAttrChecks(resourceName, checks, attrsMap)
-// 	checks = acc.AddAttrChecks(dataSourceName, checks, attrsMap)
-// 	checks = acc.AddAttrChecks(dataSourceNameOld, checks, attrsMap)
-// 	checks = acc.AddAttrSetChecks(resourceName, checks, attrsSet...)
-// 	checks = acc.AddAttrSetChecks(dataSourceName, checks, attrsSet...)
-// 	checks = acc.AddAttrSetChecks(dataSourceNameOld, checks, attrsSet...)
-// 	checks = append(checks, extra...)
-// 	return resource.ComposeAggregateTestCheckFunc(checks...)
-// }

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_test.go
@@ -726,7 +726,7 @@ func configCopySettings(terraformStr, projectID, clusterResourceName string, emp
 				should_copy_oplogs = true
 			}`, clusterResourceName)
 
-			dataSourceConfig = `data "mongodbatlas_cloud_backup_schedule" "schedule_test_old" {
+			dataSourceConfig = `data "mongodbatlas_cloud_backup_schedule" "schedule_test" {
 				cluster_name     = mongodbatlas_cloud_backup_schedule.schedule_test.cluster_name
 				project_id       = mongodbatlas_cloud_backup_schedule.schedule_test.project_id
 			}`


### PR DESCRIPTION
## Description

This PR updates `mongodbatlas_cloud_backup_schedule` data source to support independent shard scaling API changes:

- Deprecates `copy_settings.#.replication_spec_id`
- Adds `copy_settings.#.zone_id`
- Adds a new optional bool attribute `use_zone_id_for_copy_settings` that users can set to true to start leveraging the new API

Documentation will be updated in separate follow-up PRs.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
