### PR TITLE
fix: Ensures event_trigger `disabled` is included in the PUT payload

### DIFF
--- a/.changelog/2690.txt
+++ b/.changelog/2690.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_event_trigger: Ensures `disabled` is included in the PUT payload: 
+resource/mongodbatlas_event_trigger: Always includes `disabled` in the PUT payload
 ```

--- a/.changelog/2690.txt
+++ b/.changelog/2690.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_event_trigger: Ensures `disabled` is included in the PUT payload: 
+```

--- a/internal/service/eventtrigger/resource_event_trigger.go
+++ b/internal/service/eventtrigger/resource_event_trigger.go
@@ -402,7 +402,6 @@ func resourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceMongoDBAtlasEventTriggersUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	// Get the client connection.
 	conn, err := meta.(*config.MongoDBClient).GetRealmClient(ctx)
 	if err != nil {
 		return diag.FromErr(err)
@@ -418,12 +417,10 @@ func resourceMongoDBAtlasEventTriggersUpdate(ctx context.Context, d *schema.Reso
 		Name:       d.Get("name").(string),
 		Type:       typeTrigger,
 		FunctionID: d.Get("function_id").(string),
+		Disabled:   conversion.Pointer(d.Get("disabled").(bool)),
 	}
 	eventTriggerConfig := &realm.EventTriggerConfig{}
 
-	if d.HasChange("disabled") {
-		eventReq.Disabled = conversion.Pointer(d.Get("disabled").(bool))
-	}
 	if typeTrigger == "DATABASE" {
 		eventTriggerConfig.OperationTypes = cast.ToStringSlice(d.Get("config_operation_types"))
 		eventTriggerConfig.Database = d.Get("config_database").(string)

--- a/internal/service/eventtrigger/resource_event_trigger_test.go
+++ b/internal/service/eventtrigger/resource_event_trigger_test.go
@@ -26,7 +26,7 @@ func TestAccEventTrigger_basic(t *testing.T) {
 		Name:       acc.RandomName(),
 		Type:       "DATABASE",
 		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
-		Disabled:   conversion.Pointer(false),
+		Disabled:   conversion.Pointer(true),
 		Config: &realm.EventTriggerConfig{
 			OperationTypes: []string{"INSERT", "UPDATE"},
 			Database:       "sample_airbnb",
@@ -58,7 +58,7 @@ func TestAccEventTrigger_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
 				),
 			},
 			{

--- a/internal/service/eventtrigger/resource_event_trigger_test.go
+++ b/internal/service/eventtrigger/resource_event_trigger_test.go
@@ -39,7 +39,7 @@ func TestAccEventTrigger_basic(t *testing.T) {
 		Name:       acc.RandomName(),
 		Type:       "DATABASE",
 		FunctionID: os.Getenv("MONGODB_REALM_FUNCTION_ID"),
-		Disabled:   conversion.Pointer(false),
+		Disabled:   conversion.Pointer(true),
 		Config: &realm.EventTriggerConfig{
 			OperationTypes: []string{"INSERT", "UPDATE", "DELETE"},
 			Database:       "sample_airbnb",
@@ -58,6 +58,7 @@ func TestAccEventTrigger_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
 				),
 			},
 			{
@@ -65,6 +66,7 @@ func TestAccEventTrigger_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
 				),
 			},
 			{


### PR DESCRIPTION
## Description

Ensures event_trigger `disabled` is included in the PUT payload

Link to any related issue(s): CLOUDP-266602

Example run of test without fix:
```
Step 2/3 error: After applying this test step, the refresh plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # mongodbatlas_event_trigger.test will be updated in-place
          ~ resource "mongodbatlas_event_trigger" "test" {
              ~ disabled                    = false -> true
                id                          = "YXBwX2lk:NjcwZTM2ZjA0NjRkMDdjODhiMjc5Nzky-cHJvamVjdF9pZA==:NjY0NjE5ZDg3MGMyNDcyMzdmNGI4NmE2-dHJpZ2dlcl9pZA==:NjcwZTZhOTU0NjRkMDdjODhiMjg5ODVm"
                name                        = "test-acc-tf-3015544499451252308"
                # (19 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```

All tests passed.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
