### PR TITLE
fix: Enforces `priority` descending order in `region_configs` in `mongodbatlas_advanced_cluster`

### DIFF
--- a/.changelog/2640.txt
+++ b/.changelog/2640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Enforces `priority` descending order in `region_configs`
+```

--- a/.changelog/2640.txt
+++ b/.changelog/2640.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_advanced_cluster: Enforces `priority` descending order in `region_configs`
+resource/mongodbatlas_advanced_cluster: Enforces `priority` descending order in `region_configs` avoiding potential non-empty plans after apply
 ```

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -3,6 +3,7 @@ package advancedcluster
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"log"
@@ -396,6 +397,30 @@ func flattenTags(tags *[]admin.ResourceTag) []map[string]string {
 		}
 	}
 	return ret
+}
+
+func CheckRegionConfigsPriorityOrder(regionConfigs []admin.ReplicationSpec20240805) error {
+	for _, spec := range regionConfigs {
+		configs := spec.GetRegionConfigs()
+		for i := 0; i < len(configs)-1; i++ {
+			if configs[i].GetPriority() < configs[i+1].GetPriority() {
+				return errors.New("priority values in region_configs must be in descending order")
+			}
+		}
+	}
+	return nil
+}
+
+func CheckRegionConfigsPriorityOrderOld(regionConfigs []admin20240530.ReplicationSpec) error {
+	for _, spec := range regionConfigs {
+		configs := spec.GetRegionConfigs()
+		for i := 0; i < len(configs)-1; i++ {
+			if configs[i].GetPriority() < configs[i+1].GetPriority() {
+				return errors.New("priority values in region_configs must be in descending order")
+			}
+		}
+	}
+	return nil
 }
 
 func flattenConnectionStrings(str admin.ClusterConnectionStrings) []map[string]any {

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -399,6 +399,7 @@ func flattenTags(tags *[]admin.ResourceTag) []map[string]string {
 	return ret
 }
 
+// CheckRegionConfigsPriorityOrder will be deleted in CLOUDP-275825
 func CheckRegionConfigsPriorityOrder(regionConfigs []admin.ReplicationSpec20240805) error {
 	for _, spec := range regionConfigs {
 		configs := spec.GetRegionConfigs()
@@ -411,6 +412,7 @@ func CheckRegionConfigsPriorityOrder(regionConfigs []admin.ReplicationSpec202408
 	return nil
 }
 
+// CheckRegionConfigsPriorityOrderOld will be deleted in CLOUDP-275825
 func CheckRegionConfigsPriorityOrderOld(regionConfigs []admin20240530.ReplicationSpec) error {
 	for _, spec := range regionConfigs {
 		configs := spec.GetRegionConfigs()

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -458,6 +458,15 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
+	for _, spec := range params.GetReplicationSpecs() {
+		configs := spec.GetRegionConfigs()
+		for i := 0; i < len(configs)-1; i++ {
+			if configs[i].GetPriority() < configs[i+1].GetPriority() {
+				return diag.FromErr(fmt.Errorf("priority values in region_configs must be in descending order"))
+			}
+		}
+	}
+
 	cluster, _, err := connV2.ClustersApi.CreateCluster(ctx, projectID, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorCreate, err))

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -458,15 +458,9 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
-	for _, spec := range params.GetReplicationSpecs() {
-		configs := spec.GetRegionConfigs()
-		for i := 0; i < len(configs)-1; i++ {
-			if configs[i].GetPriority() < configs[i+1].GetPriority() {
-				return diag.FromErr(fmt.Errorf("priority values in region_configs must be in descending order"))
-			}
-		}
+	if err := checkRegionConfigsPriorityOrder(params.GetReplicationSpecs()); err != nil {
+		return diag.FromErr(err)
 	}
-
 	cluster, _, err := connV2.ClustersApi.CreateCluster(ctx, projectID, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorCreate, err))
@@ -808,6 +802,9 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		clusterChangeDetect := new(admin20240530.AdvancedClusterDescription)
 		if !reflect.DeepEqual(req, clusterChangeDetect) {
+			if err := checkRegionConfigsPriorityOrderOld(req.GetReplicationSpecs()); err != nil {
+				return diag.FromErr(err)
+			}
 			if _, _, err := connV220240530.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
 			}
@@ -832,6 +829,9 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		clusterChangeDetect := new(admin.ClusterDescription20240805)
 		if !reflect.DeepEqual(req, clusterChangeDetect) {
+			if err := checkRegionConfigsPriorityOrder(req.GetReplicationSpecs()); err != nil {
+				return diag.FromErr(err)
+			}
 			if _, _, err := connV2.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
 			}
@@ -1295,4 +1295,28 @@ func waitForUpdateToFinish(ctx context.Context, connV2 *admin.APIClient, project
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func checkRegionConfigsPriorityOrder(regionConfigs []admin.ReplicationSpec20240805) error {
+	for _, spec := range regionConfigs {
+		configs := spec.GetRegionConfigs()
+		for i := 0; i < len(configs)-1; i++ {
+			if configs[i].GetPriority() < configs[i+1].GetPriority() {
+				return errors.New("priority values in region_configs must be in descending order")
+			}
+		}
+	}
+	return nil
+}
+
+func checkRegionConfigsPriorityOrderOld(regionConfigs []admin20240530.ReplicationSpec) error {
+	for _, spec := range regionConfigs {
+		configs := spec.GetRegionConfigs()
+		for i := 0; i < len(configs)-1; i++ {
+			if configs[i].GetPriority() < configs[i+1].GetPriority() {
+				return errors.New("priority values in region_configs must be in descending order")
+			}
+		}
+	}
+	return nil
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -458,7 +458,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
-	if err := checkRegionConfigsPriorityOrder(params.GetReplicationSpecs()); err != nil {
+	if err := CheckRegionConfigsPriorityOrder(params.GetReplicationSpecs()); err != nil {
 		return diag.FromErr(err)
 	}
 	cluster, _, err := connV2.ClustersApi.CreateCluster(ctx, projectID, params).Execute()
@@ -802,7 +802,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		clusterChangeDetect := new(admin20240530.AdvancedClusterDescription)
 		if !reflect.DeepEqual(req, clusterChangeDetect) {
-			if err := checkRegionConfigsPriorityOrderOld(req.GetReplicationSpecs()); err != nil {
+			if err := CheckRegionConfigsPriorityOrderOld(req.GetReplicationSpecs()); err != nil {
 				return diag.FromErr(err)
 			}
 			if _, _, err := connV220240530.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
@@ -829,7 +829,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		clusterChangeDetect := new(admin.ClusterDescription20240805)
 		if !reflect.DeepEqual(req, clusterChangeDetect) {
-			if err := checkRegionConfigsPriorityOrder(req.GetReplicationSpecs()); err != nil {
+			if err := CheckRegionConfigsPriorityOrder(req.GetReplicationSpecs()); err != nil {
 				return diag.FromErr(err)
 			}
 			if _, _, err := connV2.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
@@ -1295,28 +1295,4 @@ func waitForUpdateToFinish(ctx context.Context, connV2 *admin.APIClient, project
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
-}
-
-func checkRegionConfigsPriorityOrder(regionConfigs []admin.ReplicationSpec20240805) error {
-	for _, spec := range regionConfigs {
-		configs := spec.GetRegionConfigs()
-		for i := 0; i < len(configs)-1; i++ {
-			if configs[i].GetPriority() < configs[i+1].GetPriority() {
-				return errors.New("priority values in region_configs must be in descending order")
-			}
-		}
-	}
-	return nil
-}
-
-func checkRegionConfigsPriorityOrderOld(regionConfigs []admin20240530.ReplicationSpec) error {
-	for _, spec := range regionConfigs {
-		configs := spec.GetRegionConfigs()
-		for i := 0; i < len(configs)-1; i++ {
-			if configs[i].GetPriority() < configs[i+1].GetPriority() {
-				return errors.New("priority values in region_configs must be in descending order")
-			}
-		}
-	}
-	return nil
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -804,6 +804,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyOldSchema(t *testing.T) {
 	})
 }
 
+// TestAccClusterAdvancedCluster_priorityOldSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
@@ -831,6 +832,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 	})
 }
 
+// TestAccClusterAdvancedCluster_priorityNewSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)


### PR DESCRIPTION
## Description

Enforces `priority` descending order in `region_configs` in `mongodbatlas_advanced_cluster`

Link to any related issue(s): CLOUDP-263859

## Type of change: 

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
