### PR TITLE
feat: Implements the `mongodbatlas_stream_processor` data source

### DIFF
--- a/.changelog/2497.txt
+++ b/.changelog/2497.txt
@@ -1,0 +1,3 @@
+```release-note:new-datasource
+data-source/mongodbatlas_streamprocessor
+```

--- a/internal/common/schemafunc/json.go
+++ b/internal/common/schemafunc/json.go
@@ -1,0 +1,60 @@
+package schemafunc
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func DiffSuppressJSON() planmodifier.String {
+	return diffSuppressJSONModifier{}
+}
+
+type diffSuppressJSONModifier struct {
+}
+
+func (m diffSuppressJSONModifier) Description(_ context.Context) string {
+	return "If the parsed jsons are the same, the value of this attribute in state will not change."
+}
+
+func (m diffSuppressJSONModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m diffSuppressJSONModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	old, newStr := req.StateValue.String(), req.PlanValue.String()
+	if EqualJSON(old, newStr, req.Path.String()) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func EqualJSON(old, newStr, errContext string) bool {
+	var j, j2 any
+
+	if old == "" {
+		old = "{}"
+	}
+
+	if newStr == "" {
+		newStr = "{}"
+	}
+
+	if err := json.Unmarshal([]byte(old), &j); err != nil {
+		log.Printf("[ERROR] cannot unmarshal old %s json %v", errContext, err)
+		return false
+	}
+	if err := json.Unmarshal([]byte(newStr), &j2); err != nil {
+		log.Printf("[ERROR] cannot unmarshal new %s json %v", errContext, err)
+		return false
+	}
+	return reflect.DeepEqual(&j, &j2)
+}

--- a/internal/common/schemafunc/json_test.go
+++ b/internal/common/schemafunc/json_test.go
@@ -1,0 +1,30 @@
+package schemafunc_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+)
+
+func Test_EqualJSON(t *testing.T) {
+	testCases := map[string]struct {
+		old      string
+		new      string
+		expected bool
+	}{
+		"empty strings":                      {"", "", true},
+		"different objects":                  {`{"a": 1}`, `{"b": 2}`, false},
+		"invalid object":                     {`{{"a": 1}`, `{"b": 2}`, false},
+		"double invalid object":              {`{{"a": 1}`, `{"b": 2}}`, false},
+		"equal objects with different order": {`{"a": 1, "b": 2}`, `{"b": 2, "a": 1}`, true},
+		"equal objects whitespace":           {`{"a": 1, "b": 2}`, `{"a":1,"b":2}`, true},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := schemafunc.EqualJSON(tc.old, tc.new, "vector search index")
+			if actual != tc.expected {
+				t.Errorf("Expected: %v, got: %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/searchdeployment"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streaminstance"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 )
 
@@ -433,6 +434,7 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 		streamconnection.DataSource,
 		streamconnection.PluralDataSource,
 		controlplaneipaddresses.DataSource,
+		streamprocessor.DataSource,
 	}
 	previewDataSources := []func() datasource.DataSource{} // Data sources not yet in GA
 	if providerEnablePreview {

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -114,7 +114,7 @@ func UnmarshalStoredSource(str string) (any, diag.Diagnostics) {
 }
 
 func diffSuppressJSON(k, old, newStr string, d *schema.ResourceData) bool {
-	return !schemafunc.EqualJSON(old, newStr, "vector search index")
+	return schemafunc.EqualJSON(old, newStr, "vector search index")
 }
 
 func resourceSearchIndexRefreshFunc(ctx context.Context, clusterName, projectID, indexID string, connV2 *admin.APIClient) retry.StateRefreshFunc {

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"log"
-	"reflect"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
@@ -115,27 +114,7 @@ func UnmarshalStoredSource(str string) (any, diag.Diagnostics) {
 }
 
 func diffSuppressJSON(k, old, newStr string, d *schema.ResourceData) bool {
-	var j, j2 any
-
-	if old == "" {
-		old = "{}"
-	}
-
-	if newStr == "" {
-		newStr = "{}"
-	}
-
-	if err := json.Unmarshal([]byte(old), &j); err != nil {
-		log.Printf("[ERROR] cannot unmarshal old search index analyzer json %v", err)
-	}
-	if err := json.Unmarshal([]byte(newStr), &j2); err != nil {
-		log.Printf("[ERROR] cannot unmarshal new search index analyzer json %v", err)
-	}
-	if !reflect.DeepEqual(&j, &j2) {
-		return false
-	}
-
-	return true
+	return !schemafunc.EqualJSON(old, newStr, "vector search index")
 }
 
 func resourceSearchIndexRefreshFunc(ctx context.Context, clusterName, projectID, indexID string, connV2 *admin.APIClient) retry.StateRefreshFunc {

--- a/internal/service/streamprocessor/data_source.go
+++ b/internal/service/streamprocessor/data_source.go
@@ -1,0 +1,56 @@
+package streamprocessor
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+const StreamProccesorName = "streamprocessor"
+
+var _ datasource.DataSource = &StreamProccesorDS{}
+var _ datasource.DataSourceWithConfigure = &StreamProccesorDS{}
+
+func DataSource() datasource.DataSource {
+	return &StreamProccesorDS{
+		DSCommon: config.DSCommon{
+			DataSourceName: StreamProccesorName,
+		},
+	}
+}
+
+type StreamProccesorDS struct {
+	config.DSCommon
+}
+
+func (d *StreamProccesorDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// TODO: Schema and model must be defined in data_source_schema.go. Details on scaffolding this file found in contributing/development-best-practices.md under "Scaffolding Schema and Model Definitions"
+	resp.Schema = DataSourceSchema(ctx)
+}
+
+func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var streamProccesorConfig TFStreamProcessorDSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &streamProccesorConfig)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connV2 := d.Client.AtlasV2
+	projectID := streamProccesorConfig.ProjectID.ValueString()
+	instanceName := streamProccesorConfig.InstanceName.ValueString()
+	processorName := streamProccesorConfig.ProcessorName.ValueString()
+	apiResp, _, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, instanceName, processorName).Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
+
+	newStreamTFStreamprocessorDSModelModel, diags := NewTFStreamprocessorDSModel(ctx, projectID, instanceName, apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newStreamTFStreamprocessorDSModelModel)...)
+}

--- a/internal/service/streamprocessor/data_source_schema.go
+++ b/internal/service/streamprocessor/data_source_schema.go
@@ -1,0 +1,61 @@
+package streamprocessor
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func DataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
+				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
+			},
+			"instance_name": schema.StringAttribute{
+				Required:            true,
+				Description:         "Human-readable label that identifies the stream instance.",
+				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+			},
+			"pipeline": schema.StringAttribute{
+				Computed:            true,
+				Description:         "Stream aggregation pipeline you want to apply to your streaming data.",
+				MarkdownDescription: "Stream aggregation pipeline you want to apply to your streaming data.",
+			},
+			"processor_name": schema.StringAttribute{
+				Required:            true,
+				Description:         "Human-readable label that identifies the stream processor.",
+				MarkdownDescription: "Human-readable label that identifies the stream processor.",
+			},
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				Description:         "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+			},
+			"state": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The state of the stream processor.",
+				MarkdownDescription: "The state of the stream processor.",
+			},
+			"stats": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The stats associated with the stream processor.",
+				MarkdownDescription: "The stats associated with the stream processor.",
+			},
+		},
+	}
+}
+
+type TFStreamprocessorDSModel struct {
+	ID            types.String `tfsdk:"id"`
+	InstanceName  types.String `tfsdk:"instance_name"`
+	Pipeline      types.String `tfsdk:"pipeline"`
+	ProcessorName types.String `tfsdk:"processor_name"`
+	ProjectID     types.String `tfsdk:"project_id"`
+	State         types.String `tfsdk:"state"`
+	Stats         types.String `tfsdk:"stats"`
+}

--- a/internal/service/streamprocessor/data_source_schema.go
+++ b/internal/service/streamprocessor/data_source_schema.go
@@ -50,7 +50,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-type TFStreamprocessorDSModel struct {
+type TFStreamProcessorDSModel struct {
 	ID            types.String `tfsdk:"id"`
 	InstanceName  types.String `tfsdk:"instance_name"`
 	Pipeline      types.String `tfsdk:"pipeline"`

--- a/internal/service/streamprocessor/data_source_test.go
+++ b/internal/service/streamprocessor/data_source_test.go
@@ -1,0 +1,49 @@
+package streamprocessor_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+var dataSourceName = "data.mongodbatlas_streamprocessor.test"
+
+func TestAccStreamProcessorDS_readManual(t *testing.T) {
+	acc.SkipTestForCI(t) // only for manual testing so far, will be moved to resource acceptance test
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		instanceName  = os.Getenv("MONGODB_ATLAS_STREAM_INSTANCE_NAME")
+		processorName = os.Getenv("MONGODB_ATLAS_STREAM_PROCESSOR_NAME")
+	)
+
+	checks := acc.AddAttrChecks(dataSourceName, nil, map[string]string{
+		"project_id":     projectID,
+		"instance_name":  instanceName,
+		"processor_name": processorName,
+		"state":          "CREATED",
+	})
+	checks = acc.AddAttrSetChecks(dataSourceName, checks, "id", "pipeline", "stats")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: streamProcessorConfigDS(projectID, instanceName, processorName),
+				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
+			},
+		},
+	},
+	)
+}
+
+func streamProcessorConfigDS(projectID, instanceName, processorName string) string {
+	return fmt.Sprintf(`
+	data "mongodbatlas_streamprocessor" "test" {
+		project_id = %[1]q
+		instance_name = %[2]q
+		processor_name = %[3]q
+	}`, projectID, instanceName, processorName)
+}

--- a/internal/service/streamprocessor/main_test.go
+++ b/internal/service/streamprocessor/main_test.go
@@ -1,0 +1,15 @@
+package streamprocessor_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -9,7 +9,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
-func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamprocessorDSModel, diag.Diagnostics) {
+func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorDSModel, diag.Diagnostics) {
 	if apiResp == nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}
 	}
@@ -21,7 +21,7 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName st
 	if diags.HasError() {
 		return nil, diags
 	}
-	tfModel := &TFStreamprocessorDSModel{
+	tfModel := &TFStreamProcessorDSModel{
 		ID:            types.StringPointerValue(&apiResp.Id),
 		InstanceName:  types.StringPointerValue(&instanceName),
 		Pipeline:      pipelineTF,

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -1,0 +1,53 @@
+package streamprocessor
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamprocessorDSModel, diag.Diagnostics) {
+	if apiResp == nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}
+	}
+	pipelineTF, diags := convertPipelineToTF(apiResp.GetPipeline())
+	if diags.HasError() {
+		return nil, diags
+	}
+	statsTF, diags := convertStatsToTF(apiResp.GetStats())
+	if diags.HasError() {
+		return nil, diags
+	}
+	tfModel := &TFStreamprocessorDSModel{
+		ID:            types.StringPointerValue(&apiResp.Id),
+		InstanceName:  types.StringPointerValue(&instanceName),
+		Pipeline:      pipelineTF,
+		ProcessorName: types.StringPointerValue(&apiResp.Name),
+		ProjectID:     types.StringPointerValue(&projectID),
+		State:         types.StringPointerValue(&apiResp.State),
+		Stats:         statsTF,
+	}
+	return tfModel, nil
+}
+
+func convertPipelineToTF(pipeline []any) (types.String, diag.Diagnostics) {
+	pipelineJSON, err := json.Marshal(pipeline)
+	if err != nil {
+		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal pipeline", err.Error())}
+	}
+	return types.StringValue(string(pipelineJSON)), nil
+}
+
+func convertStatsToTF(stats any) (types.String, diag.Diagnostics) {
+	if stats == nil {
+		return types.StringValue("{}"), nil
+	}
+	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal stats", err.Error())}
+	}
+	return types.StringValue(string(statsJSON)), nil
+}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -91,7 +91,7 @@ func streamProcessorWithStats(t *testing.T) *admin.StreamsProcessorWithStats {
 func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 	testCases := []struct {
 		sdkModel        *admin.StreamsProcessorWithStats
-		expectedTFModel *streamprocessor.TFStreamprocessorDSModel
+		expectedTFModel *streamprocessor.TFStreamProcessorDSModel
 		name            string
 	}{
 		{
@@ -99,7 +99,7 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 			sdkModel: admin.NewStreamsProcessorWithStats(
 				processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, "CREATED",
 			),
-			expectedTFModel: &streamprocessor.TFStreamprocessorDSModel{
+			expectedTFModel: &streamprocessor.TFStreamProcessorDSModel{
 				ID:            types.StringValue(processorID),
 				InstanceName:  types.StringValue(instanceName),
 				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
@@ -112,7 +112,7 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 		{
 			name:     "afterStarted",
 			sdkModel: streamProcessorWithStats(t),
-			expectedTFModel: &streamprocessor.TFStreamprocessorDSModel{
+			expectedTFModel: &streamprocessor.TFStreamProcessorDSModel{
 				ID:            types.StringValue(processorID),
 				InstanceName:  types.StringValue(instanceName),
 				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -1,0 +1,148 @@
+package streamprocessor_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+var (
+	projectID                 = "661fe3ad234b02027dabcabc"
+	instanceName              = "test-instance-name"
+	pipelineStageSourceSample = map[string]any{
+		"$source": map[string]any{
+			"connectionName": "sample_stream_solar",
+		},
+	}
+	pipelineStageEmitLog = map[string]any{
+		"$emit": map[string]any{
+			"connectionName": "__testLog",
+		},
+	}
+	processorName = "processor1"
+	processorID   = "66b39806187592e8d721215d"
+)
+
+var statsExample = `
+{
+	"dlqMessageCount": 0,
+	"dlqMessageSize": 0.0,
+	"inputMessageCount": 12,
+	"inputMessageSize": 4681.0,
+	"memoryTrackerBytes": 0.0,
+	"name": "processor1",
+	"ok": 1.0,
+	"operatorStats": [
+		{
+			"dlqMessageCount": 0,
+			"dlqMessageSize": 0.0,
+			"executionTimeSecs": 0,
+			"inputMessageCount": 12,
+			"inputMessageSize": 4681.0,
+			"maxMemoryUsage": 0.0,
+			"name": "SampleDataSourceOperator",
+			"outputMessageCount": 12,
+			"outputMessageSize": 0.0,
+			"stateSize": 0.0,
+			"timeSpentMillis": 0
+		},
+		{
+			"dlqMessageCount": 0,
+			"dlqMessageSize": 0.0,
+			"executionTimeSecs": 0,
+			"inputMessageCount": 12,
+			"inputMessageSize": 4681.0,
+			"maxMemoryUsage": 0.0,
+			"name": "LogSinkOperator",
+			"outputMessageCount": 12,
+			"outputMessageSize": 4681.0,
+			"stateSize": 0.0,
+			"timeSpentMillis": 0
+		}
+	],
+	"outputMessageCount": 12,
+	"outputMessageSize": 4681.0,
+	"processorId": "66b3941109bbccf048ccff06",
+	"scaleFactor": 1,
+	"stateSize": 0.0,
+	"status": "running"
+}`
+
+func streamProcessorWithStats(t *testing.T) *admin.StreamsProcessorWithStats {
+	t.Helper()
+	processor := admin.NewStreamsProcessorWithStats(
+		processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, "STARTED",
+	)
+	var stats any
+	err := json.Unmarshal([]byte(statsExample), &stats)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processor.SetStats(stats)
+	return processor
+}
+
+func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
+	testCases := []struct {
+		sdkModel        *admin.StreamsProcessorWithStats
+		expectedTFModel *streamprocessor.TFStreamprocessorDSModel
+		name            string
+	}{
+		{
+			name: "afterCreate",
+			sdkModel: admin.NewStreamsProcessorWithStats(
+				processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, "CREATED",
+			),
+			expectedTFModel: &streamprocessor.TFStreamprocessorDSModel{
+				ID:            types.StringValue(processorID),
+				InstanceName:  types.StringValue(instanceName),
+				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName: types.StringValue(processorName),
+				ProjectID:     types.StringValue(projectID),
+				State:         types.StringValue("CREATED"),
+				Stats:         types.StringValue("{}"),
+			},
+		},
+		{
+			name:     "afterStarted",
+			sdkModel: streamProcessorWithStats(t),
+			expectedTFModel: &streamprocessor.TFStreamprocessorDSModel{
+				ID:            types.StringValue(processorID),
+				InstanceName:  types.StringValue(instanceName),
+				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName: types.StringValue(processorName),
+				ProjectID:     types.StringValue(projectID),
+				State:         types.StringValue("STARTED"),
+				Stats:         types.StringValue(statsExample),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdkModel := tc.sdkModel
+			resultModel, diags := streamprocessor.NewTFStreamprocessorDSModel(context.Background(), projectID, instanceName, sdkModel)
+			if diags.HasError() {
+				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			if sdkModel.Stats != nil {
+				assert.True(t, schemafunc.EqualJSON(resultModel.Pipeline.String(), tc.expectedTFModel.Pipeline.String(), "test stream processor schema"))
+				var statsResult any
+				err := json.Unmarshal([]byte(resultModel.Stats.ValueString()), &statsResult)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assert.Len(t, sdkModel.Stats, 14)
+				assert.Len(t, statsResult, 14)
+			} else {
+				assert.Equal(t, tc.expectedTFModel, resultModel)
+			}
+		})
+	}
+}

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -14,7 +18,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"change_stream_token": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The resume token for the change stream. Only used when the pipeline source is Cluster.",
-				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
+				MarkdownDescription: "The resume token for the change stream. Only used when the pipeline source is Cluster.",
 			},
 			"id": schema.StringAttribute{
 				Optional:            true,
@@ -28,12 +32,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Human-readable label that identifies the stream instance.",
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
 			},
-			"pipeline": schema.ListNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{},
+			"pipeline": schema.StringAttribute{
+				Validators: []validator.String{
+					validate.StringIsJSON(),
 				},
-				Optional:            true,
-				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					schemafunc.DiffSuppressJSON(),
+				},
+				Required:            true,
 				Description:         "Stream aggregation pipeline you want to apply to your streaming data.",
 				MarkdownDescription: "Stream aggregation pipeline you want to apply to your streaming data.",
 			},
@@ -91,7 +97,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 type TFStreamProcessorRSModel struct {
 	InstanceName  types.String `tfsdk:"instance_name"`
 	Options       types.Object `tfsdk:"options"`
-	Pipeline      types.List   `tfsdk:"pipeline"`
+	Pipeline      types.String `tfsdk:"pipeline"`
 	ProcessorID   types.String `tfsdk:"processor_id"`
 	ProcessorName types.String `tfsdk:"processor_name"`
 	ProjectID     types.String `tfsdk:"project_id"`


### PR DESCRIPTION
## Description

- Implements the `streamprocessor` data source schema
- Updates the `pipeline` in the resource_schema to use a string and use validators & planModifiers (see below)
- Refactors `EqualJSON` used in `searchindex` to `common/schemafunc.json` and adds `DiffSuppressJSON`

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:


- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
