### PR TITLE
test: Simply migration test checks after 1.18.0 release and adjust version constraint in examples

### DIFF
--- a/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.17"
+      version = "~> 1.18"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/global-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/global-cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      version = "~> 1.18"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/multi-cloud/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/multi-cloud/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      version = "~> 1.18"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/tenant-upgrade/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/tenant-upgrade/main.tf
@@ -9,8 +9,6 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   cluster_type = "REPLICASET"
 
   replication_specs {
-    num_shards = 1
-
     region_configs {
       electable_specs {
         instance_size = var.provider_instance_size_name

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -15,31 +15,26 @@ import (
 const versionBeforeISSRelease = "1.17.6"
 
 func TestMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
-	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
-	testCase := replicaSetAWSProviderTestCase(t, false)
+	testCase := replicaSetAWSProviderTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
-	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
-	testCase := replicaSetMultiCloudTestCase(t, false)
+	testCase := replicaSetMultiCloudTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
-	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
-	testCase := singleShardedMultiCloudTestCase(t, false)
+	testCase := singleShardedMultiCloudTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_symmetricGeoShardedOldSchema(t *testing.T) {
-	// once 1.18.0 is released we can adjust this to always check new attributes - CLOUDP-266096
-	testCase := symmetricGeoShardedOldSchemaTestCase(t, false)
+	testCase := symmetricGeoShardedOldSchemaTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_asymmetricShardedNewSchema(t *testing.T) {
-	acc.SkipTestForCI(t) // latest release does not support ISS, to be adjusted in CLOUDP-266096
 	testCase := asymmetricShardedNewSchemaTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -54,9 +54,9 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
-	resource.ParallelTest(t, replicaSetAWSProviderTestCase(t, true))
+	resource.ParallelTest(t, replicaSetAWSProviderTestCase(t))
 }
-func replicaSetAWSProviderTestCase(t *testing.T, checkNewAttributes bool) resource.TestCase {
+func replicaSetAWSProviderTestCase(t *testing.T) resource.TestCase {
 	t.Helper()
 	var (
 		projectID   = acc.ProjectIDExecution(t)
@@ -70,11 +70,11 @@ func replicaSetAWSProviderTestCase(t *testing.T, checkNewAttributes bool) resour
 		Steps: []resource.TestStep{
 			{
 				Config: configReplicaSetAWSProvider(projectID, clusterName, 60, 3),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, checkNewAttributes, checkNewAttributes),
+				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, true, true),
 			},
 			{
 				Config: configReplicaSetAWSProvider(projectID, clusterName, 50, 5),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 50, 5, checkNewAttributes, checkNewAttributes),
+				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 50, 5, true, true),
 			},
 			{
 				ResourceName:            resourceName,
@@ -88,9 +88,9 @@ func replicaSetAWSProviderTestCase(t *testing.T, checkNewAttributes bool) resour
 }
 
 func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
-	resource.ParallelTest(t, replicaSetMultiCloudTestCase(t, true))
+	resource.ParallelTest(t, replicaSetMultiCloudTestCase(t))
 }
-func replicaSetMultiCloudTestCase(t *testing.T, verifyExternalID bool) resource.TestCase {
+func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
 	t.Helper()
 	var (
 		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -106,11 +106,11 @@ func replicaSetMultiCloudTestCase(t *testing.T, verifyExternalID bool) resource.
 		Steps: []resource.TestStep{
 			{
 				Config: configReplicaSetMultiCloud(orgID, projectName, clusterName),
-				Check:  checkReplicaSetMultiCloud(clusterName, 3, verifyExternalID),
+				Check:  checkReplicaSetMultiCloud(clusterName, 3),
 			},
 			{
 				Config: configReplicaSetMultiCloud(orgID, projectName, clusterNameUpdated),
-				Check:  checkReplicaSetMultiCloud(clusterNameUpdated, 3, verifyExternalID),
+				Check:  checkReplicaSetMultiCloud(clusterNameUpdated, 3),
 			},
 			{
 				ResourceName:            resourceName,
@@ -124,10 +124,10 @@ func replicaSetMultiCloudTestCase(t *testing.T, verifyExternalID bool) resource.
 }
 
 func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
-	resource.ParallelTest(t, singleShardedMultiCloudTestCase(t, true))
+	resource.ParallelTest(t, singleShardedMultiCloudTestCase(t))
 }
 
-func singleShardedMultiCloudTestCase(t *testing.T, verifyExternalID bool) resource.TestCase {
+func singleShardedMultiCloudTestCase(t *testing.T) resource.TestCase {
 	t.Helper()
 	var (
 		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -143,11 +143,11 @@ func singleShardedMultiCloudTestCase(t *testing.T, verifyExternalID bool) resour
 		Steps: []resource.TestStep{
 			{
 				Config: configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 1, "M10"),
-				Check:  checkShardedOldSchemaMultiCloud(clusterName, 1, "M10", verifyExternalID),
+				Check:  checkShardedOldSchemaMultiCloud(clusterName, 1, "M10", true),
 			},
 			{
 				Config: configShardedOldSchemaMultiCloud(orgID, projectName, clusterNameUpdated, 1, "M10"),
-				Check:  checkShardedOldSchemaMultiCloud(clusterNameUpdated, 1, "M10", verifyExternalID),
+				Check:  checkShardedOldSchemaMultiCloud(clusterNameUpdated, 1, "M10", true),
 			},
 			{
 				ResourceName:            resourceName,
@@ -535,10 +535,10 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing.T) {
-	resource.ParallelTest(t, symmetricGeoShardedOldSchemaTestCase(t, true))
+	resource.ParallelTest(t, symmetricGeoShardedOldSchemaTestCase(t))
 }
 
-func symmetricGeoShardedOldSchemaTestCase(t *testing.T, checkNewAttributes bool) resource.TestCase {
+func symmetricGeoShardedOldSchemaTestCase(t *testing.T) resource.TestCase {
 	t.Helper()
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
@@ -553,11 +553,11 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, checkNewAttributes bool)
 		Steps: []resource.TestStep{
 			{
 				Config: configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false),
-				Check:  checkGeoShardedOldSchema(clusterName, 2, 2, checkNewAttributes, false),
+				Check:  checkGeoShardedOldSchema(clusterName, 2, 2, true, false),
 			},
 			{
 				Config: configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false),
-				Check:  checkGeoShardedOldSchema(clusterName, 3, 3, checkNewAttributes, false),
+				Check:  checkGeoShardedOldSchema(clusterName, 3, 3, true, false),
 			},
 		},
 	}
@@ -1012,7 +1012,7 @@ func configReplicaSetMultiCloud(orgID, projectName, name string) string {
 	`, orgID, projectName, name)
 }
 
-func checkReplicaSetMultiCloud(name string, regionConfigs int, verifyExternalID bool) resource.TestCheckFunc {
+func checkReplicaSetMultiCloud(name string, regionConfigs int) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
 		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
@@ -1021,9 +1021,7 @@ func checkReplicaSetMultiCloud(name string, regionConfigs int, verifyExternalID 
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
 		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
-	}
-	if verifyExternalID {
-		additionalChecks = append(additionalChecks, resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"))
+		resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"),
 	}
 	return checkAggr(
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.id"},


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-266096

After 1.18.0 small simplifications can be done in migration test checks, and also aligning version constraints with new version.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
