### PR TITLE
chore: Supports `options` in read and list for `stream_processor`

### DIFF
--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -117,8 +117,25 @@ output "stream_processors_results" {
 ### Read-Only
 
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
+- `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--options))
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data.
 - `state` (String) The state of the stream processor.
 - `stats` (String) The stats associated with the stream processor.
+
+<a id="nestedatt--options"></a>
+### Nested Schema for `options`
+
+Read-Only:
+
+- `dlq` (Attributes) Dead letter queue for the stream processor. (see [below for nested schema](#nestedatt--options--dlq))
+
+<a id="nestedatt--options--dlq"></a>
+### Nested Schema for `options.dlq`
+
+Read-Only:
+
+- `coll` (String) Name of the collection that will be used for the DLQ.
+- `connection_name` (String) Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.
+- `db` (String) Name of the database that will be used for the DLQ.
 
 For more information see: [MongoDB Atlas API - Stream Processor](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createStreamProcessor) Documentation.

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -128,6 +128,7 @@ Read-Only:
 
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
 - `instance_name` (String) Human-readable label that identifies the stream instance.
+- `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--results--options))
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data.
 - `processor_name` (String) Human-readable label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
@@ -135,5 +136,21 @@ Read-Only:
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 - `state` (String) The state of the stream processor.
 - `stats` (String) The stats associated with the stream processor.
+
+<a id="nestedatt--results--options"></a>
+### Nested Schema for `results.options`
+
+Read-Only:
+
+- `dlq` (Attributes) Dead letter queue for the stream processor. (see [below for nested schema](#nestedatt--results--options--dlq))
+
+<a id="nestedatt--results--options--dlq"></a>
+### Nested Schema for `results.options.dlq`
+
+Read-Only:
+
+- `coll` (String) Name of the collection that will be used for the DLQ.
+- `connection_name` (String) Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.
+- `db` (String) Name of the database that will be used for the DLQ.
 
 For more information see: [MongoDB Atlas API - Stream Processor](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createStreamProcessor) Documentation.

--- a/internal/service/streamprocessor/data_source_schema.go
+++ b/internal/service/streamprocessor/data_source_schema.go
@@ -54,7 +54,7 @@ func DSAttributes(withArguments bool) map[string]schema.Attribute {
 			Description:         "The stats associated with the stream processor.",
 			MarkdownDescription: "The stats associated with the stream processor.",
 		},
-		"options": optionsSchema,
+		"options": optionsSchema(true),
 	}
 }
 

--- a/internal/service/streamprocessor/data_source_schema.go
+++ b/internal/service/streamprocessor/data_source_schema.go
@@ -54,12 +54,14 @@ func DSAttributes(withArguments bool) map[string]schema.Attribute {
 			Description:         "The stats associated with the stream processor.",
 			MarkdownDescription: "The stats associated with the stream processor.",
 		},
+		"options": optionsSchema,
 	}
 }
 
 type TFStreamProcessorDSModel struct {
 	ID            types.String `tfsdk:"id"`
 	InstanceName  types.String `tfsdk:"instance_name"`
+	Options       types.Object `tfsdk:"options"`
 	Pipeline      types.String `tfsdk:"pipeline"`
 	ProcessorName types.String `tfsdk:"processor_name"`
 	ProjectID     types.String `tfsdk:"project_id"`

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -101,7 +101,7 @@ func NewTFStreamprocessorDSModel(ctx context.Context, projectID, instanceName st
 }
 
 func ConvertOptionsToTF(ctx context.Context, options *admin.StreamsOptions) (*types.Object, diag.Diagnostics) {
-	if options == nil {
+	if options == nil || !options.HasDlq() {
 		optionsTF := types.ObjectNull(OptionsObjectType.AttributeTypes())
 		return &optionsTF, nil
 	}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -124,6 +124,7 @@ func optionsToTFModel(t *testing.T, options *admin.StreamsOptions) types.Object 
 	if diags.HasError() {
 		t.Fatal(diags)
 	}
+	assert.NotNil(t, result)
 	return *result
 }
 

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -27,10 +27,17 @@ var (
 			"connectionName": "__testLog",
 		},
 	}
-	processorName = "processor1"
-	processorID   = "66b39806187592e8d721215d"
-	stateCreated  = streamprocessor.CreatedState
-	stateStarted  = streamprocessor.StartedState
+	processorName        = "processor1"
+	processorID          = "66b39806187592e8d721215d"
+	stateCreated         = streamprocessor.CreatedState
+	stateStarted         = streamprocessor.StartedState
+	streamOptionsExample = admin.StreamsOptions{
+		Dlq: &admin.StreamsDLQ{
+			Coll:           conversion.StringPtr("testColl"),
+			ConnectionName: conversion.StringPtr("testConnection"),
+			Db:             conversion.StringPtr("testDB"),
+		},
+	}
 )
 
 var statsExample = `
@@ -79,7 +86,7 @@ var statsExample = `
 	"status": "running"
 }`
 
-func streamProcessorWithStats(t *testing.T) *admin.StreamsProcessorWithStats {
+func streamProcessorWithStats(t *testing.T, options *admin.StreamsOptions) *admin.StreamsProcessorWithStats {
 	t.Helper()
 	processor := admin.NewStreamsProcessorWithStats(
 		processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, stateStarted,
@@ -90,14 +97,18 @@ func streamProcessorWithStats(t *testing.T) *admin.StreamsProcessorWithStats {
 		t.Fatal(err)
 	}
 	processor.SetStats(stats)
+	if options != nil {
+		processor.SetOptions(*options)
+	}
 	return processor
 }
 
-func streamProcessorDSTFModel(t *testing.T, state, stats string) *streamprocessor.TFStreamProcessorDSModel {
+func streamProcessorDSTFModel(t *testing.T, state, stats string, options types.Object) *streamprocessor.TFStreamProcessorDSModel {
 	t.Helper()
 	return &streamprocessor.TFStreamProcessorDSModel{
 		ID:            types.StringValue(processorID),
 		InstanceName:  types.StringValue(instanceName),
+		Options:       options,
 		Pipeline:      types.StringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
 		ProcessorName: types.StringValue(processorName),
 		ProjectID:     types.StringValue(projectID),
@@ -105,6 +116,17 @@ func streamProcessorDSTFModel(t *testing.T, state, stats string) *streamprocesso
 		Stats:         conversion.StringNullIfEmpty(stats),
 	}
 }
+
+func optionsToTFModel(t *testing.T, options *admin.StreamsOptions) types.Object {
+	t.Helper()
+	ctx := context.Background()
+	result, diags := streamprocessor.ConvertOptionsToTF(ctx, options)
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+	return *result
+}
+
 func TestDSSDKToTFModel(t *testing.T) {
 	testCases := []struct {
 		sdkModel        *admin.StreamsProcessorWithStats
@@ -116,12 +138,17 @@ func TestDSSDKToTFModel(t *testing.T) {
 			sdkModel: admin.NewStreamsProcessorWithStats(
 				processorID, processorName, []any{pipelineStageSourceSample, pipelineStageEmitLog}, stateCreated,
 			),
-			expectedTFModel: streamProcessorDSTFModel(t, stateCreated, ""),
+			expectedTFModel: streamProcessorDSTFModel(t, stateCreated, "", optionsToTFModel(t, nil)),
 		},
 		{
 			name:            "afterStarted",
-			sdkModel:        streamProcessorWithStats(t),
-			expectedTFModel: streamProcessorDSTFModel(t, stateStarted, statsExample),
+			sdkModel:        streamProcessorWithStats(t, nil),
+			expectedTFModel: streamProcessorDSTFModel(t, stateStarted, statsExample, optionsToTFModel(t, nil)),
+		},
+		{
+			name:            "withOptions",
+			sdkModel:        streamProcessorWithStats(t, &streamOptionsExample),
+			expectedTFModel: streamProcessorDSTFModel(t, stateStarted, statsExample, optionsToTFModel(t, &streamOptionsExample)),
 		},
 	}
 
@@ -132,6 +159,7 @@ func TestDSSDKToTFModel(t *testing.T) {
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}
+			assert.Equal(t, tc.expectedTFModel.Options, resultModel.Options)
 			if sdkModel.Stats != nil {
 				assert.True(t, schemafunc.EqualJSON(resultModel.Pipeline.String(), tc.expectedTFModel.Pipeline.String(), "test stream processor schema"))
 				var statsResult any
@@ -172,7 +200,7 @@ func TestSDKToTFModel(t *testing.T) {
 		},
 		{
 			name:     "afterStarted",
-			sdkModel: streamProcessorWithStats(t),
+			sdkModel: streamProcessorWithStats(t, nil),
 			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{
 				InstanceName:  types.StringValue(instanceName),
 				Options:       types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes),
@@ -184,15 +212,30 @@ func TestSDKToTFModel(t *testing.T) {
 				Stats:         types.StringValue(statsExample),
 			},
 		},
+		{
+			name:     "withOptions",
+			sdkModel: streamProcessorWithStats(t, &streamOptionsExample),
+			expectedTFModel: &streamprocessor.TFStreamProcessorRSModel{
+				InstanceName:  types.StringValue(instanceName),
+				Options:       optionsToTFModel(t, &streamOptionsExample),
+				ProcessorID:   types.StringValue(processorID),
+				Pipeline:      fwtypes.JSONStringValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]"),
+				ProcessorName: types.StringValue(processorName),
+				ProjectID:     types.StringValue(projectID),
+				State:         types.StringValue("STARTED"),
+				Stats:         types.StringNull(),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdkModel := tc.sdkModel
-			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel, types.ObjectNull(streamprocessor.OptionsObjectType.AttrTypes))
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(context.Background(), projectID, instanceName, sdkModel)
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}
+			assert.Equal(t, tc.expectedTFModel.Options, resultModel.Options)
 			if sdkModel.Stats != nil {
 				assert.True(t, schemafunc.EqualJSON(resultModel.Pipeline.String(), tc.expectedTFModel.Pipeline.String(), "test stream processor schema"))
 				var statsResult any
@@ -230,7 +273,7 @@ func TestPluralDSSDKToTFModel(t *testing.T) {
 			ProjectID:    types.StringValue(projectID),
 			InstanceName: types.StringValue(instanceName),
 			Results: []streamprocessor.TFStreamProcessorDSModel{
-				*streamProcessorDSTFModel(t, stateCreated, ""),
+				*streamProcessorDSTFModel(t, stateCreated, "", optionsToTFModel(t, nil)),
 			},
 		}},
 	}

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -99,7 +99,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -128,7 +128,7 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, state.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -204,7 +204,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Error changing state of stream processor", err.Error())
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, plan.Options)
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -11,6 +11,36 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/fwtypes"
 )
 
+var optionsSchema = schema.SingleNestedAttribute{
+	Attributes: map[string]schema.Attribute{
+		"dlq": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"coll": schema.StringAttribute{
+					Required:            true,
+					Description:         "Name of the collection that will be used for the DLQ.",
+					MarkdownDescription: "Name of the collection that will be used for the DLQ.",
+				},
+				"connection_name": schema.StringAttribute{
+					Required:            true,
+					Description:         "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+					MarkdownDescription: "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+				},
+				"db": schema.StringAttribute{
+					Required:            true,
+					Description:         "Name of the database that will be used for the DLQ.",
+					MarkdownDescription: "Name of the database that will be used for the DLQ.",
+				},
+			},
+			Required:            true,
+			Description:         "Dead letter queue for the stream processor.",
+			MarkdownDescription: "Dead letter queue for the stream processor.",
+		},
+	},
+	Optional:            true,
+	Description:         "Optional configuration for the stream processor.",
+	MarkdownDescription: "Optional configuration for the stream processor.",
+}
+
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
@@ -49,35 +79,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The state of the stream processor. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`.  When a Stream Processor is created without specifying the state, it will default to `CREATED` state.\n\n**NOTE** When a stream processor is created, the only valid states are CREATED or STARTED. A stream processor can be automatically started when creating it if the state is set to STARTED.",
 				MarkdownDescription: "The state of the stream processor. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`.  When a Stream Processor is created without specifying the state, it will default to `CREATED` state.\n\n**NOTE** When a stream processor is created, the only valid states are CREATED or STARTED. A stream processor can be automatically started when creating it if the state is set to STARTED.",
 			},
-			"options": schema.SingleNestedAttribute{
-				Attributes: map[string]schema.Attribute{
-					"dlq": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"coll": schema.StringAttribute{
-								Required:            true,
-								Description:         "Name of the collection that will be used for the DLQ.",
-								MarkdownDescription: "Name of the collection that will be used for the DLQ.",
-							},
-							"connection_name": schema.StringAttribute{
-								Required:            true,
-								Description:         "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
-								MarkdownDescription: "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
-							},
-							"db": schema.StringAttribute{
-								Required:            true,
-								Description:         "Name of the database that will be used for the DLQ.",
-								MarkdownDescription: "Name of the database that will be used for the DLQ.",
-							},
-						},
-						Required:            true,
-						Description:         "Dead letter queue for the stream processor.",
-						MarkdownDescription: "Dead letter queue for the stream processor.",
-					},
-				},
-				Optional:            true,
-				Description:         "Optional configuration for the stream processor.",
-				MarkdownDescription: "Optional configuration for the stream processor.",
-			},
+			"options": optionsSchema,
 			"stats": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The stats associated with the stream processor.",

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -11,34 +11,41 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/fwtypes"
 )
 
-var optionsSchema = schema.SingleNestedAttribute{
-	Attributes: map[string]schema.Attribute{
-		"dlq": schema.SingleNestedAttribute{
-			Attributes: map[string]schema.Attribute{
-				"coll": schema.StringAttribute{
-					Required:            true,
-					Description:         "Name of the collection that will be used for the DLQ.",
-					MarkdownDescription: "Name of the collection that will be used for the DLQ.",
+func optionsSchema(isDatasource bool) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"dlq": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"coll": schema.StringAttribute{
+						Required:            !isDatasource,
+						Computed:            isDatasource,
+						Description:         "Name of the collection that will be used for the DLQ.",
+						MarkdownDescription: "Name of the collection that will be used for the DLQ.",
+					},
+					"connection_name": schema.StringAttribute{
+						Required:            !isDatasource,
+						Computed:            isDatasource,
+						Description:         "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+						MarkdownDescription: "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
+					},
+					"db": schema.StringAttribute{
+						Required:            !isDatasource,
+						Computed:            isDatasource,
+						Description:         "Name of the database that will be used for the DLQ.",
+						MarkdownDescription: "Name of the database that will be used for the DLQ.",
+					},
 				},
-				"connection_name": schema.StringAttribute{
-					Required:            true,
-					Description:         "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
-					MarkdownDescription: "Connection name that will be used to write DLQ messages to. Has to be an Atlas connection.",
-				},
-				"db": schema.StringAttribute{
-					Required:            true,
-					Description:         "Name of the database that will be used for the DLQ.",
-					MarkdownDescription: "Name of the database that will be used for the DLQ.",
-				},
+				Required:            !isDatasource,
+				Computed:            isDatasource,
+				Description:         "Dead letter queue for the stream processor.",
+				MarkdownDescription: "Dead letter queue for the stream processor.",
 			},
-			Required:            true,
-			Description:         "Dead letter queue for the stream processor.",
-			MarkdownDescription: "Dead letter queue for the stream processor.",
 		},
-	},
-	Optional:            true,
-	Description:         "Optional configuration for the stream processor.",
-	MarkdownDescription: "Optional configuration for the stream processor.",
+		Optional:            !isDatasource,
+		Computed:            isDatasource,
+		Description:         "Optional configuration for the stream processor.",
+		MarkdownDescription: "Optional configuration for the stream processor.",
+	}
 }
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -79,7 +86,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description:         "The state of the stream processor. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`.  When a Stream Processor is created without specifying the state, it will default to `CREATED` state.\n\n**NOTE** When a stream processor is created, the only valid states are CREATED or STARTED. A stream processor can be automatically started when creating it if the state is set to STARTED.",
 				MarkdownDescription: "The state of the stream processor. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`.  When a Stream Processor is created without specifying the state, it will default to `CREATED` state.\n\n**NOTE** When a stream processor is created, the only valid states are CREATED or STARTED. A stream processor can be automatically started when creating it if the state is set to STARTED.",
 			},
-			"options": optionsSchema,
+			"options": optionsSchema(false),
 			"stats": schema.StringAttribute{
 				Computed:            true,
 				Description:         "The stats associated with the stream processor.",

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -108,6 +108,13 @@ func TestAccStreamProcessor_withOptions(t *testing.T) {
 				Config: config(t, projectID, instanceName, processorName, streamprocessor.CreatedState, src, dest),
 				Check:  composeStreamProcessorChecks(projectID, instanceName, processorName, streamprocessor.CreatedState, false, true),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"stats"},
+			},
 		}})
 }
 
@@ -278,8 +285,9 @@ func composeStreamProcessorChecks(projectID, instanceName, processorName, state 
 		checks = acc.AddAttrSetChecks(pluralDataSourceName, checks, "results.0.stats", "results.0.pipeline")
 	}
 	if includeOptions {
-		// options are only included on the resource, until https://jira.mongodb.org/browse/CLOUDP-268646 is done
 		checks = acc.AddAttrSetChecks(resourceName, checks, "options.dlq.db", "options.dlq.coll", "options.dlq.connection_name")
+		checks = acc.AddAttrSetChecks(dataSourceName, checks, "options.dlq.db", "options.dlq.coll", "options.dlq.connection_name")
+		checks = acc.AddAttrSetChecks(pluralDataSourceName, checks, "results.0.options.dlq.db", "results.0.options.dlq.coll", "results.0.options.dlq.connection_name")
 	}
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }


### PR DESCRIPTION
## Description

- support `options` in read

Link to any related issue(s): CLOUDP-269860

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals, I defined an isolated PR with a relevant title as it will be used in the auto-generated changelog.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
