### PR TITLE
chore: Disables data lake acceptance tests run in CI

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -256,8 +256,6 @@ jobs:
             - 'internal/service/rolesorgid/*.go'
             - 'internal/service/team/*.go'
             - 'internal/service/thirdpartyintegration/*.go'
-          data_lake:
-            - 'internal/service/datalakepipeline/*.go'
           encryption:
             - 'internal/service/encryptionatrest/*.go' 
             - 'internal/service/encryptionatrestprivateendpoint/*.go'
@@ -494,28 +492,6 @@ jobs:
             ./internal/service/rolesorgid
             ./internal/service/team
             ./internal/service/thirdpartyintegration
-        run: make testacc
-      
-  data_lake:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.data_lake == 'true' || inputs.test_group == 'data_lake' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false    
-      - name: Acceptance Tests
-        env:
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/service/datalakepipeline
         run: make testacc
 
   encryption:


### PR DESCRIPTION
## Description

Disables data lake acceptance tests run in CI. New resources cannot be created anymore which prevent us from running tests in CI.

Link to any related issue(s): [CLOUDP-272499](https://jira.mongodb.org/browse/CLOUDP-272499)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
