### PR TITLE
test: Supporting old schema structure for defining symmetric sharded/geo-sharded clusters

### DIFF
--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -329,7 +329,6 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 	}
 
-	// TODO: CLOUDP-258711 update to use connLatest to call below API
 	processArgs, _, err := connV220231115.ClustersApi.GetClusterAdvancedConfiguration(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(ErrorAdvancedConfRead, clusterName, err))

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -69,7 +69,7 @@ func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName = acc.RandomClusterName()
-		config      = configSingleShardedMultiCloud(orgID, projectName, clusterName)
+		config      = configShardedMultiCloud(orgID, projectName, clusterName, 1, "M30")
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,13 +79,13 @@ func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 			{
 				ExternalProviders: mig.ExternalProviders(),
 				Config:            config,
-				Check:             checkSingleShardedMultiCloud(clusterName, false),
+				Check:             checkShardedMultiCloud(clusterName, 1, "M30", false),
 			},
 			mig.TestStepCheckEmptyPlan(config),
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   config,
-				Check:                    checkSingleShardedMultiCloud(clusterName, true), // external_id will be present in latest version
+				Check:                    checkShardedMultiCloud(clusterName, 1, "M30", true), // external_id will be present in latest version
 			},
 		},
 	})

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -119,7 +119,6 @@ func TestMigAdvancedCluster_singleShardPerZoneGeoSharded(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_symmetricGeoShardedOldSchema(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-260154 for ensuring old schema is supported
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -501,7 +501,6 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-260154 for ensuring this use case is supported
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -514,11 +514,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: configShardedMultiCloud(orgID, projectName, clusterName, 2, "M30"),
-				Check:  checkShardedMultiCloud(clusterName, 2, "M30", true),
+				Check:  checkShardedMultiCloud(clusterName, 2, "M30", false),
 			},
 			{
 				Config: configShardedMultiCloud(orgID, projectName, clusterName, 2, "M40"),
-				Check:  checkShardedMultiCloud(clusterName, 2, "M40", true),
+				Check:  checkShardedMultiCloud(clusterName, 2, "M40", false),
 			},
 		},
 	})
@@ -1061,7 +1061,7 @@ func checkShardedMultiCloud(name string, numShards int, analyticsSize string, ve
 		map[string]string{
 			"name":                           name,
 			"replication_specs.0.num_shards": strconv.Itoa(numShards),
-			"replication_specs.0.analytics_specs.0.instance_size": analyticsSize,
+			"replication_specs.0.region_configs.0.analytics_specs.0.instance_size": analyticsSize,
 		},
 		additionalChecks...)
 }

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_migration_test.go
@@ -42,7 +42,6 @@ func TestMigBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 }
 
 func TestMigBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-260154 for ensuring this use case is supported
 	var (
 		projectID       = acc.ProjectIDExecution(t)
 		clusterName     = acc.RandomClusterName()

--- a/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
+++ b/internal/service/cloudbackupsnapshot/resource_cloud_backup_snapshot_test.go
@@ -67,7 +67,6 @@ func TestAccBackupRSCloudBackupSnapshot_basic(t *testing.T) {
 }
 
 func TestAccBackupRSCloudBackupSnapshot_sharded(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: CLOUDP-260154 for ensuring this use case is supported
 	var (
 		projectID       = acc.ProjectIDExecution(t)
 		clusterName     = acc.RandomClusterName()

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -3,9 +3,12 @@ package acc
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"go.mongodb.org/atlas-sdk/v20240530002/admin"
 )
 
 var (
@@ -49,4 +52,18 @@ func ImportStateClusterIDFunc(resourceName string) resource.ImportStateIdFunc {
 
 		return fmt.Sprintf("%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["name"]), nil
 	}
+}
+
+func CheckClusterExistsHandlingRetry(projectID, clusterName string) error {
+	return retry.RetryContext(context.Background(), 3*time.Minute, func() *retry.RetryError {
+		_, _, err := ConnV2().ClustersApi.GetCluster(context.Background(), projectID, clusterName).Execute()
+		if apiError, ok := admin.AsError(err); ok {
+			if apiError.GetErrorCode() == "SERVICE_UNAVAILABLE" {
+				// retrying get operation because for migration test it can be the first time new API is called for a cluster so API responds with temporary error as it transition to enabling ISS FF
+				return retry.RetryableError(err)
+			}
+			return retry.NonRetryableError(err)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-260154

Adding new test and un-skipping existing test which verify support for sharded and geo-sharded cluster using old schema definition. These are included in both acceptance and migration tests.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
