### PR TITLE
fix: Sets correct `zone_id` when `use_replication_spec_per_shard` is false and refactors `replica_set_scaling_strategy` handling with old schema of advanced cluster

### DIFF
--- a/.changelog/2568.txt
+++ b/.changelog/2568.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/mongodbatlas_advanced_clusters: sets correct zone_id when use_replication_spec_per_shard is false
+data-source/mongodbatlas_advanced_clusters: Sets correct `zone_id` when `use_replication_spec_per_shard` is false
 ```

--- a/.changelog/2568.txt
+++ b/.changelog/2568.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/mongodbatlas_advanced_clusters: sets correct zone_id when use_replication_spec_per_shard is false
+```

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -295,7 +295,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replica_set_scaling_strategy", clusterName, err))
 		}
 
-		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(ctx, projectID, clusterName, connV2)
+		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(clusterDescNew)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -287,6 +287,13 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		if err := d.Set("disk_size_gb", clusterDescOld.GetDiskSizeGB()); err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "disk_size_gb", clusterName, err))
 		}
+		clusterDescNew, _, err := connV2.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
+		if err != nil {
+			return diag.FromErr(fmt.Errorf(errorRead, clusterName, err))
+		}
+		if err := d.Set("replica_set_scaling_strategy", clusterDescNew.GetReplicaSetScalingStrategy()); err != nil {
+			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replica_set_scaling_strategy", clusterName, err))
+		}
 
 		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(ctx, projectID, clusterName, connV2)
 		if err != nil {

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -373,19 +373,20 @@ func flattenAdvancedClustersOldSDK(ctx context.Context, connV20240530 *admin2024
 			log.Printf("[WARN] Error setting `advanced_configuration` for the cluster(%s): %s", cluster.GetId(), err)
 		}
 
-		zoneNameToOldReplicationSpecIDs, err := getReplicationSpecIDsFromOldAPI(ctx, cluster.GetGroupId(), cluster.GetName(), connV20240530)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		replicationSpecs, err := FlattenAdvancedReplicationSpecsOldSDK(ctx, cluster.GetReplicationSpecs(), zoneNameToOldReplicationSpecIDs, cluster.GetDiskSizeGB(), nil, d, connV2)
-		if err != nil {
-			log.Printf("[WARN] Error setting `replication_specs` for the cluster(%s): %s", cluster.GetId(), err)
-		}
 		clusterDescNew, _, err := connV2.ClustersApi.GetCluster(ctx, cluster.GetGroupId(), cluster.GetName()).Execute()
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
+		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(clusterDescNew)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
+		replicationSpecs, err := FlattenAdvancedReplicationSpecsOldSDK(ctx, cluster.GetReplicationSpecs(), zoneNameToZoneIDs, cluster.GetDiskSizeGB(), nil, d, connV2)
+		if err != nil {
+			log.Printf("[WARN] Error setting `replication_specs` for the cluster(%s): %s", cluster.GetId(), err)
+		}
+
 		result := map[string]any{
 			"advanced_configuration":               flattenProcessArgs(processArgs),
 			"backup_enabled":                       cluster.GetBackupEnabled(),

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -382,7 +382,10 @@ func flattenAdvancedClustersOldSDK(ctx context.Context, connV20240530 *admin2024
 		if err != nil {
 			log.Printf("[WARN] Error setting `replication_specs` for the cluster(%s): %s", cluster.GetId(), err)
 		}
-
+		clusterDescNew, _, err := connV2.ClustersApi.GetCluster(ctx, cluster.GetGroupId(), cluster.GetName()).Execute()
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
 		result := map[string]any{
 			"advanced_configuration":               flattenProcessArgs(processArgs),
 			"backup_enabled":                       cluster.GetBackupEnabled(),
@@ -405,6 +408,7 @@ func flattenAdvancedClustersOldSDK(ctx context.Context, connV20240530 *admin2024
 			"termination_protection_enabled":       cluster.GetTerminationProtectionEnabled(),
 			"version_release_system":               cluster.GetVersionReleaseSystem(),
 			"global_cluster_self_managed_sharding": cluster.GetGlobalClusterSelfManagedSharding(),
+			"replica_set_scaling_strategy":         clusterDescNew.GetReplicaSetScalingStrategy(),
 		}
 		results = append(results, result)
 	}

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -547,7 +547,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replica_set_scaling_strategy", clusterName, err))
 		}
 
-		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(ctx, projectID, clusterName, connV2)
+		zoneNameToZoneIDs, err := getZoneIDsFromNewAPI(cluster)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -630,11 +630,7 @@ func getReplicationSpecIDsFromOldAPI(ctx context.Context, projectID, clusterName
 }
 
 // getZoneIDsFromNewAPI returns the zone id values of replication specs coming from new API. This is used to populate zone_id when old API is called in the read.
-func getZoneIDsFromNewAPI(ctx context.Context, projectID, clusterName string, connV2 *admin.APIClient) (map[string]string, error) {
-	cluster, _, err := connV2.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
-	if err != nil {
-		return nil, fmt.Errorf("error reading  advanced cluster for fetching zone ids (%s): %s", clusterName, err)
-	}
+func getZoneIDsFromNewAPI(cluster *admin.ClusterDescription20240805) (map[string]string, error) {
 	specs := cluster.GetReplicationSpecs()
 	result := make(map[string]string, len(specs))
 	for _, spec := range specs {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2057,12 +2057,10 @@ func configReplicaSetScalingStrategyOldSchema(orgID, projectName, name, replicaS
 		data "mongodbatlas_advanced_cluster" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
-			use_replication_spec_per_shard = true
 		}
 
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
-			use_replication_spec_per_shard = true
 		}
 	`, orgID, projectName, name, replicaSetScalingStrategy)
 }


### PR DESCRIPTION
## Description

- Follow-up on comments done in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2539 after the PR was merged.
- sets correct zone_id when use_replication_spec_per_shard is false in mongodbatlas_advanced_clusters data source
Link to any related issue(s): CLOUDP-261476

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
