### PR TITLE
chore: Sleeps first time only in tests

### DIFF
--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -85,7 +85,7 @@ func ClusterNameExecution(tb testing.TB) (projectID, clusterName string) {
 	return sharedInfo.projectID, sharedInfo.clusterName
 }
 
-// SerialSleep waits a few seconds so clusters are not created concurrently in the execution project, see HELP-65223.
+// SerialSleep waits a few seconds the first time so the first cluster in a project is not created concurrently, see HELP-65223.
 // This must be called once the test is marked as parallel, e.g. in PreCheck inside Terraform tests.
 func SerialSleep(tb testing.TB) {
 	tb.Helper()
@@ -94,14 +94,20 @@ func SerialSleep(tb testing.TB) {
 
 	sharedInfo.muSleep.Lock()
 	defer sharedInfo.muSleep.Unlock()
-	time.Sleep(10 * time.Second)
+
+	if sharedInfo.alreadySlept {
+		return
+	}
+	time.Sleep(5 * time.Second)
+	sharedInfo.alreadySlept = true
 }
 
 var sharedInfo = struct {
-	projectID   string
-	projectName string
-	clusterName string
-	mu          sync.Mutex
-	muSleep     sync.Mutex
-	init        bool
+	projectID    string
+	projectName  string
+	clusterName  string
+	mu           sync.Mutex
+	muSleep      sync.Mutex
+	alreadySlept bool
+	init         bool
 }{}


### PR DESCRIPTION
## Description

Sleeps first time only in tests, more info in HELP-65223

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
