### PR TITLE
fix: Supports using decimal in cluster+adv_cluster advanced_configuration `oplog_min_retention_hours`

### DIFF
--- a/.changelog/2604.txt
+++ b/.changelog/2604.txt
@@ -3,5 +3,5 @@ resource/mongodbatlas_advanced_cluster: Supports using decimal in advanced_confi
 ```
 
 ```release-note:bug
-resource/mongodbatlascluster: Supports using decimal in advanced_configuration `oplog_min_retention_hours`
+resource/mongodbatlas_cluster: Supports using decimal in advanced_configuration `oplog_min_retention_hours`
 ```

--- a/.changelog/2604.txt
+++ b/.changelog/2604.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Supports using decimal in advanced_configuration `oplog_min_retention_hours`
+```
+
+```release-note:bug
+resource/mongodbatlascluster: Supports using decimal in advanced_configuration `oplog_min_retention_hours`
+```

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -104,7 +104,7 @@ func SchemaAdvancedConfigDS() *schema.Schema {
 					Computed: true,
 				},
 				"oplog_min_retention_hours": {
-					Type:     schema.TypeInt,
+					Type:     schema.TypeFloat,
 					Computed: true,
 				},
 				"transaction_lifetime_limit_seconds": {
@@ -237,7 +237,7 @@ func SchemaAdvancedConfig() *schema.Schema {
 					Computed: true,
 				},
 				"oplog_min_retention_hours": {
-					Type:     schema.TypeInt,
+					Type:     schema.TypeFloat,
 					Optional: true,
 				},
 				"sample_size_bi_connector": {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -385,6 +385,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
 					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.0.auto_scaling.0.compute_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_min_retention_hours", "5.5"),
 				),
 			},
 			{
@@ -1399,6 +1400,9 @@ func configReplicationSpecsAutoScaling(projectID, clusterName string, p *admin.A
 					priority      = 7
 					region_name   = "US_WEST_2"
 				}
+			}
+			advanced_configuration  {
+			    oplog_min_retention_hours = 5.5
 			}
 		}
 	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())


### PR DESCRIPTION
## Description

Supports using decimal in cluster+adv_cluster advanced_configuration `oplog_min_retention_hours`

See also #2594

Link to any related issue(s): CLOUDP-273994

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
