### PR TITLE
fix: Makes `mongodbatlas_alert_configuration` Datadog acceptance tests non-parallel

### DIFF
--- a/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
@@ -146,5 +146,5 @@ func TestMigConfigRSAlertConfiguration_withEmptyOptionalAttributes(t *testing.T)
 
 func TestMigConfigRSAlertConfiguration_withDataDog(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.20.0")
-	mig.CreateAndRunTestNonParallel(t, datadogTestCase(t))
+	mig.CreateAndRunTestNonParallel(t, datadogTestCase(t)) // not run in parallel so acc and mig tests don't interfere
 }

--- a/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_migration_test.go
@@ -146,5 +146,5 @@ func TestMigConfigRSAlertConfiguration_withEmptyOptionalAttributes(t *testing.T)
 
 func TestMigConfigRSAlertConfiguration_withDataDog(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.20.0")
-	mig.CreateAndRunTest(t, datadogTestCase(t))
+	mig.CreateAndRunTestNonParallel(t, datadogTestCase(t))
 }

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -368,7 +368,7 @@ func TestAccConfigRSAlertConfiguration_updatePagerDutyWithNotifierId(t *testing.
 }
 
 func TestAccConfigRSAlertConfiguration_withDataDog(t *testing.T) {
-	resource.Test(t, *datadogTestCase(t))
+	resource.Test(t, *datadogTestCase(t)) // not run in parallel so acc and mig tests don't interfere
 }
 
 func datadogTestCase(t *testing.T) *resource.TestCase {

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -368,7 +368,7 @@ func TestAccConfigRSAlertConfiguration_updatePagerDutyWithNotifierId(t *testing.
 }
 
 func TestAccConfigRSAlertConfiguration_withDataDog(t *testing.T) {
-	resource.ParallelTest(t, *datadogTestCase(t))
+	resource.Test(t, *datadogTestCase(t))
 }
 
 func datadogTestCase(t *testing.T) *resource.TestCase {


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
