### PR TITLE
chore: Improves doc auto-generation check

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -68,23 +68,7 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - run: make tools # all resources with auto-generated doc must be specified below here 
-      - name: Doc for control_plane_ip_addresses
-        run: make generate-doc resource_name=control_plane_ip_addresses
-      - name: Doc for push_based_log_export
-        run: make generate-doc resource_name=push_based_log_export
-      - name: Doc for search_deployment
-        run: make generate-doc resource_name=search_deployment
-      - name: Doc for encryption_at_rest
-        run: make generate-doc resource_name=encryption_at_rest
-      - name: Doc for encryption_at_rest_private_endpoint
-        run: make generate-doc resource_name=encryption_at_rest_private_endpoint
-      - name: Doc for project_ip_addresses
-        run: make generate-doc resource_name=project_ip_addresses
-      - name: Doc for stream_processor
-        run: make generate-doc resource_name=stream_processor 
-      - name: Doc for mongodb_employee_access_grant
-        run: make generate-doc resource_name=mongodb_employee_access_grant
+      - run: make tools generate-docs-all
       - name: Find mutations
         id: self_mutation
         run: |-

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -129,6 +129,11 @@ scaffold-schemas:
 generate-doc: 
 	@scripts/generate-doc.sh ${resource_name}
 
+# generate the resource documentation via tfplugindocs for all resources that have templates
+.PHONY: generate-docs-all
+generate-docs-all: 
+	@scripts/generate-docs-all.sh
+
 .PHONY: update-tf-compatibility-matrix
 update-tf-compatibility-matrix: ## Update Terraform Compatibility Matrix documentation
 	./scripts/update-tf-compatibility-matrix.sh

--- a/scripts/generate-docs-all.sh
+++ b/scripts/generate-docs-all.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Shell script to generate the Terraform documentation for the resource and data sources.
+#
+# Usage: ./generate-docs-all.sh"
+#
+# The scripts requires to install tfplugindocs and to create the resource templates in 
+# templates/resources/${resource_name}.md.tmpl and 
+# templates/data-sources/${resource_name}.md.tmpl
+# templates/data-sources/${resource_name}s.md.tmpl
+
+set -euo pipefail
+
+TF_VERSION="${TF_VERSION:-"1.9.2"}" # TF version to use when running tfplugindocs. Default: 1.9.2
+TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templates folder. Default: templates
+
+# ensure preview resource and data sources are also included during generation
+export MONGODB_ATLAS_ENABLE_PREVIEW="true" 
+
+trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
+
+tfplugindocs generate --tf-version "${TF_VERSION}" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"
+
+printf "\nStarting file move\n\n"
+
+for file in "$TEMPLATE_FOLDER_PATH/resources"/*; do
+    filenameTemplate=$(basename -- "$file")
+    filename="${filenameTemplate%.*}"     
+    if [ -f "docs-out/resources/${filename}" ]; then
+        printf "Resource file moved: %s\n" "${filename}"
+        mv "docs-out/resources/${filename}" "docs/resources/${filename}"
+    fi
+done
+
+for file in "$TEMPLATE_FOLDER_PATH/data-sources"/*; do
+    filenameTemplate=$(basename -- "$file")
+    filename="${filenameTemplate%.*}"     
+    if [ -f "docs-out/data-sources/${filename}" ]; then
+        printf "Data source file moved: %s\n" "${filename}"
+        mv "docs-out/data-sources/${filename}" "docs/data-sources/${filename}"
+    fi
+done

--- a/templates/resources/mongodb_employee_access_grant.md.tmpl
+++ b/templates/resources/mongodb_employee_access_grant.md.tmpl
@@ -9,7 +9,7 @@
 {{ .SchemaMarkdown | trimspace }}
 
 # Import 
-The resource can be imported using project ID and cluster name, in the format `PROJECTID-CLUSTERNAME`, e.g. HELLO
+The resource can be imported using project ID and cluster name, in the format `PROJECTID-CLUSTERNAME`, e.g.
 
 ```
 $ terraform import mongodbatlas_push_based_log_export.test 650972848269185c55f40ca1-MyCluster

--- a/templates/resources/mongodb_employee_access_grant.md.tmpl
+++ b/templates/resources/mongodb_employee_access_grant.md.tmpl
@@ -9,7 +9,7 @@
 {{ .SchemaMarkdown | trimspace }}
 
 # Import 
-The resource can be imported using project ID and cluster name, in the format `PROJECTID-CLUSTERNAME`, e.g.
+The resource can be imported using project ID and cluster name, in the format `PROJECTID-CLUSTERNAME`, e.g. HELLO
 
 ```
 $ terraform import mongodbatlas_push_based_log_export.test 650972848269185c55f40ca1-MyCluster


### PR DESCRIPTION
## Description

Improves doc auto-generation check.

There is a new script `generate-docs-all.sh`. No need to pass the list of resources any more in the GitHub Action, it will generate documentation for all resources that have doc templates.

It's also more efficient because current way generates all resource documentation for each resource generation, and discards all files but the ones for the resource being generated. In this PR files are generated only once.


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Output example:
```

...

Starting file move

Resource file moved: encryption_at_rest.md
Resource file moved: encryption_at_rest_private_endpoint.md
Resource file moved: mongodb_employee_access_grant.md
Resource file moved: push_based_log_export.md
Resource file moved: search_deployment.md
Resource file moved: stream_processor.md
Data source file moved: control_plane_ip_addresses.md
Data source file moved: encryption_at_rest.md
Data source file moved: encryption_at_rest_private_endpoint.md
Data source file moved: encryption_at_rest_private_endpoints.md
Data source file moved: mongodb_employee_access_grant.md
Data source file moved: project_ip_addresses.md
Data source file moved: push_based_log_export.md
Data source file moved: search_deployment.md
Data source file moved: stream_processor.md
Data source file moved: stream_processors.md
```
