### PR TITLE
fix: Errors during create should only show one error message and required actions

### DIFF
--- a/.changelog/2590.txt
+++ b/.changelog/2590.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_stream_processor: Error during create should only show one error message and required actions
+```

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -17,10 +17,11 @@ const StreamProcessorName = "stream_processor"
 
 var _ resource.ResourceWithConfigure = &streamProcessorRS{}
 var _ resource.ResourceWithImportState = &streamProcessorRS{}
-var (
-	errorDuringCreateStartActions    = "You need to fix the processor and import the resource or delete it manually and re-run terraform apply."
-	errorDuringCreateStart           = fmt.Sprintf("Error starting stream processor. %s", errorDuringCreateStartActions)
-	errorDuringCreateStartTransition = fmt.Sprintf("Error changing state of stream processor. %s", errorDuringCreateStartActions)
+
+const (
+	errorCreateStartActions    = "You need to fix the processor and import the resource or delete it manually and re-run terraform apply."
+	errorCreateStart           = "Error starting stream processor. " + errorCreateStartActions
+	errorCreateStartTransition = "Error changing state of stream processor. " + errorCreateStartActions
 )
 
 func Resource() resource.Resource {
@@ -97,12 +98,12 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 			},
 		).Execute()
 		if err != nil {
-			resp.Diagnostics.AddError(errorDuringCreateStart, err.Error())
+			resp.Diagnostics.AddError(errorCreateStart, err.Error())
 			return
 		}
 		streamProcessorResp, err = WaitStateTransition(ctx, streamProcessorParams, connV2.StreamsApi, []string{CreatedState}, []string{StartedState})
 		if err != nil {
-			resp.Diagnostics.AddError(errorDuringCreateStartTransition, err.Error())
+			resp.Diagnostics.AddError(errorCreateStartTransition, err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
## Description

Error during create should only show one error message and required actions

Link to any related issue(s): CLOUDP-273149

New error message:
```
╷
│ Error: Error starting stream processor. You need to fix the processor and import the resource or delete it manually and re-run terraform apply.
│ 
│   with mongodbatlas_stream_processor.stream-processor-sample-example,
│   on main.tf line 48, in resource "mongodbatlas_stream_processor" "stream-processor-sample-example":
│   48: resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
│ 
│ https://cloud-dev.mongodb.com/api/atlas/v2/groups/664619d870c247237f4b86a6/streams/InstanceName/processor/sampleProcessorName:start POST: HTTP 400 Bad Request (Error code:
│ "STREAM_PROCESSOR_GENERIC_ERROR") Detail: Streams Processor with this name (sampleProcessorName) had a problem occur: Found a Time Series collection solar with a timeField ts that doesn't match the
│ $emit.timeField _ts. Reason: Bad Request. Params: [sampleProcessorName Found a Time Series collection solar with a timeField ts that doesn't match the $emit.timeField _ts]
╵
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
