### PR TITLE
chore: Deprecates data_lake

### DIFF
--- a/.changelog/2599.txt
+++ b/.changelog/2599.txt
@@ -1,0 +1,19 @@
+```release-note:note
+resource/mongodbatlas_data_lake_pipeline: Data Lake is deprecated. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation
+```
+
+```release-note:note
+data-source/mongodbatlas_data_lake_pipeline_run: Data Lake is deprecated. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation
+```
+
+```release-note:note
+data-source/mongodbatlas_data_lake_pipeline_runs: Data Lake is deprecated. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation
+```
+
+```release-note:note
+data-source/mongodbatlas_data_lake_pipeline: Data Lake is deprecated. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation
+```
+
+```release-note:note
+data-source/mongodbatlas_data_lake_pipelines: Data Lake is deprecated. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation
+```

--- a/docs/data-sources/data_lake_pipeline.md
+++ b/docs/data-sources/data_lake_pipeline.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
 
 # Data Source: mongodbatlas_data_lake_pipeline
 
@@ -109,21 +109,21 @@ In addition to all arguments above, the following attributes are exported:
   * `ingestion_schedules.#.frequency_type` - Human-readable label that identifies the frequency type associated with the backup policy.
   * `ingestion_schedules.#.frequency_interval` - Number that indicates the frequency interval for a set of snapshots.
   * `ingestion_schedules.#.retention_unit` - Unit of time in which MongoDB Atlas measures snapshot retention.
-  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot. 
+  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot.
 
 ### `sink` - Ingestion destination of a Data Lake Pipeline
-  * `type` - Type of ingestion destination of this Data Lake Pipeline.
-  * `provider` - Target cloud provider for this Data Lake Pipeline.
-  * `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
-  * `partition_fields` - Ordered fields used to physically organize data in the destination.
-    * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
-    * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
-### `source` - Ingestion Source of a Data Lake Pipeline.
-  * `type` - Type of ingestion source of this Data Lake Pipeline.
-  * `cluster_name` - Human-readable name that identifies the cluster.
-  * `collection_name` - Human-readable name that identifies the collection.
-  * `database_name` - Human-readable name that identifies the database.
-  * `project_id` - Unique 24-hexadecimal character string that identifies the project.
-  * `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
+* `type` - Type of ingestion destination of this Data Lake Pipeline.
+* `provider` - Target cloud provider for this Data Lake Pipeline.
+* `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
+* `partition_fields` - Ordered fields used to physically organize data in the destination.
+  * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
+  * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
+### `source` - Ingestion Source of a Data Lake Pipeline
+* `type` - Type of ingestion source of this Data Lake Pipeline.
+* `cluster_name` - Human-readable name that identifies the cluster.
+* `collection_name` - Human-readable name that identifies the collection.
+* `database_name` - Human-readable name that identifies the database.
+* `project_id` - Unique 24-hexadecimal character string that identifies the project.
+* `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
 
 See [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Lake-Pipelines) Documentation for more information.

--- a/docs/data-sources/data_lake_pipeline.md
+++ b/docs/data-sources/data_lake_pipeline.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+
 # Data Source: mongodbatlas_data_lake_pipeline
 
 `mongodbatlas_data_lake_pipeline` describes a Data Lake Pipeline.

--- a/docs/data-sources/data_lake_pipeline_run.md
+++ b/docs/data-sources/data_lake_pipeline_run.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+
 # Data Source: mongodbatlas_data_lake_pipeline_run
 
 `mongodbatlas_data_lake_pipeline_run` describes a Data Lake Pipeline Run.

--- a/docs/data-sources/data_lake_pipeline_run.md
+++ b/docs/data-sources/data_lake_pipeline_run.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
 
 # Data Source: mongodbatlas_data_lake_pipeline_run
 
@@ -67,7 +67,7 @@ In addition to all arguments above, the following attributes are exported:
 * `created_date` - Timestamp that indicates when the pipeline run was created.
 * `last_updated_date` - Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
 * `state` - State of the pipeline run.
-* `dataset_name` - Human-readable label that identifies the dataset that Atlas generates during this pipeline run. 
+* `dataset_name` - Human-readable label that identifies the dataset that Atlas generates during this pipeline run.
 * `phase` - Processing phase of the Data Lake Pipeline.
 * `pipeline_id` - Unique 24-hexadecimal character string that identifies a Data Lake Pipeline.
 * `snapshot_id` - Unique 24-hexadecimal character string that identifies the snapshot of a cluster.

--- a/docs/data-sources/data_lake_pipeline_runs.md
+++ b/docs/data-sources/data_lake_pipeline_runs.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+
 # Data Source: mongodbatlas_data_lake_pipeline_runs
 
 `mongodbatlas_data_lake_pipeline_run` describes Data Lake Pipeline Runs.

--- a/docs/data-sources/data_lake_pipeline_runs.md
+++ b/docs/data-sources/data_lake_pipeline_runs.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
 
 # Data Source: mongodbatlas_data_lake_pipeline_runs
 
@@ -62,7 +62,7 @@ data "mongodbatlas_data_lake_pipeline_runs" "test" {
 * `created_date` - Timestamp that indicates when the pipeline run was created.
 * `last_updated_date` - Unique 24-hexadecimal character string that identifies a Data Lake Pipeline run.
 * `state` - State of the pipeline run.
-* `dataset_name` - Human-readable label that identifies the dataset that Atlas generates during this pipeline run. 
+* `dataset_name` - Human-readable label that identifies the dataset that Atlas generates during this pipeline run.
 * `phase` - Processing phase of the Data Lake Pipeline.
 * `pipeline_id` - Unique 24-hexadecimal character string that identifies a Data Lake Pipeline.
 * `snapshot_id` - Unique 24-hexadecimal character string that identifies the snapshot of a cluster.

--- a/docs/data-sources/data_lake_pipelines.md
+++ b/docs/data-sources/data_lake_pipelines.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+
 # Data Source: mongodbatlas_data_lake_pipelines
 
 `mongodbatlas_data_lake_pipelines` describes Data Lake Pipelines.

--- a/docs/data-sources/data_lake_pipelines.md
+++ b/docs/data-sources/data_lake_pipelines.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
 
 # Data Source: mongodbatlas_data_lake_pipelines
 
@@ -58,21 +58,21 @@ In addition to all arguments above, the following attributes are exported:
   * `ingestion_schedules.#.frequency_type` - Human-readable label that identifies the frequency type associated with the backup policy.
   * `ingestion_schedules.#.frequency_interval` - Number that indicates the frequency interval for a set of snapshots.
   * `ingestion_schedules.#.retention_unit` - Unit of time in which MongoDB Atlas measures snapshot retention.
-  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot. 
+  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot.
 
 ### `sink` - Ingestion destination of a Data Lake Pipeline
-  * `type` - Type of ingestion destination of this Data Lake Pipeline.
-  * `provider` - Target cloud provider for this Data Lake Pipeline.
-  * `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
-  * `partition_fields` - Ordered fields used to physically organize data in the destination.
-    * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
-    * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
-### `source` - Ingestion Source of a Data Lake Pipeline.
-  * `type` - Type of ingestion source of this Data Lake Pipeline.
-  * `cluster_name` - Human-readable name that identifies the cluster.
-  * `collection_name` - Human-readable name that identifies the collection.
-  * `database_name` - Human-readable name that identifies the database.
-  * `project_id` - Unique 24-hexadecimal character string that identifies the project.
-  * `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
+* `type` - Type of ingestion destination of this Data Lake Pipeline.
+* `provider` - Target cloud provider for this Data Lake Pipeline.
+* `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
+* `partition_fields` - Ordered fields used to physically organize data in the destination.
+  * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
+  * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
+### `source` - Ingestion Source of a Data Lake Pipeline
+* `type` - Type of ingestion source of this Data Lake Pipeline.
+* `cluster_name` - Human-readable name that identifies the cluster.
+* `collection_name` - Human-readable name that identifies the collection.
+* `database_name` - Human-readable name that identifies the database.
+* `project_id` - Unique 24-hexadecimal character string that identifies the project.
+* `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
 
 See [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Lake-Pipelines) Documentation for more information.

--- a/docs/guides/1.20.0-upgrade-guide.md
+++ b/docs/guides/1.20.0-upgrade-guide.md
@@ -12,6 +12,12 @@ The Terraform MongoDB Atlas Provider version 1.20.0 has a number of new and exci
 
 **Deprecations and removals:**
 
+- Data Lake is deprecated. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>. This impacts:
+  - resource/mongodbatlas_data_lake_pipeline
+  - data-source/mongodbatlas_data_lake_pipeline
+  - data-source/mongodbatlas_data_lake_pipelines
+  - data-source/mongodbatlas_data_lake_pipeline_run
+  - data-source/mongodbatlas_data_lake_pipeline_runs
 
 ## New Terraform MongoDB Atlas modules
 You can now leverage our [Terraform Modules](https://registry.terraform.io/namespaces/terraform-mongodbatlas-modules) to easily get started with MongoDB Atlas and critical features like [Push-based log export](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/push-based-log-export/mongodbatlas/latest), [Private Endpoints](https://registry.terraform.io/modules/terraform-mongodbatlas-modules/private-endpoint/mongodbatlas/latest), etc.

--- a/docs/resources/data_lake_pipeline.md
+++ b/docs/resources/data_lake_pipeline.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
 
 # Resource: mongodbatlas_data_lake_pipeline
 
@@ -104,22 +104,22 @@ In addition to all arguments above, the following attributes are exported:
   * `ingestion_schedules.#.frequency_type` - Human-readable label that identifies the frequency type associated with the backup policy.
   * `ingestion_schedules.#.frequency_interval` - Number that indicates the frequency interval for a set of snapshots.
   * `ingestion_schedules.#.retention_unit` - Unit of time in which MongoDB Atlas measures snapshot retention.
-  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot. 
+  * `ingestion_schedules.#.retention_value` - Duration in days, weeks, or months that MongoDB Atlas retains the snapshot.
 
 ### `sink` - Ingestion destination of a Data Lake Pipeline
-  * `type` - Type of ingestion destination of this Data Lake Pipeline.
-  * `provider` - Target cloud provider for this Data Lake Pipeline.
-  * `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
-  * `partition_fields` - Ordered fields used to physically organize data in the destination.
-    * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
-    * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
-### `source` - Ingestion Source of a Data Lake Pipeline.
-  * `type` - Type of ingestion source of this Data Lake Pipeline.
-  * `cluster_name` - Human-readable name that identifies the cluster.
-  * `collection_name` - Human-readable name that identifies the collection.
-  * `database_name` - Human-readable name that identifies the database.
-  * `project_id` - Unique 24-hexadecimal character string that identifies the project.
-  * `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
+* `type` - Type of ingestion destination of this Data Lake Pipeline.
+* `provider` - Target cloud provider for this Data Lake Pipeline.
+* `region` - Target cloud provider region for this Data Lake Pipeline. [Supported cloud provider regions](https://www.mongodb.com/docs/datalake/limitations).
+* `partition_fields` - Ordered fields used to physically organize data in the destination.
+  * `partition_fields.#.field_name` - Human-readable label that identifies the field name used to partition data.
+  * `partition_fields.#.order` - Sequence in which MongoDB Atlas slices the collection data to create partitions. The resource expresses this sequence starting with zero.
+### `source` - Ingestion Source of a Data Lake Pipeline
+* `type` - Type of ingestion source of this Data Lake Pipeline.
+* `cluster_name` - Human-readable name that identifies the cluster.
+* `collection_name` - Human-readable name that identifies the collection.
+* `database_name` - Human-readable name that identifies the database.
+* `project_id` - Unique 24-hexadecimal character string that identifies the project.
+* `policyItemId` - Unique 24-hexadecimal character string that identifies a policy item.
 
 
 ## Import
@@ -127,7 +127,7 @@ In addition to all arguments above, the following attributes are exported:
 Data Lake Pipeline can be imported using project ID, name of the data lake and name of the AWS s3 bucket, in the format `project_id`--`name`, e.g.
 
 ```
-$ terraform import mongodbatlas_data_lake_pipeline.example 1112222b3bf99403840e8934--test-data-lake-pipeline-test
+terraform import mongodbatlas_data_lake_pipeline.example 1112222b3bf99403840e8934--test-data-lake-pipeline-test
 ```
 
 See [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Data-Lake-Pipelines) Documentation for more information.

--- a/docs/resources/data_lake_pipeline.md
+++ b/docs/resources/data_lake_pipeline.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see  _[https://dochub.mongodb.org/core/data-lake-deprecation]_
+
 # Resource: mongodbatlas_data_lake_pipeline
 
 `mongodbatlas_data_lake_pipeline` provides a Data Lake Pipeline resource.

--- a/examples/mongodbatlas_data_lake_pipeline/README.md
+++ b/examples/mongodbatlas_data_lake_pipeline/README.md
@@ -2,6 +2,8 @@
 
 This project provides an example of MongoDB Atlas DataLake Pipeline.
 
+**WARNING:** Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see <https://dochub.mongodb.org/core/data-lake-deprecation>
+
 
 ## Dependencies
 

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline.go
@@ -12,7 +12,8 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRead,
+		ReadContext:        dataSourceRead,
+		DeprecationMessage: "Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation",
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline_run.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline_run.go
@@ -16,7 +16,8 @@ const errorDataLakePipelineRunRead = "error reading MongoDB Atlas DataLake Run (
 
 func DataSourceRun() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRunRead,
+		DeprecationMessage: "Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation",
+		ReadContext:        dataSourceRunRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/datalakepipeline/data_source_data_lake_pipeline_runs.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipeline_runs.go
@@ -16,7 +16,8 @@ const errorDataLakePipelineRunList = "error reading MongoDB Atlas DataLake Runs 
 
 func PluralDataSourceRun() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourcePluralRunRead,
+		DeprecationMessage: "Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation",
+		ReadContext:        dataSourcePluralRunRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/datalakepipeline/data_source_data_lake_pipelines.go
+++ b/internal/service/datalakepipeline/data_source_data_lake_pipelines.go
@@ -16,7 +16,8 @@ const errorDataLakePipelineList = "error creating MongoDB Atlas DataLake Pipelin
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourcePluralRead,
+		DeprecationMessage: "Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation",
+		ReadContext:        dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/datalakepipeline/resource_data_lake_pipeline.go
+++ b/internal/service/datalakepipeline/resource_data_lake_pipeline.go
@@ -27,10 +27,11 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCreate,
-		ReadContext:   resourceRead,
-		UpdateContext: resourceUpdate,
-		DeleteContext: resourceDelete,
+		DeprecationMessage: "Data Lake is deprecated. As of September 2024, Data Lake is deprecated and will reach end-of-life. It will be removed on September 30, 2025. If you use Data Lake, you should migrate to alternative solutions before the service is removed. To learn more, see https://dochub.mongodb.org/core/data-lake-deprecation",
+		CreateContext:      resourceCreate,
+		ReadContext:        resourceRead,
+		UpdateContext:      resourceUpdate,
+		DeleteContext:      resourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},


### PR DESCRIPTION
## Description

Deprecates data_lake resource and data-sources

Link to any related issue(s): CLOUDP-272769

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
