### PR TITLE
doc: Improves documention on how to obtain the `peering_id` for `mongodbatlas_network_peering`

### DIFF
--- a/docs/resources/network_peering.md
+++ b/docs/resources/network_peering.md
@@ -397,7 +397,7 @@ Network Peering Connections can be imported using project ID and network peering
 $ terraform import mongodbatlas_network_peering.my_peering 1112222b3bf99403840e8934-5cbf563d87d9d67253be590a-AWS
 ```
 
-To obtain your `project_id` and `peering_id` with the (MongoDB Atlas CLI)[https://www.mongodb.com/docs/atlas/cli/current/command/atlas-networking-peering-list/#std-label-atlas-networking-peering-list]. Attention: The `atlas networking peering list` command returns `AWS` peerings by default. You must include the the `--provider` parameter: Name of your cloud service provider. Valid values are AWS, AZURE, or GCP. This value defaults to "AWS".
+Use the [MongoDB Atlas CLI][https://www.mongodb.com/docs/atlas/cli/current/command/atlas-networking-peering-list/#std-label-atlas-networking-peering-list] to obtain your `project_id` and `peering_id`. Attention gcp and azure users: The `atlas networking peering list` command returns only `AWS` peerings by default. You have to include the `--provider` parameter to list peerings for your cloud provider. Valid values are AWS, AZURE, or GCP. This value defaults to "AWS".
 
 ```
 atlas projects list

--- a/docs/resources/network_peering.md
+++ b/docs/resources/network_peering.md
@@ -397,7 +397,7 @@ Network Peering Connections can be imported using project ID and network peering
 $ terraform import mongodbatlas_network_peering.my_peering 1112222b3bf99403840e8934-5cbf563d87d9d67253be590a-AWS
 ```
 
-Use the [MongoDB Atlas CLI][https://www.mongodb.com/docs/atlas/cli/current/command/atlas-networking-peering-list/#std-label-atlas-networking-peering-list] to obtain your `project_id` and `peering_id`. Attention gcp and azure users: The `atlas networking peering list` command returns only `AWS` peerings by default. You have to include the `--provider` parameter to list peerings for your cloud provider. Valid values are AWS, AZURE, or GCP. This value defaults to "AWS".
+Use the [MongoDB Atlas CLI][https://www.mongodb.com/docs/atlas/cli/current/command/atlas-networking-peering-list/#std-label-atlas-networking-peering-list] to obtain your `project_id` and `peering_id`. Attention gcp and azure users: The `atlas networking peering list` command returns only `AWS` peerings by default. You have to include the `--provider` parameter to list peerings for your cloud provider. Valid values are AWS, AZURE, or GCP.
 
 ```
 atlas projects list

--- a/docs/resources/network_peering.md
+++ b/docs/resources/network_peering.md
@@ -397,7 +397,7 @@ Network Peering Connections can be imported using project ID and network peering
 $ terraform import mongodbatlas_network_peering.my_peering 1112222b3bf99403840e8934-5cbf563d87d9d67253be590a-AWS
 ```
 
-To obtain `project_id` and `peering_id` can be obtained using atlas cli. Attention: `atlas networking peering list` needs the `--provider` parameter for AZURE and GCP as it returns only `AWS` peerings by default. 
+To obtain your `project_id` and `peering_id` with the (MongoDB Atlas CLI)[https://www.mongodb.com/docs/atlas/cli/current/command/atlas-networking-peering-list/#std-label-atlas-networking-peering-list]. Attention: The `atlas networking peering list` command returns `AWS` peerings by default. You must include the the `--provider` parameter: Name of your cloud service provider. Valid values are AWS, AZURE, or GCP. This value defaults to "AWS".
 
 ```
 atlas projects list

--- a/docs/resources/network_peering.md
+++ b/docs/resources/network_peering.md
@@ -397,6 +397,12 @@ Network Peering Connections can be imported using project ID and network peering
 $ terraform import mongodbatlas_network_peering.my_peering 1112222b3bf99403840e8934-5cbf563d87d9d67253be590a-AWS
 ```
 
+To obtain `project_id` and `peering_id` can be obtained using atlas cli. Attention: `atlas networking peering list` needs the `--provider` parameter for AZURE and GCP as it returns only `AWS` peerings by default. 
+
+```
+atlas projects list
+atlas networking peering list --projectId <projectId> --provider <AZURE|GCP|AWS>
+```
 See detailed information for arguments and attributes: [MongoDB API Network Peering Connection](https://docs.atlas.mongodb.com/reference/api/vpc-create-peering-connection/)
 
 -> **NOTE:** If you need to get an existing container ID see the [How-To Guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/howto-guide.html).


### PR DESCRIPTION
## Description

This is a copy of https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2472 created by @tback:

Improve documentation how to obtain the peering id. To my knowledge the peering id cannot be obtained from the web interface. CLI and API return only AWS peerings by default. This confuses users to assume there are no active peerings. I fell into this trap about two years ago on GCP (https://github.com/mongodb/terraform-provider-mongodbatlas/issues/789) and now on AZURE again.


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
