### PR TITLE
chore: Updates to Go 1.23

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.59.1 # Also update GOLANGCI_VERSION variable in GNUmakefile when updating this version
+          version: v1.60.3 # Also update GOLANGCI_VERSION variable in GNUmakefile when updating this version
       - name: actionlint
         run: |
           make tools

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,7 @@ linters:
     - nakedret
     - nolintlint
     - rowserrcheck
-    - exportloopref
+    - copyloopvar
     - staticcheck
     - stylecheck
     - typecheck

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.23.0
-terraform 1.9.5
+terraform 1.9.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.22.5
-terraform 1.9.2
+terraform 1.9.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.22.5
+golang 1.23.0
 terraform 1.9.5

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ GITTAG=$(shell git describe --always --tags)
 VERSION=$(GITTAG:v%=%)
 LINKER_FLAGS=-s -w -X 'github.com/mongodb/terraform-provider-mongodbatlas/version.ProviderVersion=${VERSION}'
 
-GOLANGCI_VERSION=v1.59.1 # Also update golangci-lint GH action in code-health.yml when updating this version
+GOLANGCI_VERSION=v1.60.3 # Also update golangci-lint GH action in code-health.yml when updating this version
 
 export PATH := $(shell go env GOPATH)/bin:$(PATH)
 export SHELL := env PATH=$(PATH) /bin/bash

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -74,6 +74,7 @@ lint:
 .PHONY: tools
 tools:  ## Install dev tools
 	@echo "==> Installing dependencies..."
+	go telemetry off # disable sending telemetry data, more info: https://go.dev/doc/telemetry
 	go install github.com/icholy/gomajor@latest
 	go install github.com/terraform-linters/tflint@v0.52.0
 	go install github.com/rhysd/actionlint/cmd/actionlint@latest

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Feature requests can be submitted at https://feedback.mongodb.com/forums/924145-
 ## Requirements  
 - [HashiCorp Terraform Version Compatibility Matrix](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#hashicorp-terraform-versionhttpswwwterraformiodownloadshtml-compatibility-matrix) 
 
-- [Go Version](https://golang.org/doc/install) 1.22 (to build the provider plugin)
+- [Go Version](https://golang.org/doc/install) 1.23 (to build the provider plugin)
 
 ## Using the Provider
 

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -11,7 +11,7 @@
 ### Prerequisite Tools
 
 - [Git](https://git-scm.com/)
-- [Go (at least Go 1.22)](https://golang.org/dl/)
+- [Go (at least Go 1.23)](https://golang.org/dl/)
 
 ### Environment
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/terraform-provider-mongodbatlas
 
-go 1.22
+go 1.23
 
 require (
 	github.com/andygrunwald/go-jira/v2 v2.0.0-20240116150243-50d59fe116d6


### PR DESCRIPTION
## Description

Updates to Go 1.23

This requires to also do: 

- Updates linter because message: 
```
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```
- Disables sending telemetry data, more info: https://go.dev/doc/telemetry
- Updates golang-ci to 1.60.3 so linter GHA job doesn't fail because bad cache restore (apparently they don't include Go version in the cache key)

Link to any related issue(s): CLOUDP-270497

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
