### PR TITLE
fix: Handles update of `mongodbatlas_backup_compliance_policy` as a create operation

### DIFF
--- a/.changelog/2480.txt
+++ b/.changelog/2480.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_backup_compliance_policy: Fixes issue where Update operation modified attributes which were not supposed to be updated"
+resource/mongodbatlas_backup_compliance_policy: Fixes an issue where the update operation modified attributes that were not supposed to be modified"
 ```

--- a/.changelog/2480.txt
+++ b/.changelog/2480.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_backup_compliance_policy: Fixes issue where Update operation modified attributes which were not supposed to be updated"
+```

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
@@ -263,85 +263,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	dataProtectionSettings := &admin.DataProtectionSettings20231001{
-		ProjectId:               conversion.StringPtr(projectID),
-		AuthorizedEmail:         d.Get("authorized_email").(string),
-		AuthorizedUserFirstName: d.Get("authorized_user_first_name").(string),
-		AuthorizedUserLastName:  d.Get("authorized_user_last_name").(string),
-		CopyProtectionEnabled:   conversion.Pointer(d.Get("copy_protection_enabled").(bool)),
-		EncryptionAtRestEnabled: conversion.Pointer(d.Get("encryption_at_rest_enabled").(bool)),
-		PitEnabled:              conversion.Pointer(d.Get("pit_enabled").(bool)),
-		RestoreWindowDays:       conversion.Pointer(cast.ToInt(d.Get("restore_window_days"))),
-		OnDemandPolicyItem:      expandDemandBackupPolicyItem(d),
-	}
+	err := updateOrCreateDataProtectionSetting(ctx, d, connV2)
 
-	var backupPoliciesItem []admin.BackupComplianceScheduledPolicyItem
-	if v, ok := d.GetOk("policy_item_hourly"); ok {
-		item := v.([]any)
-		itemObj := item[0].(map[string]any)
-		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-			FrequencyType:     cloudbackupschedule.Hourly,
-			RetentionUnit:     itemObj["retention_unit"].(string),
-			FrequencyInterval: itemObj["frequency_interval"].(int),
-			RetentionValue:    itemObj["retention_value"].(int),
-		})
-	}
-	if v, ok := d.GetOk("policy_item_daily"); ok {
-		item := v.([]any)
-		itemObj := item[0].(map[string]any)
-		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-			FrequencyType:     cloudbackupschedule.Daily,
-			RetentionUnit:     itemObj["retention_unit"].(string),
-			FrequencyInterval: itemObj["frequency_interval"].(int),
-			RetentionValue:    itemObj["retention_value"].(int),
-		})
-	}
-	if v, ok := d.GetOk("policy_item_weekly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Weekly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if v, ok := d.GetOk("policy_item_monthly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Monthly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if v, ok := d.GetOk("policy_item_yearly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Yearly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if len(backupPoliciesItem) > 0 {
-		dataProtectionSettings.ScheduledPolicyItems = &backupPoliciesItem
-	}
-
-	params := admin.UpdateDataProtectionSettingsApiParams{
-		GroupId:                        projectID,
-		DataProtectionSettings20231001: dataProtectionSettings,
-		OverwriteBackupPolicies:        conversion.Pointer(false),
-	}
-	_, _, err := connV2.CloudBackupsApi.UpdateDataProtectionSettingsWithParams(ctx, &params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorBackupPolicyUpdate, projectID, err))
 	}
@@ -444,97 +367,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 
-	dataProtectionSettings := &admin.DataProtectionSettings20231001{
-		ProjectId:               conversion.StringPtr(projectID),
-		AuthorizedEmail:         d.Get("authorized_email").(string),
-		AuthorizedUserFirstName: d.Get("authorized_user_first_name").(string),
-		AuthorizedUserLastName:  d.Get("authorized_user_last_name").(string),
-		OnDemandPolicyItem:      expandDemandBackupPolicyItem(d),
-	}
+	err := updateOrCreateDataProtectionSetting(ctx, d, connV2)
 
-	if d.HasChange("copy_protection_enabled") {
-		dataProtectionSettings.CopyProtectionEnabled = conversion.Pointer(d.Get("copy_protection_enabled").(bool))
-	}
-
-	if d.HasChange("encryption_at_rest_enabled") {
-		dataProtectionSettings.EncryptionAtRestEnabled = conversion.Pointer(d.Get("encryption_at_rest_enabled").(bool))
-	}
-
-	if d.HasChange("pit_enabled") {
-		dataProtectionSettings.PitEnabled = conversion.Pointer(d.Get("pit_enabled").(bool))
-	}
-
-	if d.HasChange("restore_window_days") {
-		dataProtectionSettings.RestoreWindowDays = conversion.Pointer(cast.ToInt(d.Get("restore_window_days")))
-	}
-
-	var backupPoliciesItem []admin.BackupComplianceScheduledPolicyItem
-	if v, ok := d.GetOk("policy_item_hourly"); ok {
-		item := v.([]any)
-		itemObj := item[0].(map[string]any)
-		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-			FrequencyType:     cloudbackupschedule.Hourly,
-			RetentionUnit:     itemObj["retention_unit"].(string),
-			FrequencyInterval: itemObj["frequency_interval"].(int),
-			RetentionValue:    itemObj["retention_value"].(int),
-		})
-	}
-	if v, ok := d.GetOk("policy_item_daily"); ok {
-		item := v.([]any)
-		itemObj := item[0].(map[string]any)
-		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-			FrequencyType:     cloudbackupschedule.Daily,
-			RetentionUnit:     itemObj["retention_unit"].(string),
-			FrequencyInterval: itemObj["frequency_interval"].(int),
-			RetentionValue:    itemObj["retention_value"].(int),
-		})
-	}
-	if v, ok := d.GetOk("policy_item_weekly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Weekly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if v, ok := d.GetOk("policy_item_monthly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Monthly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if v, ok := d.GetOk("policy_item_yearly"); ok {
-		items := v.([]any)
-		for _, s := range items {
-			itemObj := s.(map[string]any)
-			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
-				FrequencyType:     cloudbackupschedule.Yearly,
-				RetentionUnit:     itemObj["retention_unit"].(string),
-				FrequencyInterval: itemObj["frequency_interval"].(int),
-				RetentionValue:    itemObj["retention_value"].(int),
-			})
-		}
-	}
-	if len(backupPoliciesItem) > 0 {
-		dataProtectionSettings.ScheduledPolicyItems = &backupPoliciesItem
-	}
-
-	params := admin.UpdateDataProtectionSettingsApiParams{
-		GroupId:                        projectID,
-		DataProtectionSettings20231001: dataProtectionSettings,
-		OverwriteBackupPolicies:        conversion.Pointer(false),
-	}
-	_, _, err := connV2.CloudBackupsApi.UpdateDataProtectionSettingsWithParams(ctx, &params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorBackupPolicyUpdate, projectID, err))
 	}
@@ -621,4 +455,90 @@ func flattenBackupPolicyItems(items []admin.BackupComplianceScheduledPolicyItem,
 		}
 	}
 	return policyItems
+}
+
+func updateOrCreateDataProtectionSetting(ctx context.Context, d *schema.ResourceData, connV2 *admin.APIClient) error {
+	ids := conversion.DecodeStateID(d.Id())
+	projectID := ids["project_id"]
+
+	dataProtectionSettings := &admin.DataProtectionSettings20231001{
+		ProjectId:               conversion.StringPtr(projectID),
+		AuthorizedEmail:         d.Get("authorized_email").(string),
+		AuthorizedUserFirstName: d.Get("authorized_user_first_name").(string),
+		AuthorizedUserLastName:  d.Get("authorized_user_last_name").(string),
+		CopyProtectionEnabled:   conversion.Pointer(d.Get("copy_protection_enabled").(bool)),
+		EncryptionAtRestEnabled: conversion.Pointer(d.Get("encryption_at_rest_enabled").(bool)),
+		PitEnabled:              conversion.Pointer(d.Get("pit_enabled").(bool)),
+		RestoreWindowDays:       conversion.Pointer(cast.ToInt(d.Get("restore_window_days"))),
+		OnDemandPolicyItem:      expandDemandBackupPolicyItem(d),
+	}
+
+	var backupPoliciesItem []admin.BackupComplianceScheduledPolicyItem
+	if v, ok := d.GetOk("policy_item_hourly"); ok {
+		item := v.([]any)
+		itemObj := item[0].(map[string]any)
+		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+			FrequencyType:     cloudbackupschedule.Hourly,
+			RetentionUnit:     itemObj["retention_unit"].(string),
+			FrequencyInterval: itemObj["frequency_interval"].(int),
+			RetentionValue:    itemObj["retention_value"].(int),
+		})
+	}
+	if v, ok := d.GetOk("policy_item_daily"); ok {
+		item := v.([]any)
+		itemObj := item[0].(map[string]any)
+		backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+			FrequencyType:     cloudbackupschedule.Daily,
+			RetentionUnit:     itemObj["retention_unit"].(string),
+			FrequencyInterval: itemObj["frequency_interval"].(int),
+			RetentionValue:    itemObj["retention_value"].(int),
+		})
+	}
+	if v, ok := d.GetOk("policy_item_weekly"); ok {
+		items := v.([]any)
+		for _, s := range items {
+			itemObj := s.(map[string]any)
+			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+				FrequencyType:     cloudbackupschedule.Weekly,
+				RetentionUnit:     itemObj["retention_unit"].(string),
+				FrequencyInterval: itemObj["frequency_interval"].(int),
+				RetentionValue:    itemObj["retention_value"].(int),
+			})
+		}
+	}
+	if v, ok := d.GetOk("policy_item_monthly"); ok {
+		items := v.([]any)
+		for _, s := range items {
+			itemObj := s.(map[string]any)
+			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+				FrequencyType:     cloudbackupschedule.Monthly,
+				RetentionUnit:     itemObj["retention_unit"].(string),
+				FrequencyInterval: itemObj["frequency_interval"].(int),
+				RetentionValue:    itemObj["retention_value"].(int),
+			})
+		}
+	}
+	if v, ok := d.GetOk("policy_item_yearly"); ok {
+		items := v.([]any)
+		for _, s := range items {
+			itemObj := s.(map[string]any)
+			backupPoliciesItem = append(backupPoliciesItem, admin.BackupComplianceScheduledPolicyItem{
+				FrequencyType:     cloudbackupschedule.Yearly,
+				RetentionUnit:     itemObj["retention_unit"].(string),
+				FrequencyInterval: itemObj["frequency_interval"].(int),
+				RetentionValue:    itemObj["retention_value"].(int),
+			})
+		}
+	}
+	if len(backupPoliciesItem) > 0 {
+		dataProtectionSettings.ScheduledPolicyItems = &backupPoliciesItem
+	}
+
+	params := admin.UpdateDataProtectionSettingsApiParams{
+		GroupId:                        projectID,
+		DataProtectionSettings20231001: dataProtectionSettings,
+		OverwriteBackupPolicies:        conversion.Pointer(false),
+	}
+	_, _, err := connV2.CloudBackupsApi.UpdateDataProtectionSettingsWithParams(ctx, &params).Execute()
+	return err
 }

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy.go
@@ -263,7 +263,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 
-	err := updateOrCreateDataProtectionSetting(ctx, d, connV2)
+	err := updateOrCreateDataProtectionSetting(ctx, d, connV2, projectID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorBackupPolicyUpdate, projectID, err))
@@ -367,7 +367,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 
-	err := updateOrCreateDataProtectionSetting(ctx, d, connV2)
+	err := updateOrCreateDataProtectionSetting(ctx, d, connV2, projectID)
 
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorBackupPolicyUpdate, projectID, err))
@@ -457,10 +457,7 @@ func flattenBackupPolicyItems(items []admin.BackupComplianceScheduledPolicyItem,
 	return policyItems
 }
 
-func updateOrCreateDataProtectionSetting(ctx context.Context, d *schema.ResourceData, connV2 *admin.APIClient) error {
-	ids := conversion.DecodeStateID(d.Id())
-	projectID := ids["project_id"]
-
+func updateOrCreateDataProtectionSetting(ctx context.Context, d *schema.ResourceData, connV2 *admin.APIClient, projectID string) error {
 	dataProtectionSettings := &admin.DataProtectionSettings20231001{
 		ProjectId:               conversion.StringPtr(projectID),
 		AuthorizedEmail:         d.Get("authorized_email").(string),

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -458,7 +458,7 @@ func basicChecks() []resource.TestCheckFunc {
 
 func configBasicWithOptionalAttributesWithNonDefaultValues(projectName, orgID, projectOwnerID string) string {
 	return acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false) +
-		`resource "mongodbatlas_backup_compliance_policy" "backup_policy_update" {
+		`resource "mongodbatlas_backup_compliance_policy" "backup_policy_res" {
 		project_id                 = mongodbatlas_project.test.id
 		authorized_email           = "test@example.com"
 		authorized_user_first_name = "First"

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
@@ -111,6 +112,41 @@ func TestAccBackupCompliancePolicy_withoutRestoreWindowDays(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "copy_protection_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_at_rest_enabled", "false"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBackupCompliancePolicy_UpdateSetsAllAttributes(t *testing.T) {
+	var (
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName    = acc.RandomProjectName() // No ProjectIDExecution to avoid conflicts with backup compliance policy
+		projectOwnerID = os.Getenv("MONGODB_ATLAS_PROJECT_OWNER_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasicWithOptionalAttributesWithNonDefaultValues(projectName, orgID, projectOwnerID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authorized_user_first_name", "First"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_user_last_name", "Last"),
+					resource.TestCheckResourceAttr(resourceName, "pit_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_at_rest_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "copy_protection_enabled", "true"),
+				),
+			},
+			{
+				Config: configBasicWithOptionalAttributesWithNonDefaultValues(projectName, orgID, projectOwnerID),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acc.DebugPlan(),
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -418,4 +454,49 @@ func basicChecks() []resource.TestCheckFunc {
 	checks = acc.AddAttrChecks(dataSourceName, checks, commonChecks)
 	checks = append(checks, checkExists(resourceName), checkExists(dataSourceName))
 	return checks
+}
+
+func configBasicWithOptionalAttributesWithNonDefaultValues(projectName, orgID, projectOwnerID string) string {
+	return acc.ConfigProjectWithSettings(projectName, orgID, projectOwnerID, false) +
+		`resource "mongodbatlas_backup_compliance_policy" "backup_policy_update" {
+		project_id                 = mongodbatlas_project.test.id
+		authorized_email           = "test@example.com"
+		authorized_user_first_name = "First"
+		authorized_user_last_name  = "Last"
+		copy_protection_enabled    = true
+		pit_enabled                = false
+		encryption_at_rest_enabled = false
+		
+		restore_window_days = 7
+		
+		on_demand_policy_item {
+			frequency_interval = 0
+			retention_unit     = "days"
+			retention_value    = 3
+		}
+		
+		policy_item_hourly {
+			frequency_interval = 6
+			retention_unit     = "days"
+			retention_value    = 7
+		}
+		
+		policy_item_daily {
+			frequency_interval = 0
+			retention_unit     = "days"
+			retention_value    = 7
+		}
+		
+		policy_item_weekly {
+			frequency_interval = 0
+			retention_unit     = "weeks"
+			retention_value    = 4
+		}
+		
+		policy_item_monthly {
+			frequency_interval = 0
+			retention_unit     = "months"
+			retention_value    = 12
+		}
+  }`
 }


### PR DESCRIPTION
## Description

Handles update of `mongodbatlas_backup_compliance_policy` as a create operation
- This change is needed because the update endpoint is a PUT, instead of a PATCH. We were only setting values to the attributes being modified, and the ones not being modified were being modified to the default value. 

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
