### PR TITLE
feat: Updates `mongodbatlas_encryption_at_rest` resource to use new `azure_key_vault_config.require_private_networking` field

### DIFF
--- a/.changelog/2509.txt
+++ b/.changelog/2509.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_encryption_at_rest: Adds new `azure_key_vault_config.require_private_networking` field to enable connection to Azure Key Vault over private networking
+```

--- a/.changelog/2509.txt
+++ b/.changelog/2509.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_encryption_at_rest: Adds new `azure_key_vault_config.require_private_networking` field to enable connection to Azure Key Vault over private networking
+resource/mongodbatlas_encryption_at_rest: Adds new `azure_key_vault_config.#.require_private_networking` field to enable connection to Azure Key Vault over private networking
 ```

--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -62,3 +62,8 @@ func IsStringPresent(strPtr *string) bool {
 func MongoDBRegionToAWSRegion(region string) string {
 	return strings.ReplaceAll(strings.ToLower(region), "_", "-")
 }
+
+// AWSRegionToMongoDBRegion converts region in us-east-1-like format to US_EAST_1-like
+func AWSRegionToMongoDBRegion(region string) string {
+	return strings.ReplaceAll(strings.ToUpper(region), "-", "_")
+}

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 )
 
 func TestTimeWithoutNanos(t *testing.T) {
@@ -75,6 +76,22 @@ func TestMongoDBRegionToAWSRegion(t *testing.T) {
 	for _, test := range tests {
 		if resp := conversion.MongoDBRegionToAWSRegion(test.region); resp != test.expected {
 			t.Errorf("MongoDBRegionToAWSRegion(%v) = %v; want %v", test.region, resp, test.expected)
+		}
+	}
+}
+
+func TestAWSRegionToMongoDBRegion(t *testing.T) {
+	tests := []struct {
+		region   string
+		expected string
+	}{
+		{"us-east-1", "US_EAST_1"},
+		{"US-EAST-1", "US_EAST_1"},
+	}
+
+	for _, test := range tests {
+		if resp := conversion.AWSRegionToMongoDBRegion(test.region); resp != test.expected {
+			t.Errorf("AWSRegionToMongoDBRegion(%v) = %v; want %v", test.region, resp, test.expected)
 		}
 	}
 }

--- a/internal/service/encryptionatrest/model_encryption_at_rest.go
+++ b/internal/service/encryptionatrest/model_encryption_at_rest.go
@@ -3,9 +3,11 @@ package encryptionatrest
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 )
 
 func NewTfEncryptionAtRestRSModel(ctx context.Context, projectID string, encryptionResp *admin.EncryptionAtRest) *TfEncryptionAtRestRSModel {
@@ -42,15 +44,16 @@ func NewTFAzureKeyVaultConfig(ctx context.Context, az *admin.AzureKeyVault) []Tf
 
 	return []TfAzureKeyVaultConfigModel{
 		{
-			Enabled:           types.BoolPointerValue(az.Enabled),
-			ClientID:          types.StringValue(az.GetClientID()),
-			AzureEnvironment:  types.StringValue(az.GetAzureEnvironment()),
-			SubscriptionID:    types.StringValue(az.GetSubscriptionID()),
-			ResourceGroupName: types.StringValue(az.GetResourceGroupName()),
-			KeyVaultName:      types.StringValue(az.GetKeyVaultName()),
-			KeyIdentifier:     types.StringValue(az.GetKeyIdentifier()),
-			TenantID:          types.StringValue(az.GetTenantID()),
-			Secret:            conversion.StringNullIfEmpty(az.GetSecret()),
+			Enabled:                  types.BoolPointerValue(az.Enabled),
+			ClientID:                 types.StringValue(az.GetClientID()),
+			AzureEnvironment:         types.StringValue(az.GetAzureEnvironment()),
+			SubscriptionID:           types.StringValue(az.GetSubscriptionID()),
+			ResourceGroupName:        types.StringValue(az.GetResourceGroupName()),
+			KeyVaultName:             types.StringValue(az.GetKeyVaultName()),
+			KeyIdentifier:            types.StringValue(az.GetKeyIdentifier()),
+			TenantID:                 types.StringValue(az.GetTenantID()),
+			Secret:                   conversion.StringNullIfEmpty(az.GetSecret()),
+			RequirePrivateNetworking: types.BoolValue(az.GetRequirePrivateNetworking()),
 		},
 	}
 }
@@ -107,14 +110,15 @@ func NewAtlasAzureKeyVault(tfAzKeyVaultConfigSlice []TfAzureKeyVaultConfigModel)
 	v := tfAzKeyVaultConfigSlice[0]
 
 	return &admin.AzureKeyVault{
-		Enabled:           v.Enabled.ValueBoolPointer(),
-		ClientID:          v.ClientID.ValueStringPointer(),
-		AzureEnvironment:  v.AzureEnvironment.ValueStringPointer(),
-		SubscriptionID:    v.SubscriptionID.ValueStringPointer(),
-		ResourceGroupName: v.ResourceGroupName.ValueStringPointer(),
-		KeyVaultName:      v.KeyVaultName.ValueStringPointer(),
-		KeyIdentifier:     v.KeyIdentifier.ValueStringPointer(),
-		Secret:            v.Secret.ValueStringPointer(),
-		TenantID:          v.TenantID.ValueStringPointer(),
+		Enabled:                  v.Enabled.ValueBoolPointer(),
+		ClientID:                 v.ClientID.ValueStringPointer(),
+		AzureEnvironment:         v.AzureEnvironment.ValueStringPointer(),
+		SubscriptionID:           v.SubscriptionID.ValueStringPointer(),
+		ResourceGroupName:        v.ResourceGroupName.ValueStringPointer(),
+		KeyVaultName:             v.KeyVaultName.ValueStringPointer(),
+		KeyIdentifier:            v.KeyIdentifier.ValueStringPointer(),
+		Secret:                   v.Secret.ValueStringPointer(),
+		TenantID:                 v.TenantID.ValueStringPointer(),
+		RequirePrivateNetworking: v.RequirePrivateNetworking.ValueBoolPointer(),
 	}
 }

--- a/internal/service/encryptionatrest/model_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/model_encryption_at_rest_test.go
@@ -4,31 +4,34 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest"
-	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest"
 )
 
 var (
-	projectID            = "projectID"
-	enabled              = true
-	customerMasterKeyID  = "CustomerMasterKeyID"
-	region               = "Region"
-	accessKeyID          = "AccessKeyID"
-	secretAccessKey      = "SecretAccessKey"
-	roleID               = "RoleID"
-	clientID             = "clientID"
-	azureEnvironment     = "AzureEnvironment"
-	subscriptionID       = "SubscriptionID"
-	resourceGroupName    = "ResourceGroupName"
-	keyVaultName         = "KeyVaultName"
-	keyIdentifier        = "KeyIdentifier"
-	tenantID             = "TenantID"
-	secret               = "Secret"
-	keyVersionResourceID = "KeyVersionResourceID"
-	serviceAccountKey    = "ServiceAccountKey"
-	AWSKMSConfiguration  = &admin.AWSKMSConfiguration{
+	projectID                = "projectID"
+	enabled                  = true
+	requirePrivateNetworking = true
+	customerMasterKeyID      = "CustomerMasterKeyID"
+	region                   = "Region"
+	accessKeyID              = "AccessKeyID"
+	secretAccessKey          = "SecretAccessKey"
+	roleID                   = "RoleID"
+	clientID                 = "clientID"
+	azureEnvironment         = "AzureEnvironment"
+	subscriptionID           = "SubscriptionID"
+	resourceGroupName        = "ResourceGroupName"
+	keyVaultName             = "KeyVaultName"
+	keyIdentifier            = "KeyIdentifier"
+	tenantID                 = "TenantID"
+	secret                   = "Secret"
+	keyVersionResourceID     = "KeyVersionResourceID"
+	serviceAccountKey        = "ServiceAccountKey"
+	AWSKMSConfiguration      = &admin.AWSKMSConfiguration{
 		Enabled:             &enabled,
 		CustomerMasterKeyID: &customerMasterKeyID,
 		Region:              &region,
@@ -45,26 +48,28 @@ var (
 		RoleID:              types.StringValue(roleID),
 	}
 	AzureKeyVault = &admin.AzureKeyVault{
-		Enabled:           &enabled,
-		ClientID:          &clientID,
-		AzureEnvironment:  &azureEnvironment,
-		SubscriptionID:    &subscriptionID,
-		ResourceGroupName: &resourceGroupName,
-		KeyVaultName:      &keyVaultName,
-		KeyIdentifier:     &keyIdentifier,
-		TenantID:          &tenantID,
-		Secret:            &secret,
+		Enabled:                  &enabled,
+		ClientID:                 &clientID,
+		AzureEnvironment:         &azureEnvironment,
+		SubscriptionID:           &subscriptionID,
+		ResourceGroupName:        &resourceGroupName,
+		KeyVaultName:             &keyVaultName,
+		KeyIdentifier:            &keyIdentifier,
+		TenantID:                 &tenantID,
+		Secret:                   &secret,
+		RequirePrivateNetworking: &requirePrivateNetworking,
 	}
 	TfAzureKeyVaultConfigModel = encryptionatrest.TfAzureKeyVaultConfigModel{
-		Enabled:           types.BoolValue(enabled),
-		ClientID:          types.StringValue(clientID),
-		AzureEnvironment:  types.StringValue(azureEnvironment),
-		SubscriptionID:    types.StringValue(subscriptionID),
-		ResourceGroupName: types.StringValue(resourceGroupName),
-		KeyVaultName:      types.StringValue(keyVaultName),
-		KeyIdentifier:     types.StringValue(keyIdentifier),
-		TenantID:          types.StringValue(tenantID),
-		Secret:            types.StringValue(secret),
+		Enabled:                  types.BoolValue(enabled),
+		ClientID:                 types.StringValue(clientID),
+		AzureEnvironment:         types.StringValue(azureEnvironment),
+		SubscriptionID:           types.StringValue(subscriptionID),
+		ResourceGroupName:        types.StringValue(resourceGroupName),
+		KeyVaultName:             types.StringValue(keyVaultName),
+		KeyIdentifier:            types.StringValue(keyIdentifier),
+		TenantID:                 types.StringValue(tenantID),
+		Secret:                   types.StringValue(secret),
+		RequirePrivateNetworking: types.BoolValue(requirePrivateNetworking),
 	}
 	GoogleCloudKMS = &admin.GoogleCloudKMS{
 		Enabled:              &enabled,

--- a/internal/service/encryptionatrest/resource_encryption_at_rest.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"time"
 
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,12 +21,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/project"
-	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
 const (
@@ -67,15 +69,16 @@ type TfAwsKmsConfigModel struct {
 	Enabled             types.Bool   `tfsdk:"enabled"`
 }
 type TfAzureKeyVaultConfigModel struct {
-	ClientID          types.String `tfsdk:"client_id"`
-	AzureEnvironment  types.String `tfsdk:"azure_environment"`
-	SubscriptionID    types.String `tfsdk:"subscription_id"`
-	ResourceGroupName types.String `tfsdk:"resource_group_name"`
-	KeyVaultName      types.String `tfsdk:"key_vault_name"`
-	KeyIdentifier     types.String `tfsdk:"key_identifier"`
-	Secret            types.String `tfsdk:"secret"`
-	TenantID          types.String `tfsdk:"tenant_id"`
-	Enabled           types.Bool   `tfsdk:"enabled"`
+	ClientID                 types.String `tfsdk:"client_id"`
+	AzureEnvironment         types.String `tfsdk:"azure_environment"`
+	SubscriptionID           types.String `tfsdk:"subscription_id"`
+	ResourceGroupName        types.String `tfsdk:"resource_group_name"`
+	KeyVaultName             types.String `tfsdk:"key_vault_name"`
+	KeyIdentifier            types.String `tfsdk:"key_identifier"`
+	Secret                   types.String `tfsdk:"secret"`
+	TenantID                 types.String `tfsdk:"tenant_id"`
+	Enabled                  types.Bool   `tfsdk:"enabled"`
+	RequirePrivateNetworking types.Bool   `tfsdk:"require_private_networking"`
 }
 type TfGcpKmsConfigModel struct {
 	ServiceAccountKey    types.String `tfsdk:"service_account_key"`
@@ -172,6 +175,13 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						"tenant_id": schema.StringAttribute{
 							Optional:  true,
 							Sensitive: true,
+						},
+						"require_private_networking": schema.BoolAttribute{
+							Optional: true,
+							Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -60,7 +60,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 }
 
 func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t)
+	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -25,7 +25,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),
 			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-			Region:              conversion.StringPtr(os.Getenv("AWS_REGION")),
+			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
 	)
@@ -60,15 +60,11 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 }
 
 func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t) // needs AWS configuration
+	acc.SkipTestForCI(t) // TODO: enable in CI as part of CLOUDP-267663
 
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		// accessKeyID  = os.Getenv("AWS_ACCESS_KEY_ID")
-		// secretKey    = os.Getenv("AWS_SECRET_ACCESS_KEY")
-		// policyName   = acc.RandomName()
-		// roleName     = acc.RandomName()
 
 		awsIAMRoleName       = acc.RandomIAMRole()
 		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
@@ -76,8 +72,7 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled: conversion.Pointer(true),
-			// CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-			Region: conversion.StringPtr(os.Getenv("AWS_REGION")),
+			Region:  conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 		}
 	)
 
@@ -87,20 +82,17 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProvidersWithAWS(),
-				// Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
+				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
 			},
 			{
 				ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				// Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
+				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.GetRegion()),
-					// resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -216,7 +208,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 			AccessKeyID:         conversion.StringPtr(os.Getenv("AWS_ACCESS_KEY_ID")),
 			SecretAccessKey:     conversion.StringPtr(os.Getenv("AWS_SECRET_ACCESS_KEY")),
 			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-			Region:              conversion.StringPtr(os.Getenv("AWS_REGION")),
+			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
 	)

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -60,7 +60,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 }
 
 func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: enable in CI as part of CLOUDP-267663
+	acc.SkipTestForCI(t)
 
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"
@@ -71,8 +71,9 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 		awsKeyName           = acc.RandomName()
 
 		awsKms = admin.AWSKMSConfiguration{
-			Enabled: conversion.Pointer(true),
-			Region:  conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			Enabled:             conversion.Pointer(true),
+			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
 		}
 	)
 

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -288,7 +288,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 }
 
 func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t)
+	acc.SkipTestForCI(t) // needs AWS configuration
 	var (
 		resourceName         = "mongodbatlas_encryption_at_rest.test"
 		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -189,7 +189,7 @@ func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T
 			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED")),
 			Secret:                   conversion.StringPtr(os.Getenv("AZURE_SECRET_UPDATED")),
 			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-			RequirePrivateNetworking: conversion.Pointer(true),
+			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 	)
 

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -132,6 +132,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVault.GetAzureEnvironment()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVault.GetResourceGroupName()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVault.GetKeyVaultName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.require_private_networking", "false"),
 				),
 			},
 			{
@@ -143,6 +144,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVaultUpdated.GetAzureEnvironment()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVaultUpdated.GetResourceGroupName()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVaultUpdated.GetKeyVaultName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.require_private_networking", "false"),
 				),
 			},
 			{

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -5,99 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
+
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+	"go.mongodb.org/atlas-sdk/v20240805001/mockadmin"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/encryptionatrest"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"go.mongodb.org/atlas-sdk/v20240805001/admin"
-	"go.mongodb.org/atlas-sdk/v20240805001/mockadmin"
 )
 
 const (
 	initialConfigEncryptionRestRoleAWS = `
-provider "aws" {
-	region     = lower(replace("%[1]s", "_", "-"))
-	access_key = "%[2]s"
-	secret_key = "%[3]s"
-}
 
-%[7]s
-
-resource "mongodbatlas_cloud_provider_access" "test" {
-	project_id = "%[4]s"
-	provider_name = "AWS"
-	%[8]s
-		
-}
-
-resource "aws_iam_role_policy" "test_policy" {
-  name = "%[5]s"
-  role = aws_iam_role.test_role.id
-
-  policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Deny",
-		"Action": "*",
-		"Resource": "*"
-      }
-    ]
-  }
-  EOF
-}
-
-resource "aws_iam_role" "test_role" {
- name = "%[6]s"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${mongodbatlas_cloud_provider_access.test.atlas_aws_account_arn}"
-      },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "StringEquals": {
-          "sts:ExternalId": "${mongodbatlas_cloud_provider_access.test.atlas_assumed_role_external_id}"
-        }
-      }
-    }
-  ]
-}
-EOF
-
-}
-
-%[9]s
-
-`
-	configEncryptionRest = `
-resource "mongodbatlas_encryption_at_rest" "test" {
-	project_id = "%s"
-
-	aws_kms_config {
-		enabled                = %t
-		customer_master_key_id = "%s"
-		region                 = "%s"
-		role_id = mongodbatlas_cloud_provider_access.test.role_id
-	}
-}`
-	dataAWSARNConfig = `
-data "aws_iam_role" "test" {
-  name = "%s"
-}
 
 `
 )
@@ -112,7 +40,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),
 			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-			Region:              conversion.StringPtr(os.Getenv("AWS_REGION")),
+			Region:              conversion.StringPtr(os.Getenv("AWS_REGION")), // TODO: convert region to atlas one here
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
 
@@ -203,7 +131,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault),
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -214,7 +142,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated),
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -222,6 +150,81 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVaultUpdated.GetAzureEnvironment()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVaultUpdated.GetResourceGroupName()),
 					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVaultUpdated.GetKeyVaultName()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// "azure_key_vault_config.0.secret" is a sensitive value not returned by the API
+				ImportStateVerifyIgnore: []string{"azure_key_vault_config.0.secret"},
+			},
+		},
+	})
+}
+
+func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T) {
+	acc.SkipTestForCI(t) // needs Azure configuration
+
+	var (
+		resourceName = "mongodbatlas_encryption_at_rest.test"
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		azureKeyVault = admin.AzureKeyVault{
+			Enabled:                  conversion.Pointer(true),
+			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID")),
+			AzureEnvironment:         conversion.StringPtr("AZURE"),
+			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
+			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
+			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME")),
+			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER")),
+			Secret:                   conversion.StringPtr(os.Getenv("AZURE_SECRET")),
+			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
+			RequirePrivateNetworking: conversion.Pointer(true),
+		}
+
+		azureKeyVaultUpdated = admin.AzureKeyVault{
+			Enabled:                  conversion.Pointer(true),
+			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID_UPDATED")),
+			AzureEnvironment:         conversion.StringPtr("AZURE"),
+			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
+			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME_UPDATED")),
+			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED")),
+			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED")),
+			Secret:                   conversion.StringPtr(os.Getenv("AZURE_SECRET_UPDATED")),
+			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
+			RequirePrivateNetworking: conversion.Pointer(true),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzure(t); acc.PreCheckPreviewFlag(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVault.GetAzureEnvironment()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVault.GetResourceGroupName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVault.GetKeyVaultName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.require_private_networking", strconv.FormatBool((azureKeyVault.GetRequirePrivateNetworking()))),
+				),
+			},
+			{
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.azure_environment", azureKeyVaultUpdated.GetAzureEnvironment()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.resource_group_name", azureKeyVaultUpdated.GetResourceGroupName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.key_vault_name", azureKeyVaultUpdated.GetKeyVaultName()),
+					resource.TestCheckResourceAttr(resourceName, "azure_key_vault_config.0.require_private_networking", strconv.FormatBool((azureKeyVaultUpdated.GetRequirePrivateNetworking()))),
 				),
 			},
 			{
@@ -292,16 +295,15 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // For now it will skipped because of aws errors reasons, already made another test using terratest.
 	var (
-		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		accessKeyID  = os.Getenv("AWS_ACCESS_KEY_ID")
-		secretKey    = os.Getenv("AWS_SECRET_ACCESS_KEY")
-		policyName   = acc.RandomName()
-		roleName     = acc.RandomName()
-		awsKms       = admin.AWSKMSConfiguration{
-			Enabled:             conversion.Pointer(true),
-			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-			Region:              conversion.StringPtr(os.Getenv("AWS_REGION")),
+		resourceName         = "mongodbatlas_encryption_at_rest.test"
+		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		awsIAMRoleName       = acc.RandomIAMRole()
+		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
+		awsKeyName           = acc.RandomName()
+		awsKms               = admin.AWSKMSConfiguration{
+			Enabled: conversion.Pointer(true),
+			// CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			Region: conversion.StringPtr(os.Getenv("AWS_REGION")),
 		}
 	)
 
@@ -312,14 +314,8 @@ func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
-			},
-			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, true, &awsKms),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-				),
+				// Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(awsKms.GetRegion(), accessKeyID, secretKey, projectID, policyName, roleName, false, &awsKms),
+				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
 			},
 			{
 				ResourceName:      resourceName,
@@ -614,7 +610,29 @@ func testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID string, aws *admi
 	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId())
 }
 
-func testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID string, azure *admin.AzureKeyVault) string {
+func testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useRequirePrivateNetworking bool) string {
+	if useRequirePrivateNetworking {
+		return fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  azure_key_vault_config {
+				enabled             = %t
+				client_id           = "%s"
+				azure_environment   = "%s"
+				subscription_id     = "%s"
+				resource_group_name = "%s"
+				key_vault_name  	  = "%s"
+				key_identifier  	  = "%s"
+				secret  						= "%s"
+				tenant_id  					= "%s"
+				require_private_networking = %t
+			}
+		}
+	`, projectID, *azure.Enabled, azure.GetClientID(), azure.GetAzureEnvironment(), azure.GetSubscriptionID(), azure.GetResourceGroupName(),
+			azure.GetKeyVaultName(), azure.GetKeyIdentifier(), azure.GetSecret(), azure.GetTenantID(), azure.GetRequirePrivateNetworking())
+	}
+
 	return fmt.Sprintf(`
 		resource "mongodbatlas_encryption_at_rest" "test" {
 			project_id = "%s"
@@ -649,15 +667,106 @@ func testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID string, g
 	`, projectID, *google.Enabled, google.GetServiceAccountKey(), google.GetKeyVersionResourceID())
 }
 
-func testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName string, isUpdate bool, aws *admin.AWSKMSConfiguration) string {
-	cfg := fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, "", "", "")
-	if isUpdate {
-		configEncrypt := fmt.Sprintf(configEncryptionRest, projectID, *aws.Enabled, aws.GetCustomerMasterKeyID(), aws.GetRegion())
-		dataAWSARN := fmt.Sprintf(dataAWSARNConfig, awsRoleName)
-		dataARN := `iam_assumed_role_arn = data.aws_iam_role.test.arn`
-		cfg = fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, dataAWSARN, dataARN, configEncrypt)
+// func testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName string, isUpdate bool, aws *admin.AWSKMSConfiguration) string {
+// 	cfg := fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, "", "", "")
+// 	if isUpdate {
+// 		configEncrypt := fmt.Sprintf(configEncryptionRest, projectID, *aws.Enabled, aws.GetCustomerMasterKeyID(), aws.GetRegion())
+// 		dataAWSARN := fmt.Sprintf(dataAWSARNConfig, awsRoleName)
+// 		dataARN := `iam_assumed_role_arn = data.aws_iam_role.test.arn`
+// 		cfg = fmt.Sprintf(initialConfigEncryptionRestRoleAWS, region, awsAccesKey, awsSecretKey, projectID, policyName, awsRoleName, dataAWSARN, dataARN, configEncrypt)
+// 	}
+// 	return cfg
+// }
+
+func testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName string, awsEar *admin.AWSKMSConfiguration) string {
+	test := fmt.Sprintf(`
+	locals {
+		project_id = %[1]q
+		aws_iam_role_policy_name = %[2]q
+		aws_iam_role_name        = %[3]q
+		aws_kms_key_name         = %[4]q
+	  }
+
+		  %[5]s	
+`, projectID, awsIAMRolePolicyName, awsIAMRoleName, awsKeyName, awsIAMroleAuthAndEarConfigUsingLocals(awsEar))
+	return test
+}
+
+func awsIAMroleAuthAndEarConfigUsingLocals(awsEar *admin.AWSKMSConfiguration) string {
+	return fmt.Sprintf(`
+	resource "aws_kms_key" "kms_key" {
+		description = local.aws_kms_key_name
 	}
-	return cfg
+	  
+	resource "aws_iam_role_policy" "test_policy" {
+		name = local.aws_iam_role_policy_name
+		role = aws_iam_role.test_role.id
+	  
+		policy = jsonencode({
+		  "Version" : "2012-10-17",
+		  "Statement" : [
+			{
+			  "Effect" : "Allow",
+			  "Action" : [
+				"kms:Decrypt",
+				"kms:Encrypt",
+				"kms:DescribeKey"
+			  ],
+			  "Resource" : [
+				"${aws_kms_key.kms_key.arn}"
+			  ]
+			}
+		  ]
+		})
+	  }
+	  
+	resource "aws_iam_role" "test_role" {
+		name = local.aws_iam_role_name
+	  
+		assume_role_policy = jsonencode({
+		  "Version" : "2012-10-17",
+		  "Statement" : [
+			{
+			  "Effect" : "Allow",
+			  "Principal" : {
+				"AWS" : "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config[0].atlas_aws_account_arn}"
+			  },
+			  "Action" : "sts:AssumeRole",
+			  "Condition" : {
+				"StringEquals" : {
+				  "sts:ExternalId" : "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config[0].atlas_assumed_role_external_id}"
+				}
+			  }
+			}
+		  ]
+		})
+	  }
+
+	resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
+		project_id    = local.project_id
+		provider_name = "AWS"
+	  }
+	  
+	  resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+		project_id = local.project_id
+		role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
+	  
+		aws {
+		  iam_assumed_role_arn = aws_iam_role.test_role.arn
+		}
+	  }
+
+resource "mongodbatlas_encryption_at_rest" "test" {
+  project_id = local.project_id
+
+  aws_kms_config {
+    enabled                = %[1]t
+    customer_master_key_id = aws_kms_key.kms_key.id
+	region                 = %[2]q
+    role_id                = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+  }
+}
+	`, awsEar.GetEnabled(), awsEar.GetRegion())
 }
 
 func testAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -288,7 +288,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 }
 
 func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t) // TODO: As part of CLOUDP-267663, check if we need both this and TestAccEncryptionAtRest_basicAWS tests
+	acc.SkipTestForCI(t)
 	var (
 		resourceName         = "mongodbatlas_encryption_at_rest.test"
 		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")


### PR DESCRIPTION
## Description

Updates `mongodbatlas_encryption_at_rest` resource to use new `azure_key_vault_config.require_private_networking` field and updates tests.

Link to any related issue(s): [CLOUDP-267658](https://jira.mongodb.org/browse/CLOUDP-267658)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
- Currently below error shows if user tries to enable the new flag without enabling the feature flag at project level:
```
      ~ azure_key_vault_config {
          ~ require_private_networking = false -> true
            # (9 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
mongodbatlas_encryption_at_rest.test: Modifying... [id=6697e11ce89c955b64899b6d]
╷
│ Error: error updating encryption at rest
│ 
│   with mongodbatlas_encryption_at_rest.test,
│   on main.tf line 1, in resource "mongodbatlas_encryption_at_rest" "test":
│    1: resource "mongodbatlas_encryption_at_rest" "test" {
│ 
│ error updating Encryption At Rest: https://cloud-dev.mongodb.com/api/atlas/v2/groups/6697e11ce89c955b64899b6d/encryptionAtRest PATCH: HTTP 403 Forbidden (Error code:
│ "FEATURE_UNSUPPORTED") Detail: Feature not supported by current account level. Reason: Forbidden. Params: []
```
- All tests run locally:
![Screenshot 2024-08-16 at 14 16 47](https://github.com/user-attachments/assets/8009f27c-8544-44de-9ffe-2b6763ff82de)
