### PR TITLE
test: Adds error and migration tests

### DIFF
--- a/internal/common/fwtypes/json_string.go
+++ b/internal/common/fwtypes/json_string.go
@@ -1,0 +1,141 @@
+package fwtypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+)
+
+var (
+	_ basetypes.StringTypable                    = (*jsonStringType)(nil)
+	_ basetypes.StringValuable                   = (*JSONString)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*JSONString)(nil)
+)
+
+type jsonStringType struct {
+	basetypes.StringType
+}
+
+var (
+	JSONStringType = jsonStringType{}
+)
+
+func (t jsonStringType) Equal(o attr.Type) bool {
+	other, ok := o.(jsonStringType)
+	if !ok {
+		return false
+	}
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t jsonStringType) String() string {
+	return "jsonStringType"
+}
+
+func (t jsonStringType) ValueFromString(_ context.Context, in types.String) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if in.IsNull() {
+		return JSONStringNull(), diags
+	}
+	if in.IsUnknown() {
+		return JSONStringUnknown(), diags
+	}
+	return JSONString{StringValue: in}, diags
+}
+
+func (t jsonStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+	return stringValuable, nil
+}
+
+func (t jsonStringType) ValueType(context.Context) attr.Value {
+	return JSONString{}
+}
+
+func (t jsonStringType) Validate(ctx context.Context, in tftypes.Value, attrPath path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+	var value string
+	err := in.As(&value)
+	if err != nil {
+		diags.AddAttributeError(
+			attrPath,
+			"Invalid Terraform Value",
+			"An unexpected error occurred while attempting to convert a Terraform value to a string. "+
+				"This generally is an issue with the provider schema implementation. "+
+				"Please contact the provider developers.\n\n"+
+				"Path: "+attrPath.String()+"\n"+
+				"Error: "+err.Error(),
+		)
+		return diags
+	}
+	if !json.Valid([]byte(value)) {
+		diags.AddAttributeError(
+			attrPath,
+			"Invalid JSON String Value",
+			"A string value was provided that is not valid JSON string format (RFC 7159).\n\n"+
+				"Path: "+attrPath.String()+"\n"+
+				"Given Value: "+value+"\n",
+		)
+		return diags
+	}
+	return diags
+}
+
+func JSONStringNull() JSONString {
+	return JSONString{StringValue: basetypes.NewStringNull()}
+}
+
+func JSONStringUnknown() JSONString {
+	return JSONString{StringValue: basetypes.NewStringUnknown()}
+}
+
+func JSONStringValue(value string) JSONString {
+	return JSONString{StringValue: basetypes.NewStringValue(value)}
+}
+
+type JSONString struct {
+	basetypes.StringValue
+}
+
+func (v JSONString) Equal(o attr.Value) bool {
+	other, ok := o.(JSONString)
+	if !ok {
+		return false
+	}
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v JSONString) Type(context.Context) attr.Type {
+	return JSONStringType
+}
+
+func (v JSONString) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	newValue, ok := newValuable.(JSONString)
+	if !ok {
+		return false, diags
+	}
+	return schemafunc.EqualJSON(v.ValueString(), newValue.ValueString(), "JsonString"), diags
+}

--- a/internal/common/schemafunc/json.go
+++ b/internal/common/schemafunc/json.go
@@ -1,41 +1,10 @@
 package schemafunc
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 	"reflect"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
-
-func DiffSuppressJSON() planmodifier.String {
-	return diffSuppressJSONModifier{}
-}
-
-type diffSuppressJSONModifier struct {
-}
-
-func (m diffSuppressJSONModifier) Description(_ context.Context) string {
-	return "If the parsed jsons are the same, the value of this attribute in state will not change."
-}
-
-func (m diffSuppressJSONModifier) MarkdownDescription(ctx context.Context) string {
-	return m.Description(ctx)
-}
-
-func (m diffSuppressJSONModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if req.StateValue.IsNull() {
-		return
-	}
-	if req.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
-		return
-	}
-	old, newStr := req.StateValue.String(), req.PlanValue.String()
-	if EqualJSON(old, newStr, req.Path.String()) {
-		resp.PlanValue = req.StateValue
-	}
-}
 
 func EqualJSON(old, newStr, errContext string) bool {
 	var j, j2 any
@@ -47,7 +16,6 @@ func EqualJSON(old, newStr, errContext string) bool {
 	if newStr == "" {
 		newStr = "{}"
 	}
-
 	if err := json.Unmarshal([]byte(old), &j); err != nil {
 		log.Printf("[ERROR] cannot unmarshal old %s json %v", errContext, err)
 		return false

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/fwtypes"
 	"go.mongodb.org/atlas-sdk/v20240805001/admin"
 )
 
@@ -42,7 +42,7 @@ func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) 
 	return streamProcessor, nil
 }
 
-func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats, stateOptions types.Object, pipelinePlan string) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats, stateOptions types.Object) (*TFStreamProcessorRSModel, diag.Diagnostics) {
 	if apiResp == nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}
 	}
@@ -53,13 +53,6 @@ func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName st
 	if diags.HasError() {
 		return nil, diags
 	}
-	// we need to use pipelinePlan as the state must match the configuration in case the json has extra whitespace or different ordering
-	// however, during import it will not be set
-	if pipelinePlan == "" {
-		pipelinePlan = pipelineTF.ValueString()
-	} else if !schemafunc.EqualJSON(pipelinePlan, pipelineTF.ValueString(), "pipeline") {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("pipeline plan and pipeline from API response are not equal", "")}
-	}
 	statsTF, diags := convertStatsToTF(apiResp.GetStats())
 	if diags.HasError() {
 		return nil, diags
@@ -67,7 +60,7 @@ func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName st
 	tfModel := &TFStreamProcessorRSModel{
 		InstanceName:  types.StringPointerValue(&instanceName),
 		Options:       stateOptions,
-		Pipeline:      types.StringValue(pipelinePlan),
+		Pipeline:      pipelineTF,
 		ProcessorID:   types.StringPointerValue(&apiResp.Id),
 		ProcessorName: types.StringPointerValue(&apiResp.Name),
 		ProjectID:     types.StringPointerValue(&projectID),
@@ -92,7 +85,7 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName st
 	tfModel := &TFStreamProcessorDSModel{
 		ID:            types.StringPointerValue(&apiResp.Id),
 		InstanceName:  types.StringPointerValue(&instanceName),
-		Pipeline:      pipelineTF,
+		Pipeline:      types.StringValue(pipelineTF.ValueString()),
 		ProcessorName: types.StringPointerValue(&apiResp.Name),
 		ProjectID:     types.StringPointerValue(&projectID),
 		State:         types.StringPointerValue(&apiResp.State),
@@ -101,12 +94,12 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName st
 	return tfModel, nil
 }
 
-func convertPipelineToTF(pipeline []any) (types.String, diag.Diagnostics) {
+func convertPipelineToTF(pipeline []any) (fwtypes.JSONString, diag.Diagnostics) {
 	pipelineJSON, err := json.Marshal(pipeline)
 	if err != nil {
-		return types.StringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal pipeline", err.Error())}
+		return fwtypes.JSONStringValue(""), diag.Diagnostics{diag.NewErrorDiagnostic("failed to marshal pipeline", err.Error())}
 	}
-	return types.StringValue(string(pipelineJSON)), nil
+	return fwtypes.JSONStringValue(string(pipelineJSON)), nil
 }
 
 func convertStatsToTF(stats any) (types.String, diag.Diagnostics) {

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/fwtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/stretchr/testify/assert"
@@ -162,7 +163,7 @@ func TestSDKToTFModel(t *testing.T) {
 				InstanceName:  types.StringValue(instanceName),
 				Options:       types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
 				ProcessorID:   types.StringValue(processorID),
-				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				Pipeline:      fwtypes.JSONStringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 				State:         types.StringValue("CREATED"),
@@ -176,7 +177,7 @@ func TestSDKToTFModel(t *testing.T) {
 				InstanceName:  types.StringValue(instanceName),
 				Options:       types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
 				ProcessorID:   types.StringValue(processorID),
-				Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				Pipeline:      fwtypes.JSONStringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
 				ProcessorName: types.StringValue(processorName),
 				ProjectID:     types.StringValue(projectID),
 				State:         types.StringValue("STARTED"),
@@ -188,7 +189,7 @@ func TestSDKToTFModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdkModel := tc.sdkModel
-			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes), tc.expectedTFModel.Pipeline.ValueString())
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes))
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -188,7 +188,7 @@ func TestSDKToTFModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdkModel := tc.sdkModel
-			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes), tc.expectedTFModel.Pipeline.String())
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes), tc.expectedTFModel.Pipeline.ValueString())
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -188,7 +188,7 @@ func TestSDKToTFModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdkModel := tc.sdkModel
-			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes))
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes), tc.expectedTFModel.Pipeline.String())
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -56,6 +56,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 			needsStarting = false
 		default:
 			resp.Diagnostics.AddError("When creating a stream processor, the only valid states are CREATED and STARTED", "")
+			return
 		}
 	}
 

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -62,6 +62,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 	projectID := plan.ProjectID.ValueString()
 	instanceName := plan.InstanceName.ValueString()
 	processorName := plan.ProcessorName.ValueString()
+	pipelinePlan := plan.Pipeline.ValueString()
 	_, _, err := connV2.StreamsApi.CreateStreamProcessor(ctx, projectID, instanceName, streamProcessorReq).Execute()
 
 	if err != nil {
@@ -97,7 +98,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options, pipelinePlan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -126,7 +127,7 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options, state.Pipeline.ValueString())
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -197,7 +198,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Error changing state of stream processor", err.Error())
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options, plan.Pipeline.ValueString())
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -153,7 +153,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	instanceName := plan.InstanceName.ValueString()
 	processorName := plan.ProcessorName.ValueString()
 	currentState := state.State.ValueString()
-	if plan.State.Equal(state.State) {
+	if !updatedStateOnly(&plan, &state) {
 		resp.Diagnostics.AddError("updating a Stream Processor is not supported", "")
 		return
 	}
@@ -252,4 +252,13 @@ func splitImportID(id string) (projectID, instanceName, processorName *string, e
 	processorName = &parts[3]
 
 	return
+}
+
+func updatedStateOnly(plan, state *TFStreamProcessorRSModel) bool {
+	return plan.ProjectID.Equal(state.ProjectID) &&
+		plan.InstanceName.Equal(state.InstanceName) &&
+		plan.ProcessorName.Equal(state.ProcessorName) &&
+		plan.Pipeline.Equal(state.Pipeline) &&
+		(plan.Options.Equal(state.Options) || plan.Options.IsUnknown()) &&
+		!plan.State.Equal(state.State)
 }

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -64,7 +64,6 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 	projectID := plan.ProjectID.ValueString()
 	instanceName := plan.InstanceName.ValueString()
 	processorName := plan.ProcessorName.ValueString()
-	pipelinePlan := plan.Pipeline.ValueString()
 	_, _, err := connV2.StreamsApi.CreateStreamProcessor(ctx, projectID, instanceName, streamProcessorReq).Execute()
 
 	if err != nil {
@@ -100,7 +99,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options, pipelinePlan)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -129,7 +128,7 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options, state.Pipeline.ValueString())
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -205,7 +204,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Error changing state of stream processor", err.Error())
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options, plan.Pipeline.ValueString())
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamprocessor/resource_migration_test.go
+++ b/internal/service/streamprocessor/resource_migration_test.go
@@ -1,0 +1,12 @@
+package streamprocessor_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestMigStreamProcessor_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.19.0") // when resource 1st released
+	mig.CreateAndRunTest(t, basicTestCase(t))
+}

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -7,9 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/fwtypes"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -29,9 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
 			},
 			"pipeline": schema.StringAttribute{
-				Validators: []validator.String{
-					validate.StringIsJSON(),
-				},
+				CustomType:          fwtypes.JSONStringType,
 				Required:            true,
 				Description:         "Stream aggregation pipeline you want to apply to your streaming data.",
 				MarkdownDescription: "Stream aggregation pipeline you want to apply to your streaming data.",
@@ -92,14 +89,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFStreamProcessorRSModel struct {
-	InstanceName  types.String `tfsdk:"instance_name"`
-	Options       types.Object `tfsdk:"options"`
-	Pipeline      types.String `tfsdk:"pipeline"`
-	ProcessorID   types.String `tfsdk:"id"`
-	ProcessorName types.String `tfsdk:"processor_name"`
-	ProjectID     types.String `tfsdk:"project_id"`
-	State         types.String `tfsdk:"state"`
-	Stats         types.String `tfsdk:"stats"`
+	InstanceName  types.String       `tfsdk:"instance_name"`
+	Options       types.Object       `tfsdk:"options"`
+	Pipeline      fwtypes.JSONString `tfsdk:"pipeline"`
+	ProcessorID   types.String       `tfsdk:"id"`
+	ProcessorName types.String       `tfsdk:"processor_name"`
+	ProjectID     types.String       `tfsdk:"project_id"`
+	State         types.String       `tfsdk:"state"`
+	Stats         types.String       `tfsdk:"stats"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 )
 
@@ -32,9 +31,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"pipeline": schema.StringAttribute{
 				Validators: []validator.String{
 					validate.StringIsJSON(),
-				},
-				PlanModifiers: []planmodifier.String{
-					schemafunc.DiffSuppressJSON(),
 				},
 				Required:            true,
 				Description:         "Stream aggregation pipeline you want to apply to your streaming data.",

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -165,6 +165,7 @@ func TestAccStreamProcessor_createErrors(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
 				Config:      config(t, projectID, instanceName, processorName, streamprocessor.StoppedState, invalidJSONConfig, testLogDestConfig),

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -35,13 +35,18 @@ var (
 )
 
 func TestAccStreamProcessor_basic(t *testing.T) {
+	resource.ParallelTest(t, *basicTestCase(t))
+}
+
+func basicTestCase(t *testing.T) *resource.TestCase {
+	t.Helper()
 	var (
 		projectID     = acc.ProjectIDExecution(t)
 		processorName = "new-processor"
 		instanceName  = acc.RandomName()
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroyStreamProcessor,
@@ -61,7 +66,7 @@ func TestAccStreamProcessor_basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"stats"},
 			},
-		}})
+		}}
 }
 
 func TestAccStreamProcessor_withOptions(t *testing.T) {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -169,7 +169,7 @@ func TestAccStreamProcessor_createErrors(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config(t, projectID, instanceName, processorName, streamprocessor.StoppedState, invalidJSONConfig, testLogDestConfig),
-				ExpectError: regexp.MustCompile("Attribute pipeline string value must be a valid JSON, got"),
+				ExpectError: regexp.MustCompile("Invalid JSON String Value"),
 			},
 			{
 				Config:      config(t, projectID, instanceName, processorName, streamprocessor.StoppedState, sampleSrcConfig, testLogDestConfig),


### PR DESCRIPTION
## Description

Changes:
- Add migration tests
- Add and Support TestAccStreamProcessor_JSONWhiteSpaceFormat
  - See [Failed test](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/10504792980/job/29101199975?pr=2519)
 - Fix updates to `state` and other attribute simultaneously should raise error
   - See [Failed test](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/10505399331/job/29103069516)
- Fix exit/return when invalid state is set on create, see [e880821af2537f8de20cb05b349510738abc0aef](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2519/commits/e880821af2537f8de20cb05b349510738abc0aef)
- Fix invalid transition from CREATED -> STOPPED [1f06993](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2519/commits/1f06993b9bf1ff2045b83979a4c6263fe26bfbe2)

Link to any related issue(s): CLOUDP-269090

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
