### PR TITLE
feat: Implements `mongodbatlas_stream_processor` resource

### DIFF
--- a/.changelog/2501.txt
+++ b/.changelog/2501.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+mongodbatlas_stream_processor
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -279,6 +279,7 @@ jobs:
           stream:
             - 'internal/service/streamconnection/*.go'
             - 'internal/service/streaminstance/*.go'
+            - 'internal/service/streamprocessor/*.go'
           control_plane_ip_addresses:
             - 'internal/service/controlplaneipaddresses/*.go'
 
@@ -833,6 +834,7 @@ jobs:
           ACCTEST_PACKAGES: |
             ./internal/service/streamconnection
             ./internal/service/streaminstance
+            ./internal/service/streamprocessor
         run: make testacc
     
   control_plane_ip_addresses:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/searchdeployment"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streaminstance"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 )
 
@@ -452,6 +453,7 @@ func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resou
 		pushbasedlogexport.Resource,
 		streaminstance.Resource,
 		streamconnection.Resource,
+		streamprocessor.Resource,
 	}
 	previewResources := []func() resource.Resource{} // Resources not yet in GA
 	if providerEnablePreview {

--- a/internal/service/streamprocessor/data_source.go
+++ b/internal/service/streamprocessor/data_source.go
@@ -7,15 +7,13 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
-const StreamProccesorName = "streamprocessor"
-
 var _ datasource.DataSource = &StreamProccesorDS{}
 var _ datasource.DataSourceWithConfigure = &StreamProccesorDS{}
 
 func DataSource() datasource.DataSource {
 	return &StreamProccesorDS{
 		DSCommon: config.DSCommon{
-			DataSourceName: StreamProccesorName,
+			DataSourceName: StreamProcessorName,
 		},
 	}
 }

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -1,0 +1,20 @@
+package streamprocessor
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+func NewTFStreamProcessor(ctx context.Context, apiResp *admin.StreamsProcessor) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	return &TFStreamProcessorRSModel{}, nil
+}
+
+func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.StreamsProcessor, diag.Diagnostics) {
+	return &admin.StreamsProcessor{}, nil
+}
+
+func NewStreamProcessorWithStats(ctx context.Context, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	return &TFStreamProcessorRSModel{}, nil
+}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
@@ -15,6 +16,14 @@ func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) 
 	return &admin.StreamsProcessor{}, nil
 }
 
-func NewStreamProcessorWithStats(ctx context.Context, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
-	return &TFStreamProcessorRSModel{}, nil
+func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	tfModel := &TFStreamProcessorRSModel{
+		InstanceName:      types.StringValue(instanceName),
+		ProcessorName:     types.StringPointerValue(&apiResp.Name),
+		ProjectID:         types.StringValue(projectID),
+		State:             types.StringPointerValue(&apiResp.State),
+		ProcessorID:       types.StringNull(),
+		ChangeStreamToken: types.StringNull(),
+	}
+	return tfModel, nil
 }

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.StreamsProcessor, diag.Diagnostics) {
-	pipeline, diags := convertPipelineToSdk(plan.Pipeline.ValueStringPointer())
+	pipeline, diags := convertPipelineToSdk(plan.Pipeline.ValueString())
 	if diags != nil {
 		return nil, diags
 	}
@@ -141,9 +141,9 @@ func extractChangeStreamTokenFromStats(stats any) (types.String, diag.Diagnostic
 	return types.StringNull(), nil
 }
 
-func convertPipelineToSdk(pipeline *string) ([]any, diag.Diagnostics) {
+func convertPipelineToSdk(pipeline string) ([]any, diag.Diagnostics) {
 	var pipelineSliceOfMaps []any
-	err := json.Unmarshal([]byte(*pipeline), &pipelineSliceOfMaps)
+	err := json.Unmarshal([]byte(pipeline), &pipelineSliceOfMaps)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("failed to unmarshal pipeline", err.Error())}
 	}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -103,7 +103,7 @@ func convertPipelineToTF(pipeline []any) (types.String, diag.Diagnostics) {
 
 func convertStatsToTF(stats any) (types.String, diag.Diagnostics) {
 	if stats == nil {
-		return types.StringValue("{}"), nil
+		return types.StringNull(), nil
 	}
 	statsJSON, err := json.Marshal(stats)
 	if err != nil {

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -9,6 +9,26 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
+func NewTFStreamProcessor(ctx context.Context, apiResp *admin.StreamsProcessor) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	return &TFStreamProcessorRSModel{}, nil
+}
+
+func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.StreamsProcessor, diag.Diagnostics) {
+	return &admin.StreamsProcessor{}, nil
+}
+
+func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	tfModel := &TFStreamProcessorRSModel{
+		InstanceName:      types.StringValue(instanceName),
+		ProcessorName:     types.StringPointerValue(&apiResp.Name),
+		ProjectID:         types.StringValue(projectID),
+		State:             types.StringPointerValue(&apiResp.State),
+		ProcessorID:       types.StringNull(),
+		ChangeStreamToken: types.StringNull(),
+	}
+	return tfModel, nil
+}
+
 func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorDSModel, diag.Diagnostics) {
 	if apiResp == nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -9,22 +9,31 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
-func NewTFStreamProcessor(ctx context.Context, apiResp *admin.StreamsProcessor) (*TFStreamProcessorRSModel, diag.Diagnostics) {
-	return &TFStreamProcessorRSModel{}, nil
-}
-
 func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.StreamsProcessor, diag.Diagnostics) {
 	return &admin.StreamsProcessor{}, nil
 }
 
-func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats, stateOptions types.Object) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+	if apiResp == nil {
+		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}
+	}
+	pipelineTF, diags := convertPipelineToTF(apiResp.GetPipeline())
+	if diags.HasError() {
+		return nil, diags
+	}
+	changeStreamToken, diags := extractChangeStreamTokenFromStats(apiResp.GetStats())
+	if diags.HasError() {
+		return nil, diags
+	}
 	tfModel := &TFStreamProcessorRSModel{
-		InstanceName:      types.StringValue(instanceName),
+		InstanceName:      types.StringPointerValue(&instanceName),
+		Options:           stateOptions,
+		Pipeline:          pipelineTF,
+		ProcessorID:       types.StringPointerValue(&apiResp.Id),
 		ProcessorName:     types.StringPointerValue(&apiResp.Name),
-		ProjectID:         types.StringValue(projectID),
+		ProjectID:         types.StringPointerValue(&projectID),
 		State:             types.StringPointerValue(&apiResp.State),
-		ProcessorID:       types.StringNull(),
-		ChangeStreamToken: types.StringNull(),
+		ChangeStreamToken: changeStreamToken,
 	}
 	return tfModel, nil
 }
@@ -70,4 +79,25 @@ func convertStatsToTF(stats any) (types.String, diag.Diagnostics) {
 		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal stats", err.Error())}
 	}
 	return types.StringValue(string(statsJSON)), nil
+}
+
+func extractChangeStreamTokenFromStats(stats any) (types.String, diag.Diagnostics) {
+	if stats == nil {
+		return types.StringValue("{}"), nil
+	}
+	var statsMap map[string]interface{}
+
+	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal stats", err.Error())}
+	}
+
+	err = json.Unmarshal(statsJSON, &statsMap)
+	if err != nil {
+		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to unmarshal stats", err.Error())}
+	}
+
+	changeStreamToken := statsMap["data"].(map[string]interface{})["changeStreamToken"]
+
+	return types.StringValue(changeStreamToken.(string)), nil
 }

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -129,10 +129,12 @@ func extractChangeStreamTokenFromStats(stats any) (types.String, diag.Diagnostic
 	}
 
 	if data := statsMap["data"]; data != nil {
-		dataMap := data.(map[string]interface{})
-		changeStreamToken, ok := dataMap["changeStreamToken"]
+		dataMap, ok := data.(map[string]interface{})
 		if ok {
-			return types.StringValue(changeStreamToken.(string)), nil
+			changeStreamToken, ok := dataMap["changeStreamToken"]
+			if ok {
+				return types.StringValue(changeStreamToken.(string)), nil
+			}
 		}
 	}
 
@@ -140,9 +142,6 @@ func extractChangeStreamTokenFromStats(stats any) (types.String, diag.Diagnostic
 }
 
 func convertPipelineToSdk(pipeline *string) ([]any, diag.Diagnostics) {
-	if pipeline == nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Pipeline is required", "")}
-	}
 	var pipelineSliceOfMaps []any
 	err := json.Unmarshal([]byte(*pipeline), &pipelineSliceOfMaps)
 	if err != nil {

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -128,10 +128,10 @@ func extractChangeStreamTokenFromStats(stats any) (types.String, diag.Diagnostic
 		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to unmarshal stats", err.Error())}
 	}
 
-	if data := statsMap["data"]; data != nil {
+	if data := statsMap["changeStreamState"]; data != nil {
 		dataMap, ok := data.(map[string]interface{})
 		if ok {
-			changeStreamToken, ok := dataMap["changeStreamToken"]
+			changeStreamToken, ok := dataMap["_data"]
 			if ok {
 				return types.StringValue(changeStreamToken.(string)), nil
 			}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -25,8 +25,9 @@ var (
 			"connectionName": "__testLog",
 		},
 	}
-	processorName = "processor1"
-	processorID   = "66b39806187592e8d721215d"
+	processorName     = "processor1"
+	processorID       = "66b39806187592e8d721215d"
+	changeStreamToken = "changeStreamTokenValue"
 )
 
 var statsExample = `
@@ -38,6 +39,7 @@ var statsExample = `
 	"memoryTrackerBytes": 0.0,
 	"name": "processor1",
 	"ok": 1.0,
+	"data": { "changeStreamToken": "changeStreamTokenValue" },
 	"operatorStats": [
 		{
 			"dlqMessageCount": 0,
@@ -138,11 +140,62 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				assert.Len(t, sdkModel.Stats, 14)
-				assert.Len(t, statsResult, 14)
+				assert.Len(t, sdkModel.Stats, 15)
+				assert.Len(t, statsResult, 15)
 			} else {
 				assert.Equal(t, tc.expectedTFModel, resultModel)
 			}
+		})
+	}
+}
+
+func TestTeamsResourceSDKToTFModel(t *testing.T) {
+	testCases := []struct {
+		sdkModel        *admin.StreamsProcessorWithStats
+		expectedTFModel *streamprocessor.TFStreamProcessorRSModel
+		name            string
+	}{
+		{
+			name: "afterCreate",
+			sdkModel: admin.NewStreamsProcessorWithStats(
+				processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, "CREATED",
+			),
+			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{
+				InstanceName:      types.StringValue(instanceName),
+				Options:           types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
+				ProcessorID:       types.StringValue(processorID),
+				Pipeline:          types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName:     types.StringValue(processorName),
+				ProjectID:         types.StringValue(projectID),
+				State:             types.StringValue("CREATED"),
+				ChangeStreamToken: types.StringNull(),
+			},
+		},
+		{
+			name:     "afterStarted",
+			sdkModel: streamProcessorWithStats(t),
+			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{
+				InstanceName:      types.StringValue(instanceName),
+				Options:           types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
+				ProcessorID:       types.StringValue(processorID),
+				Pipeline:          types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName:     types.StringValue(processorName),
+				ProjectID:         types.StringValue(projectID),
+				State:             types.StringValue("STARTED"),
+				ChangeStreamToken: types.StringValue(changeStreamToken),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdkModel := tc.sdkModel
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes))
+			if diags.HasError() {
+				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedTFModel.ChangeStreamToken, resultModel.ChangeStreamToken)
+			assert.Equal(t, tc.expectedTFModel, resultModel)
 		})
 	}
 }

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -107,7 +107,7 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 				State:         types.StringValue("CREATED"),
-				Stats:         types.StringValue("{}"),
+				Stats:         types.StringNull(),
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestTeamsResourceSDKToTFModel(t *testing.T) {
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 				State:         types.StringValue("CREATED"),
-				Stats:         types.StringValue("{}"),
+				Stats:         types.StringNull(),
 			},
 		},
 		{

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -1,0 +1,58 @@
+package streamprocessor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+type sdkToTFModelTestCase struct {
+	SDKResp         *admin.StreamsProcessor
+	expectedTFModel *streamprocessor.TFStreamProcessorRSModel
+}
+
+func TestStreamProcessorSDKToTFModel(t *testing.T) {
+	testCases := map[string]sdkToTFModelTestCase{ // TODO: consider adding test cases to contemplate all possible API responses
+		"Complete SDK response": {
+			SDKResp:         &admin.StreamsProcessor{},
+			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resultModel, diags := streamprocessor.NewTFStreamProcessor(context.Background(), tc.SDKResp)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}
+
+type tfToSDKModelTestCase struct {
+	tfModel        *streamprocessor.TFStreamProcessorRSModel
+	expectedSDKReq *admin.StreamsProcessor
+}
+
+func TestStreamProcessorTFModelToSDK(t *testing.T) {
+	testCases := map[string]tfToSDKModelTestCase{
+		"Complete TF state": {
+			tfModel:        &streamprocessor.TFStreamProcessorRSModel{},
+			expectedSDKReq: &admin.StreamsProcessor{},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			apiReqResult, diags := streamprocessor.NewStreamProcessorReq(context.Background(), tc.tfModel)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
+		})
+	}
+}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -39,7 +39,7 @@ var statsExample = `
 	"memoryTrackerBytes": 0.0,
 	"name": "processor1",
 	"ok": 1.0,
-	"data": { "changeStreamToken": "changeStreamTokenValue" },
+	"changeStreamState": { "_data": "changeStreamTokenValue" },
 	"operatorStats": [
 		{
 			"dlqMessageCount": 0,

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -194,16 +194,16 @@ func (r *streamProcessorRS) ImportState(ctx context.Context, req resource.Import
 }
 
 func splitStreamProcessorImportID(id string) (projectID, instanceName, processorName *string, err error) {
-	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-(.*)$`)
+	var re = regexp.MustCompile(`^(.*)-([0-9a-fA-F]{24})-(.*)$`)
 	parts := re.FindStringSubmatch(id)
 
 	if len(parts) != 4 {
-		err = errors.New("import format error: to import a stream processor, use the format {project_id}-{instance_name}-{processor_name}")
+		err = errors.New("import format error: to import a stream processor, use the format {instance_name}-{project_id}-(processor_name)")
 		return
 	}
 
-	projectID = &parts[1]
-	instanceName = &parts[2]
+	instanceName = &parts[1]
+	projectID = &parts[2]
 	processorName = &parts[3]
 
 	return

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -150,7 +150,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	projectID := plan.ProjectID.ValueString()
 	instanceName := plan.InstanceName.ValueString()
 	processorName := plan.ProcessorName.ValueString()
-	if plan.State.Equal(state.State) || !updatedStateOnly(&plan, &state) {
+	if plan.State.Equal(state.State) {
 		resp.Diagnostics.AddError("updating a Stream Processor is not supported", "")
 		return
 	}
@@ -245,13 +245,4 @@ func splitStreamProcessorImportID(id string) (projectID, instanceName, processor
 	processorName = &parts[3]
 
 	return
-}
-
-func updatedStateOnly(plan, state *TFStreamProcessorRSModel) bool {
-	return plan.ProjectID.Equal(state.ProjectID) &&
-		plan.InstanceName.Equal(state.InstanceName) &&
-		plan.ProcessorName.Equal(state.ProcessorName) &&
-		plan.Pipeline.Equal(state.Pipeline) &&
-		(plan.Options.Equal(state.Options) || plan.Options.IsUnknown()) &&
-		!plan.State.Equal(state.State)
 }

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -88,7 +88,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -117,7 +117,7 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -188,7 +188,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Error changing state of stream processor", err.Error())
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -1,0 +1,210 @@
+package streamprocessor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+const streamProcessorName = "stream_processor"
+
+var _ resource.ResourceWithConfigure = &streamProcessorRS{}
+var _ resource.ResourceWithImportState = &streamProcessorRS{}
+
+func Resource() resource.Resource {
+	return &streamProcessorRS{
+		RSCommon: config.RSCommon{
+			ResourceName: streamProcessorName,
+		},
+	}
+}
+
+type streamProcessorRS struct {
+	config.RSCommon
+}
+
+func (r *streamProcessorRS) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema(ctx)
+}
+
+func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var streamProcessorPlan TFStreamProcessorRSModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &streamProcessorPlan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	streamProcessorReq, diags := NewStreamProcessorReq(ctx, &streamProcessorPlan)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	connV2 := r.Client.AtlasV2
+	_, _, err := connV2.StreamsApi.CreateStreamProcessor(ctx, streamProcessorPlan.ProjectID.ValueString(), streamProcessorPlan.InstanceName.ValueString(), streamProcessorReq).Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("error creating resource", err.Error())
+		return
+	}
+
+	streamProcessorParams := &admin.GetStreamProcessorApiParams{
+		GroupId:       streamProcessorPlan.ProjectID.ValueString(),
+		TenantName:    streamProcessorPlan.InstanceName.ValueString(),
+		ProcessorName: streamProcessorPlan.ProcessorName.ValueString(),
+	}
+
+	streamProcessorResp, err := WaitStateTransition(ctx, streamProcessorParams, connV2.StreamsApi, []string{InitiatingState, CreatingState}, []string{CreatedState, FailedState})
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating stream processor", err.Error())
+	}
+
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, streamProcessorResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newStreamProcessorModel)...)
+}
+
+func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var streamProcessorState TFStreamProcessorRSModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &streamProcessorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connV2 := r.Client.AtlasV2
+	streamProcessor, apiResp, err := connV2.StreamsApi.GetStreamProcessor(ctx, streamProcessorState.ProjectID.ValueString(), streamProcessorState.InstanceName.ValueString(), streamProcessorState.ProcessorName.ValueString()).Execute()
+	if err != nil {
+		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
+
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, streamProcessor)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newStreamProcessorModel)...)
+}
+
+func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan TFStreamProcessorRSModel
+	var state TFStreamProcessorRSModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connV2 := r.Client.AtlasV2
+	pendingStates := []string{CreatedState}
+	desiredState := []string{}
+	if !plan.State.Equal(state.State) {
+		switch plan.State.ValueString() {
+		case StartedState:
+			desiredState = append(desiredState, StartedState)
+			pendingStates = append(pendingStates, StoppedState)
+			_, _, err := connV2.StreamsApi.StartStreamProcessorWithParams(ctx,
+				&admin.StartStreamProcessorApiParams{
+					GroupId:       plan.ProjectID.ValueString(),
+					TenantName:    plan.InstanceName.ValueString(),
+					ProcessorName: plan.ProcessorName.ValueString(),
+				},
+			).Execute()
+			if err != nil {
+				resp.Diagnostics.AddError("Error starting stream processor", err.Error())
+			}
+		case StoppedState:
+			desiredState = append(desiredState, StoppedState)
+			pendingStates = append(pendingStates, StartedState)
+			_, _, err := connV2.StreamsApi.StopStreamProcessorWithParams(ctx,
+				&admin.StopStreamProcessorApiParams{
+					GroupId:       plan.ProjectID.ValueString(),
+					TenantName:    plan.InstanceName.ValueString(),
+					ProcessorName: plan.ProcessorName.ValueString(),
+				},
+			).Execute()
+			if err != nil {
+				resp.Diagnostics.AddError("Error stopping stream processor", err.Error())
+			}
+		default:
+			resp.Diagnostics.AddError("transitions to states other than STARTED or STOPPED are not supported", "")
+			return
+		}
+	} else {
+		resp.Diagnostics.AddError("updating a Stream Processor is not supported. Please follow this guide to update it", "TODO")
+		return
+	}
+	requestParams := &admin.GetStreamProcessorApiParams{
+		GroupId:       plan.ProjectID.ValueString(),
+		TenantName:    plan.InstanceName.ValueString(),
+		ProcessorName: plan.ProcessorName.ValueString(),
+	}
+
+	streamProcessorResp, err := WaitStateTransition(ctx, requestParams, connV2.StreamsApi, pendingStates, desiredState)
+	if err != nil {
+		resp.Diagnostics.AddError("Error changing state of stream processor", err.Error())
+	}
+
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, streamProcessorResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newStreamProcessorModel)...)
+}
+
+func (r *streamProcessorRS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var streamProcessorState *TFStreamProcessorRSModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &streamProcessorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connV2 := r.Client.AtlasV2
+	if _, err := connV2.StreamsApi.DeleteStreamProcessor(ctx, streamProcessorState.ProjectID.ValueString(), streamProcessorState.InstanceName.ValueString(), streamProcessorState.ProcessorName.ValueString()).Execute(); err != nil {
+		resp.Diagnostics.AddError("error deleting resource", err.Error())
+		return
+	}
+}
+
+func (r *streamProcessorRS) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	projectID, instanceName, processorName, err := splitStreamProcessorImportID(req.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("error splitting import ID", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("instance_name"), instanceName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("processor_name"), processorName)...)
+}
+
+func splitStreamProcessorImportID(id string) (projectID, instanceName, processorName *string, err error) {
+	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-(.*)$`)
+	parts := re.FindStringSubmatch(id)
+
+	if len(parts) != 4 {
+		err = errors.New("import format error: to import a stream processor, use the format {project_id}-{instance_name}-{processor_name}")
+		return
+	}
+
+	projectID = &parts[1]
+	instanceName = &parts[2]
+	processorName = &parts[3]
+
+	return
+}

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -253,6 +253,6 @@ func updatedStateOnly(plan, state *TFStreamProcessorRSModel) bool {
 		plan.InstanceName.Equal(state.InstanceName) &&
 		plan.ProcessorName.Equal(state.ProcessorName) &&
 		plan.Pipeline.Equal(state.Pipeline) &&
-		plan.Options.Equal(state.Options) &&
+		(plan.Options.Equal(state.Options) || plan.Options.IsUnknown()) &&
 		!plan.State.Equal(state.State)
 }

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -75,7 +75,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		ProcessorName: processorName,
 	}
 
-	streamProcessorResp, err := WaitStateTransition(ctx, streamProcessorParams, connV2.StreamsApi, []string{InitiatingState, CreatingState}, []string{CreatedState, FailedState})
+	streamProcessorResp, err := WaitStateTransition(ctx, streamProcessorParams, connV2.StreamsApi, []string{InitiatingState, CreatingState}, []string{CreatedState})
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating stream processor", err.Error())
 	}
@@ -120,7 +120,6 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 	if err != nil {
 		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.AddError("resource not found", err.Error())
 			return
 		}
 		resp.Diagnostics.AddError("error fetching resource", err.Error())

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -20,8 +20,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The resume token for the change stream. Only used when the pipeline source is Cluster.",
 				MarkdownDescription: "The resume token for the change stream. Only used when the pipeline source is Cluster.",
 			},
-			"processor_id": schema.StringAttribute{
-				Optional:            true,
+			"id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
 				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
@@ -97,7 +96,7 @@ type TFStreamProcessorRSModel struct {
 	InstanceName      types.String `tfsdk:"instance_name"`
 	Options           types.Object `tfsdk:"options"`
 	Pipeline          types.String `tfsdk:"pipeline"`
-	ProcessorID       types.String `tfsdk:"processor_id"`
+	ProcessorID       types.String `tfsdk:"id"`
 	ProcessorName     types.String `tfsdk:"processor_name"`
 	ProjectID         types.String `tfsdk:"project_id"`
 	State             types.String `tfsdk:"state"`

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -85,13 +83,8 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 				Optional:            true,
-				Computed:            true,
 				Description:         "Optional configuration for the stream processor.",
 				MarkdownDescription: "Optional configuration for the stream processor.",
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
-				Default: objectdefault.StaticValue(types.ObjectNull(OptionsObjectType.AttrTypes)),
 			},
 			"stats": schema.StringAttribute{
 				Computed:            true,

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -94,13 +94,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFStreamProcessorRSModel struct {
-	InstanceName  types.String `tfsdk:"instance_name"`
-	Options       types.Object `tfsdk:"options"`
-	Pipeline      types.String `tfsdk:"pipeline"`
-	ProcessorID   types.String `tfsdk:"processor_id"`
-	ProcessorName types.String `tfsdk:"processor_name"`
-	ProjectID     types.String `tfsdk:"project_id"`
-	State         types.String `tfsdk:"state"`
+	InstanceName      types.String `tfsdk:"instance_name"`
+	Options           types.Object `tfsdk:"options"`
+	Pipeline          types.String `tfsdk:"pipeline"`
+	ProcessorID       types.String `tfsdk:"processor_id"`
+	ProcessorName     types.String `tfsdk:"processor_name"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	State             types.String `tfsdk:"state"`
+	ChangeStreamToken types.String `tfsdk:"change_stream_token"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
@@ -19,6 +22,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
 				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"instance_name": schema.StringAttribute{
 				Required:            true,
@@ -82,6 +88,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Description:         "Optional configuration for the stream processor.",
 				MarkdownDescription: "Optional configuration for the stream processor.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Default: objectdefault.StaticValue(types.ObjectNull(OptionsObjectType.AttrTypes)),
 			},
 			"stats": schema.StringAttribute{
 				Computed:            true,

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -96,6 +96,7 @@ type TFStreamProcessorRSModel struct {
 	ProcessorName types.String `tfsdk:"processor_name"`
 	ProjectID     types.String `tfsdk:"project_id"`
 	State         types.String `tfsdk:"state"`
+	//TODO: add changeStreamToken
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -1,1 +1,120 @@
 package streamprocessor
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"change_stream_token": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The resume token for the change stream. Only used when the pipeline source is Cluster.",
+				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
+			},
+			"id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
+				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
+			},
+			"instance_name": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Human-readable label that identifies the stream instance.",
+				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+			},
+			"pipeline": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Stream aggregation pipeline you want to apply to your streaming data.",
+				MarkdownDescription: "Stream aggregation pipeline you want to apply to your streaming data.",
+			},
+			"processor_name": schema.StringAttribute{
+				Required:            true,
+				Description:         "Human-readable label that identifies the stream processor.",
+				MarkdownDescription: "Human-readable label that identifies the stream processor.",
+			},
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				Description:         "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+			},
+			"state": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "The state of the stream processor.",
+				MarkdownDescription: "The state of the stream processor.",
+			},
+			"options": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"dlq": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"coll": schema.StringAttribute{
+								Required:            true,
+								Description:         "Name of the collection that will be used for the DLQ.",
+								MarkdownDescription: "Name of the collection that will be used for the DLQ.",
+							},
+							"connection_name": schema.StringAttribute{
+								Required:            true,
+								Description:         "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+								MarkdownDescription: "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+							},
+							"db": schema.StringAttribute{
+								Required:            true,
+								Description:         "Name of the database that will be used for the DLQ.",
+								MarkdownDescription: "Name of the database that will be used for the DLQ.",
+							},
+						},
+						Optional:            true,
+						Computed:            true,
+						Description:         "Dead letter queue for the stream processor.",
+						MarkdownDescription: "Dead letter queue for the stream processor.",
+					},
+				},
+				Optional:            true,
+				Computed:            true,
+				Description:         "Optional configuration for the stream processor.",
+				MarkdownDescription: "Optional configuration for the stream processor.",
+			},
+		},
+	}
+}
+
+type TFStreamProcessorRSModel struct {
+	InstanceName  types.String `tfsdk:"instance_name"`
+	Options       types.Object `tfsdk:"options"`
+	Pipeline      types.List   `tfsdk:"pipeline"`
+	ProcessorID   types.String `tfsdk:"processor_id"`
+	ProcessorName types.String `tfsdk:"processor_name"`
+	ProjectID     types.String `tfsdk:"project_id"`
+	State         types.String `tfsdk:"state"`
+}
+
+type TFOptionsModel struct {
+	Dlq types.Object `tfsdk:"dlq"`
+}
+
+type TFDlqModel struct {
+	Coll           types.String `tfsdk:"coll"`
+	ConnectionName types.String `tfsdk:"connection_name"`
+	DB             types.String `tfsdk:"db"`
+}
+
+var OptionsObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"dlq": DlqObjectType,
+}}
+
+var DlqObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"coll":            types.StringType,
+	"connection_name": types.StringType,
+	"db":              types.StringType,
+},
+}

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -15,11 +15,6 @@ import (
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"change_stream_token": schema.StringAttribute{
-				Computed:            true,
-				Description:         "The resume token for the change stream. Only used when the pipeline source is Cluster.",
-				MarkdownDescription: "The resume token for the change stream. Only used when the pipeline source is Cluster.",
-			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
@@ -88,19 +83,24 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "Optional configuration for the stream processor.",
 				MarkdownDescription: "Optional configuration for the stream processor.",
 			},
+			"stats": schema.StringAttribute{
+				Computed:            true,
+				Description:         "The stats associated with the stream processor.",
+				MarkdownDescription: "The stats associated with the stream processor.",
+			},
 		},
 	}
 }
 
 type TFStreamProcessorRSModel struct {
-	InstanceName      types.String `tfsdk:"instance_name"`
-	Options           types.Object `tfsdk:"options"`
-	Pipeline          types.String `tfsdk:"pipeline"`
-	ProcessorID       types.String `tfsdk:"id"`
-	ProcessorName     types.String `tfsdk:"processor_name"`
-	ProjectID         types.String `tfsdk:"project_id"`
-	State             types.String `tfsdk:"state"`
-	ChangeStreamToken types.String `tfsdk:"change_stream_token"`
+	InstanceName  types.String `tfsdk:"instance_name"`
+	Options       types.Object `tfsdk:"options"`
+	Pipeline      types.String `tfsdk:"pipeline"`
+	ProcessorID   types.String `tfsdk:"id"`
+	ProcessorName types.String `tfsdk:"processor_name"`
+	ProjectID     types.String `tfsdk:"project_id"`
+	State         types.String `tfsdk:"state"`
+	Stats         types.String `tfsdk:"stats"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -16,15 +16,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The resume token for the change stream. Only used when the pipeline source is Cluster.",
 				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
 			},
-			"id": schema.StringAttribute{
+			"processor_id": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
 				Description:         "Unique 24-hexadecimal character string that identifies the stream processor.",
 				MarkdownDescription: "Unique 24-hexadecimal character string that identifies the stream processor.",
 			},
 			"instance_name": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
+				Required:            true,
 				Description:         "Human-readable label that identifies the stream instance.",
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
 			},
@@ -89,13 +88,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFStreamProcessorRSModel struct {
-	InstanceName  types.String `tfsdk:"instance_name"`
-	Options       types.Object `tfsdk:"options"`
-	Pipeline      types.List   `tfsdk:"pipeline"`
-	ProcessorID   types.String `tfsdk:"processor_id"`
-	ProcessorName types.String `tfsdk:"processor_name"`
-	ProjectID     types.String `tfsdk:"project_id"`
-	State         types.String `tfsdk:"state"`
+	InstanceName      types.String `tfsdk:"instance_name"`
+	Options           types.Object `tfsdk:"options"`
+	Pipeline          types.List   `tfsdk:"pipeline"`
+	ProcessorID       types.String `tfsdk:"processor_id"`
+	ProcessorName     types.String `tfsdk:"processor_name"`
+	ProjectID         types.String `tfsdk:"project_id"`
+	State             types.String `tfsdk:"state"`
+	ChangeStreamToken types.String `tfsdk:"change_stream_token"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -1,35 +1,192 @@
 package streamprocessor_test
 
-// import (
-// 	"testing"
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-// 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-// )
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-// TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
-// In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
-// func TestAccStreamProcessorRS_basic(t *testing.T) {
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:                 func() { acc.PreCheckBasic(t) },
-// 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-// 		//		CheckDestroy:             checkDestroyStreamProcessor,
-// 		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
-// 			//			{
-// 			//				Config: streamProcessorConfig(),
-// 			//				Check:  streamProcessorAttributeChecks(),
-// 			//			},
-// 			//          {
-// 			//				Config: streamProcessorConfig(),
-// 			//				Check:  streamProcessorAttributeChecks(),
-// 			//			},
-// 			//			{
-// 			//				Config:            streamProcessorConfig(),
-// 			//				ResourceName:      resourceName,
-// 			//				ImportStateIdFunc: checkStreamProcessorImportStateIDFunc,
-// 			//				ImportState:       true,
-// 			//				ImportStateVerify: true,
-// 		},
-// 	},
-// 	)
-// }
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+var (
+	resourceName = "mongodbatlas_stream_processor.processor"
+)
+
+func TestAccStreamProcessorRS_basic(t *testing.T) {
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		processorName = "new-processor"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config: streamProcessorConfigWithSampleConnection(projectID, processorName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "processor_name"),
+					resource.TestCheckResourceAttr(resourceName, "processor_name", processorName),
+					resource.TestCheckResourceAttr(resourceName, "state", "CREATED"),
+				),
+			},
+			{
+				Config: streamProcessorConfigWithSampleConnection(projectID, processorName, "STARTED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "processor_name"),
+					resource.TestCheckResourceAttr(resourceName, "processor_name", processorName),
+					resource.TestCheckResourceAttr(resourceName, "state", "STARTED"),
+				),
+			},
+			{
+				Config:            streamProcessorConfigWithSampleConnection(projectID, processorName, ""),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		}})
+}
+
+func TestAccStreamProcessorRS_createWithAutoStart(t *testing.T) {
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		processorName = "new-processor"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config: streamProcessorConfigWithSampleConnection(projectID, processorName, "STARTED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "processor_name"),
+					resource.TestCheckResourceAttr(resourceName, "processor_name", processorName),
+					resource.TestCheckResourceAttr(resourceName, "state", "STARTED"),
+				),
+			},
+			{
+				Config: streamProcessorConfigWithSampleConnection(projectID, processorName, "STOPPED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "processor_name"),
+					resource.TestCheckResourceAttr(resourceName, "processor_name", processorName),
+					resource.TestCheckResourceAttr(resourceName, "state", "STOPPED"),
+				),
+			},
+		}})
+}
+
+func TestAccStreamProcessorRS_failWithInvalidStateOnCreation(t *testing.T) {
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		processorName = "new-processor"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config:      streamProcessorConfigWithSampleConnection(projectID, processorName, "STOPPED"),
+				ExpectError: regexp.MustCompile("When creating a stream processor, the only valid states are CREATED and STARTED"),
+			},
+		}})
+}
+
+func streamProcessorConfigWithSampleConnection(projectID, processorName, state string) string {
+	// Add mongodbatlas_stream_connection once sample stream connection is not created by default
+	// resource "mongodbatlas_stream_connection" "sample" {
+	// 	project_id      = %[1]q
+	// 	instance_name   = mongodbatlas_stream_instance.instance.instance_name
+	// 	connection_name = "sample_stream_solar_2"
+	// 	type            = "Sample"
+	// }
+	stateConfig := ""
+	if state != "" {
+		stateConfig = fmt.Sprintf(`state = %[1]q`, state)
+	}
+	return fmt.Sprintf(`
+	resource "mongodbatlas_stream_instance" "instance" {
+		project_id    = %[1]q
+		instance_name = "test-instance"
+		data_process_region = {
+			region         = "VIRGINIA_USA"
+			cloud_provider = "AWS"
+		}
+	}
+
+	resource "mongodbatlas_stream_processor" "processor" {
+		project_id     = %[1]q
+		instance_name  = mongodbatlas_stream_instance.instance.instance_name
+		processor_name = %[2]q
+		pipeline       = "[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"
+		%[3]s
+	}
+	`, projectID, processorName, stateConfig)
+}
+
+func checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		projectID := rs.Primary.Attributes["project_id"]
+		instanceName := rs.Primary.Attributes["instance_name"]
+		processorName := rs.Primary.Attributes["processor_name"]
+		_, _, err := acc.ConnV2().StreamsApi.GetStreamProcessor(context.Background(), projectID, instanceName, processorName).Execute()
+
+		if err != nil {
+			return fmt.Errorf("Stream processor (%s) does not exist", processorName)
+		}
+
+		return nil
+	}
+}
+
+func checkDestroyStreamProcessor(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_stream_processor" {
+			continue
+		}
+		ids := conversion.DecodeStateID(rs.Primary.ID)
+		_, _, err := acc.ConnV2().StreamsApi.GetStreamProcessor(context.Background(), ids["project_id"], ids["instance_name"], ids["processor_name"]).Execute()
+		if err == nil {
+			return fmt.Errorf("Stream processor (%s) still exists", ids["processor_name"])
+		}
+	}
+
+	return nil
+}
+
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["instance_name"], rs.Primary.Attributes["project_id"], rs.Primary.Attributes["processor_name"]), nil
+	}
+}

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -51,11 +51,12 @@ func TestAccStreamProcessorRS_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:            streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, ""),
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config:                  streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, ""),
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"stats"},
 			},
 		}})
 }
@@ -123,6 +124,7 @@ func TestAccStreamProcessorRS_clusterType(t *testing.T) {
 			},
 		}})
 }
+
 func TestAccStreamProcessorRS_failWithInvalidStateOnCreation(t *testing.T) {
 	var (
 		projectID     = acc.ProjectIDExecution(t)
@@ -160,8 +162,9 @@ func streamProcessorConfigWithSampleConnection(projectID, instanceName, processo
 	resource "mongodbatlas_stream_connection" "sample" {
 		project_id      = %[1]q
 		instance_name   = mongodbatlas_stream_instance.instance.instance_name
-		connection_name = "sample_stream_solar_2"
+		connection_name = "sample_stream_solar"
 		type            = "Sample"
+		depends_on = [mongodbatlas_stream_instance.instance] 
 	}
 
 	resource "mongodbatlas_stream_processor" "processor" {
@@ -170,6 +173,8 @@ func streamProcessorConfigWithSampleConnection(projectID, instanceName, processo
 		processor_name = %[3]q
 		pipeline       = "[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"
 		%[4]s
+		depends_on = [mongodbatlas_stream_connection.sample] 
+
 	}
 	`, projectID, instanceName, processorName, stateConfig)
 }

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -1,35 +1,35 @@
 package streamprocessor_test
 
-import (
-	"testing"
+// import (
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-)
+// 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+// 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+// )
 
 // TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
 // In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
-func TestAccStreamProcessorRS_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		//		CheckDestroy:             checkDestroyStreamProcessor,
-		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
-			//			{
-			//				Config: streamProcessorConfig(),
-			//				Check:  streamProcessorAttributeChecks(),
-			//			},
-			//          {
-			//				Config: streamProcessorConfig(),
-			//				Check:  streamProcessorAttributeChecks(),
-			//			},
-			//			{
-			//				Config:            streamProcessorConfig(),
-			//				ResourceName:      resourceName,
-			//				ImportStateIdFunc: checkStreamProcessorImportStateIDFunc,
-			//				ImportState:       true,
-			//				ImportStateVerify: true,
-		},
-	},
-	)
-}
+// func TestAccStreamProcessorRS_basic(t *testing.T) {
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:                 func() { acc.PreCheckBasic(t) },
+// 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+// 		//		CheckDestroy:             checkDestroyStreamProcessor,
+// 		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
+// 			//			{
+// 			//				Config: streamProcessorConfig(),
+// 			//				Check:  streamProcessorAttributeChecks(),
+// 			//			},
+// 			//          {
+// 			//				Config: streamProcessorConfig(),
+// 			//				Check:  streamProcessorAttributeChecks(),
+// 			//			},
+// 			//			{
+// 			//				Config:            streamProcessorConfig(),
+// 			//				ResourceName:      resourceName,
+// 			//				ImportStateIdFunc: checkStreamProcessorImportStateIDFunc,
+// 			//				ImportState:       true,
+// 			//				ImportStateVerify: true,
+// 		},
+// 	},
+// 	)
+// }

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -29,7 +29,7 @@ func TestAccStreamProcessorRS_basic(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config: streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, ""),
+				Config: configWithSampleConnection(projectID, instanceName, processorName, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -40,7 +40,7 @@ func TestAccStreamProcessorRS_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, "STARTED"),
+				Config: configWithSampleConnection(projectID, instanceName, processorName, "STARTED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -51,7 +51,7 @@ func TestAccStreamProcessorRS_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:                  streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, ""),
+				Config:                  configWithSampleConnection(projectID, instanceName, processorName, ""),
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       importStateIDFunc(resourceName),
 				ImportState:             true,
@@ -74,7 +74,7 @@ func TestAccStreamProcessorRS_withOptions(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config: streamProcessorConfigWithKafkaConnection(projectID, clusterName, instanceName, processorName, "CREATED"),
+				Config: configWithKafkaConnection(projectID, clusterName, instanceName, processorName, "CREATED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -100,7 +100,7 @@ func TestAccStreamProcessorRS_createWithAutoStart(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config: streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, "STARTED"),
+				Config: configWithSampleConnection(projectID, instanceName, processorName, "STARTED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -111,7 +111,7 @@ func TestAccStreamProcessorRS_createWithAutoStart(t *testing.T) {
 				),
 			},
 			{
-				Config: streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, "STOPPED"),
+				Config: configWithSampleConnection(projectID, instanceName, processorName, "STOPPED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -137,7 +137,7 @@ func TestAccStreamProcessorRS_clusterType(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config: streamProcessorConfigWithClusterConnection(projectID, clusterName, instanceName, processorName, "STARTED"),
+				Config: configWithClusterConnection(projectID, clusterName, instanceName, processorName, "STARTED"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -164,13 +164,13 @@ func TestAccStreamProcessorRS_failWithInvalidStateOnCreation(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config:      streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, "STOPPED"),
+				Config:      configWithSampleConnection(projectID, instanceName, processorName, "STOPPED"),
 				ExpectError: regexp.MustCompile("When creating a stream processor, the only valid states are CREATED and STARTED"),
 			},
 		}})
 }
 
-func streamProcessorConfigWithSampleConnection(projectID, instanceName, processorName, state string) string {
+func configWithSampleConnection(projectID, instanceName, processorName, state string) string {
 	stateConfig := ""
 	if state != "" {
 		stateConfig = fmt.Sprintf(`state = %[1]q`, state)
@@ -205,7 +205,7 @@ func streamProcessorConfigWithSampleConnection(projectID, instanceName, processo
 	`, projectID, instanceName, processorName, stateConfig)
 }
 
-func streamProcessorConfigWithClusterConnection(projectID, clusterName, instanceName, processorName, state string) string {
+func configWithClusterConnection(projectID, clusterName, instanceName, processorName, state string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_stream_instance" "instance" {
 		project_id    = %[1]q
@@ -240,7 +240,7 @@ func streamProcessorConfigWithClusterConnection(projectID, clusterName, instance
 	`, projectID, instanceName, clusterName, processorName, state)
 }
 
-func streamProcessorConfigWithKafkaConnection(projectID, clusterName, instanceName, processorName, state string) string {
+func configWithKafkaConnection(projectID, clusterName, instanceName, processorName, state string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_stream_instance" "instance" {
 		project_id    = %[1]q
@@ -297,7 +297,10 @@ func streamProcessorConfigWithKafkaConnection(projectID, clusterName, instanceNa
 				db = "test"
 			}
 		}
-		depends_on = [mongodbatlas_stream_connection.kafka,mongodbatlas_stream_connection.cluster] 
+		depends_on = [
+			mongodbatlas_stream_connection.kafka,
+			mongodbatlas_stream_connection.cluster
+		] 
 	}
 	`, projectID, instanceName, clusterName, processorName, state)
 }

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -1,0 +1,35 @@
+package streamprocessor_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
+// In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
+func TestAccStreamProcessorRS_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		//		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
+			//			{
+			//				Config: streamProcessorConfig(),
+			//				Check:  streamProcessorAttributeChecks(),
+			//			},
+			//          {
+			//				Config: streamProcessorConfig(),
+			//				Check:  streamProcessorAttributeChecks(),
+			//			},
+			//			{
+			//				Config:            streamProcessorConfig(),
+			//				ResourceName:      resourceName,
+			//				ImportStateIdFunc: checkStreamProcessorImportStateIDFunc,
+			//				ImportState:       true,
+			//				ImportStateVerify: true,
+		},
+	},
+	)
+}

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -65,6 +65,7 @@ func TestAccStreamProcessorRS_createWithAutoStart(t *testing.T) {
 	var (
 		projectID     = acc.ProjectIDExecution(t)
 		processorName = "new-processor"
+		instanceName  = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -101,6 +102,7 @@ func TestAccStreamProcessorRS_failWithInvalidStateOnCreation(t *testing.T) {
 	var (
 		projectID     = acc.ProjectIDExecution(t)
 		processorName = "new-processor"
+		instanceName  = acc.RandomName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -173,10 +172,12 @@ func checkDestroyStreamProcessor(s *terraform.State) error {
 		if rs.Type != "mongodbatlas_stream_processor" {
 			continue
 		}
-		ids := conversion.DecodeStateID(rs.Primary.ID)
-		_, _, err := acc.ConnV2().StreamsApi.GetStreamProcessor(context.Background(), ids["project_id"], ids["instance_name"], ids["processor_name"]).Execute()
+		projectID := rs.Primary.Attributes["project_id"]
+		instanceName := rs.Primary.Attributes["instance_name"]
+		processorName := rs.Primary.Attributes["processor_name"]
+		_, _, err := acc.ConnV2().StreamsApi.GetStreamProcessor(context.Background(), projectID, instanceName, processorName).Execute()
 		if err == nil {
-			return fmt.Errorf("Stream processor (%s) still exists", ids["processor_name"])
+			return fmt.Errorf("Stream processor (%s) still exists", processorName)
 		}
 	}
 

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -118,7 +118,7 @@ func TestAccStreamProcessorRS_clusterType(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "processor_name"),
 					resource.TestCheckResourceAttr(resourceName, "processor_name", processorName),
 					resource.TestCheckResourceAttr(resourceName, "state", "STARTED"),
-					resource.TestCheckResourceAttrSet(resourceName, "change_stream_token"),
+					resource.TestCheckResourceAttrSet(resourceName, "stats"),
 				),
 			},
 		}})

--- a/internal/service/streamprocessor/state_transition.go
+++ b/internal/service/streamprocessor/state_transition.go
@@ -1,0 +1,61 @@
+package streamprocessor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+const (
+	InitiatingState = "INIT"
+	CreatingState   = "CREATING"
+	CreatedState    = "CREATED"
+	StartedState    = "STARTED"
+	StoppedState    = "STOPPED"
+	DroppedState    = "DROPPED"
+	FailedState     = "FAILED"
+)
+
+func WaitStateTransition(ctx context.Context, requestParams *admin.GetStreamProcessorApiParams, client admin.StreamsApi, pendingStates, desiredStates []string) (*admin.StreamsProcessorWithStats, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    pendingStates,
+		Target:     desiredStates,
+		Refresh:    refreshFunc(ctx, requestParams, client),
+		Timeout:    1 * time.Minute,
+		MinTimeout: 60 * time.Second,
+		Delay:      0,
+	}
+
+	streamProcessorResp, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if streamProcessor, ok := streamProcessorResp.(*admin.StreamsProcessorWithStats); ok && streamProcessor != nil {
+		return streamProcessor, nil
+	}
+
+	return nil, errors.New("did not obtain valid result when waiting for stream processor state transition")
+}
+
+func refreshFunc(ctx context.Context, requestParams *admin.GetStreamProcessorApiParams, client admin.StreamsApi) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		streamProcessor, resp, err := client.GetStreamProcessorWithParams(ctx, requestParams).Execute()
+		if err != nil {
+			return nil, FailedState, err
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return "", DroppedState, nil
+		}
+		state := streamProcessor.GetState()
+		if state == FailedState {
+			return nil, state, fmt.Errorf("error creating MongoDB Stream Processor(%s) status was: %s", requestParams.ProcessorName, state)
+		}
+		return streamProcessor, state, nil
+	}
+}

--- a/internal/service/streamprocessor/state_transition.go
+++ b/internal/service/streamprocessor/state_transition.go
@@ -27,7 +27,7 @@ func WaitStateTransition(ctx context.Context, requestParams *admin.GetStreamProc
 		Target:     desiredStates,
 		Refresh:    refreshFunc(ctx, requestParams, client),
 		Timeout:    1 * time.Minute,
-		MinTimeout: 60 * time.Second,
+		MinTimeout: 3 * time.Second,
 		Delay:      0,
 	}
 

--- a/internal/service/streamprocessor/state_transition_test.go
+++ b/internal/service/streamprocessor/state_transition_test.go
@@ -1,0 +1,145 @@
+package streamprocessor_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+	"go.mongodb.org/atlas-sdk/v20240805001/mockadmin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
+)
+
+var (
+	InitiatingState = "INIT"
+	CreatingState   = "CREATING"
+	CreatedState    = "CREATED"
+	StartedState    = "STARTED"
+	StoppedState    = "STOPPED"
+	DroppedState    = "DROPPED"
+	FailedState     = "FAILED"
+	sc500           = conversion.IntPtr(500)
+	sc200           = conversion.IntPtr(200)
+	processorName   = "processorName"
+	requestParams   = &admin.GetStreamProcessorApiParams{
+		GroupId:       "groupId",
+		TenantName:    "tenantName",
+		ProcessorName: processorName,
+	}
+)
+
+type testCase struct {
+	expectedState *string
+	name          string
+	mockResponses []response
+	desiredStates []string
+	pendingStates []string
+	expectedError bool
+}
+
+func TestStreamProcessorStateTransition(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Successful transition to CREATED",
+			mockResponses: []response{
+				{state: &InitiatingState, statusCode: sc200},
+				{state: &CreatingState, statusCode: sc200},
+				{state: &CreatedState, statusCode: sc200},
+			},
+			expectedState: &CreatedState,
+			expectedError: false,
+			desiredStates: []string{CreatedState, FailedState},
+			pendingStates: []string{InitiatingState, CreatingState},
+		},
+		{
+			name: "Successful transition to STARTED",
+			mockResponses: []response{
+				{state: &CreatedState, statusCode: sc200},
+				{state: &StartedState, statusCode: sc200},
+			},
+			expectedState: &StartedState,
+			expectedError: false,
+			desiredStates: []string{StartedState},
+			pendingStates: []string{CreatedState, StoppedState},
+		},
+		{
+			name: "Successful transition to STOPPED",
+			mockResponses: []response{
+				{state: &StartedState, statusCode: sc200},
+				{state: &StoppedState, statusCode: sc200},
+			},
+			expectedState: &StoppedState,
+			expectedError: false,
+			desiredStates: []string{StoppedState},
+			pendingStates: []string{StartedState},
+		},
+		{
+			name: "Error when transitioning to FAILED state",
+			mockResponses: []response{
+				{state: &InitiatingState, statusCode: sc200},
+				{state: &FailedState, statusCode: sc200},
+			},
+			expectedState: nil,
+			expectedError: true,
+			desiredStates: []string{CreatedState, FailedState},
+			pendingStates: []string{InitiatingState, CreatingState},
+		},
+		{
+			name: "Error when API responds with error",
+			mockResponses: []response{
+				{statusCode: sc500, err: errors.New("Internal server error")},
+			},
+			expectedState: nil,
+			expectedError: true,
+			desiredStates: []string{CreatedState, FailedState},
+			pendingStates: []string{InitiatingState, CreatingState},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mockadmin.NewStreamsApi(t)
+			m.EXPECT().GetStreamProcessorWithParams(mock.Anything, mock.Anything).Return(admin.GetStreamProcessorApiRequest{ApiService: m})
+
+			for _, resp := range tc.mockResponses {
+				modelResp, httpResp, err := resp.get()
+				m.EXPECT().GetStreamProcessorExecute(mock.Anything).Return(modelResp, httpResp, err).Once()
+			}
+			resp, err := streamprocessor.WaitStateTransition(context.Background(), requestParams, m, tc.pendingStates, tc.desiredStates)
+			assert.Equal(t, tc.expectedError, err != nil)
+			if resp != nil {
+				assert.Equal(t, *tc.expectedState, resp.State)
+			}
+		})
+	}
+}
+
+type response struct {
+	state      *string
+	statusCode *int
+	err        error
+}
+
+func (r *response) get() (*admin.StreamsProcessorWithStats, *http.Response, error) {
+	var httpResp *http.Response
+	if r.statusCode != nil {
+		httpResp = &http.Response{StatusCode: *r.statusCode}
+	}
+	return responseWithState(r.state), httpResp, r.err
+}
+
+func responseWithState(state *string) *admin.StreamsProcessorWithStats {
+	if state == nil {
+		return nil
+	}
+	return &admin.StreamsProcessorWithStats{
+		Name:  processorName,
+		State: *state,
+	}
+}

--- a/internal/service/streamprocessor/state_transition_test.go
+++ b/internal/service/streamprocessor/state_transition_test.go
@@ -55,7 +55,7 @@ func TestStreamProcessorStateTransition(t *testing.T) {
 			},
 			expectedState: &CreatedState,
 			expectedError: false,
-			desiredStates: []string{CreatedState, FailedState},
+			desiredStates: []string{CreatedState},
 			pendingStates: []string{InitiatingState, CreatingState},
 		},
 		{
@@ -88,7 +88,7 @@ func TestStreamProcessorStateTransition(t *testing.T) {
 			},
 			expectedState: nil,
 			expectedError: true,
-			desiredStates: []string{CreatedState, FailedState},
+			desiredStates: []string{CreatedState},
 			pendingStates: []string{InitiatingState, CreatingState},
 		},
 		{

--- a/internal/service/streamprocessor/state_transition_test.go
+++ b/internal/service/streamprocessor/state_transition_test.go
@@ -17,20 +17,20 @@ import (
 )
 
 var (
-	InitiatingState = "INIT"
-	CreatingState   = "CREATING"
-	CreatedState    = "CREATED"
-	StartedState    = "STARTED"
-	StoppedState    = "STOPPED"
-	DroppedState    = "DROPPED"
-	FailedState     = "FAILED"
-	sc500           = conversion.IntPtr(500)
-	sc200           = conversion.IntPtr(200)
-	processorName   = "processorName"
-	requestParams   = &admin.GetStreamProcessorApiParams{
+	InitiatingState     = "INIT"
+	CreatingState       = "CREATING"
+	CreatedState        = "CREATED"
+	StartedState        = "STARTED"
+	StoppedState        = "STOPPED"
+	DroppedState        = "DROPPED"
+	FailedState         = "FAILED"
+	sc500               = conversion.IntPtr(500)
+	sc200               = conversion.IntPtr(200)
+	streamProcessorName = "processorName"
+	requestParams       = &admin.GetStreamProcessorApiParams{
 		GroupId:       "groupId",
 		TenantName:    "tenantName",
-		ProcessorName: processorName,
+		ProcessorName: streamProcessorName,
 	}
 )
 
@@ -139,7 +139,7 @@ func responseWithState(state *string) *admin.StreamsProcessorWithStats {
 		return nil
 	}
 	return &admin.StreamsProcessorWithStats{
-		Name:  processorName,
+		Name:  streamProcessorName,
 		State: *state,
 	}
 }

--- a/internal/service/streamprocessor/state_transition_test.go
+++ b/internal/service/streamprocessor/state_transition_test.go
@@ -26,6 +26,7 @@ var (
 	FailedState         = "FAILED"
 	sc500               = conversion.IntPtr(500)
 	sc200               = conversion.IntPtr(200)
+	sc404               = conversion.IntPtr(404)
 	streamProcessorName = "processorName"
 	requestParams       = &admin.GetStreamProcessorApiParams{
 		GroupId:       "groupId",
@@ -96,6 +97,16 @@ func TestStreamProcessorStateTransition(t *testing.T) {
 				{statusCode: sc500, err: errors.New("Internal server error")},
 			},
 			expectedState: nil,
+			expectedError: true,
+			desiredStates: []string{CreatedState, FailedState},
+			pendingStates: []string{InitiatingState, CreatingState},
+		},
+		{
+			name: "Dropped state when 404 is returned",
+			mockResponses: []response{
+				{statusCode: sc404, err: errors.New("Not found")},
+			},
+			expectedState: &DroppedState,
 			expectedError: true,
 			desiredStates: []string{CreatedState, FailedState},
 			pendingStates: []string{InitiatingState, CreatingState},

--- a/internal/service/streamprocessor/tfplugingen/generator_config.yml
+++ b/internal/service/streamprocessor/tfplugingen/generator_config.yml
@@ -1,8 +1,6 @@
 provider:
   name: mongodbatlas
 
-# TODO: Endpoints from Atlas Admin API must be specified for schema and model generation. Singular or plural data sources can be removed if not used.
-
 resources:
   stream_processor:
     read:
@@ -14,7 +12,6 @@ resources:
     delete:
       path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}
       method: DELETE
-
 
 data_sources:
   stream_processor:

--- a/internal/service/streamprocessor/tfplugingen/generator_config.yml
+++ b/internal/service/streamprocessor/tfplugingen/generator_config.yml
@@ -1,0 +1,27 @@
+provider:
+  name: mongodbatlas
+
+# TODO: Endpoints from Atlas Admin API must be specified for schema and model generation. Singular or plural data sources can be removed if not used.
+
+resources:
+  stream_processor:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}
+      method: GET
+    create:
+      path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor
+      method: POST
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}
+      method: DELETE
+
+
+data_sources:
+  stream_processor:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}
+      method: GET
+  stream_processors:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}/processors
+      method: GET

--- a/scripts/schema-scaffold.sh
+++ b/scripts/schema-scaffold.sh
@@ -50,5 +50,5 @@ rename_file() {
 }
 
 rename_file "${resource_name_snake_case}_data_source_gen.go" "data_source_schema.go"
-rename_file "${resource_name_snake_case}s_data_source_gen.go" "pural_data_source_schema.go"
+rename_file "${resource_name_snake_case}s_data_source_gen.go" "plural_data_source_schema.go"
 rename_file "${resource_name_snake_case}_resource_gen.go" "resource_schema.go"

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -56,6 +56,7 @@
     {{ else if eq .Name "mongodbatlas_ldap_verify" }}
     {{ else if eq .Name "mongodbatlas_third_party_integration" }}
     {{ else if eq .Name "mongodbatlas_x509_authentication_database_user" }}
+    {{ else if eq .Name "mongodbatlas_stream_processor" }}
     {{ else if eq .Name "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" }}
     {{ else }}
         {{ tffile (printf "examples/%s/main.tf" .Name )}}


### PR DESCRIPTION
## Description

Implements `mongodbatlas_stream_processor`
- Create operation
   - Can auto start the stream if the `state` attribute is set to `STARTED`. If attribute is not set or set to `CREATED`, the stream processor will only be created. Using any other `state` value will cause the creation of the Stream processor to fail 
- Update Operation
   - Can only Start or Stop the stream, setting the `state` attribute to `STARTED` or `STOPPED`. If any other attribute is modified, the operation will fail.
- Delete operation
- Import operation

Link to any related issue(s): CLOUDP-264839

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
