### PR TITLE
doc: Include changelog entries to mention 2 new guides

### DIFF
--- a/.changelog/2505.txt
+++ b/.changelog/2505.txt
@@ -1,0 +1,7 @@
+```release-note:new-guide
+Migration Guide: Advanced Cluster New Sharding Schema. This enables Independent Shard Scaling.
+```
+
+```release-note:new-guide
+Migration Guide: Cluster to Advanced Cluster
+```

--- a/.changelog/2505.txt
+++ b/.changelog/2505.txt
@@ -1,7 +1,7 @@
 ```release-note:new-guide
-Migration Guide: Advanced Cluster New Sharding Schema. This enables Independent Shard Scaling.
+[Migration Guide: Advanced Cluster New Sharding Schema](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/advanced-cluster-new-sharding-schema). This enables Independent Shard Scaling.
 ```
 
 ```release-note:new-guide
-Migration Guide: Cluster to Advanced Cluster
+[Migration Guide: Cluster to Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ NOTES:
 * resource/mongodbatlas_advanced_cluster: Deprecates `replication_specs.#.id`, `replication_specs.#.num_shards`, `disk_size_gb`, `advanced_configuration.0.default_read_concern`, and  `advanced_configuration.0.fail_index_key_too_long`. To learn more, see the [1.18.0 Migration Guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide). ([#2420](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2420))
 * resource/mongodbatlas_advanced_cluster: Using this new version impacts the possibility of editing the definition of multi shard clusters in the Atlas UI. This impact is limited to the first weeks of August. ([#2478](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2478))
 
+FEATURES:
+
+* **New Guide:** [Migration Guide: Advanced Cluster New Sharding Schema](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/advanced-cluster-new-sharding-schema). This enables Independent Shard Scaling. ([#2505](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2505))
+* **New Guide:** [Migration Guide: Cluster to Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide) ([#2505](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2505))
+
 ENHANCEMENTS:
 
 * data-source/mongodbatlas_advanced_cluster: Adds `use_replication_spec_per_shard`, `replication_specs.*.zone_id`, and `replication_specs.*.region_configs.*.(electable_specs|analytics_specs|read_only_specs).disk_size_gb` attributes. To learn more, see the [1.18.0 Migration Guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide) and data source documentation. ([#2478](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2478))

--- a/scripts/changelog/release-note.tmpl
+++ b/scripts/changelog/release-note.tmpl
@@ -4,7 +4,7 @@
 {{- else if eq "new-datasource" .Type -}}
 * **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/{{- .Issue -}}))
 {{- else if eq "new-guide" .Type -}}
-* **New Guide:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/{{- .Issue -}}))
+* **New Guide:** {{.Body}} ([#{{- .Issue -}}](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/{{- .Issue -}}))
 {{- else -}}
 * {{.Body}} ([#{{- .Issue -}}](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/{{- .Issue -}}))
 {{- end -}}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-267637

Gives exposure to the new guides in the changelog.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
