### PR TITLE
doc: Removes `stream_processor` `__testLog` from examples and fixes pipeline definitions in example

### DIFF
--- a/examples/mongodbatlas_stream_processor/main.tf
+++ b/examples/mongodbatlas_stream_processor/main.tf
@@ -49,24 +49,33 @@ resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
   project_id     = var.project_id
   instance_name  = mongodbatlas_stream_instance.example.instance_name
   processor_name = "sampleProcessorName"
-  pipeline       = jsonencode([{ "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } }, { "$emit" = { "connectionName" : "__testLog" } }])
-  state          = "CREATED"
+  pipeline = jsonencode([
+    { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } },
+    { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "sample", "coll" : "solar", "timeseries" : { "timeField" : "_ts" } } }
+  ])
+  state = "STARTED"
 }
 
-resource "mongodbatlas_stream_processor" "stream-processor-cluster-example" {
+resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-example" {
   project_id     = var.project_id
   instance_name  = mongodbatlas_stream_instance.example.instance_name
   processor_name = "clusterProcessorName"
-  pipeline       = jsonencode([{ "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } }, { "$emit" = { "connectionName" : "__testLog" } }])
-  state          = "STARTED"
+  pipeline = jsonencode([
+    { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } },
+    { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_from_cluster" } }
+  ])
+  state = "CREATED"
 }
 
-resource "mongodbatlas_stream_processor" "stream-processor-kafka-example" {
+resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-example" {
   project_id     = var.project_id
   instance_name  = mongodbatlas_stream_instance.example.instance_name
   processor_name = "kafkaProcessorName"
-  pipeline       = jsonencode([{ "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } }, { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "example_topic" } }])
-  state          = "CREATED"
+  pipeline = jsonencode([
+    { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_source" } },
+    { "$emit" = { "connectionName" : resource.mongodbatlas_stream_connection.example-cluster.connection_name, "db" : "kafka", "coll" : "topic_source", "timeseries" : { "timeField" : "ts" } }
+  }])
+  state = "CREATED"
   options = {
     dlq = {
       coll            = "exampleColumn"

--- a/templates/resources/stream_processor.md.tmpl
+++ b/templates/resources/stream_processor.md.tmpl
@@ -11,7 +11,7 @@
 2. Update the `pipeline` argument setting `config.StartAfter` with the value retrieved in the previous step. More details in the [MongoDB Collection Change Stream](https://www.mongodb.com/docs/atlas/atlas-stream-processing/sp-agg-source/#mongodb-collection-change-stream) documentation.
 	- Example: 
 		```
-		pipeline = jsonencode([{ "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name, "config" = { "startAfter" = { "_data" : "8266C71562000000012B0429296E1404" } } } }, { "$emit" = { "connectionName" : "__testLog" } }])
+		pipeline = jsonencode([{ "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name, "config" = { "startAfter" = { "_data" : "8266C71562000000012B0429296E1404" } } } }, { "$emit" = { "connectionName" : "KafkaConnectionDest", "topic": "kafka-topic" } }])
 		```
 3. Delete the existing Atlas Stream Processor and then create a new Atlas Stream Processor with updated pipeline parameter and the updated values.  
 


### PR DESCRIPTION
## Description

Removes `__testLog` and fixes pipeline definitions in example. It is only meant to be used in dev, not by customers

Link to any related issue(s): CLOUDP-273141

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
