### PR TITLE
fix: Fixes inconsistent result when using a multi-region cluster by always using a single spec

### DIFF
--- a/.changelog/2685.txt
+++ b/.changelog/2685.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_search_deployment: Fixes inconsistent result when using a multi-region cluster by always using a single spec
+```

--- a/.changelog/2685.txt
+++ b/.changelog/2685.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_search_deployment: Fixes inconsistent result when using a multi-region cluster by always using a single spec
+resource/mongodbatlas_search_deployment: Fixes inconsistent result for a multi-region cluster that always uses a single spec.
 ```

--- a/internal/service/searchdeployment/data_source_search_deployment.go
+++ b/internal/service/searchdeployment/data_source_search_deployment.go
@@ -44,7 +44,7 @@ func (d *searchDeploymentDS) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	newSearchDeploymentModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, nil)
+	newSearchDeploymentModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, nil, 0)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/searchdeployment/data_source_search_deployment.go
+++ b/internal/service/searchdeployment/data_source_search_deployment.go
@@ -44,7 +44,7 @@ func (d *searchDeploymentDS) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	newSearchDeploymentModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, nil, 0)
+	newSearchDeploymentModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, nil, true)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/searchdeployment/model_search_deployment_test.go
+++ b/internal/service/searchdeployment/model_search_deployment_test.go
@@ -55,7 +55,7 @@ func TestSearchDeploymentSDKToTFModel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resultModel, diags := searchdeployment.NewTFSearchDeployment(context.Background(), tc.clusterName, tc.SDKResp, nil, 0)
+			resultModel, diags := searchdeployment.NewTFSearchDeployment(context.Background(), tc.clusterName, tc.SDKResp, nil, false)
 			if diags.HasError() {
 				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/searchdeployment/model_search_deployment_test.go
+++ b/internal/service/searchdeployment/model_search_deployment_test.go
@@ -55,7 +55,7 @@ func TestSearchDeploymentSDKToTFModel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resultModel, diags := searchdeployment.NewTFSearchDeployment(context.Background(), tc.clusterName, tc.SDKResp, nil)
+			resultModel, diags := searchdeployment.NewTFSearchDeployment(context.Background(), tc.clusterName, tc.SDKResp, nil, 0)
 			if diags.HasError() {
 				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/searchdeployment/resource_search_deployment.go
+++ b/internal/service/searchdeployment/resource_search_deployment.go
@@ -37,14 +37,14 @@ func (r *searchDeploymentRS) Schema(ctx context.Context, req resource.SchemaRequ
 }
 
 const defaultSearchNodeTimeout time.Duration = 3 * time.Hour
-const minTimeoutCreateUpdate time.Duration = 1 * time.Minute
+const minTimeoutCreateUpdate time.Duration = 30 * time.Second
 const minTimeoutDelete time.Duration = 30 * time.Second
 
 func retryTimeConfig(configuredTimeout, minTimeout time.Duration) retrystrategy.TimeConfig {
 	return retrystrategy.TimeConfig{
 		Timeout:    configuredTimeout,
 		MinTimeout: minTimeout,
-		Delay:      1 * time.Minute,
+		Delay:      30 * time.Second,
 	}
 }
 
@@ -75,7 +75,7 @@ func (r *searchDeploymentRS) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("error during search deployment creation", err.Error())
 		return
 	}
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts)
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, len(searchDeploymentReq.GetSpecs()))
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -103,7 +103,7 @@ func (r *searchDeploymentRS) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts)
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, 0)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -138,7 +138,7 @@ func (r *searchDeploymentRS) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.AddError("error during search deployment update", err.Error())
 		return
 	}
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts)
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, len(searchDeploymentReq.GetSpecs()))
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/searchdeployment/resource_search_deployment.go
+++ b/internal/service/searchdeployment/resource_search_deployment.go
@@ -75,7 +75,7 @@ func (r *searchDeploymentRS) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("error during search deployment creation", err.Error())
 		return
 	}
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, len(searchDeploymentReq.GetSpecs()))
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, false)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -103,7 +103,7 @@ func (r *searchDeploymentRS) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, 0)
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, false)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -138,7 +138,7 @@ func (r *searchDeploymentRS) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.AddError("error during search deployment update", err.Error())
 		return
 	}
-	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, len(searchDeploymentReq.GetSpecs()))
+	newSearchNodeModel, diagnostics := NewTFSearchDeployment(ctx, clusterName, deploymentResp, &searchDeploymentPlan.Timeouts, false)
 	resp.Diagnostics.Append(diagnostics...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/service/searchdeployment/resource_search_deployment.go
+++ b/internal/service/searchdeployment/resource_search_deployment.go
@@ -37,14 +37,14 @@ func (r *searchDeploymentRS) Schema(ctx context.Context, req resource.SchemaRequ
 }
 
 const defaultSearchNodeTimeout time.Duration = 3 * time.Hour
-const minTimeoutCreateUpdate time.Duration = 30 * time.Second
+const minTimeoutCreateUpdate time.Duration = 1 * time.Minute
 const minTimeoutDelete time.Duration = 30 * time.Second
 
 func retryTimeConfig(configuredTimeout, minTimeout time.Duration) retrystrategy.TimeConfig {
 	return retrystrategy.TimeConfig{
 		Timeout:    configuredTimeout,
 		MinTimeout: minTimeout,
-		Delay:      30 * time.Second,
+		Delay:      1 * time.Minute,
 	}
 }
 

--- a/internal/service/searchdeployment/resource_search_deployment_test.go
+++ b/internal/service/searchdeployment/resource_search_deployment_test.go
@@ -11,24 +11,28 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
+const (
+	resourceID   = "mongodbatlas_search_deployment.test"
+	dataSourceID = "data.mongodbatlas_search_deployment.test"
+)
+
 func TestAccSearchDeployment_basic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_search_deployment.test"
-		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName  = acc.RandomProjectName()
-		clusterName  = acc.RandomClusterName()
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
-			newSearchNodeTestStep(resourceName, orgID, projectName, clusterName, "S20_HIGHCPU_NVME", 3),
-			newSearchNodeTestStep(resourceName, orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
+			newSearchNodeTestStep(resourceID, orgID, projectName, clusterName, "S20_HIGHCPU_NVME", 3),
+			newSearchNodeTestStep(resourceID, orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
 			{
 				Config:            configBasic(orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ResourceName:      resourceID,
+				ImportStateIdFunc: importStateIDFunc(resourceID),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -36,9 +40,39 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 	})
 }
 
+func TestAccSearchDeployment_multiRegion(t *testing.T) {
+	var (
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			ClusterName: "multi-region-cluster",
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{
+					Region: "US_EAST_1",
+					ExtraRegionConfigs: []acc.ReplicationSpecRequest{
+						{Region: "US_WEST_2", Priority: 6, InstanceSize: "M10", NodeCount: 2},
+					},
+				},
+			},
+		})
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: clusterInfo.TerraformStr + configSearchDeployment(clusterInfo.ProjectID, clusterInfo.TerraformNameRef, "M10", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceID),
+					resource.TestCheckResourceAttr(resourceID, "specs.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func newSearchNodeTestStep(resourceName, orgID, projectName, clusterName, instanceSize string, searchNodeCount int) resource.TestStep {
 	resourceChecks := searchNodeChecks(resourceName, clusterName, instanceSize, searchNodeCount)
-	dataSourceChecks := searchNodeChecks(fmt.Sprintf("data.%s", resourceName), clusterName, instanceSize, searchNodeCount)
+	dataSourceChecks := searchNodeChecks(dataSourceID, clusterName, instanceSize, searchNodeCount)
 	return resource.TestStep{
 		Config: configBasic(orgID, projectName, clusterName, instanceSize, searchNodeCount),
 		Check:  resource.ComposeAggregateTestCheckFunc(append(resourceChecks, dataSourceChecks...)...),
@@ -78,6 +112,21 @@ func configBasic(orgID, projectName, clusterName, instanceSize string, searchNod
 			cluster_name = mongodbatlas_search_deployment.test.cluster_name
 		}
 	`, clusterConfig, instanceSize, searchNodeCount)
+}
+
+func configSearchDeployment(projectID, clusterNameRef, instanceSize string, searchNodeCount int) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_search_deployment" "test" {
+		project_id = %[1]q
+		cluster_name = %[2]s
+		specs = [
+			{
+				instance_size = %[3]q
+				node_count = %[4]d
+			}
+		]
+	}
+	`, projectID, clusterNameRef, instanceSize, searchNodeCount)
 }
 
 func advancedClusterConfig(orgID, projectName, clusterName string) string {

--- a/internal/service/searchdeployment/resource_search_deployment_test.go
+++ b/internal/service/searchdeployment/resource_search_deployment_test.go
@@ -60,7 +60,7 @@ func TestAccSearchDeployment_multiRegion(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: clusterInfo.TerraformStr + configSearchDeployment(clusterInfo.ProjectID, clusterInfo.TerraformNameRef, "M10", 2),
+				Config: clusterInfo.TerraformStr + configSearchDeployment(clusterInfo.ProjectID, clusterInfo.TerraformNameRef, "S20_HIGHCPU_NVME", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceID),
 					resource.TestCheckResourceAttr(resourceID, "specs.#", "1"),


### PR DESCRIPTION
## Description

Fixes inconsistent result when using a multi-region cluster by always using a single spec

Link to any related issue(s): CLOUDP-274519 #2612 

Please see further comments section below for problem/solution details

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
In the API Spec we have:
```yaml
ApiSearchDeploymentRequest:
    type: object
    properties:
    specs:
        type: array
        description: List of settings that configure the Search Nodes for your cluster.
        items:
        $ref: "#/components/schemas/ApiSearchDeploymentSpec"
        maxItems: 1 # notice the validation
        minItems: 1 # notice the validation
    required:
    - specs
ApiSearchDeploymentResponse:
    type: object
    properties:
    specs:
        type: array
        description: List of settings that configure the Search Nodes for your cluster.
        items:
        $ref: "#/components/schemas/ApiSearchDeploymentSpec"
        readOnly: true
```
- The bug happens since the response returns multiple items in `specs`
- According to [IPA 111](https://docs.devprod.prod.corp.mongodb.com/ipa/111) there should be a single owner. Therefore, it is unexpected that backend returns multiple items.
- Is it worth raising this issue to upstream?
- e0e0149 shows how multiple specs could be supported in the config but since we already use the validation of 1 item in `specs` I prefer the solution in 5332ce6

### From the Docs
From the [Multi-Region and Multi-Cloud Clusters documentation.](https://www.mongodb.com/docs/atlas/cluster-config/multi-cloud-distribution/#std-label-multi-region-search-nodes)
- Atlas deploys the same number of Search Nodes in each region.
- All nodes across regions have the same search tier.