### PR TITLE
test: Refactor migration tests to use utility function and cover migration scenarios coming from 1.17.5

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -18,12 +18,14 @@ func TestMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
-	testCase := replicaSetMultiCloudTestCase(t)
+	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
+	testCase := replicaSetMultiCloudTestCase(t, false)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
-	testCase := singleShardedMultiCloudTestCase(t)
+	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
+	testCase := singleShardedMultiCloudTestCase(t, false)
 	mig.CreateAndRunTest(t, &testCase)
 }
 

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -54,23 +54,27 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
+	resource.ParallelTest(t, replicaSetAWSProviderTestCase(t, true))
+}
+func replicaSetAWSProviderTestCase(t *testing.T, checkNewAttributes bool) resource.TestCase {
+	t.Helper()
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
 				Config: configReplicaSetAWSProvider(projectID, clusterName, 60, 3),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, true, true),
+				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, checkNewAttributes, checkNewAttributes),
 			},
 			{
 				Config: configReplicaSetAWSProvider(projectID, clusterName, 50, 5),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 50, 5, true, true),
+				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 50, 5, checkNewAttributes, checkNewAttributes),
 			},
 			{
 				ResourceName:            resourceName,
@@ -80,10 +84,14 @@ func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"replication_specs", "retain_backups_enabled"},
 			},
 		},
-	})
+	}
 }
 
 func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
+	resource.ParallelTest(t, replicaSetMultiCloudTestCase(t))
+}
+func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
+	t.Helper()
 	var (
 		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName        = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -91,7 +99,7 @@ func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 		clusterNameUpdated = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
@@ -112,10 +120,15 @@ func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"replication_specs", "retain_backups_enabled"},
 			},
 		},
-	})
+	}
 }
 
 func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
+	resource.ParallelTest(t, singleShardedMultiCloudTestCase(t))
+}
+
+func singleShardedMultiCloudTestCase(t *testing.T) resource.TestCase {
+	t.Helper()
 	var (
 		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName        = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -123,7 +136,7 @@ func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 		clusterNameUpdated = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
@@ -144,7 +157,7 @@ func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"replication_specs"},
 			},
 		},
-	})
+	}
 }
 
 func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
@@ -522,27 +535,32 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing.T) {
+	resource.ParallelTest(t, symmetricGeoShardedOldSchemaTestCase(t, true))
+}
+
+func symmetricGeoShardedOldSchemaTestCase(t *testing.T, checkNewAttributes bool) resource.TestCase {
+	t.Helper()
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
 		clusterName = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
 				Config: configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false),
-				Check:  checkGeoShardedOldSchema(clusterName, 2, 2, true, false),
+				Check:  checkGeoShardedOldSchema(clusterName, 2, 2, checkNewAttributes, false),
 			},
 			{
 				Config: configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false),
-				Check:  checkGeoShardedOldSchema(clusterName, 3, 3, true, false),
+				Check:  checkGeoShardedOldSchema(clusterName, 3, 3, checkNewAttributes, false),
 			},
 		},
-	})
+	}
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel(t *testing.T) {
@@ -598,13 +616,18 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T) {
+	resource.ParallelTest(t, asymmetricShardedNewSchemaTestCase(t))
+}
+
+func asymmetricShardedNewSchemaTestCase(t *testing.T) resource.TestCase {
+	t.Helper()
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
 		clusterName = acc.RandomClusterName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
@@ -614,7 +637,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T
 				Check:  checkShardedNewSchema(50, "M30", "M40", "2000", "2500", true, false),
 			},
 		},
-	})
+	}
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemovingShard(t *testing.T) {


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-258475

This PR refactors migrations tests to use our utility function `mig.CreateAndRunTest`, this allows reusing test cases from acceptance tests.

Additionally added specific migration tests to verify support for updating and transitioning from old schema structure when coming from `1.17.4`. This ensure transition is handled correctly even when coming from a version that was not consuming the new API.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
