### PR TITLE
doc: Adjust instance size of sharded clusters in docs and examples

### DIFF
--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -102,7 +102,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     num_shards = 2
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -117,7 +117,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -140,7 +140,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     zone_name  = "zone n1"
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -153,7 +153,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     zone_name  = "zone n1"
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -166,7 +166,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     zone_name  = "zone n2"
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -179,7 +179,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     zone_name  = "zone n2"
     region_configs {
     electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
     }
     provider_name = "AWS"
@@ -211,7 +211,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     replication_specs {
         region_configs {
             electable_specs {
-                instance_size = "M10"
+                instance_size = "M30"
                 node_count    = 3
             }
             provider_name = "AZURE"
@@ -235,7 +235,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     replication_specs {
         region_configs {
             electable_specs {
-                instance_size = "M10"
+                instance_size = "M30"
                 node_count    = 3
             }
             provider_name = "AZURE"
@@ -259,7 +259,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     replication_specs { # first shard
         region_configs {
             electable_specs {
-                instance_size = "M10"
+                instance_size = "M30"
                 node_count    = 3
             }
             provider_name = "AZURE"
@@ -271,7 +271,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
     replication_specs { # second shard
         region_configs {
             electable_specs {
-                instance_size = "M10"
+                instance_size = "M30"
                 node_count    = 3
             }
             provider_name = "AZURE"

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -138,7 +138,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   replication_specs {   # shard 1
     region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -148,7 +148,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
      region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -160,7 +160,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   replication_specs {   # shard 2
     region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -168,9 +168,9 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
       region_name   = "US_EAST_1"
     }
 
-     region_configs { 
+    region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -200,7 +200,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -210,7 +210,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -224,7 +224,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -234,7 +234,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -248,7 +248,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -258,7 +258,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -272,7 +272,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs { 
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -282,7 +282,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"

--- a/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/main.tf
@@ -22,10 +22,10 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   }
 
-  replication_specs { # shard 2 - M20 instance size
+  replication_specs { # shard 2 - M30 instance size
     region_configs {
       electable_specs {
-        instance_size = "M20"
+        instance_size = "M30"
         disk_iops     = 3000
         node_count    = 3
       }
@@ -35,10 +35,10 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   }
 
-  replication_specs { # shard 3 - M10 instance size
+  replication_specs { # shard 3 - M40 instance size
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M40"
         disk_iops     = 3000
         node_count    = 3
       }
@@ -48,10 +48,10 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
     }
   }
 
-  replication_specs { # shard 4 - M10 instance size
+  replication_specs { # shard 4 - M40 instance size
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M40"
         disk_iops     = 3000
         node_count    = 3
       }

--- a/examples/mongodbatlas_advanced_cluster/global-cluster/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/global-cluster/main.tf
@@ -18,7 +18,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -28,7 +28,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -42,7 +42,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -52,7 +52,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -66,7 +66,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -76,7 +76,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"
@@ -90,7 +90,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       provider_name = "AWS"
@@ -100,7 +100,7 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       provider_name = "AZURE"

--- a/examples/mongodbatlas_advanced_cluster/multi-cloud/main.tf
+++ b/examples/mongodbatlas_advanced_cluster/multi-cloud/main.tf
@@ -12,11 +12,11 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   replication_specs { # shard 1
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       analytics_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 1
       }
       provider_name = "AWS"
@@ -26,11 +26,11 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       analytics_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 1
       }
       provider_name = "AZURE"
@@ -42,11 +42,11 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
   replication_specs { # shard 2
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 3
       }
       analytics_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 1
       }
       provider_name = "AWS"
@@ -56,11 +56,11 @@ resource "mongodbatlas_advanced_cluster" "cluster" {
 
     region_configs {
       electable_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 2
       }
       analytics_specs {
-        instance_size = "M10"
+        instance_size = "M30"
         node_count    = 1
       }
       provider_name = "AZURE"


### PR DESCRIPTION
## Description

Suggestion was brought up by Jack from AD team.

In dev and qa it’s ok to create sharded cluster with instance size < M30, but in prod it requires product team approval via support ticket.

This PRs adjusts examples of sharded cluster to use M30 and above to avoid any errors.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
