### PR TITLE
chore: Uses name of resource policy instead of random value when validating

### DIFF
--- a/internal/service/resourcepolicy/resource.go
+++ b/internal/service/resourcepolicy/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"regexp"
 
@@ -39,17 +38,6 @@ type resourcePolicyRS struct {
 	config.RSCommon
 }
 
-var charSetAlphaNum = []rune("abcdefghijklmnopqrstuvwxyz012346789")
-
-// randPolicyName to workaround for POLICY_CANNOT_CONTAIN_A_DUPLICATE_NAME error until https://jira.mongodb.org/browse/CLOUDP-274990 is resolved.
-func randPolicyName(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = charSetAlphaNum[rand.Intn(len(charSetAlphaNum))] //nolint:gosec // This is not a security-sensitive operation, only to avoid POLICY_CANNOT_CONTAIN_A_DUPLICATE_NAME error
-	}
-	return string(b)
-}
-
 func (r *resourcePolicyRS) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	var policies []TFPolicyModel
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("policies"), &policies)...)
@@ -64,7 +52,7 @@ func (r *resourcePolicyRS) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 	sdkCreate := &admin.ApiAtlasResourcePolicyCreate{
-		Name:     randPolicyName(16),
+		Name:     *name,
 		Policies: sdkPolicies,
 	}
 	connV2 := r.Client.AtlasV2


### PR DESCRIPTION
## Description

API now does not fail with POLICY_CANNOT_CONTAIN_A_DUPLICATE_NAME when using the name of the resource policy. 

Link to any related issue(s): CLOUDP-275416

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
