### PR TITLE
fix: Support update of usernames in `mongodbatlas_team` resource by ensuring team is never empty

### DIFF
--- a/.changelog/2669.txt
+++ b/.changelog/2669.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_team: Fixes update logic of `usernames` attribute ensuring team is never emptied
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -38,9 +38,6 @@ on:
       mongodb_atlas_teams_ids:
         type: string
         required: true  
-      mongodb_atlas_username:
-        type: string
-        required: true 
       azure_atlas_app_id:
         type: string
         required: true
@@ -503,7 +500,8 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_PROJECT_OWNER_ID: ${{ inputs.mongodb_atlas_project_owner_id }}
-          MONGODB_ATLAS_USERNAME: ${{ inputs.mongodb_atlas_username }}
+          MONGODB_ATLAS_USERNAME: ${{ vars.MONGODB_ATLAS_USERNAME }}
+          MONGODB_ATLAS_USERNAME_2: ${{ vars.MONGODB_ATLAS_USERNAME_2 }}
           AZURE_ATLAS_APP_ID: ${{ inputs.azure_atlas_app_id }}
           AZURE_SERVICE_PRINCIPAL_ID: ${{ inputs.azure_service_principal_id }}
           AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -97,7 +97,6 @@ jobs:
       mongodb_atlas_base_url: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_BASE_URL_QA || vars.MONGODB_ATLAS_BASE_URL }}
       mongodb_atlas_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_PROJECT_OWNER_ID }}
       mongodb_atlas_teams_ids: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_TEAMS_IDS_QA || vars.MONGODB_ATLAS_TEAMS_IDS }}
-      mongodb_atlas_username: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_USERNAME_CLOUD_QA || vars.MONGODB_ATLAS_USERNAME_CLOUD_DEV }}
       azure_atlas_app_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AZURE_ATLAS_APP_ID_QA || vars.AZURE_ATLAS_APP_ID }}
       azure_service_principal_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AZURE_SERVICE_PRINCIPAL_ID_QA || vars.AZURE_SERVICE_PRINCIPAL_ID }}
       azure_tenant_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AZURE_TENANT_ID_QA || vars.AZURE_TENANT_ID }}

--- a/internal/service/team/resource_team_test.go
+++ b/internal/service/team/resource_team_test.go
@@ -65,6 +65,56 @@ func TestAccConfigRSTeam_basic(t *testing.T) {
 	})
 }
 
+func TestAccConfigRSTeam_updatingUsernames(t *testing.T) {
+	var (
+		resourceName          = "mongodbatlas_team.test"
+		orgID                 = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		usernames             = []string{os.Getenv("MONGODB_ATLAS_USERNAME")}
+		updatedSingleUsername = []string{os.Getenv("MONGODB_ATLAS_USERNAME_2")}
+		updatedBothUsername   = []string{os.Getenv("MONGODB_ATLAS_USERNAME"), os.Getenv("MONGODB_ATLAS_USERNAME_2")}
+		name                  = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckAtlasUsernames(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyTeam,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(orgID, name, usernames),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", usernames[0]),
+				),
+			},
+			{
+				Config: configBasic(orgID, name, updatedSingleUsername),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", updatedSingleUsername[0]),
+				),
+			},
+			{
+				Config: configBasic(orgID, name, updatedBothUsername),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", updatedBothUsername[0]),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", updatedBothUsername[1]),
+				),
+			},
+		},
+	})
+}
+
 func TestAccConfigRSTeam_legacyName(t *testing.T) {
 	var (
 		resourceName   = "mongodbatlas_teams.test"

--- a/internal/service/team/resource_team_test.go
+++ b/internal/service/team/resource_team_test.go
@@ -69,9 +69,11 @@ func TestAccConfigRSTeam_updatingUsernames(t *testing.T) {
 	var (
 		resourceName          = "mongodbatlas_team.test"
 		orgID                 = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		usernames             = []string{os.Getenv("MONGODB_ATLAS_USERNAME")}
-		updatedSingleUsername = []string{os.Getenv("MONGODB_ATLAS_USERNAME_2")}
-		updatedBothUsername   = []string{os.Getenv("MONGODB_ATLAS_USERNAME"), os.Getenv("MONGODB_ATLAS_USERNAME_2")}
+		firstUser             = os.Getenv("MONGODB_ATLAS_USERNAME")
+		secondUser            = os.Getenv("MONGODB_ATLAS_USERNAME_2")
+		usernames             = []string{firstUser}
+		updatedSingleUsername = []string{secondUser}
+		updatedBothUsername   = []string{firstUser, secondUser}
 		name                  = acc.RandomName()
 	)
 

--- a/internal/service/team/update_user.go
+++ b/internal/service/team/update_user.go
@@ -58,10 +58,6 @@ func GetChangesForTeamUsers(currentUsers, newUsers []admin.CloudAppUser) (toAdd,
 	currentUsersSet := InitUserSet(currentUsers)
 	newUsersSet := InitUserSet(newUsers)
 
-	// Create two arrays to store the elements to be added and deleted
-	toAdd = []string{}
-	toDelete = []string{}
-
 	// Iterate over the elements in B and add them to the toAdd array if they are not in A
 	for elem := range newUsersSet {
 		if _, ok := currentUsersSet[elem]; !ok {
@@ -76,7 +72,6 @@ func GetChangesForTeamUsers(currentUsers, newUsers []admin.CloudAppUser) (toAdd,
 		}
 	}
 
-	// Return the two arrays
 	return toAdd, toDelete, nil
 }
 

--- a/internal/service/team/update_user.go
+++ b/internal/service/team/update_user.go
@@ -1,0 +1,89 @@
+package team
+
+import (
+	"context"
+
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+)
+
+func UpdateTeamUsers(teamsAPI admin.TeamsApi, usersAPI admin.MongoDBCloudUsersApi, existingTeamUsers *admin.PaginatedApiAppUser, newUsernames []string, orgID, teamID string) error {
+	validNewUsers, err := ValidateUsernames(usersAPI, newUsernames)
+	if err != nil {
+		return err
+	}
+	usersToAdd, usersToRemove, err := GetChangesForTeamUsers(existingTeamUsers.GetResults(), validNewUsers)
+	if err != nil {
+		return err
+	}
+
+	// Avoid leaving the team empty with no users by first making new additions, ensuring no API validation errors
+
+	var userToAddModels []admin.AddUserToTeam
+	for i := range usersToAdd {
+		userToAddModels = append(userToAddModels, admin.AddUserToTeam{Id: usersToAdd[i]})
+	}
+	// save all users to add
+	if len(userToAddModels) > 0 {
+		_, _, err = teamsAPI.AddTeamUser(context.Background(), orgID, teamID, &userToAddModels).Execute()
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := range usersToRemove {
+		// remove user from team
+		_, err := teamsAPI.RemoveTeamUser(context.Background(), orgID, teamID, usersToRemove[i]).Execute()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ValidateUsernames(c admin.MongoDBCloudUsersApi, usernames []string) ([]admin.CloudAppUser, error) {
+	var validUsers []admin.CloudAppUser
+	for _, elem := range usernames {
+		userToAdd, _, err := c.GetUserByUsername(context.Background(), elem).Execute()
+		if err != nil {
+			return nil, err
+		}
+		validUsers = append(validUsers, *userToAdd)
+	}
+	return validUsers, nil
+}
+
+func GetChangesForTeamUsers(currentUsers, newUsers []admin.CloudAppUser) (toAdd, toDelete []string, err error) {
+	// Create two sets to store the elements in A and B
+	currentUsersSet := InitUserSet(currentUsers)
+	newUsersSet := InitUserSet(newUsers)
+
+	// Create two arrays to store the elements to be added and deleted
+	toAdd = []string{}
+	toDelete = []string{}
+
+	// Iterate over the elements in B and add them to the toAdd array if they are not in A
+	for elem := range newUsersSet {
+		if _, ok := currentUsersSet[elem]; !ok {
+			toAdd = append(toAdd, elem)
+		}
+	}
+
+	// Iterate over the elements in A and add them to the toDelete array if they are not in B
+	for elem := range currentUsersSet {
+		if _, ok := newUsersSet[elem]; !ok {
+			toDelete = append(toDelete, elem)
+		}
+	}
+
+	// Return the two arrays
+	return toAdd, toDelete, nil
+}
+
+func InitUserSet(users []admin.CloudAppUser) map[string]interface{} {
+	usersSet := make(map[string]interface{}, len(users))
+	for i := 0; i < len(users); i++ {
+		usersSet[users[i].GetId()] = true
+	}
+	return usersSet
+}

--- a/internal/service/team/update_user_test.go
+++ b/internal/service/team/update_user_test.go
@@ -1,0 +1,161 @@
+package team_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/team"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+	"go.mongodb.org/atlas-sdk/v20240805004/mockadmin"
+)
+
+func TestGetChangesForTeamUsers(t *testing.T) {
+	user1 := "user1"
+	user2 := "user2"
+	user3 := "user3"
+
+	testCases := map[string]struct {
+		testName         string
+		currentUsers     []admin.CloudAppUser
+		newUsers         []admin.CloudAppUser
+		expectedToAdd    []string
+		expectedToDelete []string
+	}{
+		"succeeds adding a new user and removing an existing one": {
+			currentUsers: []admin.CloudAppUser{
+				{Id: &user1},
+				{Id: &user2},
+			},
+			newUsers: []admin.CloudAppUser{
+				{Id: &user1},
+				{Id: &user3},
+			},
+			expectedToAdd:    []string{user3},
+			expectedToDelete: []string{user2},
+		},
+		"succeeds adding all users": {
+			currentUsers: []admin.CloudAppUser{},
+			newUsers: []admin.CloudAppUser{
+				{Id: &user1},
+				{Id: &user2},
+			},
+			expectedToAdd:    []string{user1, user2},
+			expectedToDelete: []string{},
+		},
+		"succeeds removing both users": {
+			currentUsers: []admin.CloudAppUser{
+				{Id: &user1},
+				{Id: &user2},
+			},
+			newUsers:         []admin.CloudAppUser{},
+			expectedToAdd:    []string{},
+			expectedToDelete: []string{user1, user2},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			toAdd, toDelete, err := team.GetChangesForTeamUsers(testCase.currentUsers, testCase.newUsers)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, testCase.expectedToAdd, toAdd)
+			assert.ElementsMatch(t, testCase.expectedToDelete, toDelete)
+		})
+	}
+}
+
+func TestUpdateTeamUsers(t *testing.T) {
+	validuser1 := "validuser1"
+	validuser2 := "validuser2"
+	invaliduser1 := "invaliduser1"
+
+	testCases := map[string]struct {
+		mockFuncExpectations func(*mockadmin.TeamsApi, *mockadmin.MongoDBCloudUsersApi)
+		existingTeamUsers    *admin.PaginatedApiAppUser
+		expectError          require.ErrorAssertionFunc
+		testName             string
+		usernames            []string
+	}{
+		"succeeds but no changes are required": {
+			mockFuncExpectations: func(mockTeamsApi *mockadmin.TeamsApi, mockUsersApi *mockadmin.MongoDBCloudUsersApi) {
+				mockValidUser1 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockValidUser2 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser1).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser1})
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser2).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser2})
+				mockValidUser1.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser1}, nil, nil)
+				mockValidUser2.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser2}, nil, nil)
+			},
+			existingTeamUsers: &admin.PaginatedApiAppUser{Results: &[]admin.CloudAppUser{{Id: &validuser1}, {Id: &validuser2}}},
+			usernames:         []string{validuser1, validuser2},
+			expectError:       require.NoError,
+		},
+		"fails because one user is invalid": {
+			mockFuncExpectations: func(mockTeamsApi *mockadmin.TeamsApi, mockUsersApi *mockadmin.MongoDBCloudUsersApi) {
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, invaliduser1).Return(admin.GetUserByUsernameApiRequest{ApiService: mockUsersApi})
+				mockUsersApi.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(nil, nil, errors.New("invalid username"))
+			},
+			existingTeamUsers: nil,
+			usernames:         []string{invaliduser1},
+			expectError:       require.Error,
+		},
+		"succeeds with one user to be added": {
+			mockFuncExpectations: func(mockTeamsApi *mockadmin.TeamsApi, mockUsersApi *mockadmin.MongoDBCloudUsersApi) {
+				mockValidUser1 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockValidUser2 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser1).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser1})
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser2).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser2})
+				mockValidUser1.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser1}, nil, nil)
+				mockValidUser2.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser2}, nil, nil)
+
+				mockTeamsApi.EXPECT().AddTeamUser(mock.Anything, mock.Anything, mock.Anything, &[]admin.AddUserToTeam{{Id: validuser2}}).Return(admin.AddTeamUserApiRequest{ApiService: mockTeamsApi})
+				mockTeamsApi.EXPECT().AddTeamUserExecute(mock.Anything).Return(nil, nil, nil)
+			},
+			existingTeamUsers: &admin.PaginatedApiAppUser{Results: &[]admin.CloudAppUser{{Id: &validuser1}}},
+			usernames:         []string{validuser1, validuser2},
+			expectError:       require.NoError,
+		},
+		"succeeds with one user to be removed": {
+			mockFuncExpectations: func(mockTeamsApi *mockadmin.TeamsApi, mockUsersApi *mockadmin.MongoDBCloudUsersApi) {
+				mockValidUser2 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser2).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser2})
+				mockValidUser2.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser2}, nil, nil)
+
+				mockTeamsApi.EXPECT().RemoveTeamUser(mock.Anything, mock.Anything, mock.Anything, validuser1).Return(admin.RemoveTeamUserApiRequest{ApiService: mockTeamsApi})
+				mockTeamsApi.EXPECT().RemoveTeamUserExecute(mock.Anything).Return(nil, nil)
+			},
+			existingTeamUsers: &admin.PaginatedApiAppUser{Results: &[]admin.CloudAppUser{{Id: &validuser1}, {Id: &validuser2}}},
+			usernames:         []string{validuser2},
+			expectError:       require.NoError,
+		},
+		"succeeds with one user to be added and the other removed": {
+			mockFuncExpectations: func(mockTeamsApi *mockadmin.TeamsApi, mockUsersApi *mockadmin.MongoDBCloudUsersApi) {
+				mockValidUser2 := mockadmin.NewMongoDBCloudUsersApi(t)
+				mockUsersApi.EXPECT().GetUserByUsername(mock.Anything, validuser1).Return(admin.GetUserByUsernameApiRequest{ApiService: mockValidUser2})
+				mockValidUser2.EXPECT().GetUserByUsernameExecute(mock.Anything).Return(&admin.CloudAppUser{Id: &validuser1}, nil, nil)
+
+				addCall := mockTeamsApi.EXPECT().AddTeamUser(mock.Anything, mock.Anything, mock.Anything, &[]admin.AddUserToTeam{{Id: validuser1}}).Return(admin.AddTeamUserApiRequest{ApiService: mockTeamsApi})
+				mockTeamsApi.EXPECT().AddTeamUserExecute(mock.Anything).Return(nil, nil, nil)
+
+				removeCall := mockTeamsApi.EXPECT().RemoveTeamUser(mock.Anything, mock.Anything, mock.Anything, validuser2).Return(admin.RemoveTeamUserApiRequest{ApiService: mockTeamsApi})
+				removeCall.NotBefore(addCall.Call) // Ensures new additions are made before removing
+				mockTeamsApi.EXPECT().RemoveTeamUserExecute(mock.Anything).Return(nil, nil)
+
+				
+			},
+			existingTeamUsers: &admin.PaginatedApiAppUser{Results: &[]admin.CloudAppUser{{Id: &validuser2}}},
+			usernames:         []string{validuser1},
+			expectError:       require.NoError,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			mockTeamsAPI := mockadmin.NewTeamsApi(t)
+			mockUsersAPI := mockadmin.NewMongoDBCloudUsersApi(t)
+			testCase.mockFuncExpectations(mockTeamsAPI, mockUsersAPI)
+			testCase.expectError(t, team.UpdateTeamUsers(mockTeamsAPI, mockUsersAPI, testCase.existingTeamUsers, testCase.usernames, "orgID", "teamID"))
+		})
+	}
+}

--- a/internal/service/team/update_user_test.go
+++ b/internal/service/team/update_user_test.go
@@ -141,8 +141,6 @@ func TestUpdateTeamUsers(t *testing.T) {
 				removeCall := mockTeamsApi.EXPECT().RemoveTeamUser(mock.Anything, mock.Anything, mock.Anything, validuser2).Return(admin.RemoveTeamUserApiRequest{ApiService: mockTeamsApi})
 				removeCall.NotBefore(addCall.Call) // Ensures new additions are made before removing
 				mockTeamsApi.EXPECT().RemoveTeamUserExecute(mock.Anything).Return(nil, nil)
-
-				
 			},
 			existingTeamUsers: &admin.PaginatedApiAppUser{Results: &[]admin.CloudAppUser{{Id: &validuser2}}},
 			usernames:         []string{validuser1},

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -82,6 +82,14 @@ func PreCheckAtlasUsername(tb testing.TB) {
 	}
 }
 
+func PreCheckAtlasUsernames(tb testing.TB) {
+	tb.Helper()
+	PreCheckAtlasUsername(tb)
+	if os.Getenv("MONGODB_ATLAS_USERNAME_2") == "" {
+		tb.Fatal("`MONGODB_ATLAS_USERNAME_2` must be set")
+	}
+}
+
 func PreCheckProjectTeamsIDsWithMinCount(tb testing.TB, minTeamsCount int) {
 	tb.Helper()
 	envVar := os.Getenv("MONGODB_ATLAS_TEAMS_IDS")


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-277323 (https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2662), HELP-65735

**Context**: A new validation has been added in the API which verifies a team is never empty. Our existing logic for updating the `usernames` attribute removed all users and then added the new ones, but this now fails before removing the last user.

**Solution**: Logic is very similar to [CFN implementation](https://github.com/mongodb/mongodbatlas-cloudformation-resources/blob/master/cfn-resources/teams/cmd/resource/team-user/team_user.go#L26), which only add and removes the changed users. Some adjustments where made:
- ensures that additions are done before removals, if all usernames are different the team will not be empty at any point.
- for unit testing mocking is done directly with SDK mocks and no intermediate service interface.

Both of these adjustments will need to be moved to CFN, and also brings the question of how we could have this common code in a single repository and avoid duplicating logic/testing in both places.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
