### PR TITLE
feat: Implements `mongodbatlas_encryption_at_rest_private_endpoint` resource

### DIFF
--- a/.changelog/2512.txt
+++ b/.changelog/2512.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+resource/mongodbatlas_encryption_at_rest_private_endpoint
+```

--- a/internal/common/retrystrategy/retry_state.go
+++ b/internal/common/retrystrategy/retry_state.go
@@ -6,6 +6,7 @@ const (
 	RetryStrategyErrorState      = "ERROR"
 	RetryStrategyPausedState     = "PAUSED"
 	RetryStrategyUpdatingState   = "UPDATING"
+	RetryStrategyDeletingState   = "DELETING"
 	RetryStrategyInitiatingState = "INITIATING"
 	RetryStrategyIdleState       = "IDLE"
 	RetryStrategyFailedState     = "FAILED"

--- a/internal/common/retrystrategy/retry_state.go
+++ b/internal/common/retrystrategy/retry_state.go
@@ -8,6 +8,7 @@ const (
 	RetryStrategyUpdatingState   = "UPDATING"
 	RetryStrategyInitiatingState = "INITIATING"
 	RetryStrategyIdleState       = "IDLE"
+	RetryStrategyFailedState     = "FAILED"
 	RetryStrategyActiveState     = "ACTIVE"
 	RetryStrategyDeletedState    = "DELETED"
 

--- a/internal/common/retrystrategy/retry_state.go
+++ b/internal/common/retrystrategy/retry_state.go
@@ -1,11 +1,16 @@
 package retrystrategy
 
 const (
-	RetryStrategyPendingState   = "PENDING"
-	RetryStrategyCompletedState = "COMPLETED"
-	RetryStrategyErrorState     = "ERROR"
-	RetryStrategyPausedState    = "PAUSED"
-	RetryStrategyUpdatingState  = "UPDATING"
-	RetryStrategyIdleState      = "IDLE"
-	RetryStrategyDeletedState   = "DELETED"
+	RetryStrategyPendingState    = "PENDING"
+	RetryStrategyCompletedState  = "COMPLETED"
+	RetryStrategyErrorState      = "ERROR"
+	RetryStrategyPausedState     = "PAUSED"
+	RetryStrategyUpdatingState   = "UPDATING"
+	RetryStrategyInitiatingState = "INITIATING"
+	RetryStrategyIdleState       = "IDLE"
+	RetryStrategyActiveState     = "ACTIVE"
+	RetryStrategyDeletedState    = "DELETED"
+
+	RetryStrategyPendingAcceptanceState = "PENDING_ACCEPTANCE"
+	RetryStrategyPendingRecreationState = "PENDING_RECREATION"
 )

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_migration_test.go
@@ -132,7 +132,7 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, false),
+				Config:            acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -144,7 +144,7 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, false),
+				Config:                   acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acc.DebugPlan(),

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -119,7 +119,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzure(t) },
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{
@@ -194,7 +194,7 @@ func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzure(t); acc.PreCheckPreviewFlag(t) },
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t); acc.PreCheckPreviewFlag(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -124,7 +124,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, false),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -136,7 +136,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -199,7 +199,7 @@ func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T
 		CheckDestroy:             testAccCheckMongoDBAtlasEncryptionAtRestDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVault, true),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -211,7 +211,7 @@ func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -602,49 +602,6 @@ func testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID string, aws *admi
 			}
 		}
 	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId())
-}
-
-func testAccMongoDBAtlasEncryptionAtRestConfigAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useRequirePrivateNetworking bool) string {
-	if useRequirePrivateNetworking {
-		return fmt.Sprintf(`
-		resource "mongodbatlas_encryption_at_rest" "test" {
-			project_id = "%s"
-
-		  azure_key_vault_config {
-				enabled             = %t
-				client_id           = "%s"
-				azure_environment   = "%s"
-				subscription_id     = "%s"
-				resource_group_name = "%s"
-				key_vault_name  	  = "%s"
-				key_identifier  	  = "%s"
-				secret  						= "%s"
-				tenant_id  					= "%s"
-				require_private_networking = %t
-			}
-		}
-	`, projectID, *azure.Enabled, azure.GetClientID(), azure.GetAzureEnvironment(), azure.GetSubscriptionID(), azure.GetResourceGroupName(),
-			azure.GetKeyVaultName(), azure.GetKeyIdentifier(), azure.GetSecret(), azure.GetTenantID(), azure.GetRequirePrivateNetworking())
-	}
-
-	return fmt.Sprintf(`
-		resource "mongodbatlas_encryption_at_rest" "test" {
-			project_id = "%s"
-
-		  azure_key_vault_config {
-				enabled             = %t
-				client_id           = "%s"
-				azure_environment   = "%s"
-				subscription_id     = "%s"
-				resource_group_name = "%s"
-				key_vault_name  	  = "%s"
-				key_identifier  	  = "%s"
-				secret  						= "%s"
-				tenant_id  					= "%s"
-			}
-		}
-	`, projectID, *azure.Enabled, azure.GetClientID(), azure.GetAzureEnvironment(), azure.GetSubscriptionID(), azure.GetResourceGroupName(),
-		azure.GetKeyVaultName(), azure.GetKeyIdentifier(), azure.GetSecret(), azure.GetTenantID())
 }
 
 func testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID string, google *admin.GoogleCloudKMS) string {

--- a/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
+++ b/internal/service/encryptionatrest/resource_encryption_at_rest_test.go
@@ -23,12 +23,15 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
+const (
+	resourceName = "mongodbatlas_encryption_at_rest.test"
+)
+
 func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
-		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),
@@ -90,8 +93,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	acc.SkipTestForCI(t) // needs Azure configuration
 
 	var (
-		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 
 		azureKeyVault = admin.AzureKeyVault{
 			Enabled:           conversion.Pointer(true),
@@ -163,8 +165,7 @@ func TestAccEncryptionAtRest_azure_requirePrivateNetworking_preview(t *testing.T
 	acc.SkipTestForCI(t) // needs Azure configuration
 
 	var (
-		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 
 		azureKeyVault = admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
@@ -238,8 +239,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 	acc.SkipTestForCI(t) // needs GCP configuration
 
 	var (
-		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 
 		googleCloudKms = admin.GoogleCloudKMS{
 			Enabled:              conversion.Pointer(true),
@@ -290,7 +290,6 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 	var (
-		resourceName         = "mongodbatlas_encryption_at_rest.test"
 		projectID            = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		awsIAMRoleName       = acc.RandomIAMRole()
 		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)

--- a/internal/service/encryptionatrestprivateendpoint/main_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/main_test.go
@@ -1,0 +1,15 @@
+package encryptionatrestprivateendpoint_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/encryptionatrestprivateendpoint/model.go
+++ b/internal/service/encryptionatrestprivateendpoint/model.go
@@ -1,11 +1,9 @@
 package encryptionatrestprivateendpoint
 
 import (
-	"go.mongodb.org/atlas-sdk/v20240805001/admin"
-
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
 func NewTFEarPrivateEndpoint(apiResp *admin.EARPrivateEndpoint, projectID string) *TFEarPrivateEndpointModel {

--- a/internal/service/encryptionatrestprivateendpoint/model.go
+++ b/internal/service/encryptionatrestprivateendpoint/model.go
@@ -28,11 +28,7 @@ func NewEarPrivateEndpointReq(tfPlan *TFEarPrivateEndpointModel) *admin.EARPriva
 		return nil
 	}
 	return &admin.EARPrivateEndpoint{
-		CloudProvider:                 tfPlan.CloudProvider.ValueStringPointer(),
-		ErrorMessage:                  tfPlan.ErrorMessage.ValueStringPointer(),
-		Id:                            tfPlan.ID.ValueStringPointer(),
-		RegionName:                    tfPlan.RegionName.ValueStringPointer(),
-		Status:                        tfPlan.Status.ValueStringPointer(),
-		PrivateEndpointConnectionName: tfPlan.PrivateEndpointConnectionName.ValueStringPointer(),
+		CloudProvider: tfPlan.CloudProvider.ValueStringPointer(),
+		RegionName:    tfPlan.RegionName.ValueStringPointer(),
 	}
 }

--- a/internal/service/encryptionatrestprivateendpoint/model_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/model_test.go
@@ -93,28 +93,9 @@ func TestEncryptionAtRestPrivateEndpointTFModelToSDK(t *testing.T) {
 				Status:                        types.StringValue(testStatus),
 				PrivateEndpointConnectionName: types.StringValue(testPEConnectionName)},
 			expectedSDKReq: &admin.EARPrivateEndpoint{
-				CloudProvider:                 admin.PtrString(testCloudProvider),
-				ErrorMessage:                  nil,
-				Id:                            admin.PtrString(testID),
-				RegionName:                    admin.PtrString(testRegionName),
-				Status:                        admin.PtrString(testStatus),
-				PrivateEndpointConnectionName: admin.PtrString(testPEConnectionName)},
-		},
-		"Complete TF state with error message": {
-			tfModel: &encryptionatrestprivateendpoint.TFEarPrivateEndpointModel{
-				CloudProvider:                 types.StringValue(testCloudProvider),
-				ErrorMessage:                  types.StringValue(testErrMsg),
-				ID:                            types.StringValue(testID),
-				RegionName:                    types.StringValue(testRegionName),
-				Status:                        types.StringValue(testStatus),
-				PrivateEndpointConnectionName: types.StringValue(testPEConnectionName)},
-			expectedSDKReq: &admin.EARPrivateEndpoint{
-				CloudProvider:                 admin.PtrString(testCloudProvider),
-				ErrorMessage:                  admin.PtrString(testErrMsg),
-				Id:                            admin.PtrString(testID),
-				RegionName:                    admin.PtrString(testRegionName),
-				Status:                        admin.PtrString(testStatus),
-				PrivateEndpointConnectionName: admin.PtrString(testPEConnectionName)},
+				CloudProvider: admin.PtrString(testCloudProvider),
+				RegionName:    admin.PtrString(testRegionName),
+			},
 		},
 	}
 

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -117,9 +117,13 @@ func (r *encryptionAtRestPrivateEndpointRS) Delete(ctx context.Context, req reso
 		return
 	}
 
-	if err := WaitDeleteStateTransition(ctx, projectID, cloudProvider, endpointID, connV2.EncryptionAtRestUsingCustomerKeyManagementApi); err != nil {
+	model, err := WaitDeleteStateTransition(ctx, projectID, cloudProvider, endpointID, connV2.EncryptionAtRestUsingCustomerKeyManagementApi)
+	if err != nil {
 		resp.Diagnostics.AddError("error when waiting for status transition in delete", err.Error())
 		return
+	}
+	if err := getErrorMsgForFailedStatus(model); err != nil {
+		resp.Diagnostics.AddError(failedStatusErrorMessage, err.Error())
 	}
 }
 

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -1,4 +1,3 @@
-//nolint:gocritic
 package encryptionatrestprivateendpoint
 
 import (
@@ -53,6 +52,7 @@ func (r *encryptionAtRestPrivateEndpointRS) Create(ctx context.Context, req reso
 		return
 	}
 
+	// TODO handle state transition
 	newencryptionAtRestPrivateEndpointModel := NewTFEarPrivateEndpoint(createResp, projectID)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newencryptionAtRestPrivateEndpointModel)...)
 }
@@ -101,6 +101,8 @@ func (r *encryptionAtRestPrivateEndpointRS) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("error deleting resource", err.Error())
 		return
 	}
+
+	// TODO handle state transition
 }
 
 func (r *encryptionAtRestPrivateEndpointRS) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -52,7 +52,7 @@ func (r *encryptionAtRestPrivateEndpointRS) Create(ctx context.Context, req reso
 		return
 	}
 
-	finalState, err := WaitStateTransition(ctx, projectID, cloudProvider, createResp.GetId(), connV2.EncryptionAtRestUsingCustomerKeyManagementApi)
+	finalState, err := waitStateTransition(ctx, projectID, cloudProvider, createResp.GetId(), connV2.EncryptionAtRestUsingCustomerKeyManagementApi)
 	if err != nil {
 		resp.Diagnostics.AddError("error when waiting for status transition in creation", err.Error())
 		return

--- a/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestMigEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.18.1")
+	mig.SkipIfVersionBelow(t, "1.19.0")
 	testCase := basicTestCase(t)
 	mig.CreateAndRunTest(t, testCase)
 }

--- a/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
@@ -1,0 +1,13 @@
+package encryptionatrestprivateendpoint_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestMigEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.18.1")
+	testCase := basicTestCase(t)
+	mig.CreateAndRunTest(t, testCase)
+}

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -39,7 +39,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 	)
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		PreCheck:                 func() { acc.PreCheck(tb); acc.PreCheckEncryptionAtRestEnvAzure(tb); acc.PreCheckPreviewFlag(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork(t *
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckEncryptionAtRestEnvAzure(t); acc.PreCheckPreviewFlag(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
@@ -51,7 +52,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 				Config: configPrivateEndpointAzureBasic(projectID, azureKeyVault, region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_ACCEPTANCE"),
+					resource.TestCheckResourceAttr(resourceName, "status", retrystrategy.RetryStrategyPendingAcceptanceState),
 				),
 			},
 			{

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -1,29 +1,47 @@
-//nolint:gocritic
 package encryptionatrestprivateendpoint_test
 
-// TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
-// In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
-// func TestAccEncryptionatrestprivateendpointRS_basic(t *testing.T) {
+// import (
+// 	"fmt"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+// 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+// )
+
+// func TestAccEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
+// 	acc.SkipTestForCI(t) // needs Azure configuration
+
 // 	resource.ParallelTest(t, resource.TestCase{
 // 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 // 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 // 		//		CheckDestroy:             checkDestroyEncryptionatrestprivateendpoint,
-// 		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
-// 			//			{
-// 			//				Config: encryptionatrestprivateendpointConfig(),
-// 			//				Check:  encryptionatrestprivateendpointAttributeChecks(),
-// 			//			},
-// 			//          {
-// 			//				Config: encryptionatrestprivateendpointConfig(),
-// 			//				Check:  encryptionatrestprivateendpointAttributeChecks(),
-// 			//			},
-// 			//			{
-// 			//				Config:            encryptionatrestprivateendpointConfig(),
-// 			//				ResourceName:      resourceName,
-// 			//				ImportStateIdFunc: checkEncryptionatrestprivateendpointImportStateIDFunc,
-// 			//				ImportState:       true,
-// 			//				ImportStateVerify: true,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: encryptionatrestprivateendpointConfig(),
+// 				Check:  encryptionatrestprivateendpointAttributeChecks(),
+// 			},
+// 			{
+// 				Config:            encryptionatrestprivateendpointConfig(),
+// 				ResourceName:      resourceName,
+// 				ImportStateIdFunc: checkEncryptionatrestprivateendpointImportStateIDFunc,
+// 				ImportState:       true,
+// 				ImportStateVerify: true,
+// 			},
 // 		},
 // 	},
 // 	)
+// }
+
+// func configAzureBasic(projectID string, azure *admin.AzureKeyVault, region string) string {
+// 	var encryptionAtRestConfig string
+
+// 	return fmt.Sprintf(`
+// 		%s
+
+// 		resource "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
+// 		    project_id = mongodbatlas_encryption_at_rest.test.project_id
+// 		    cloud_provider = "AZURE"
+// 		    region_name =
+// 		}
+// 	`, encryptionAtRestConfig, region)
 // }

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -13,6 +13,11 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
+const (
+	resourceName    = "mongodbatlas_encryption_at_rest_private_endpoint.test"
+	earResourceName = "mongodbatlas_encryption_at_rest.test"
+)
+
 func TestAccEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
 }
@@ -21,7 +26,6 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 	tb.Helper()
 	acc.SkipTestForCI(tb) // needs Azure configuration
 	var (
-		resourceName  = "mongodbatlas_encryption_at_rest_private_endpoint.test"
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 		azureKeyVault = &admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
@@ -64,10 +68,8 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork(t *testing.T) {
 	acc.SkipTestForCI(t) // needs Azure configuration
 	var (
-		earResourceName             = "mongodbatlas_encryption_at_rest.test"
-		privateEndpointResourceName = "mongodbatlas_encryption_at_rest_private_endpoint.test"
-		projectID                   = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
-		azureKeyVault               = &admin.AzureKeyVault{
+		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		azureKeyVault = &admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
 			RequirePrivateNetworking: conversion.Pointer(true),
 			AzureEnvironment:         conversion.StringPtr("AZURE"),
@@ -98,8 +100,8 @@ func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork(t *
 				Config: configPrivateEndpointAzureBasic(projectID, azureKeyVault, region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.require_private_networking", "true"),
-					resource.TestCheckResourceAttrSet(privateEndpointResourceName, "id"),
-					resource.TestCheckResourceAttr(privateEndpointResourceName, "status", "PENDING_ACCEPTANCE"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_ACCEPTANCE"),
 				),
 			},
 		},

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -1,47 +1,101 @@
 package encryptionatrestprivateendpoint_test
 
-// import (
-// 	"fmt"
-// 	"testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-// 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-// )
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
 
-// func TestAccEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
-// 	acc.SkipTestForCI(t) // needs Azure configuration
+func TestAccEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
+	resource.ParallelTest(t, *basicTestCase(t))
+}
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:                 func() { acc.PreCheckBasic(t) },
-// 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-// 		//		CheckDestroy:             checkDestroyEncryptionatrestprivateendpoint,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: encryptionatrestprivateendpointConfig(),
-// 				Check:  encryptionatrestprivateendpointAttributeChecks(),
-// 			},
-// 			{
-// 				Config:            encryptionatrestprivateendpointConfig(),
-// 				ResourceName:      resourceName,
-// 				ImportStateIdFunc: checkEncryptionatrestprivateendpointImportStateIDFunc,
-// 				ImportState:       true,
-// 				ImportStateVerify: true,
-// 			},
-// 		},
-// 	},
-// 	)
-// }
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+	acc.SkipTestForCI(tb) // needs Azure configuration
+	var (
+		resourceName  = "mongodbatlas_encryption_at_rest_private_endpoint.test"
+		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		azureKeyVault = &admin.AzureKeyVault{
+			Enabled:                  conversion.Pointer(true),
+			RequirePrivateNetworking: conversion.Pointer(true),
+			AzureEnvironment:         conversion.StringPtr("AZURE"),
+			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID")),
+			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
+			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
+			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME")),
+			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER")),
+			Secret:                   conversion.StringPtr(os.Getenv("AZURE_SECRET")),
+			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
+		}
+		region = os.Getenv("AZURE_PRIVATE_ENDPOINT_REGION")
+	)
 
-// func configAzureBasic(projectID string, azure *admin.AzureKeyVault, region string) string {
-// 	var encryptionAtRestConfig string
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configAzureBasic(projectID, azureKeyVault, region),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_ACCEPTANCE"),
+				),
+			},
+			{
+				Config:            configAzureBasic(projectID, azureKeyVault, region),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	}
+}
 
-// 	return fmt.Sprintf(`
-// 		%s
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		return fmt.Sprintf("%s-%s-%s", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cloud_provider"], rs.Primary.Attributes["id"]), nil
+	}
+}
 
-// 		resource "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
-// 		    project_id = mongodbatlas_encryption_at_rest.test.project_id
-// 		    cloud_provider = "AZURE"
-// 		    region_name =
-// 		}
-// 	`, encryptionAtRestConfig, region)
-// }
+func configAzureBasic(projectID string, azure *admin.AzureKeyVault, region string) string {
+	encryptionAtRestConfig := acc.ConfigEARAzureKeyVault(projectID, azure, true)
+	return fmt.Sprintf(`
+		%[1]s
+
+		resource "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
+		    project_id = mongodbatlas_encryption_at_rest.test.project_id
+		    cloud_provider = "AZURE"
+		    region_name = %[2]q
+		}
+	`, encryptionAtRestConfig, region)
+}
+
+func checkDestroy(state *terraform.State) error {
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type != "mongodbatlas_encryption_at_rest_private_endpoint" {
+			continue
+		}
+		projectID := rs.Primary.Attributes["project_id"]
+		cloudProvider := rs.Primary.Attributes["cloud_provider"]
+		endpointID := rs.Primary.Attributes["id"]
+		_, _, err := acc.ConnV2().EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRestPrivateEndpoint(context.Background(), projectID, cloudProvider, endpointID).Execute()
+		if err == nil {
+			return fmt.Errorf("EAR private endpoint (%s:%s:%s) still exists", projectID, cloudProvider, endpointID)
+		}
+	}
+	return nil
+}

--- a/internal/service/encryptionatrestprivateendpoint/state_transition.go
+++ b/internal/service/encryptionatrestprivateendpoint/state_transition.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	defaultTimeout    = 20 * time.Minute // The amount of time to wait before timeout
-	defaultMinTimeout = 1 * time.Minute  // Smallest time to wait before refreshes
+	defaultMinTimeout = 30 * time.Second // Smallest time to wait before refreshes
 )
 
 func waitStateTransition(ctx context.Context, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) (*admin.EARPrivateEndpoint, error) {

--- a/internal/service/encryptionatrestprivateendpoint/state_transition.go
+++ b/internal/service/encryptionatrestprivateendpoint/state_transition.go
@@ -18,7 +18,7 @@ func waitStateTransition(ctx context.Context, projectID, cloudProvider, endpoint
 func WaitStateTransitionWithMinTimeout(ctx context.Context, minTimeout time.Duration, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) (*admin.EARPrivateEndpoint, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{retrystrategy.RetryStrategyInitiatingState},
-		Target:     []string{retrystrategy.RetryStrategyPendingAcceptanceState, retrystrategy.RetryStrategyActiveState},
+		Target:     []string{retrystrategy.RetryStrategyPendingAcceptanceState, retrystrategy.RetryStrategyActiveState, retrystrategy.RetryStrategyFailedState},
 		Refresh:    refreshFunc(ctx, projectID, cloudProvider, endpointID, client),
 		Timeout:    20 * time.Minute,
 		MinTimeout: minTimeout,
@@ -41,7 +41,7 @@ func WaitDeleteStateTransition(ctx context.Context, projectID, cloudProvider, en
 
 func WaitDeleteStateTransitionWithMinTimeout(ctx context.Context, minTimeout time.Duration, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) error {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{retrystrategy.RetryStrategyPendingAcceptanceState, retrystrategy.RetryStrategyActiveState, retrystrategy.RetryStrategyPendingRecreationState},
+		Pending:    []string{retrystrategy.RetryStrategyPendingAcceptanceState, retrystrategy.RetryStrategyActiveState, retrystrategy.RetryStrategyPendingRecreationState, retrystrategy.RetryStrategyFailedState},
 		Target:     []string{retrystrategy.RetryStrategyDeletedState},
 		Refresh:    refreshFunc(ctx, projectID, cloudProvider, endpointID, client),
 		Timeout:    20 * time.Minute,

--- a/internal/service/encryptionatrestprivateendpoint/state_transition.go
+++ b/internal/service/encryptionatrestprivateendpoint/state_transition.go
@@ -1,0 +1,63 @@
+package encryptionatrestprivateendpoint
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+func WaitStateTransition(ctx context.Context, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) (*admin.EARPrivateEndpoint, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{retrystrategy.RetryStrategyInitiatingState},
+		Target:     []string{retrystrategy.RetryStrategyPendingAcceptanceState},
+		Refresh:    refreshFunc(ctx, projectID, cloudProvider, endpointID, client),
+		Timeout:    20 * time.Minute,
+		MinTimeout: 1 * time.Minute,
+		Delay:      0,
+	}
+
+	result, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if privateEndpointResp, ok := result.(*admin.EARPrivateEndpoint); ok && privateEndpointResp != nil {
+		return privateEndpointResp, nil
+	}
+	return nil, errors.New("did not obtain valid result when waiting for state transition")
+}
+
+func WaitDeleteStateTransition(ctx context.Context, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{retrystrategy.RetryStrategyPendingAcceptanceState, retrystrategy.RetryStrategyActiveState, retrystrategy.RetryStrategyPendingRecreationState},
+		Target:     []string{retrystrategy.RetryStrategyDeletedState},
+		Refresh:    refreshFunc(ctx, projectID, cloudProvider, endpointID, client),
+		Timeout:    20 * time.Minute,
+		MinTimeout: 1 * time.Minute,
+		Delay:      0,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+// TODO leave generic, add testing
+func refreshFunc(ctx context.Context, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		model, resp, err := client.GetEncryptionAtRestPrivateEndpoint(ctx, projectID, cloudProvider, endpointID).Execute()
+		if err != nil && model == nil && resp == nil {
+			return nil, "", err
+		}
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return "", retrystrategy.RetryStrategyDeletedState, nil
+			}
+			return nil, "", err
+		}
+		status := model.GetStatus()
+		return model, status, nil
+	}
+}

--- a/internal/service/encryptionatrestprivateendpoint/state_transition.go
+++ b/internal/service/encryptionatrestprivateendpoint/state_transition.go
@@ -44,7 +44,7 @@ func WaitDeleteStateTransition(ctx context.Context, projectID, cloudProvider, en
 	return err
 }
 
-// TODO leave generic, add testing
+// TODO add testing
 func refreshFunc(ctx context.Context, projectID, cloudProvider, endpointID string, client admin.EncryptionAtRestUsingCustomerKeyManagementApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		model, resp, err := client.GetEncryptionAtRestPrivateEndpoint(ctx, projectID, cloudProvider, endpointID).Execute()

--- a/internal/service/encryptionatrestprivateendpoint/state_transition_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/state_transition_test.go
@@ -41,13 +41,13 @@ func TestStateTransition(t *testing.T) {
 			expectedState: conversion.StringPtr(retrystrategy.RetryStrategyActiveState),
 			expectedError: false,
 		},
-		"Error when transitioning to FAILED state": {
+		"Return model without error when transitioning to FAILED state": {
 			mockResponses: []response{
 				{state: conversion.StringPtr(retrystrategy.RetryStrategyInitiatingState)},
-				{state: conversion.StringPtr("FAILED")},
+				{state: conversion.StringPtr(retrystrategy.RetryStrategyFailedState)},
 			},
-			expectedState: nil,
-			expectedError: true,
+			expectedState: conversion.StringPtr(retrystrategy.RetryStrategyFailedState),
+			expectedError: false,
 		},
 		"Error when API responds with error": {
 			mockResponses: []response{
@@ -92,12 +92,12 @@ func TestDeleteStateTransition(t *testing.T) {
 			},
 			expectedError: false,
 		},
-		"Error when transitioning into FAILED state": {
+		"Successful transitioning from FAILED to deleted": {
 			mockResponses: []response{
-				{state: conversion.StringPtr(retrystrategy.RetryStrategyActiveState)},
-				{state: conversion.StringPtr("FAILED")},
+				{state: conversion.StringPtr(retrystrategy.RetryStrategyFailedState)},
+				{state: conversion.StringPtr(retrystrategy.RetryStrategyDeletedState)},
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 	}
 

--- a/internal/testutil/acc/encryption_at_rest.go
+++ b/internal/testutil/acc/encryption_at_rest.go
@@ -1,0 +1,34 @@
+package acc
+
+import (
+	"fmt"
+
+	"go.mongodb.org/atlas-sdk/v20240805001/admin"
+)
+
+func ConfigEARAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useRequirePrivateNetworking bool) string {
+	var requirePrivateNetworkingAttr string
+	if useRequirePrivateNetworking {
+		requirePrivateNetworkingAttr = fmt.Sprintf("require_private_networking = %t", azure.GetRequirePrivateNetworking())
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  azure_key_vault_config {
+				enabled             = %t
+				client_id           = "%s"
+				azure_environment   = "%s"
+				subscription_id     = "%s"
+				resource_group_name = "%s"
+				key_vault_name  	  = "%s"
+				key_identifier  	  = "%s"
+				secret  						= "%s"
+				tenant_id  					= "%s"
+				%s
+			}
+		}
+	`, projectID, *azure.Enabled, azure.GetClientID(), azure.GetAzureEnvironment(), azure.GetSubscriptionID(), azure.GetResourceGroupName(),
+		azure.GetKeyVaultName(), azure.GetKeyIdentifier(), azure.GetSecret(), azure.GetTenantID(), requirePrivateNetworkingAttr)
+}

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -136,16 +136,25 @@ func PreCheckPeeringEnvAzure(tb testing.TB) {
 func PreCheckEncryptionAtRestEnvAzure(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AZURE_CLIENT_ID") == "" ||
-		os.Getenv("AZURE_CLIENT_ID_UPDATED") == "" ||
 		os.Getenv("AZURE_SUBSCRIPTION_ID") == "" ||
 		os.Getenv("AZURE_RESOURCE_GROUP_NAME") == "" ||
-		os.Getenv("AZURE_RESOURCE_GROUP_NAME_UPDATED") == "" ||
 		os.Getenv("AZURE_SECRET") == "" ||
 		os.Getenv("AZURE_KEY_VAULT_NAME") == "" ||
-		os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED") == "" ||
 		os.Getenv("AZURE_KEY_IDENTIFIER") == "" ||
-		os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED") == "" ||
 		os.Getenv("AZURE_TENANT_ID") == "" {
+		tb.Fatal(`'AZURE_CLIENT_ID', 'AZURE_SUBSCRIPTION_ID',
+		'AZURE_RESOURCE_GROUP_NAME', 'AZURE_SECRET', 'AZURE_KEY_VAULT_NAME', 'AZURE_KEY_IDENTIFIER', and 'AZURE_TENANT_ID' must be set for Encryption At Rest acceptance testing`)
+	}
+}
+
+func PreCheckEncryptionAtRestEnvAzureWithUpdate(tb testing.TB) {
+	tb.Helper()
+	PreCheckEncryptionAtRestEnvAzure(tb)
+
+	if os.Getenv("AZURE_CLIENT_ID_UPDATED") == "" ||
+		os.Getenv("AZURE_RESOURCE_GROUP_NAME_UPDATED") == "" ||
+		os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED") == "" ||
+		os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED") == "" {
 		tb.Fatal(`'AZURE_CLIENT_ID','AZURE_CLIENT_ID_UPDATED', 'AZURE_SUBSCRIPTION_ID',
 		'AZURE_RESOURCE_GROUP_NAME','AZURE_RESOURCE_GROUP_NAME_UPDATED', 'AZURE_SECRET',
 		'AZURE_SECRET_UPDATED', 'AZURE_KEY_VAULT_NAME', 'AZURE_KEY_IDENTIFIER', 'AZURE_KEY_VAULT_NAME_UPDATED',


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-267659

Documentation, examples, and enabling tests in CI are handled in follow up tickets.

**Note**: Was not able to reproduce locally the scenario of removing private endpoint connection in networking tab (in azure key vault) and seeing a FAILED status in the Atlas API response. Following GET request continue to return pending acceptance. Will reach out to see if there is some aspect I am missing.

Running acceptance test locally:
> 2024-08-26T15:00:00.974+0200 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccEncryptionAtRestPrivateEndpoint_basic
> PASS

> 2024-08-26T15:24:50.315+0200 [DEBUG] sdk.helper_resource: Finished TestCase: test_name=TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork
PASS

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
