### PR TITLE
feat: Support update transitioning from old to new sharding schema

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -978,57 +978,6 @@ func updateRequestOldAPI(d *schema.ResourceData, clusterName string) (*admin2023
 	return cluster, nil
 }
 
-func noIDsPopulatedInReplicationSpecs(replicationSpecs *[]admin.ReplicationSpec20250101) bool {
-	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
-		return false
-	}
-	for _, spec := range *replicationSpecs {
-		if conversion.IsStringPresent(spec.Id) {
-			return false
-		}
-	}
-	return true
-}
-
-func populateIDValuesUsingNewAPI(ctx context.Context, projectID, clusterName string, connV2CLusterAPI admin.ClustersApi, replicationSpecs *[]admin.ReplicationSpec20250101) (*[]admin.ReplicationSpec20250101, diag.Diagnostics) {
-	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
-		return replicationSpecs, nil
-	}
-	cluster, _, err := connV2CLusterAPI.GetCluster(ctx, projectID, clusterName).Execute()
-	if err != nil {
-		return nil, diag.FromErr(fmt.Errorf(errorRead, clusterName, err))
-	}
-
-	zoneToReplicationSpecsIDs := groupIDsByZone(cluster.GetReplicationSpecs())
-	result := addIDsToReplicationSpecs(*replicationSpecs, zoneToReplicationSpecsIDs)
-	return &result, nil
-}
-
-func addIDsToReplicationSpecs(replicationSpecs []admin.ReplicationSpec20250101, zoneToReplicationSpecsIDs map[string][]string) []admin.ReplicationSpec20250101 {
-	for zoneName, availableIDs := range zoneToReplicationSpecsIDs {
-		var indexOfIDToUse = 0
-		for i := range replicationSpecs {
-			if indexOfIDToUse >= len(availableIDs) {
-				break // all available ids for this zone have been used
-			}
-			if replicationSpecs[i].GetZoneName() == zoneName {
-				newID := availableIDs[indexOfIDToUse]
-				indexOfIDToUse++
-				replicationSpecs[i].Id = &newID
-			}
-		}
-	}
-	return replicationSpecs
-}
-
-func groupIDsByZone(specs []admin.ReplicationSpec20250101) map[string][]string {
-	result := make(map[string][]string)
-	for _, spec := range specs {
-		result[spec.GetZoneName()] = append(result[spec.GetZoneName()], spec.GetId())
-	}
-	return result
-}
-
 func isUpdateAllowed(d *schema.ResourceData) (bool, error) {
 	cs, us := d.GetChange("replication_specs")
 	currentSpecs, updatedSpecs := cs.([]any), us.([]any)

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -814,7 +814,7 @@ func updateRequest(ctx context.Context, d *schema.ResourceData, projectID, clust
 		}
 		updatedReplicationSpecs := expandAdvancedReplicationSpecs(d.Get("replication_specs").([]any), updatedDiskSizeGB)
 
-		// case where sharding schema is transitioning from legacy to new structure (external_id was not present in the state)
+		// case where sharding schema is transitioning from legacy to new structure (external_id is not present in the state so no ids are are currently present)
 		if noIDsPopulatedInReplicationSpecs(updatedReplicationSpecs) {
 			// ids need to be populated to avoid error in the update request
 			specsWithIDs, diags := populateIDValuesUsingNewAPI(ctx, projectID, clusterName, connV2.ClustersApi, updatedReplicationSpecs)

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -141,6 +141,56 @@ func TestMigAdvancedCluster_symmetricGeoShardedOldSchema(t *testing.T) {
 	})
 }
 
+func TestMigAdvancedCluster_shardedTransitionFromOldToNewSchema(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
+				Check:             checkShardedTransitionOldToNewSchema(false),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
+				Check:                    checkShardedTransitionOldToNewSchema(true),
+			},
+		},
+	})
+}
+
+func TestMigAdvancedCluster_geoShardedTransitionFromOldToNewSchema(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckBasic(t) },
+		CheckDestroy: acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
+				Check:             checkGeoShardedTransitionOldToNewSchema(false),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
+				Check:                    checkGeoShardedTransitionOldToNewSchema(true),
+			},
+		},
+	})
+}
+
 func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -7,10 +7,12 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	admin20231115 "go.mongodb.org/atlas-sdk/v20231115014/admin"
 	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -659,11 +661,26 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 		ids := conversion.DecodeStateID(rs.Primary.ID)
-		if _, _, err := acc.ConnV2().ClustersApi.GetCluster(context.Background(), ids["project_id"], ids["cluster_name"]).Execute(); err == nil {
+		err := getClusterHandlingRetry(ids["project_id"], ids["cluster_name"])
+		if err == nil {
 			return nil
 		}
-		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["project_id"], rs.Primary.ID)
+		return fmt.Errorf("cluster(%s:%s) does not exist: %w", rs.Primary.Attributes["project_id"], rs.Primary.ID, err)
 	}
+}
+
+func getClusterHandlingRetry(projectID, clusterName string) error {
+	return retry.RetryContext(context.Background(), 3*time.Minute, func() *retry.RetryError {
+		_, _, err := acc.ConnV2().ClustersApi.GetCluster(context.Background(), projectID, clusterName).Execute()
+		if apiError, ok := admin.AsError(err); ok {
+			if apiError.GetErrorCode() == "SERVICE_UNAVAILABLE" {
+				// retrying get operation because for migration test it can be the first time new API is called for a cluster so API responds with temporary error as it transition to enabling ISS FF
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 }
 
 func configTenant(projectID, name string) string {
@@ -1718,8 +1735,8 @@ func checkGeoShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestChe
 				"replication_specs.#":           "4",
 				"replication_specs.0.zone_name": "zone 1",
 				"replication_specs.1.zone_name": "zone 1",
+				"replication_specs.2.zone_name": "zone 2",
 				"replication_specs.3.zone_name": "zone 2",
-				"replication_specs.4.zone_name": "zone 2",
 			},
 		)
 	}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1571,6 +1571,11 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 		replicationSpecs = replicationSpec
 	}
 
+	var dataSourceFlag string
+	if useNewSchema {
+		dataSourceFlag = `use_replication_spec_per_shard = true`
+	}
+
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
@@ -1589,14 +1594,14 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 		data "mongodbatlas_advanced_cluster" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
-			use_replication_spec_per_shard = true
+			%[5]s
 		}
 
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
-			use_replication_spec_per_shard = true
+			%[5]s
 		}
-	`, orgID, projectName, name, replicationSpecs)
+	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
 }
 
 func checkShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckFunc {
@@ -1670,6 +1675,11 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 			fmt.Sprintf(replicationSpec, numShardsStr, "EU_WEST_1", "zone 2"), fmt.Sprintf(replicationSpec, numShardsStr, "EU_WEST_1", "zone 2"))
 	}
 
+	var dataSourceFlag string
+	if useNewSchema {
+		dataSourceFlag = `use_replication_spec_per_shard = true`
+	}
+
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
@@ -1688,14 +1698,14 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 		data "mongodbatlas_advanced_cluster" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
-			use_replication_spec_per_shard = true
+			%[5]s
 		}
 
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
-			use_replication_spec_per_shard = true
+			%[5]s
 		}
-	`, orgID, projectName, name, replicationSpecs)
+	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
 }
 
 func checkGeoShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckFunc {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1547,11 +1547,11 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 			%[1]s
 			region_configs {
 				electable_specs {
-					instance_size = M10
+					instance_size = "M10"
 					node_count    = 3
 				}
 				analytics_specs {
-					instance_size = M10
+					instance_size = "M10"
 					node_count    = 1
 				}
 				provider_name = "AWS"
@@ -1639,11 +1639,11 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 			%[1]s
 			region_configs {
 				electable_specs {
-					instance_size = M10
+					instance_size = "M10"
 					node_count    = 3
 				}
 				analytics_specs {
-					instance_size = M10
+					instance_size = "M10"
 					node_count    = 1
 				}
 				provider_name = "AWS"

--- a/internal/service/advancedcluster/resource_update_logic.go
+++ b/internal/service/advancedcluster/resource_update_logic.go
@@ -1,0 +1,61 @@
+package advancedcluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
+)
+
+func noIDsPopulatedInReplicationSpecs(replicationSpecs *[]admin.ReplicationSpec20250101) bool {
+	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
+		return false
+	}
+	for _, spec := range *replicationSpecs {
+		if conversion.IsStringPresent(spec.Id) {
+			return false
+		}
+	}
+	return true
+}
+
+func populateIDValuesUsingNewAPI(ctx context.Context, projectID, clusterName string, connV2CLusterAPI admin.ClustersApi, replicationSpecs *[]admin.ReplicationSpec20250101) (*[]admin.ReplicationSpec20250101, diag.Diagnostics) {
+	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
+		return replicationSpecs, nil
+	}
+	cluster, _, err := connV2CLusterAPI.GetCluster(ctx, projectID, clusterName).Execute()
+	if err != nil {
+		return nil, diag.FromErr(fmt.Errorf(errorRead, clusterName, err))
+	}
+
+	zoneToReplicationSpecsIDs := groupIDsByZone(cluster.GetReplicationSpecs())
+	result := AddIDsToReplicationSpecs(*replicationSpecs, zoneToReplicationSpecsIDs)
+	return &result, nil
+}
+
+func AddIDsToReplicationSpecs(replicationSpecs []admin.ReplicationSpec20250101, zoneToReplicationSpecsIDs map[string][]string) []admin.ReplicationSpec20250101 {
+	for zoneName, availableIDs := range zoneToReplicationSpecsIDs {
+		var indexOfIDToUse = 0
+		for i := range replicationSpecs {
+			if indexOfIDToUse >= len(availableIDs) {
+				break // all available ids for this zone have been used
+			}
+			if replicationSpecs[i].GetZoneName() == zoneName {
+				newID := availableIDs[indexOfIDToUse]
+				indexOfIDToUse++
+				replicationSpecs[i].Id = &newID
+			}
+		}
+	}
+	return replicationSpecs
+}
+
+func groupIDsByZone(specs []admin.ReplicationSpec20250101) map[string][]string {
+	result := make(map[string][]string)
+	for _, spec := range specs {
+		result[spec.GetZoneName()] = append(result[spec.GetZoneName()], spec.GetId())
+	}
+	return result
+}

--- a/internal/service/advancedcluster/resource_update_logic.go
+++ b/internal/service/advancedcluster/resource_update_logic.go
@@ -21,11 +21,11 @@ func noIDsPopulatedInReplicationSpecs(replicationSpecs *[]admin.ReplicationSpec2
 	return true
 }
 
-func populateIDValuesUsingNewAPI(ctx context.Context, projectID, clusterName string, connV2CLusterAPI admin.ClustersApi, replicationSpecs *[]admin.ReplicationSpec20250101) (*[]admin.ReplicationSpec20250101, diag.Diagnostics) {
+func populateIDValuesUsingNewAPI(ctx context.Context, projectID, clusterName string, connV2ClusterAPI admin.ClustersApi, replicationSpecs *[]admin.ReplicationSpec20250101) (*[]admin.ReplicationSpec20250101, diag.Diagnostics) {
 	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
 		return replicationSpecs, nil
 	}
-	cluster, _, err := connV2CLusterAPI.GetCluster(ctx, projectID, clusterName).Execute()
+	cluster, _, err := connV2ClusterAPI.GetCluster(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return nil, diag.FromErr(fmt.Errorf(errorRead, clusterName, err))
 	}

--- a/internal/service/advancedcluster/resource_update_logic_test.go
+++ b/internal/service/advancedcluster/resource_update_logic_test.go
@@ -1,0 +1,125 @@
+package advancedcluster_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
+)
+
+func TestAddIDsToReplicationSpecs(t *testing.T) {
+	testCases := map[string]struct {
+		ReplicationSpecs          []admin.ReplicationSpec20250101
+		ZoneToReplicationSpecsIDs map[string][]string
+		ExpectedReplicationSpecs  []admin.ReplicationSpec20250101
+	}{
+		"two zones with same amount of available ids and replication specs to populate": {
+			ReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+				},
+			},
+			ZoneToReplicationSpecsIDs: map[string][]string{
+				"Zone 1": {"zone1-id1", "zone1-id2"},
+				"Zone 2": {"zone2-id1", "zone2-id2"},
+			},
+			ExpectedReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       admin.PtrString("zone1-id1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+					Id:       admin.PtrString("zone2-id1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       admin.PtrString("zone1-id2"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+					Id:       admin.PtrString("zone2-id2"),
+				},
+			},
+		},
+		"less available ids than replication specs to populate": {
+			ReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+				},
+			},
+			ZoneToReplicationSpecsIDs: map[string][]string{
+				"Zone 1": {"zone1-id1"},
+				"Zone 2": {"zone2-id1"},
+			},
+			ExpectedReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       admin.PtrString("zone1-id1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       nil,
+				},
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       nil,
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+					Id:       admin.PtrString("zone2-id1"),
+				},
+			},
+		},
+		"more available ids than replication specs to populate": {
+			ReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+				},
+			},
+			ZoneToReplicationSpecsIDs: map[string][]string{
+				"Zone 1": {"zone1-id1", "zone1-id2"},
+				"Zone 2": {"zone2-id1", "zone2-id2"},
+			},
+			ExpectedReplicationSpecs: []admin.ReplicationSpec20250101{
+				{
+					ZoneName: admin.PtrString("Zone 1"),
+					Id:       admin.PtrString("zone1-id1"),
+				},
+				{
+					ZoneName: admin.PtrString("Zone 2"),
+					Id:       admin.PtrString("zone2-id1"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			resultSpecs := advancedcluster.AddIDsToReplicationSpecs(tc.ReplicationSpecs, tc.ZoneToReplicationSpecsIDs)
+			assert.Equal(t, tc.ExpectedReplicationSpecs, resultSpecs)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-260664

Supports transition of going from usage of numShards > 1 to having split replication specs. 
The main complexity here is that configs with numShards > 1 do not have `replication_specs.*.external_id` defined, so once a users transitions to the new schema we invoke the new API for the PATCH request but need to obtain the correct ids to send in the request.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
