### PR TITLE
chore: PoC - Define make command to call code generation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ vendor/
 *.winfile eol=crlf
 /.vs
 node_modules
+
+#used for schema code generation but is not commited to avoid constant updates
+tools/codegen/open-api-spec.yml

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -155,5 +155,5 @@ jira-release-version:
 	go run ./tools/jira-release-version/*.go
 
 .PHONY: generate-schema
-generate-schema:
+generate-schema: # resource_name is optional, if not provided all configured resources will be generated
 	@go run ./tools/codegen/main.go $(resource_name)

--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/openapi"
 )
 
-func ToCodeSpecModel(atlasAdminAPISpecFilePath, configPath string, resourceName string) (*Model, error) {
+func ToCodeSpecModel(atlasAdminAPISpecFilePath, configPath string, resourceName SnakeCaseString) (*Model, error) {
 	apiSpec, err := openapi.ParseAtlasAdminAPI(atlasAdminAPISpecFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse Atlas Admin API: %v", err)
@@ -27,18 +27,18 @@ func ToCodeSpecModel(atlasAdminAPISpecFilePath, configPath string, resourceName 
 	}
 
 	// find resource operations, schemas, etc from OAS
-	oasResource, err := getAPISpecResource(apiSpec.Model, config.Resources[resourceName], resourceName)
+	oasResource, err := getAPISpecResource(apiSpec.Model, config.Resources[resourceName.SnakeCase()], resourceName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get APISpecResource schema: %v", err)
 	}
 
 	// map OAS resource model to CodeSpecModel
-	codeSpecResource := apiSpecResourceToCodeSpecModel(oasResource, config.Resources[resourceName], resourceName)
+	codeSpecResource := apiSpecResourceToCodeSpecModel(oasResource, config.Resources[resourceName.SnakeCase()], resourceName)
 
 	return &Model{Resources: []Resource{*codeSpecResource}}, nil
 }
 
-func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig config.Resource, name string) *Resource {
+func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig config.Resource, name SnakeCaseString) *Resource {
 	createOp := oasResource.CreateOp
 	readOp := oasResource.ReadOp
 
@@ -126,7 +126,7 @@ func opResponseToAttributes(op *high.Operation) Attributes {
 	return responseAttributes
 }
 
-func getAPISpecResource(spec high.Document, resourceConfig config.Resource, name string) (APISpecResource, error) {
+func getAPISpecResource(spec high.Document, resourceConfig config.Resource, name SnakeCaseString) (APISpecResource, error) {
 	var errResult error
 	var resourceDeprecationMsg *string
 

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -98,7 +98,7 @@ func TestConvertToProviderSpec(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, tc.inputResourceName)
+			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, codespec.SnakeCaseString(tc.inputResourceName))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 		})
@@ -269,7 +269,7 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, tc.inputResourceName)
+			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, codespec.SnakeCaseString(tc.inputResourceName))
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 		})

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -98,7 +98,7 @@ func TestConvertToProviderSpec(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, codespec.SnakeCaseString(tc.inputResourceName))
+			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, &tc.inputResourceName)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 		})
@@ -269,7 +269,7 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, codespec.SnakeCaseString(tc.inputResourceName))
+			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, &tc.inputResourceName)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 		})

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -348,7 +348,7 @@ func TestConvertToProviderSpec_nested_schemaOverrides(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, tc.inputResourceName)
+			result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, &tc.inputResourceName)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, result, "Expected result to match the specified structure")
 		})

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -65,7 +65,7 @@ func applyAlias(attr *Attribute, attrPathName *string, schemaOptions config.Sche
 			parts[i] = newName
 
 			if i == len(parts)-1 {
-				attr.Name = AttributeName(newName)
+				attr.Name = SnakeCaseString(newName)
 			}
 		}
 	}

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -1,7 +1,5 @@
 package codespec
 
-import "strings"
-
 type ElemType int
 
 const (
@@ -19,7 +17,7 @@ type Model struct {
 
 type Resource struct {
 	Schema *Schema
-	Name   string
+	Name   SnakeCaseString
 }
 
 type Schema struct {
@@ -48,27 +46,10 @@ type Attribute struct {
 	SingleNested *SingleNestedAttribute
 
 	Description              *string
-	Name                     AttributeName
+	Name                     SnakeCaseString
 	DeprecationMessage       *string
 	Sensitive                *bool
 	ComputedOptionalRequired ComputedOptionalRequired
-}
-
-type AttributeName string // stored in snake case
-
-func (snake AttributeName) SnakeCase() string {
-	return string(snake)
-}
-
-func (snake AttributeName) PascalCase() string {
-	words := strings.Split(string(snake), "_")
-	var pascalCase string
-	for i := range words {
-		if words[i] != "" {
-			pascalCase += strings.ToUpper(string(words[i][0])) + strings.ToLower(words[i][1:])
-		}
-	}
-	return pascalCase
 }
 
 type BoolAttribute struct {

--- a/tools/codegen/codespec/string_case.go
+++ b/tools/codegen/codespec/string_case.go
@@ -2,6 +2,8 @@ package codespec
 
 import (
 	"strings"
+
+	"github.com/huandu/xstrings"
 )
 
 type SnakeCaseString string
@@ -11,14 +13,7 @@ func (snake SnakeCaseString) SnakeCase() string {
 }
 
 func (snake SnakeCaseString) PascalCase() string {
-	words := strings.Split(string(snake), "_")
-	var pascalCase string
-	for i := range words {
-		if words[i] != "" {
-			pascalCase += strings.ToUpper(string(words[i][0])) + strings.ToLower(words[i][1:])
-		}
-	}
-	return pascalCase
+	return xstrings.ToCamelCase(string(snake)) // in xstrings v1.15.0 we can switch to using ToPascalCase for same functionality
 }
 
 func (snake SnakeCaseString) LowerCaseNoUnderscore() string {

--- a/tools/codegen/codespec/string_case.go
+++ b/tools/codegen/codespec/string_case.go
@@ -1,7 +1,6 @@
 package codespec
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -24,13 +23,4 @@ func (snake SnakeCaseString) PascalCase() string {
 
 func (snake SnakeCaseString) LowerCaseNoUnderscore() string {
 	return strings.ReplaceAll(string(snake), "_", "")
-}
-
-func ValidateSnakeCase(s string) bool {
-	snakeCaseRegex := `^[a-z]+(_[a-z]+)*$`
-	matched, err := regexp.MatchString(snakeCaseRegex, s)
-	if err != nil {
-		return false
-	}
-	return matched
 }

--- a/tools/codegen/codespec/string_case.go
+++ b/tools/codegen/codespec/string_case.go
@@ -1,0 +1,36 @@
+package codespec
+
+import (
+	"regexp"
+	"strings"
+)
+
+type SnakeCaseString string
+
+func (snake SnakeCaseString) SnakeCase() string {
+	return string(snake)
+}
+
+func (snake SnakeCaseString) PascalCase() string {
+	words := strings.Split(string(snake), "_")
+	var pascalCase string
+	for i := range words {
+		if words[i] != "" {
+			pascalCase += strings.ToUpper(string(words[i][0])) + strings.ToLower(words[i][1:])
+		}
+	}
+	return pascalCase
+}
+
+func (snake SnakeCaseString) LowerCaseNoUnderscore() string {
+	return strings.ReplaceAll(string(snake), "_", "")
+}
+
+func ValidateSnakeCase(s string) bool {
+	snakeCaseRegex := `^[a-z]+(_[a-z]+)*$`
+	matched, err := regexp.MatchString(snakeCaseRegex, s)
+	if err != nil {
+		return false
+	}
+	return matched
+}

--- a/tools/codegen/codespec/terraform_helper.go
+++ b/tools/codegen/codespec/terraform_helper.go
@@ -11,9 +11,9 @@ var (
 	unsupportedCharacters = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 )
 
-func terraformAttrName(attrName string) AttributeName {
+func terraformAttrName(attrName string) SnakeCaseString {
 	if attrName == "" {
-		return AttributeName(attrName)
+		return SnakeCaseString(attrName)
 	}
 
 	removedUnsupported := unsupportedCharacters.ReplaceAllString(attrName, "")
@@ -24,5 +24,5 @@ func terraformAttrName(attrName string) AttributeName {
 		return fmt.Sprintf("%c_%s", firstChar, strings.ToLower(restOfString))
 	})
 
-	return AttributeName(strings.ToLower(insertedUnderscores))
+	return SnakeCaseString(strings.ToLower(insertedUnderscores))
 }

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -33,3 +33,16 @@ resources:
             computed: true
       
       timeouts: ["create", "read", "delete"]
+  
+  search_deployment:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment
+      method: GET
+    create:
+      path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment
+      method: POST
+    schema:
+      aliases:
+        group_id: project_id
+      ignores: ["links"]
+      timeouts: ["create", "read", "delete"]

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -26,7 +26,7 @@ resources:
             ],
             definition: "stringvalidator.ConflictsWith(path.MatchRoot(\"name\"))"
           }]
-        
+      
         prefix_path:
           computability:
             optional: true

--- a/tools/codegen/main.go
+++ b/tools/codegen/main.go
@@ -45,17 +45,10 @@ func getOsArg() *string {
 }
 
 func writeToFile(fileName, content string) error {
-	// Open the file with write-only permission, create it if it doesn't exist and truncate its content if it exists
-	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	// will override content if file exists
+	err := os.WriteFile(fileName, []byte(content), 0o600)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-
-	_, err = file.WriteString(content)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/tools/codegen/main.go
+++ b/tools/codegen/main.go
@@ -13,24 +13,17 @@ import (
 const (
 	atlasAdminAPISpecURL = "https://raw.githubusercontent.com/mongodb/atlas-sdk-go/main/openapi/atlas-api-transformed.yaml"
 	configPath           = "tools/codegen/config.yml"
-	specFilePath         = "open-api-spec.yml"
+	specFilePath         = "tools/codegen/open-api-spec.yml"
 )
 
 func main() {
 	resourceName := getOsArg()
-	if resourceName == nil {
-		log.Fatal("No resource name provided")
-	}
-	if !codespec.ValidateSnakeCase(*resourceName) {
-		log.Fatal("Resource name must be snake case")
-	}
-	log.Printf("Resource name: %s\n", *resourceName)
 
 	if err := openapi.DownloadOpenAPISpec(atlasAdminAPISpecURL, specFilePath); err != nil {
 		log.Fatalf("an error occurred when downloading Atlas Admin API spec: %v", err)
 	}
 
-	model, err := codespec.ToCodeSpecModel(specFilePath, configPath, codespec.SnakeCaseString(*resourceName))
+	model, err := codespec.ToCodeSpecModel(specFilePath, configPath, resourceName)
 	if err != nil {
 		log.Fatalf("an error occurred while generating codespec.Model: %v", err)
 	}

--- a/tools/codegen/schema/schema_file.go
+++ b/tools/codegen/schema/schema_file.go
@@ -3,16 +3,16 @@ package schema
 import (
 	"go/format"
 
-	genconfigmapper "github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
+	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
 	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/schema/codetemplate"
 )
 
-func GenerateGoCode(input genconfigmapper.Resource) string {
+func GenerateGoCode(input codespec.Resource) string {
 	schemaAttrs := GenerateSchemaAttributes(input.Schema.Attributes)
 	models := GenerateTypedModels(input.Schema.Attributes)
 
 	tmplInputs := codetemplate.SchemaFileInputs{
-		PackageName:      input.Name,
+		PackageName:      input.Name.LowerCaseNoUnderscore(),
 		Imports:          append(schemaAttrs.Imports, models.Imports...),
 		SchemaAttributes: schemaAttrs.Code,
 		Models:           models.Code,

--- a/tools/codegen/schema/testdata/nested-attributes.golden.go
+++ b/tools/codegen/schema/testdata/nested-attributes.golden.go
@@ -1,4 +1,4 @@
-package test_name
+package testname
 
 import (
 	"context"

--- a/tools/codegen/schema/testdata/primitive-attributes.golden.go
+++ b/tools/codegen/schema/testdata/primitive-attributes.golden.go
@@ -1,4 +1,4 @@
-package test_name
+package testname
 
 import (
 	"context"


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-279066

Following commands are now supported:
- generates all resources defined in the config file -> `make generate-schema` 
- generate a specific resource -> `make generate-schema resource_name=push_based_log_export` 

Additionally added location of downloaded api spec into gitignore, this way file is available for referencing locally but will cause constant changes in our PRs.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
