### PR TITLE
chore: PoC - Fix code generation of list set and map nested attribute

### DIFF
--- a/tools/codegen/schema/schema_nested_attribute.go
+++ b/tools/codegen/schema/schema_nested_attribute.go
@@ -15,7 +15,7 @@ func (l *ListNestedAttrGenerator) TypeDefinition() string {
 }
 
 func (l *ListNestedAttrGenerator) TypeSpecificProperties() []CodeStatement {
-	return []CodeStatement{getPropertyForNestedObj(l.model.NestedObject)}
+	return []CodeStatement{nestedObjectProperty(l.model.NestedObject)}
 }
 
 type SetNestedGenerator struct {
@@ -27,7 +27,7 @@ func (s *SetNestedGenerator) TypeDefinition() string {
 }
 
 func (s *SetNestedGenerator) TypeSpecificProperties() []CodeStatement {
-	return []CodeStatement{getPropertyForNestedObj(s.model.NestedObject)}
+	return []CodeStatement{nestedObjectProperty(s.model.NestedObject)}
 }
 
 type MapNestedAttrGenerator struct {
@@ -39,7 +39,7 @@ func (m *MapNestedAttrGenerator) TypeDefinition() string {
 }
 
 func (m *MapNestedAttrGenerator) TypeSpecificProperties() []CodeStatement {
-	return []CodeStatement{getPropertyForNestedObj(m.model.NestedObject)}
+	return []CodeStatement{nestedObjectProperty(m.model.NestedObject)}
 }
 
 type SingleNestedAttrGenerator struct {
@@ -51,10 +51,10 @@ func (s *SingleNestedAttrGenerator) TypeDefinition() string {
 }
 
 func (s *SingleNestedAttrGenerator) TypeSpecificProperties() []CodeStatement {
-	return []CodeStatement{getPropertyForNestedObj(s.model.NestedObject)}
+	return []CodeStatement{attributesProperty(s.model.NestedObject)}
 }
 
-func getPropertyForNestedObj(nested codespec.NestedAttributeObject) CodeStatement {
+func attributesProperty(nested codespec.NestedAttributeObject) CodeStatement {
 	attrs := GenerateSchemaAttributes(nested.Attributes)
 	attributeProperty := fmt.Sprintf(`Attributes: map[string]schema.Attribute{ 
 		%s 
@@ -62,5 +62,16 @@ func getPropertyForNestedObj(nested codespec.NestedAttributeObject) CodeStatemen
 	return CodeStatement{
 		Code:    attributeProperty,
 		Imports: attrs.Imports,
+	}
+}
+
+func nestedObjectProperty(nested codespec.NestedAttributeObject) CodeStatement {
+	result := attributesProperty(nested)
+	nestedObj := fmt.Sprintf(`NestedObject: schema.NestedAttributeObject{
+		%s,
+	}`, result.Code)
+	return CodeStatement{
+		Code:    nestedObj,
+		Imports: result.Imports,
 	}
 }

--- a/tools/codegen/schema/testdata/nested-attributes.golden.go
+++ b/tools/codegen/schema/testdata/nested-attributes.golden.go
@@ -28,14 +28,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"nested_list_attr": schema.ListNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "nested list attribute",
-				Attributes: map[string]schema.Attribute{
-					"string_attr": schema.StringAttribute{
-						Optional:            true,
-						MarkdownDescription: "string attribute",
-					},
-					"int_attr": schema.Int64Attribute{
-						Required:            true,
-						MarkdownDescription: "int attribute",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"string_attr": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "string attribute",
+						},
+						"int_attr": schema.Int64Attribute{
+							Required:            true,
+							MarkdownDescription: "int attribute",
+						},
 					},
 				},
 			},
@@ -43,14 +45,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "set nested attribute",
-				Attributes: map[string]schema.Attribute{
-					"string_attr": schema.StringAttribute{
-						Optional:            true,
-						MarkdownDescription: "string attribute",
-					},
-					"int_attr": schema.Int64Attribute{
-						Required:            true,
-						MarkdownDescription: "int attribute",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"string_attr": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "string attribute",
+						},
+						"int_attr": schema.Int64Attribute{
+							Required:            true,
+							MarkdownDescription: "int attribute",
+						},
 					},
 				},
 			},
@@ -58,14 +62,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "map nested attribute",
-				Attributes: map[string]schema.Attribute{
-					"string_attr": schema.StringAttribute{
-						Optional:            true,
-						MarkdownDescription: "string attribute",
-					},
-					"int_attr": schema.Int64Attribute{
-						Required:            true,
-						MarkdownDescription: "int attribute",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"string_attr": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "string attribute",
+						},
+						"int_attr": schema.Int64Attribute{
+							Required:            true,
+							MarkdownDescription: "int attribute",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description

SIngleNestAttribute defines `Attributes` property directly, while ListNestedAttribute, SetNestedAttribute, and MapNestedAttribute need an overlapping `NestedObject`

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
