### PR TITLE
chore: Changes only latest version in SDK update

### DIFF
--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -16,10 +16,20 @@
 
 set -euo pipefail
 
+CURRENT_SDK_RELEASE=$(grep 'go.mongodb.org/atlas-sdk/v' go.mod | 
+											awk '{print $1}' | 
+											sed 's/go.mongodb.org\/atlas-sdk\///' | 
+											sort -V | 
+											tail -n 1)
+echo "CURRENT_SDK_RELEASE: $CURRENT_SDK_RELEASE"
+
 LATEST_SDK_TAG=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name')
+echo "LATEST_SDK_TAG: $LATEST_SDK_TAG"
 
 LATEST_SDK_RELEASE=$(echo "${LATEST_SDK_TAG}" | cut -d '.' -f 1)
-echo  "==> Updating SDK to latest major version ${LATEST_SDK_TAG}"
-gomajor get "go.mongodb.org/atlas-sdk/${LATEST_SDK_RELEASE}@${LATEST_SDK_TAG}"
+echo "LATEST_SDK_RELEASE: $LATEST_SDK_RELEASE"
+echo  "==> Updating SDK ${CURRENT_SDK_RELEASE} to latest major version ${LATEST_SDK_TAG}"
+
+gomajor get --rewrite "go.mongodb.org/atlas-sdk/${CURRENT_SDK_RELEASE}" "go.mongodb.org/atlas-sdk/${LATEST_SDK_RELEASE}@${LATEST_SDK_TAG}"
 go mod tidy
 echo "Done"


### PR DESCRIPTION
## Description

Changes only latest version in SDK update

Link to any related issue(s): CLOUDP-276362

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
