### PR TITLE
chore: Uses `qa` for TestSuite on Sundays

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,7 +33,9 @@ on:
         default: true
 
   schedule:
-    - cron: "0 0 2-31 * *" # workflow runs every day at midnight UTC except on the first day of the month
+    # https://crontab.guru/#0_0_2-31_*_0
+    - cron: "0 0 2-31 * 1-6" # workflow runs at 00:00 on every day-of-month from 2 through 31 and on every day-of-week from Monday through Saturday.
+    - cron: "0 0 2-31 * 0" # workflow runs at 00:00 on every day-of-month from 2 through 31 and on Sunday.
    
 concurrency:
   group: '${{ github.workflow }}'
@@ -71,7 +73,7 @@ jobs:
     with:
       terraform_version: ${{ matrix.terraform_version }}
       provider_version: ${{ matrix.provider_version }}
-      atlas_cloud_env: ${{ inputs.atlas_cloud_env }}
+      atlas_cloud_env: ${{ inputs.atlas_cloud_env || github.event.schedule == '0 0 2-31 * 0' && 'qa' || 'dev' }}
 
   clean-after:
     needs: tests


### PR DESCRIPTION
## Description

Uses `qa` for TestSuite on Sundays

Link to any related issue(s): CLOUDP-269325

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
Created a [repo](https://github.com/EspenAlbert/schedule-test) to validate this works.
Workflow file:
```yaml
name: 'Test Suite'

on:
  workflow_dispatch:
    inputs:
      atlas_cloud_env:
        description: 'Atlas cloud environment used, can be either `dev` or `qa`, empty for `dev`'     
        type: string
        required: false
  workflow_call:
    inputs:
      atlas_cloud_env:
        description: 'Atlas cloud environment used, can be either `dev` or `qa`, empty for `dev`'     
        type: string
        required: false
  schedule:
    # https://crontab.guru/#0_0_2-31_*_0
    - cron: "9,14,19,24,29 * * * *" # expecting qa
    - cron: "5,10,15,20,25 * 2-31 * 1-6" # expecting dev
   

jobs:
  tests:
    runs-on: ubuntu-latest
    name: tests-output-of-atlas-cloud-env
    env:
      atlas_cloud_env: ${{ inputs.atlas_cloud_env || github.event.schedule == '9,14,19,24,29 * * * *' && 'qa' || 'dev' }}
    steps:
      - run: |
          echo $atlas_cloud_env
          echo ${{ github.event.schedule }}
```
### QA Screenshot
<img width="299" alt="image" src="https://github.com/user-attachments/assets/f4c19451-9aca-421e-832f-b0a1448a49bd">

### Dev Screenshot
<img width="312" alt="image" src="https://github.com/user-attachments/assets/201bd361-d95b-4c71-bf88-6112297d2b13">
