### PR TITLE
feat: Adds `custom_zone_mapping_zone_id` to `mongodbatlas_global_cluster_config` and deprecates `custom_zone_mapping`

### DIFF
--- a/.changelog/2637.txt
+++ b/.changelog/2637.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_global_cluster_config: Adds `custom_zone_mapping_zone_id` attribute
+```
+
+```release-note:note
+resource/mongodbatlas_global_cluster_config: Deprecates `custom_zone_mapping` in favor of `custom_zone_mapping_zone_id`
+```

--- a/.changelog/2637.txt
+++ b/.changelog/2637.txt
@@ -2,6 +2,14 @@
 resource/mongodbatlas_global_cluster_config: Adds `custom_zone_mapping_zone_id` attribute
 ```
 
+```release-note:enhancement
+data-source/mongodbatlas_global_cluster_config: Adds `custom_zone_mapping_zone_id` attribute
+```
+
 ```release-note:note
 resource/mongodbatlas_global_cluster_config: Deprecates `custom_zone_mapping` in favor of `custom_zone_mapping_zone_id`
+```
+
+```release-note:note
+data-source/mongodbatlas_global_cluster_config: Deprecates `custom_zone_mapping` in favor of `custom_zone_mapping_zone_id`
 ```

--- a/docs/data-sources/global_cluster_config.md
+++ b/docs/data-sources/global_cluster_config.md
@@ -97,7 +97,7 @@ resource "mongodbatlas_global_cluster_config" "config" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to create the database user.
-* `cluster_name - (Required) The name of the Global Cluster.
+* `cluster_name` - (Required) The name of the Global Cluster.
 
 ## Attributes Reference
 

--- a/docs/data-sources/global_cluster_config.md
+++ b/docs/data-sources/global_cluster_config.md
@@ -104,7 +104,8 @@ resource "mongodbatlas_global_cluster_config" "config" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
-* `custom_zone_mapping` - A map of all custom zone mappings defined for the Global Cluster. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
+* `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead.
 *  `managed_namespaces` - Add a managed namespaces to a Global Cluster. For more information about managed namespaces, see [Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/). See [Managed Namespace](#managed-namespace) below for more details.
 
 ### Managed Namespace

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -92,7 +92,8 @@ resource "mongodbatlas_global_cluster_config" "config" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
-* `custom_zone_mapping` - A map of all custom zone mappings defined for the Global Cluster. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
+* `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead.
 
 ## Import
 

--- a/internal/common/constant/deprecation.go
+++ b/internal/common/constant/deprecation.go
@@ -3,10 +3,8 @@ package constant
 const (
 	DeprecationParam                           = "This parameter is deprecated."
 	DeprecationParamWithReplacement            = "This parameter is deprecated. Please transition to %s."
-	DeprecationParamByDate                     = "This parameter is deprecated and will be removed by %s."
-	DeprecationParamByDateWithReplacement      = "This parameter is deprecated and will be removed by %s. Please transition to %s."
+	DeprecationParamByVersionWithReplacement   = "This parameter is deprecated and will be removed in version %s. Please transition to %s."
 	DeprecationParamFutureWithReplacement      = "This parameter is deprecated and will be removed in the future. Please transition to %s"
-	DeprecationParamByVersion                  = "This parameter is deprecated and will be removed in version %s."
 	DeprecationResourceByDateWithReplacement   = "This resource is deprecated and will be removed in %s. Please transition to %s."
 	DeprecationDataSourceByDateWithReplacement = "This data source is deprecated and will be removed in %s. Please transition to %s."
 )

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -54,8 +55,9 @@ func DataSource() *schema.Resource {
 				},
 			},
 			"custom_zone_mapping": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
+				Type:       schema.TypeMap,
+				Computed:   true,
 			},
 			"custom_zone_mapping_zone_id": {
 				Type:     schema.TypeMap,

--- a/internal/service/globalclusterconfig/data_source_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/data_source_global_cluster_config.go
@@ -55,7 +55,7 @@ func DataSource() *schema.Resource {
 				},
 			},
 			"custom_zone_mapping": {
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
 				Type:       schema.TypeMap,
 				Computed:   true,
 			},

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
@@ -93,8 +94,9 @@ func Resource() *schema.Resource {
 				},
 			},
 			"custom_zone_mapping": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
+				Type:       schema.TypeMap,
+				Computed:   true,
 			},
 			"custom_zone_mapping_zone_id": {
 				Type:     schema.TypeMap,

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
 )
 
 const (
@@ -107,7 +107,7 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
 
@@ -115,25 +115,25 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		for _, m := range v.(*schema.Set).List() {
 			mn := m.(map[string]any)
 
-			addManagedNamespace := &admin20240530.ManagedNamespace{
-				Collection:     conversion.StringPtr(mn["collection"].(string)),
-				Db:             conversion.StringPtr(mn["db"].(string)),
-				CustomShardKey: conversion.StringPtr(mn["custom_shard_key"].(string)),
+			req := &admin.ManagedNamespaces{
+				Collection:     mn["collection"].(string),
+				Db:             mn["db"].(string),
+				CustomShardKey: mn["custom_shard_key"].(string),
 			}
 
 			if isCustomShardKeyHashed, okCustomShard := mn["is_custom_shard_key_hashed"]; okCustomShard {
-				addManagedNamespace.IsCustomShardKeyHashed = conversion.Pointer[bool](isCustomShardKeyHashed.(bool))
+				req.IsCustomShardKeyHashed = conversion.Pointer[bool](isCustomShardKeyHashed.(bool))
 			}
 
 			if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
-				addManagedNamespace.IsShardKeyUnique = conversion.Pointer[bool](isShardKeyUnique.(bool))
+				req.IsShardKeyUnique = conversion.Pointer[bool](isShardKeyUnique.(bool))
 			}
 
 			err := retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
-				_, _, err := connV220240530.GlobalClustersApi.CreateManagedNamespace(ctx, projectID, clusterName, addManagedNamespace).Execute()
+				_, _, err := connV2.GlobalClustersApi.CreateManagedNamespace(ctx, projectID, clusterName, req).Execute()
 				if err != nil {
-					if admin20240530.IsErrorCode(err, "DUPLICATE_MANAGED_NAMESPACE") {
-						if err := removeManagedNamespaces(ctx, connV220240530, v.(*schema.Set).List(), projectID, clusterName); err != nil {
+					if admin.IsErrorCode(err, "DUPLICATE_MANAGED_NAMESPACE") {
+						if err := removeManagedNamespaces(ctx, connV2, v.(*schema.Set).List(), projectID, clusterName); err != nil {
 							return retry.NonRetryableError(fmt.Errorf(errorGlobalClusterCreate, err))
 						}
 						return retry.RetryableError(err)
@@ -149,13 +149,13 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if v, ok := d.GetOk("custom_zone_mappings"); ok {
-		_, _, err := connV220240530.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin20240530.CustomZoneMappings{
+		_, _, err := connV2.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin.CustomZoneMappings{
 			CustomZoneMappings: newCustomZoneMappings(v.(*schema.Set).List()),
 		}).Execute()
 
 		if err != nil {
 			if v2, ok2 := d.GetOk("managed_namespaces"); ok2 {
-				if err := removeManagedNamespaces(ctx, connV220240530, v2.(*schema.Set).List(), projectID, clusterName); err != nil {
+				if err := removeManagedNamespaces(ctx, connV2, v2.(*schema.Set).List(), projectID, clusterName); err != nil {
 					return diag.FromErr(fmt.Errorf(errorGlobalClusterCreate, err))
 				}
 			}
@@ -178,6 +178,14 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
+	resp, httpResp, err := connV2.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
+	if err != nil {
+		if httpResp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
+	}
 	oldResp, httpResp, err := connV220240530.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if httpResp.StatusCode == http.StatusNotFound {
@@ -186,22 +194,14 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		}
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
-	newResp, httpResp, err := connV2.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
-	if err != nil {
-		if httpResp.StatusCode == http.StatusNotFound {
-			d.SetId("")
-			return nil
-		}
+
+	if err := d.Set("managed_namespaces", flattenManagedNamespaces(resp.GetManagedNamespaces())); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
-
-	if err := d.Set("managed_namespaces", flattenManagedNamespaces(oldResp.GetManagedNamespaces())); err != nil {
+	if err := d.Set("custom_zone_mapping_zone_id", resp.GetCustomZoneMapping()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 	if err := d.Set("custom_zone_mapping", oldResp.GetCustomZoneMapping()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
-	}
-	if err := d.Set("custom_zone_mapping_zone_id", newResp.GetCustomZoneMapping()); err != nil {
 		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
 	}
 
@@ -215,20 +215,20 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
 	if v, ok := d.GetOk("managed_namespaces"); ok {
-		if err := removeManagedNamespaces(ctx, connV220240530, v.(*schema.Set).List(), projectID, clusterName); err != nil {
+		if err := removeManagedNamespaces(ctx, connV2, v.(*schema.Set).List(), projectID, clusterName); err != nil {
 			return diag.FromErr(fmt.Errorf(errorGlobalClusterDelete, clusterName, err))
 		}
 	}
 
 	if v, ok := d.GetOk("custom_zone_mappings"); ok {
 		if v.(*schema.Set).Len() > 0 {
-			if _, _, err := connV220240530.GlobalClustersApi.DeleteAllCustomZoneMappings(ctx, projectID, clusterName).Execute(); err != nil {
+			if _, _, err := connV2.GlobalClustersApi.DeleteAllCustomZoneMappings(ctx, projectID, clusterName).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorGlobalClusterDelete, clusterName, err))
 			}
 		}
@@ -237,7 +237,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	return nil
 }
 
-func flattenManagedNamespaces(managedNamespaces []admin20240530.ManagedNamespaces) []map[string]any {
+func flattenManagedNamespaces(managedNamespaces []admin.ManagedNamespaces) []map[string]any {
 	var results []map[string]any
 
 	if len(managedNamespaces) > 0 {
@@ -281,17 +281,17 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 	return []*schema.ResourceData{d}, nil
 }
 
-func removeManagedNamespaces(ctx context.Context, connV220240530 *admin20240530.APIClient, remove []any, projectID, clusterName string) error {
+func removeManagedNamespaces(ctx context.Context, connV2 *admin.APIClient, remove []any, projectID, clusterName string) error {
 	for _, m := range remove {
 		mn := m.(map[string]any)
-		managedNamespace := &admin20240530.DeleteManagedNamespaceApiParams{
+		managedNamespace := &admin.DeleteManagedNamespaceApiParams{
 			Collection:  conversion.StringPtr(mn["collection"].(string)),
 			Db:          conversion.StringPtr(mn["db"].(string)),
 			ClusterName: clusterName,
 			GroupId:     projectID,
 		}
 
-		_, _, err := connV220240530.GlobalClustersApi.DeleteManagedNamespaceWithParams(ctx, managedNamespace).Execute()
+		_, _, err := connV2.GlobalClustersApi.DeleteManagedNamespaceWithParams(ctx, managedNamespace).Execute()
 
 		if err != nil {
 			return err
@@ -300,12 +300,12 @@ func removeManagedNamespaces(ctx context.Context, connV220240530 *admin20240530.
 	return nil
 }
 
-func newCustomZoneMapping(tfMap map[string]any) *admin20240530.ZoneMapping {
+func newCustomZoneMapping(tfMap map[string]any) *admin.ZoneMapping {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &admin20240530.ZoneMapping{
+	apiObject := &admin.ZoneMapping{
 		Location: tfMap["location"].(string),
 		Zone:     tfMap["zone"].(string),
 	}
@@ -313,12 +313,12 @@ func newCustomZoneMapping(tfMap map[string]any) *admin20240530.ZoneMapping {
 	return apiObject
 }
 
-func newCustomZoneMappings(tfList []any) *[]admin20240530.ZoneMapping {
+func newCustomZoneMappings(tfList []any) *[]admin.ZoneMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	apiObjects := make([]admin20240530.ZoneMapping, len(tfList))
+	apiObjects := make([]admin.ZoneMapping, len(tfList))
 	if len(tfList) > 0 {
 		for i, tfMapRaw := range tfList {
 			if tfMap, ok := tfMapRaw.(map[string]any); ok {

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -94,7 +94,7 @@ func Resource() *schema.Resource {
 				},
 			},
 			"custom_zone_mapping": {
-				Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
+				Deprecated: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.23.0", "custom_zone_mapping_zone_id"),
 				Type:       schema.TypeMap,
 				Computed:   true,
 			},

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_migration_test.go
@@ -7,5 +7,6 @@ import (
 )
 
 func TestMigGlobalClusterConfig_basic(t *testing.T) {
-	mig.CreateAndRunTest(t, basicTestCase(t, false))
+	checkZoneID := mig.IsProviderVersionAtLeast("1.21.0")
+	mig.CreateAndRunTest(t, basicTestCase(t, checkZoneID, false))
 }

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -28,11 +28,7 @@ func TestAccGlobalClusterConfig_withBackup(t *testing.T) {
 
 func basicTestCase(tb testing.TB, withBackup bool) *resource.TestCase {
 	tb.Helper()
-	var specs []acc.ReplicationSpecRequest
-	if withBackup {
-		specs = []acc.ReplicationSpecRequest{{Region: "US_EAST_1"}}
-	}
-	clusterInfo := acc.GetClusterInfo(tb, &acc.ClusterRequest{Geosharded: true, CloudBackup: withBackup, ReplicationSpecs: specs})
+	clusterInfo := acc.GetClusterInfo(tb, &acc.ClusterRequest{Geosharded: true, CloudBackup: withBackup})
 
 	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(tb) },

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -28,7 +28,11 @@ func TestAccGlobalClusterConfig_withBackup(t *testing.T) {
 
 func basicTestCase(tb testing.TB, withBackup bool) *resource.TestCase {
 	tb.Helper()
-	clusterInfo := acc.GetClusterInfo(tb, &acc.ClusterRequest{Geosharded: true, CloudBackup: withBackup})
+	var specs []acc.ReplicationSpecRequest
+	if withBackup {
+		specs = []acc.ReplicationSpecRequest{{Region: "US_EAST_1"}}
+	}
+	clusterInfo := acc.GetClusterInfo(tb, &acc.ClusterRequest{Geosharded: true, CloudBackup: withBackup, ReplicationSpecs: specs})
 
 	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(tb) },

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -39,13 +39,19 @@ func basicTestCase(tb testing.TB, withBackup bool) *resource.TestCase {
 				Config: configBasic(&clusterInfo, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
-					acc.CheckRSAndDS(resourceName, nil, nil,
-						[]string{"custom_zone_mappings.#", "custom_zone_mapping.%", "custom_zone_mapping.CA", "project_id"},
+					resource.TestCheckResourceAttrPair(resourceName, "custom_zone_mapping_zone_id.CA", clusterInfo.ResourceName, "replication_specs.0.zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "custom_zone_mapping_zone_id.CA", clusterInfo.ResourceName, "replication_specs.0.zone_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "custom_zone_mapping.CA", clusterInfo.ResourceName, "replication_specs.0.id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "custom_zone_mapping.CA", clusterInfo.ResourceName, "replication_specs.0.id"),
+					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil,
+						[]string{"project_id"},
 						map[string]string{
 							"cluster_name":         clusterInfo.Name,
 							"managed_namespaces.#": "1",
 							"managed_namespaces.0.is_custom_shard_key_hashed": "false",
 							"managed_namespaces.0.is_shard_key_unique":        "false",
+							"custom_zone_mapping.%":                           "1",
+							"custom_zone_mapping_zone_id.%":                   "1",
 						}),
 				),
 			},
@@ -118,8 +124,8 @@ func TestAccGlobalClusterConfig_database(t *testing.T) {
 				Config: configWithDBConfig(&clusterInfo, customZone),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
-					acc.CheckRSAndDS(resourceName, nil, nil,
-						[]string{"custom_zone_mappings.#", "custom_zone_mapping.%", "custom_zone_mapping.US", "custom_zone_mapping.IE", "custom_zone_mapping.DE", "project_id"},
+					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil,
+						[]string{"custom_zone_mapping.%", "custom_zone_mapping.US", "custom_zone_mapping.IE", "custom_zone_mapping.DE", "project_id"},
 						map[string]string{
 							"cluster_name":         clusterInfo.Name,
 							"managed_namespaces.#": "5",

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -234,6 +234,8 @@ func configBasic(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool) st
 				location = "CA"
 				zone     = "Zone 1"
 			}
+
+			depends_on = [%[5]s]
 		}
 
 		data "mongodbatlas_global_cluster_config" "config" {
@@ -241,7 +243,7 @@ func configBasic(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool) st
 			cluster_name     = mongodbatlas_global_cluster_config.config.cluster_name
 			depends_on = [mongodbatlas_global_cluster_config.config]
 		}	
-	`, info.TerraformNameRef, info.ProjectID, isCustomShard, isShardKeyUnique)
+	`, info.TerraformNameRef, info.ProjectID, isCustomShard, isShardKeyUnique, info.ResourceName)
 }
 
 func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
@@ -276,6 +278,8 @@ func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
 				custom_shard_key = "orgId"
 			}
 			%[3]s
+
+			depends_on = [%[4]s]
 		}
 
 		data "mongodbatlas_global_cluster_config" "config" {
@@ -283,5 +287,5 @@ func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
 			cluster_name     = mongodbatlas_global_cluster_config.config.cluster_name
 			depends_on = [mongodbatlas_global_cluster_config.config]
 		}	
-	`, info.TerraformNameRef, info.ProjectID, zones)
+	`, info.TerraformNameRef, info.ProjectID, zones, info.ResourceName)
 }

--- a/internal/service/project/data_source_project.go
+++ b/internal/service/project/data_source_project.go
@@ -142,7 +142,7 @@ func (d *projectDS) Schema(ctx context.Context, req datasource.SchemaRequest, re
 			},
 			"ip_addresses": schema.SingleNestedAttribute{
 				Computed:           true,
-				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
+				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
 				Attributes: map[string]schema.Attribute{
 					"services": schema.SingleNestedAttribute{
 						Computed: true,

--- a/internal/service/project/data_source_projects.go
+++ b/internal/service/project/data_source_projects.go
@@ -138,7 +138,7 @@ func (d *ProjectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, r
 						},
 						"ip_addresses": schema.SingleNestedAttribute{
 							Computed:           true,
-							DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
+							DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
 							Attributes: map[string]schema.Attribute{
 								"services": schema.SingleNestedAttribute{
 									Computed: true,

--- a/internal/service/project/resource_project.go
+++ b/internal/service/project/resource_project.go
@@ -223,7 +223,7 @@ func (r *projectRS) Schema(ctx context.Context, req resource.SchemaRequest, resp
 			},
 			"ip_addresses": schema.SingleNestedAttribute{
 				Computed:           true,
-				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByDateWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
+				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
## Description

Adds `custom_zone_mapping_zone_id` to `mongodbatlas_global_cluster_config` and deprecates `custom_zone_mapping`

Link to any related issue(s): CLOUDP-263795

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
