### PR TITLE
chore: Add mention of support ticket when opening a pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Link to any related issue(s):
 - [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
 - [ ] I have added any necessary documentation (if appropriate)
 - [ ] I have run make fmt and formatted my code
-- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
+- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
 - [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
 
 ## Further comments

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -51,7 +51,7 @@ For more explained information about plugin override check [Development Override
 - Make sure that the PR title follows [*Conventional Commits*](https://www.conventionalcommits.org/).
 - Add comments around your new code that explain what's happening.
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
-- A repo maintainer will review your pull request. **Note**: If you have an active MongoDB Atlas Support contract, creating a support ticket will give the review process more priority.
+- A repo maintainer will review your pull request. **Note**: If you have an active MongoDB Atlas Support contract, you can optionally create a support ticket to address questions on this process.
 
 ### Merging a Pull Request
 Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -51,7 +51,7 @@ For more explained information about plugin override check [Development Override
 - Make sure that the PR title follows [*Conventional Commits*](https://www.conventionalcommits.org/).
 - Add comments around your new code that explain what's happening.
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
-- A repo maintainer will review your pull request. **Note**: If you have an active MongoDB Atlas Support contract, you can optionally create a support ticket to address questions on this process.
+- A repo maintainer will review your pull request. **Note**: If you have an active [MongoDB Atlas Support](https://www.mongodb.com/services/support/atlas-support-plans) contract, we recommend also creating a support ticket for any questions related to this process.
 
 ### Merging a Pull Request
 Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -51,7 +51,7 @@ For more explained information about plugin override check [Development Override
 - Make sure that the PR title follows [*Conventional Commits*](https://www.conventionalcommits.org/).
 - Add comments around your new code that explain what's happening.
 - Commit and push your changes to your branch then submit a pull request against the `master` branch.
-- A repo maintainer will review your pull request. 
+- A repo maintainer will review your pull request. **Note**: If you have an active MongoDB Atlas Support contract, creating a support ticket will give the review process more priority.
 
 ### Merging a Pull Request
 Due to security reasons, there are restrictions on how external contributions can be handled, especially concerning the use of repository secrets and running tests from forks.


### PR DESCRIPTION
## Description

Small adjustment in contributing guide giving visibility on creating support ticket when possible.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
