### PR TITLE
chore: Sleeps a few seconds before returning from ProjectIDExecution

### DIFF
--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -49,7 +49,7 @@ func ProjectIDExecution(tb testing.TB) string {
 		tb.Logf("Creating execution project: %s\n", sharedInfo.projectName)
 		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
 	} else {
-		time.Sleep(5 * time.Second) // HELP-65223: sleep a few seconds so clusters are not created concurrently in the execution project
+		time.Sleep(20 * time.Second) // HELP-65223: sleep a few seconds so clusters are not created concurrently in the execution project
 	}
 
 	return sharedInfo.projectID

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +48,8 @@ func ProjectIDExecution(tb testing.TB) string {
 		sharedInfo.projectName = RandomProjectName()
 		tb.Logf("Creating execution project: %s\n", sharedInfo.projectName)
 		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
+	} else {
+		time.Sleep(10 * time.Second) // HELP-65223: sleep a few seconds so clusters are not created concurrently in the execution project
 	}
 
 	return sharedInfo.projectID

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -49,7 +49,7 @@ func ProjectIDExecution(tb testing.TB) string {
 		tb.Logf("Creating execution project: %s\n", sharedInfo.projectName)
 		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
 	} else {
-		time.Sleep(10 * time.Second) // HELP-65223: sleep a few seconds so clusters are not created concurrently in the execution project
+		time.Sleep(5 * time.Second) // HELP-65223: sleep a few seconds so clusters are not created concurrently in the execution project
 	}
 
 	return sharedInfo.projectID


### PR DESCRIPTION
## Description

Sleeps a few seconds before returning from ProjectIDExecution so clusters are not created concurrently in the execution project. See HELP-65223 for more info

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
