### PR TITLE
chore: Adds `mongodbatlas_encryption_at_rest_private_endpoint` acceptance test using azapi to approve private endpoint & check ACTIVE status

### DIFF
--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -29,6 +29,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
+		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -37,7 +38,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, false), // not using data source as it was introduced in 1.19.0
+				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource), // not using data source as it was introduced in 1.19.0
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -46,16 +47,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource)),
 		},
 	})
 }
@@ -134,6 +126,8 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 			"subscription_id":     azureKeyVault.GetSubscriptionID(),
 			"tenant_id":           azureKeyVault.GetTenantID(),
 		}
+
+		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -142,23 +136,14 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, false), // not using data source as it was introduced in 1.19.0
+				Config:            acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, useDatasource), // not using data source as it was introduced in 1.19.0
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "azure_key_vault_config.0", attrMap),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, useDatasource)),
 		},
 	})
 }
@@ -175,6 +160,7 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 			ServiceAccountKey:    conversion.StringPtr(os.Getenv("GCP_SERVICE_ACCOUNT_KEY")),
 			KeyVersionResourceID: conversion.StringPtr(os.Getenv("GCP_KEY_VERSION_RESOURCE_ID")),
 		}
+		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -183,7 +169,7 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, false), // not using data source as it was introduced in 1.19.0
+				Config:            testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, useDatasource), // not using data source as it was introduced in 1.19.0
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -191,16 +177,7 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "google_cloud_kms_config.0.key_version_resource_id"),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, useDatasource)),
 		},
 	})
 }
@@ -220,6 +197,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
+		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -228,7 +206,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProvidersWithAWS("1.11.0"),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, false), // not using data source as it was introduced in 1.19.0
+				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource), // not using data source as it was introduced in 1.19.0
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -237,16 +215,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, false),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acc.DebugPlan(),
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
+			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource)),
 		},
 	})
 }

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -34,20 +34,20 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheck(t); acc.PreCheckAwsEnv(t) },
-		CheckDestroy: acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource), // not using data source as it was introduced in 1.19.0
+				Config:            configAwsKms(projectID, &awsKms, useDatasource),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.GetRegion()),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource)),
+			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource)),
 		},
 	})
 }
@@ -72,7 +72,7 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheck(t); acc.PreCheckAwsEnv(t) },
-		CheckDestroy: acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProvidersWithAWS(),
@@ -83,7 +83,7 @@ func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.GetRegion()),
@@ -132,15 +132,15 @@ func TestMigEncryptionAtRest_basicAzure(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t); acc.PreCheckEncryptionAtRestEnvAzure(t) },
-		CheckDestroy: acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, useDatasource), // not using data source as it was introduced in 1.19.0
+				Config:            acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, useDatasource),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "azure_key_vault_config.0", attrMap),
+					acc.EARCheckResourceAttr(resourceName, "azure_key_vault_config.0", attrMap),
 				),
 			},
 			mig.TestStepCheckEmptyPlan(acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, useDatasource)),
@@ -165,19 +165,19 @@ func TestMigEncryptionAtRest_basicGCP(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheck(t); acc.PreCheckGPCEnv(t) },
-		CheckDestroy: acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, useDatasource), // not using data source as it was introduced in 1.19.0
+				Config:            configGoogleCloudKms(projectID, &googleCloudKms, useDatasource),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "google_cloud_kms_config.0.key_version_resource_id"),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, useDatasource)),
+			mig.TestStepCheckEmptyPlan(configGoogleCloudKms(projectID, &googleCloudKms, useDatasource)),
 		},
 	})
 }
@@ -202,20 +202,20 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.PreCheck(t); acc.PreCheckAwsEnv(t) },
-		CheckDestroy: acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProvidersWithAWS("1.11.0"),
-				Config:            testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource), // not using data source as it was introduced in 1.19.0
+				Config:            configAwsKms(projectID, &awsKms, useDatasource),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.region", awsKms.GetRegion()),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, useDatasource)),
+			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource)),
 		},
 	})
 }

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -64,39 +64,39 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckAwsEnv(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKms, true),
+				Config: configAwsKms(projectID, &awsKms, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "aws_kms_config.0", awsKmsAttrMap),
+					acc.EARCheckResourceAttr(resourceName, "aws_kms_config.0", awsKmsAttrMap),
 
 					resource.TestCheckNoResourceAttr(resourceName, "azure_key_vault_config.#"),
 					resource.TestCheckNoResourceAttr(resourceName, "google_cloud_kms_config.#"),
 
 					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(datasourceName, "aws_kms_config.", awsKmsAttrMap),
+					acc.EARCheckResourceAttr(datasourceName, "aws_kms_config.", awsKmsAttrMap),
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID, &awsKmsUpdated, true),
+				Config: configAwsKms(projectID, &awsKmsUpdated, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "aws_kms_config.0", awsKmsUpdatedAttrMap),
+					acc.EARCheckResourceAttr(resourceName, "aws_kms_config.0", awsKmsUpdatedAttrMap),
 
 					resource.TestCheckNoResourceAttr(resourceName, "azure_key_vault_config.#"),
 					resource.TestCheckNoResourceAttr(resourceName, "google_cloud_kms_config.#"),
 
 					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(datasourceName, "aws_kms_config", awsKmsUpdatedAttrMap),
+					acc.EARCheckResourceAttr(datasourceName, "aws_kms_config", awsKmsUpdatedAttrMap),
 				),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: acc.TestAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportStateIdFunc: acc.EARImportStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -121,7 +121,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 
-		azureKeyVaultAttrMap = acc.ConvertToAzureKeyVaultEncryptionAtRestAttrMap(&azureKeyVault)
+		azureKeyVaultAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVault)
 
 		azureKeyVaultUpdated = admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
@@ -136,37 +136,37 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 
-		azureKeyVaultUpdatedAttrMap = acc.ConvertToAzureKeyVaultEncryptionAtRestAttrMap(&azureKeyVaultUpdated)
+		azureKeyVaultUpdatedAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVaultUpdated)
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "azure_key_vault_config.0", azureKeyVaultAttrMap),
+					acc.EARCheckResourceAttr(resourceName, "azure_key_vault_config.0", azureKeyVaultAttrMap),
 					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(datasourceName, "azure_key_vault_config", azureKeyVaultAttrMap),
+					acc.EARCheckResourceAttr(datasourceName, "azure_key_vault_config", azureKeyVaultAttrMap),
 				),
 			},
 			{
 				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(resourceName, "azure_key_vault_config.0", azureKeyVaultUpdatedAttrMap),
+					acc.EARCheckResourceAttr(resourceName, "azure_key_vault_config.0", azureKeyVaultUpdatedAttrMap),
 					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
-					acc.TestEncryptionAtRestCheckResourceAttr(datasourceName, "azure_key_vault_config", azureKeyVaultUpdatedAttrMap),
+					acc.EARCheckResourceAttr(datasourceName, "azure_key_vault_config", azureKeyVaultUpdatedAttrMap),
 				),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: acc.TestAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportStateIdFunc: acc.EARImportStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 				// "azure_key_vault_config.0.secret" is a sensitive value not returned by the API
@@ -198,12 +198,12 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckGPCEnv(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKms, true),
+				Config: configGoogleCloudKms(projectID, &googleCloudKms, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.valid", "true"),
@@ -216,9 +216,9 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID, &googleCloudKmsUpdated, true),
+				Config: configGoogleCloudKms(projectID, &googleCloudKmsUpdated, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName),
+					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.valid", "true"),
@@ -232,7 +232,7 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: acc.TestAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportStateIdFunc: acc.EARImportStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 				// "google_cloud_kms_config.0.service_account_key" is a sensitive value not returned by the API
@@ -260,14 +260,14 @@ func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckAwsEnv(t) },
 		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.TestAccCheckMongoDBAtlasEncryptionAtRestDestroy,
+		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateIdFunc: acc.TestAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName),
+				ImportStateIdFunc: acc.EARImportStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -510,7 +510,7 @@ func TestResourceMongoDBAtlasEncryptionAtRestCreateRefreshFunc(t *testing.T) {
 	}
 }
 
-func testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID string, aws *admin.AWSKMSConfiguration, useDatasource bool) string {
+func configAwsKms(projectID string, aws *admin.AWSKMSConfiguration, useDatasource bool) string {
 	config := fmt.Sprintf(`
 		resource "mongodbatlas_encryption_at_rest" "test" {
 			project_id = %[1]q
@@ -525,12 +525,12 @@ func testAccMongoDBAtlasEncryptionAtRestConfigAwsKms(projectID string, aws *admi
 	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId())
 
 	if useDatasource {
-		return fmt.Sprintf(`%s %s`, config, acc.TestAccDatasourceConfig())
+		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
 	}
 	return config
 }
 
-func testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID string, google *admin.GoogleCloudKMS, useDatasource bool) string {
+func configGoogleCloudKms(projectID string, google *admin.GoogleCloudKMS, useDatasource bool) string {
 	config := fmt.Sprintf(`
 		resource "mongodbatlas_encryption_at_rest" "test" {
 			project_id = "%s"
@@ -544,7 +544,7 @@ func testAccMongoDBAtlasEncryptionAtRestConfigGoogleCloudKms(projectID string, g
 	`, projectID, *google.Enabled, google.GetServiceAccountKey(), google.GetKeyVersionResourceID())
 
 	if useDatasource {
-		return fmt.Sprintf(`%s %s`, config, acc.TestAccDatasourceConfig())
+		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
 	}
 	return config
 }

--- a/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
@@ -9,5 +9,5 @@ import (
 func TestMigEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.19.0")
 	testCase := basicTestCase(t)
-	mig.CreateAndRunTest(t, testCase)
+	mig.CreateAndRunTestNonParallel(t, testCase)
 }

--- a/internal/testutil/acc/encryption_at_rest.go
+++ b/internal/testutil/acc/encryption_at_rest.go
@@ -38,18 +38,18 @@ func ConfigEARAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useReq
 		azure.GetKeyVaultName(), azure.GetKeyIdentifier(), azure.GetSecret(), azure.GetTenantID(), requirePrivateNetworkingAttr)
 
 	if useDatasource {
-		return fmt.Sprintf(`%s %s`, config, TestAccDatasourceConfig())
+		return fmt.Sprintf(`%s %s`, config, EARDatasourceConfig())
 	}
 	return config
 }
 
-func TestAccDatasourceConfig() string {
+func EARDatasourceConfig() string {
 	return `data "mongodbatlas_encryption_at_rest" "test" {
 			project_id = mongodbatlas_encryption_at_rest.test.project_id
 		}`
 }
 
-func TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resource.TestCheckFunc {
+func CheckEARExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -65,7 +65,7 @@ func TestAccCheckMongoDBAtlasEncryptionAtRestExists(resourceName string) resourc
 	}
 }
 
-func ConvertToAzureKeyVaultEncryptionAtRestAttrMap(az *admin.AzureKeyVault) map[string]string {
+func ConvertToAzureKeyVaultEARAttrMap(az *admin.AzureKeyVault) map[string]string {
 	return map[string]string{
 		"enabled":                    strconv.FormatBool(az.GetEnabled()),
 		"azure_environment":          az.GetAzureEnvironment(),
@@ -79,13 +79,13 @@ func ConvertToAzureKeyVaultEncryptionAtRestAttrMap(az *admin.AzureKeyVault) map[
 	}
 }
 
-func TestEncryptionAtRestCheckResourceAttr(resourceName, prefix string, attrsMap map[string]string) resource.TestCheckFunc {
+func EARCheckResourceAttr(resourceName, prefix string, attrsMap map[string]string) resource.TestCheckFunc {
 	checks := AddAttrChecksPrefix(resourceName, []resource.TestCheckFunc{}, attrsMap, prefix)
 
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func TestAccCheckMongoDBAtlasEncryptionAtRestDestroy(s *terraform.State) error {
+func EARDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_encryption_at_rest" {
 			continue
@@ -102,7 +102,7 @@ func TestAccCheckMongoDBAtlasEncryptionAtRestDestroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccCheckMongoDBAtlasEncryptionAtRestImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func EARImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {

--- a/internal/testutil/acc/provider.go
+++ b/internal/testutil/acc/provider.go
@@ -8,6 +8,7 @@ import (
 )
 
 const AwsProviderVersion = "5.1.0"
+const azapiProviderVersion = "1.15.0"
 
 func ExternalProviders(versionAtlasProvider string) map[string]resource.ExternalProvider {
 	return map[string]resource.ExternalProvider{
@@ -28,6 +29,12 @@ func ExternalProvidersOnlyAWS() map[string]resource.ExternalProvider {
 	}
 }
 
+func ExternalProvidersOnlyAzapi() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"azapi": *providerAzapi(),
+	}
+}
+
 func providerAtlas(versionAtlasProvider string) *resource.ExternalProvider {
 	return &resource.ExternalProvider{
 		VersionConstraint: versionAtlasProvider,
@@ -39,6 +46,13 @@ func providerAWS() *resource.ExternalProvider {
 	return &resource.ExternalProvider{
 		VersionConstraint: AwsProviderVersion,
 		Source:            "hashicorp/aws",
+	}
+}
+
+func providerAzapi() *resource.ExternalProvider {
+	return &resource.ExternalProvider{
+		VersionConstraint: azapiProviderVersion,
+		Source:            "Azure/azapi",
 	}
 }
 
@@ -60,4 +74,17 @@ provider %[1]q {
 // Remember to use PreCheckGovBasic when using this.
 func ConfigGovProvider() string {
 	return configProvider(os.Getenv("MONGODB_ATLAS_GOV_PUBLIC_KEY"), os.Getenv("MONGODB_ATLAS_GOV_PRIVATE_KEY"), os.Getenv("MONGODB_ATLAS_GOV_BASE_URL"))
+}
+
+// configAzapiProvider creates a new azure/azapi provider with credentials explicit in config.
+// This will authorize the provider for a client
+func ConfigAzapiProvider(subscriptionID, clientID, clientSecret, tenantID string) string {
+	return fmt.Sprintf(`
+provider "azapi" {
+	subscription_id = %[1]q
+    client_id       = %[2]q
+    client_secret   = %[3]q
+    tenant_id       = %[4]q
+}
+`, subscriptionID, clientID, clientSecret, tenantID)
 }


### PR DESCRIPTION
## Description

Adds `mongodbatlas_encryption_at_rest_private_endpoint` acceptance test using azapi to approve private endpoint & check ACTIVE status and minor improvements to tests.

The new test uses azure/azapi Terraform provider which can log sensitive information in CI like Azure subscriptionID used in parent_id of the resource in case of failures, hence this test is disabled to run in CI but maybe run locally without any additional setup.

Link to any related issue(s): [CLOUDP-270777](https://jira.mongodb.org/browse/CLOUDP-270777)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
