### PR TITLE
fix: Avoids setting organization id to empty when the USER_IS_NOT_FOUND

### DIFF
--- a/.changelog/2684.txt
+++ b/.changelog/2684.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_organization: Avoids provider produced inconsistent result when `USER_NOT_FOUND`
+```

--- a/.changelog/2684.txt
+++ b/.changelog/2684.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_organization: Avoids provider produced inconsistent result when `USER_NOT_FOUND`
+resource/mongodbatlas_organization: Avoids inconsistent result returned by provider when `USER_NOT_FOUND`
 ```

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"go.mongodb.org/atlas-sdk/v20240805004/admin"
 
@@ -88,7 +89,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 	organization, resp, err := conn.OrganizationsApi.CreateOrganization(ctx, newCreateOrganizationRequest(d)).Execute()
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound && !strings.Contains(err.Error(), "USER_NOT_FOUND") {
 			d.SetId("")
 			return nil
 		}

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -89,7 +89,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 	organization, resp, err := conn.OrganizationsApi.CreateOrganization(ctx, newCreateOrganizationRequest(d)).Execute()
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound && !strings.Contains(err.Error(), "USER_NOT_FOUND") {
+		if resp.StatusCode == http.StatusNotFound && !strings.Contains(err.Error(), "USER_NOT_FOUND") {
 			d.SetId("")
 			return nil
 		}

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -148,7 +148,7 @@ func TestAccOrganizationCreate_Errors(t *testing.T) {
 		roleName    = "ORG_OWNER"
 		unknownUser = "65def6160f722a1507105aaa"
 	)
-	acc.SkipTestForCI(t) // affects the org
+	acc.SkipTestForCI(t) // test will fail in CI since API_KEY_MUST_BE_ASSOCIATED_WITH_PAYING_ORG is returned
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheck(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -143,6 +143,24 @@ func TestAccConfigRSOrganization_Settings(t *testing.T) {
 	})
 }
 
+func TestAccOrganizationCreate_Errors(t *testing.T) {
+	var (
+		roleName    = "ORG_OWNER"
+		unknownUser = "65def6160f722a1507105aaa"
+	)
+	acc.SkipTestForCI(t) // affects the org
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      configBasic(unknownUser, acc.RandomName(), "should fail since user is not found", roleName),
+				ExpectError: regexp.MustCompile(`USER_NOT_FOUND`),
+			},
+		},
+	})
+}
+
 func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]


### PR DESCRIPTION
## Description

Avoids provider produced inconsistent result when `USER_NOT_FOUND`

Link to any related issue(s): CLOUDP-270746

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
