### PR TITLE
chore: Fails on update of `mongodbatlas_stream_processor`

### DIFF
--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -150,7 +150,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	projectID := plan.ProjectID.ValueString()
 	instanceName := plan.InstanceName.ValueString()
 	processorName := plan.ProcessorName.ValueString()
-	if plan.State.Equal(state.State) {
+	if plan.State.Equal(state.State) || !updatedStateOnly(&plan, &state) {
 		resp.Diagnostics.AddError("updating a Stream Processor is not supported", "")
 		return
 	}
@@ -245,4 +245,13 @@ func splitImportID(id string) (projectID, instanceName, processorName *string, e
 	processorName = &parts[3]
 
 	return
+}
+
+func updatedStateOnly(plan, state *TFStreamProcessorRSModel) bool {
+	return plan.ProjectID.Equal(state.ProjectID) &&
+		plan.InstanceName.Equal(state.InstanceName) &&
+		plan.ProcessorName.Equal(state.ProcessorName) &&
+		plan.Pipeline.Equal(state.Pipeline) &&
+		(plan.Options.Equal(state.Options) || plan.Options.IsUnknown()) &&
+		!plan.State.Equal(state.State)
 }

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -147,6 +147,29 @@ func TestAccStreamProcessor_failWithInvalidStateOnCreation(t *testing.T) {
 		}})
 }
 
+func TestAccStreamProcessor_failOnUpdate(t *testing.T) {
+	var (
+		projectID     = acc.ProjectIDExecution(t)
+		processorName = "new-processor"
+		instanceName  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroyStreamProcessor,
+		Steps: []resource.TestStep{
+			{
+				Config:      config(t, projectID, instanceName, processorName, streamprocessor.StartedState, sampleSrcConfig, testLogDestConfig),
+				ExpectError: regexp.MustCompile("When creating a stream processor, the only valid states are CREATED and STARTED"),
+			},
+			{
+				Config:      config(t, projectID, instanceName, processorName+"suffix", streamprocessor.StoppedState, sampleSrcConfig, testLogDestConfig),
+				ExpectError: regexp.MustCompile("updating a Stream Processor is not supported"),
+			},
+		}})
+}
+
 func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -160,8 +160,8 @@ func TestAccStreamProcessor_failOnUpdate(t *testing.T) {
 		CheckDestroy:             checkDestroyStreamProcessor,
 		Steps: []resource.TestStep{
 			{
-				Config:      config(t, projectID, instanceName, processorName, streamprocessor.StartedState, sampleSrcConfig, testLogDestConfig),
-				ExpectError: regexp.MustCompile("When creating a stream processor, the only valid states are CREATED and STARTED"),
+				Config: config(t, projectID, instanceName, processorName, streamprocessor.StartedState, sampleSrcConfig, testLogDestConfig),
+				Check:  composeStreamProcessorChecks(projectID, instanceName, processorName, streamprocessor.StartedState, true, false),
 			},
 			{
 				Config:      config(t, projectID, instanceName, processorName+"suffix", streamprocessor.StoppedState, sampleSrcConfig, testLogDestConfig),


### PR DESCRIPTION
## Description

Fails on update of `mongodbatlas_stream_processor`
- Before this change, if updating `state` and another attribute, the update flow to start/stop would be executed, but with wrong value for the other attribute changed, causing a failure. 
- This change is needed to handle the case where `state` and another attribute are changed on the same plan/apply and provide a relevant error message to the user. 

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
