### PR TITLE
feat: Create / Read / Delete implementation and tests for `mongodbatlas_employee_access_grant`

### DIFF
--- a/internal/service/employeeaccessgrant/data_source.go
+++ b/internal/service/employeeaccessgrant/data_source.go
@@ -13,7 +13,7 @@ var _ datasource.DataSourceWithConfigure = &employeeAccessGrantDS{}
 func DataSource() datasource.DataSource {
 	return &employeeAccessGrantDS{
 		DSCommon: config.DSCommon{
-			DataSourceName: employeeAccessGrantName,
+			DataSourceName: resourceName,
 		},
 	}
 }

--- a/internal/service/employeeaccessgrant/main_test.go
+++ b/internal/service/employeeaccessgrant/main_test.go
@@ -1,0 +1,15 @@
+package employeeaccessgrant_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/employeeaccessgrant/model.go
+++ b/internal/service/employeeaccessgrant/model.go
@@ -1,0 +1,30 @@
+package employeeaccessgrant
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20240805003/admin"
+)
+
+func NewTFModel(projectID, clusterName string, apiResp *admin.EmployeeAccessGrant) *TFEmployeeAccessGrantModel {
+	return &TFEmployeeAccessGrantModel{
+		ProjectID:      types.StringValue(projectID),
+		ClusterName:    types.StringValue(clusterName),
+		GrantType:      types.StringValue(apiResp.GetGrantType()),
+		ExpirationTime: types.StringValue(conversion.TimeToString(apiResp.GetExpirationTime())),
+	}
+}
+
+func NewAtlasReq(tfModel *TFEmployeeAccessGrantModel) (*admin.EmployeeAccessGrant, error) {
+	expirationTimeStr := tfModel.ExpirationTime.ValueString()
+	expirationTime, ok := conversion.StringToTime(expirationTimeStr)
+	if !ok {
+		return nil, fmt.Errorf("expiration_time format is incorrect: %s", expirationTimeStr)
+	}
+	return &admin.EmployeeAccessGrant{
+		GrantType:      tfModel.GrantType.ValueString(),
+		ExpirationTime: expirationTime,
+	}, nil
+}

--- a/internal/service/employeeaccessgrant/model.go
+++ b/internal/service/employeeaccessgrant/model.go
@@ -8,8 +8,8 @@ import (
 	"go.mongodb.org/atlas-sdk/v20240805003/admin"
 )
 
-func NewTFModel(projectID, clusterName string, apiResp *admin.EmployeeAccessGrant) *TFEmployeeAccessGrantModel {
-	return &TFEmployeeAccessGrantModel{
+func NewTFModel(projectID, clusterName string, apiResp *admin.EmployeeAccessGrant) *TFModel {
+	return &TFModel{
 		ProjectID:      types.StringValue(projectID),
 		ClusterName:    types.StringValue(clusterName),
 		GrantType:      types.StringValue(apiResp.GetGrantType()),
@@ -17,7 +17,7 @@ func NewTFModel(projectID, clusterName string, apiResp *admin.EmployeeAccessGran
 	}
 }
 
-func NewAtlasReq(tfModel *TFEmployeeAccessGrantModel) (*admin.EmployeeAccessGrant, error) {
+func NewAtlasReq(tfModel *TFModel) (*admin.EmployeeAccessGrant, error) {
 	expirationTimeStr := tfModel.ExpirationTime.ValueString()
 	expirationTime, ok := conversion.StringToTime(expirationTimeStr)
 	if !ok {

--- a/internal/service/employeeaccessgrant/model_test.go
+++ b/internal/service/employeeaccessgrant/model_test.go
@@ -71,7 +71,8 @@ func TestNewAtlasReq(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			req, err := employeeaccessgrant.NewAtlasReq(tc.tfModel)
-			if tc.expectedErrContains == "" {
+			assert.Equal(t, tc.expectedErrContains == "", err == nil)
+			if err == nil {
 				assert.Equal(t, tc.expectedReq, req)
 			} else {
 				assert.Contains(t, err.Error(), tc.expectedErrContains)

--- a/internal/service/employeeaccessgrant/model_test.go
+++ b/internal/service/employeeaccessgrant/model_test.go
@@ -1,0 +1,80 @@
+package employeeaccessgrant_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/employeeaccessgrant"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20240805003/admin"
+)
+
+func TestNewTFModel(t *testing.T) {
+	testCases := map[string]struct {
+		apiResp         *admin.EmployeeAccessGrant
+		expectedTFModel *employeeaccessgrant.TFModel
+		projectID       string
+		clusterName     string
+	}{
+		"valid": {
+			projectID:   "projectID",
+			clusterName: "clusterName",
+			apiResp: &admin.EmployeeAccessGrant{
+				GrantType:      "grantType",
+				ExpirationTime: time.Date(2024, 10, 13, 0, 0, 0, 0, time.UTC),
+			},
+			expectedTFModel: &employeeaccessgrant.TFModel{
+				ProjectID:      types.StringValue("projectID"),
+				ClusterName:    types.StringValue("clusterName"),
+				GrantType:      types.StringValue("grantType"),
+				ExpirationTime: types.StringValue("2024-10-13T00:00:00Z"),
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tfModel := employeeaccessgrant.NewTFModel(tc.projectID, tc.clusterName, tc.apiResp)
+			assert.Equal(t, tc.expectedTFModel, tfModel)
+		})
+	}
+}
+
+func TestNewAtlasReq(t *testing.T) {
+	testCases := map[string]struct {
+		tfModel        *employeeaccessgrant.TFModel
+		expectedReq    *admin.EmployeeAccessGrant
+		expectedHasErr bool
+	}{
+		"valid": {
+			tfModel: &employeeaccessgrant.TFModel{
+				ProjectID:      types.StringValue("projectID"),
+				ClusterName:    types.StringValue("clusterName"),
+				GrantType:      types.StringValue("grantType"),
+				ExpirationTime: types.StringValue("2024-10-13T00:00:00Z"),
+			},
+			expectedReq: &admin.EmployeeAccessGrant{
+				GrantType:      "grantType",
+				ExpirationTime: time.Date(2024, 10, 13, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"invalid expiration time": {
+			tfModel: &employeeaccessgrant.TFModel{
+				ProjectID:      types.StringValue("projectID"),
+				ClusterName:    types.StringValue("clusterName"),
+				GrantType:      types.StringValue("grantType"),
+				ExpirationTime: types.StringValue("invalid_time"),
+			},
+			expectedHasErr: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			req, err := employeeaccessgrant.NewAtlasReq(tc.tfModel)
+			assert.Equal(t, tc.expectedHasErr, err != nil)
+			if err == nil {
+				assert.Equal(t, tc.expectedReq, req)
+			}
+		})
+	}
+}

--- a/internal/service/employeeaccessgrant/model_test.go
+++ b/internal/service/employeeaccessgrant/model_test.go
@@ -42,9 +42,9 @@ func TestNewTFModel(t *testing.T) {
 
 func TestNewAtlasReq(t *testing.T) {
 	testCases := map[string]struct {
-		tfModel        *employeeaccessgrant.TFModel
-		expectedReq    *admin.EmployeeAccessGrant
-		expectedHasErr bool
+		tfModel             *employeeaccessgrant.TFModel
+		expectedReq         *admin.EmployeeAccessGrant
+		expectedErrContains string
 	}{
 		"valid": {
 			tfModel: &employeeaccessgrant.TFModel{
@@ -65,15 +65,16 @@ func TestNewAtlasReq(t *testing.T) {
 				GrantType:      types.StringValue("grantType"),
 				ExpirationTime: types.StringValue("invalid_time"),
 			},
-			expectedHasErr: true,
+			expectedErrContains: "invalid_time",
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			req, err := employeeaccessgrant.NewAtlasReq(tc.tfModel)
-			assert.Equal(t, tc.expectedHasErr, err != nil)
-			if err == nil {
+			if tc.expectedErrContains == "" {
 				assert.Equal(t, tc.expectedReq, req)
+			} else {
+				assert.Contains(t, err.Error(), tc.expectedErrContains)
 			}
 		})
 	}

--- a/internal/service/employeeaccessgrant/resource.go
+++ b/internal/service/employeeaccessgrant/resource.go
@@ -36,7 +36,7 @@ func (r *employeeAccessGrantRS) Schema(ctx context.Context, req resource.SchemaR
 }
 
 func (r *employeeAccessGrantRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var tfModel TFEmployeeAccessGrantModel
+	var tfModel TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfModel)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -57,7 +57,7 @@ func (r *employeeAccessGrantRS) Create(ctx context.Context, req resource.CreateR
 }
 
 func (r *employeeAccessGrantRS) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var tfModel TFEmployeeAccessGrantModel
+	var tfModel TFModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &tfModel)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -83,7 +83,7 @@ func (r *employeeAccessGrantRS) Read(ctx context.Context, req resource.ReadReque
 }
 
 func (r *employeeAccessGrantRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var tfPlan TFEmployeeAccessGrantModel
+	var tfPlan TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfPlan)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -92,7 +92,7 @@ func (r *employeeAccessGrantRS) Update(ctx context.Context, req resource.UpdateR
 }
 
 func (r *employeeAccessGrantRS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var tfModel TFEmployeeAccessGrantModel
+	var tfModel TFModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &tfModel)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/employeeaccessgrant/resource.go
+++ b/internal/service/employeeaccessgrant/resource.go
@@ -2,12 +2,19 @@ package employeeaccessgrant
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
-const employeeAccessGrantName = "employee_access_grant"
+const (
+	resourceName     = "employee_access_grant"
+	fullResourceName = "mongodbatlas_" + resourceName
+	errorCreate      = "Error creating resource " + fullResourceName
+	errorRead        = "Error retrieving info for resource " + fullResourceName
+	errorDelete      = "Error deleting resource " + fullResourceName
+)
 
 var _ resource.ResourceWithConfigure = &employeeAccessGrantRS{}
 var _ resource.ResourceWithImportState = &employeeAccessGrantRS{}
@@ -15,7 +22,7 @@ var _ resource.ResourceWithImportState = &employeeAccessGrantRS{}
 func Resource() resource.Resource {
 	return &employeeAccessGrantRS{
 		RSCommon: config.RSCommon{
-			ResourceName: employeeAccessGrantName,
+			ResourceName: resourceName,
 		},
 	}
 }
@@ -29,15 +36,50 @@ func (r *employeeAccessGrantRS) Schema(ctx context.Context, req resource.SchemaR
 }
 
 func (r *employeeAccessGrantRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var tfPlan TFEmployeeAccessGrantModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfPlan)...)
+	var tfModel TFEmployeeAccessGrantModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, tfPlan)...)
+	atlasReq, err := NewAtlasReq(&tfModel)
+	if err != nil {
+		resp.Diagnostics.AddError(errorCreate, err.Error())
+		return
+	}
+	connV2 := r.Client.AtlasV2
+	projectID := tfModel.ProjectID.ValueString()
+	clusterName := tfModel.ClusterName.ValueString()
+	if _, _, err := connV2.ClustersApi.GrantMongoDBEmployeeAccess(ctx, projectID, clusterName, atlasReq).Execute(); err != nil {
+		resp.Diagnostics.AddError(errorCreate, err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, tfModel)...)
 }
 
 func (r *employeeAccessGrantRS) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var tfModel TFEmployeeAccessGrantModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &tfModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	connV2 := r.Client.AtlasV2
+	projectID := tfModel.ProjectID.ValueString()
+	clusterName := tfModel.ClusterName.ValueString()
+	cluster, httpResp, err := connV2.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
+	if httpResp.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(errorCreate, err.Error())
+		return
+	}
+	atlasResp, _ := cluster.GetMongoDBEmployeeAccessGrantOk()
+	if atlasResp == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, NewTFModel(projectID, clusterName, atlasResp))...)
 }
 
 func (r *employeeAccessGrantRS) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -50,6 +92,19 @@ func (r *employeeAccessGrantRS) Update(ctx context.Context, req resource.UpdateR
 }
 
 func (r *employeeAccessGrantRS) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var tfModel TFEmployeeAccessGrantModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &tfModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	connV2 := r.Client.AtlasV2
+	projectID := tfModel.ProjectID.ValueString()
+	clusterName := tfModel.ClusterName.ValueString()
+	_, httpResp, err := connV2.ClustersApi.RevokeMongoDBEmployeeAccess(ctx, projectID, clusterName).Execute()
+	if err != nil && httpResp.StatusCode != http.StatusNotFound {
+		resp.Diagnostics.AddError(errorDelete, err.Error())
+		return
+	}
 }
 
 func (r *employeeAccessGrantRS) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/service/employeeaccessgrant/resource_migration_test.go
+++ b/internal/service/employeeaccessgrant/resource_migration_test.go
@@ -1,0 +1,12 @@
+package employeeaccessgrant_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestMigEmployeeAccessGrant_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.20.0")                  // this feature was introduced in provider version 1.20.0
+	mig.CreateAndRunTestNonParallel(t, basicTestCase(t)) // does not run in parallel to reuse same execution project and cluster
+}

--- a/internal/service/employeeaccessgrant/resource_schema.go
+++ b/internal/service/employeeaccessgrant/resource_schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-type TFEmployeeAccessGrantModel struct {
+type TFModel struct {
 	ProjectID      types.String `tfsdk:"project_id"`
 	ClusterName    types.String `tfsdk:"cluster_name"`
 	GrantType      types.String `tfsdk:"grant_type"`

--- a/internal/service/employeeaccessgrant/resource_test.go
+++ b/internal/service/employeeaccessgrant/resource_test.go
@@ -1,0 +1,96 @@
+package employeeaccessgrant_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const (
+	resourceName   = "mongodbatlas_employee_access_grant.test"
+	dataSourceName = "data.mongodbatlas_employee_access_grant.test"
+)
+
+func TestAccEmployeeAccessGrant_basic(t *testing.T) {
+	resource.Test(t, *basicTestCase(t))
+}
+
+func basicTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(tb)
+	)
+
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(projectID, clusterName, "CLUSTER_INFRASTRUCTURE", "2025-08-01T12:00:00Z"),
+				Check:  checkBasic(projectID, clusterName, "CLUSTER_INFRASTRUCTURE", "2025-08-01T12:00:00Z"),
+			},
+		},
+	}
+}
+
+func configBasic(projectID, clusterName, grantType, expirationTime string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_employee_access_grant" "test" {
+			project_id 			= %[1]q
+			cluster_name 		= %[2]q
+			grant_type 			= %[3]q
+			expiration_time = %[4]q
+		}
+	`, projectID, clusterName, grantType, expirationTime)
+}
+
+func checkBasic(projectID, clusterName, grantType, expirationTime string) resource.TestCheckFunc {
+	checks := []resource.TestCheckFunc{checkExists(resourceName)}
+	attrsMap := map[string]string{
+		"project_id":      projectID,
+		"cluster_name":    clusterName,
+		"grant_type":      grantType,
+		"expiration_time": expirationTime,
+	}
+	checks = acc.AddAttrChecks(resourceName, checks, attrsMap)
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if !exists(rs) {
+			return fmt.Errorf("employee access grant (%s) does not exist", resourceName)
+		}
+		return nil
+	}
+}
+
+func checkDestroy(state *terraform.State) error {
+	for _, rs := range state.RootModule().Resources {
+		if rs.Type == "mongodbatlas_employee_access_grant" {
+			if exists(rs) {
+				return fmt.Errorf("employee access grant still exists")
+			}
+		}
+	}
+	return nil
+}
+
+func exists(rs *terraform.ResourceState) bool {
+	projectID := rs.Primary.Attributes["project_id"]
+	clusterName := rs.Primary.Attributes["cluster_name"]
+	cluster, _, _ := acc.ConnV2().ClustersApi.GetCluster(context.Background(), projectID, clusterName).Execute()
+	resp, _ := cluster.GetMongoDBEmployeeAccessGrantOk()
+	return resp != nil
+}


### PR DESCRIPTION
## Description

Create / Read / Delete implementation and tests for `mongodbatlas_employee_access_grant`.

Only create and delete resource `mongodbatlas_employee_access_grant` can be done in this PR.  In following PRs the rest of operations will be implemented. Also acc and mig tests will be added to CI.


Link to any related issue(s): CLOUDP-272251

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
