### PR TITLE
chore: Removes deprecation warnings for `labels` in cluster/adv_cluster

### DIFF
--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -124,8 +124,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
 Key-value pairs that categorize the cluster. Each key and value has a maximum length of 255 characters.  You cannot set the key `Infrastructure Tool`, it is used for internal purposes to track aggregate usage.
 
 * `key` - The key that you want to write.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -126,8 +126,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
 Key-value pairs that categorize the cluster. Each key and value has a maximum length of 255 characters.  You cannot set the key `Infrastructure Tool`, it is used for internal purposes to track aggregate usage.
 
 * `key` - The key that you want to write.

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -168,8 +168,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### Labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
 Key-value pairs that categorize the cluster. Each key and value has a maximum length of 255 characters.  You cannot set the key `Infrastructure Tool`, it is used for internal purposes to track aggregate usage.
 
 * `key` - The key that you want to write.

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -159,8 +159,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### Labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
 Key-value pairs that categorize the cluster. Each key and value has a maximum length of 255 characters.  You cannot set the key `Infrastructure Tool`, it is used for internal purposes to track aggregate usage.
 
 * `key` - The key that you want to write.

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -483,8 +483,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
  ```terraform
  labels {
         key   = "Key 1"

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -522,8 +522,6 @@ To learn more, see [Resource Tags](https://dochub.mongodb.org/core/add-cluster-t
 
 ### Labels
 
-**WARNING:** This property is deprecated and will be removed in the future, use the `tags` attribute instead.
-
  ```terraform
  labels {
         key   = "Key 1"

--- a/internal/service/advancedcluster/data_source_advanced_cluster.go
+++ b/internal/service/advancedcluster/data_source_advanced_cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -68,9 +67,8 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"labels": {
-				Type:       schema.TypeSet,
-				Computed:   true,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+				Type:     schema.TypeSet,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {

--- a/internal/service/advancedcluster/data_source_advanced_clusters.go
+++ b/internal/service/advancedcluster/data_source_advanced_clusters.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -81,9 +80,8 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"labels": {
-							Type:       schema.TypeSet,
-							Computed:   true,
-							Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+							Type:     schema.TypeSet,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -123,10 +123,9 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"labels": {
-				Type:       schema.TypeSet,
-				Optional:   true,
-				Set:        HashFunctionForKeyValuePair,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      HashFunctionForKeyValuePair,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {

--- a/internal/service/cluster/data_source_cluster.go
+++ b/internal/service/cluster/data_source_cluster.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -287,9 +286,8 @@ func DataSource() *schema.Resource {
 				Computed: true,
 			},
 			"labels": {
-				Type:       schema.TypeSet,
-				Computed:   true,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+				Type:     schema.TypeSet,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {

--- a/internal/service/cluster/data_source_clusters.go
+++ b/internal/service/cluster/data_source_clusters.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	matlas "go.mongodb.org/atlas/mongodbatlas"
@@ -290,9 +289,8 @@ func PluralDataSource() *schema.Resource {
 							Computed: true,
 						},
 						"labels": {
-							Type:       schema.TypeSet,
-							Computed:   true,
-							Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+							Type:     schema.TypeSet,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"key": {

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spf13/cast"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -311,10 +310,9 @@ func Resource() *schema.Resource {
 			},
 			"advanced_configuration": advancedcluster.SchemaAdvancedConfig(),
 			"labels": {
-				Type:       schema.TypeSet,
-				Optional:   true,
-				Set:        advancedcluster.HashFunctionForKeyValuePair,
-				Deprecated: fmt.Sprintf(constant.DeprecationParamFutureWithReplacement, "tags"),
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      advancedcluster.HashFunctionForKeyValuePair,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {


### PR DESCRIPTION
## Description

Removes deprecation warnings for `labels` in cluster/adv_cluster

Link to any related issue(s): CLOUDP-273888

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
