### PR TITLE
feat: Implements `mongodbatlas_encryption_at_rest_private_endpoint` singular data source

### DIFF
--- a/.changelog/2527.txt
+++ b/.changelog/2527.txt
@@ -1,0 +1,3 @@
+```release-note:new-datasource
+data-source/mongodbatlas_encryption_at_rest_private_endpoint
+```

--- a/internal/service/encryptionatrestprivateendpoint/data_source.go
+++ b/internal/service/encryptionatrestprivateendpoint/data_source.go
@@ -35,14 +35,16 @@ func (d *encryptionAtRestPrivateEndpointDS) Read(ctx context.Context, req dataso
 		return
 	}
 
-	// TODO: make get request to resource
+	connV2 := d.Client.AtlasV2
+	projectID := earPrivateEndpointConfig.ProjectID.ValueString()
+	cloudProvider := earPrivateEndpointConfig.CloudProvider.ValueString()
+	endpointID := earPrivateEndpointConfig.ID.ValueString()
 
-	// connV2 := d.Client.AtlasV2
-	// if err != nil {
-	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
-	//	return
-	//}
+	endpointModel, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRestPrivateEndpoint(ctx, projectID, cloudProvider, endpointID).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
 
-	// TODO: process response into new terraform state
-	//  resp.Diagnostics.Append(resp.State.Set(ctx, NewTFEarPrivateEndpoint(apiResp))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, NewTFEarPrivateEndpoint(endpointModel, projectID))...)
 }


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-267660

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
