### PR TITLE
fix: Handles FAILED status as acceptable target state in `mongodbatlas_network_peering` resource

### DIFF
--- a/.changelog/2514.txt
+++ b/.changelog/2514.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_network_peering: Handles FAILED status as acceptable target state
+```

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -50,6 +51,8 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "vnet_name", vNetName),
 					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+					resource.TestCheckResourceAttr(resourceName, "status", "AVAILABLE"),
+					resource.TestCheckResourceAttr(resourceName, "error_state", ""),
 				),
 			},
 			{
@@ -61,6 +64,8 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "provider_name", providerName),
 					resource.TestCheckResourceAttr(resourceName, "vnet_name", updatedvNetName),
 					resource.TestCheckResourceAttr(resourceName, "azure_directory_id", directoryID),
+					resource.TestCheckResourceAttr(resourceName, "status", "AVAILABLE"),
+					resource.TestCheckResourceAttr(resourceName, "error_state", ""),
 				),
 			},
 			{


### PR DESCRIPTION
## Description

TestAccNetworkRSNetworkPeering_Azure fails often and as per the error in [the recent logs](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/10462943118/job/28974186455) we don't handle FAILED as an acceptable target status. The API is expected to populate `error_state` field with actual failure cause.

I was not able to reproduce/figure out the actual cause of the failure yet but this PR also updates the `TestAccNetworkRSNetworkPeering_Azure` which should help us see the actual error the next time this test fails.

To summarize,
- For users, this PR prevents them from running into `error creating MongoDB Network Peering Connection: unexpected state 'FAILED', wanted target 'AVAILABLE, PENDING_ACCEPTANCE'. `
- For us, updating `TestAccNetworkRSNetworkPeering_Azure` will give details of the error message that is received from the API so we may handle it appropriately.


Link to any related issue(s): [CLOUDP-268949](https://jira.mongodb.org/browse/CLOUDP-268949)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
