### PR TITLE
chore: Adds state transition logic to mongodbatlas_flex_cluster resource

### DIFF
--- a/internal/common/retrystrategy/retry_state.go
+++ b/internal/common/retrystrategy/retry_state.go
@@ -12,6 +12,7 @@ const (
 	RetryStrategyFailedState     = "FAILED"
 	RetryStrategyActiveState     = "ACTIVE"
 	RetryStrategyDeletedState    = "DELETED"
+	RetryStrategyCreatingState   = "CREATING"
 
 	RetryStrategyPendingAcceptanceState = "PENDING_ACCEPTANCE"
 	RetryStrategyPendingRecreationState = "PENDING_RECREATION"

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -33,12 +32,12 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, false),
-				Check:  checksFlexCluster(projectID, clusterName, false),
-			},
-			{
 				Config: configBasic(projectID, clusterName, true),
 				Check:  checksFlexCluster(projectID, clusterName, true),
+			},
+			{
+				Config: configBasic(projectID, clusterName, false),
+				Check:  checksFlexCluster(projectID, clusterName, false),
 			},
 			{
 				Config:            configBasic(projectID, clusterName, true),
@@ -92,7 +91,6 @@ func checkExists() resource.TestCheckFunc {
 }
 
 func checkDestroy(state *terraform.State) error {
-	time.Sleep(1 * time.Minute) //TODO: To be removed once CLOUDP-279544 is implemented
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type == resourceType {
 			projectID := rs.Primary.Attributes["project_id"]

--- a/internal/service/flexcluster/state_transition.go
+++ b/internal/service/flexcluster/state_transition.go
@@ -1,0 +1,51 @@
+package flexcluster
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+)
+
+const (
+	IdleState      = "IDLE"
+	CreatingState  = "CREATING"
+	UpdatingState  = "UPDATING"
+	DeletingState  = "DELETING"
+	RepairingState = "REPAIRING"
+)
+
+func WaitStateTransition(ctx context.Context, requestParams *admin.GetFlexClusterApiParams, client admin.FlexClustersApi, pendingStates, desiredStates []string) (*admin.FlexClusterDescription20250101, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    pendingStates,
+		Target:     desiredStates,
+		Refresh:    refreshFunc(ctx, requestParams, client),
+		Timeout:    5 * time.Minute,
+		MinTimeout: 3 * time.Second,
+		Delay:      0,
+	}
+
+	flexClusterResp, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if flexCluster, ok := flexClusterResp.(*admin.FlexClusterDescription20250101); ok && flexCluster != nil {
+		return flexCluster, nil
+	}
+
+	return nil, errors.New("did not obtain valid result when waiting for flex cluster state transition")
+}
+
+func refreshFunc(ctx context.Context, requestParams *admin.GetFlexClusterApiParams, client admin.FlexClustersApi) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		flexCluster, _, err := client.GetFlexClusterWithParams(ctx, requestParams).Execute()
+		if err != nil {
+			return nil, "", err
+		}
+		state := flexCluster.GetStateName()
+		return flexCluster, state, nil
+	}
+}

--- a/internal/service/flexcluster/state_transition_test.go
+++ b/internal/service/flexcluster/state_transition_test.go
@@ -1,0 +1,119 @@
+package flexcluster_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+	"go.mongodb.org/atlas-sdk/v20240805004/mockadmin"
+)
+
+var (
+	IdleState      = "IDLE"
+	CreatingState  = "CREATING"
+	UpdatingState  = "UPDATING"
+	DeletingState  = "DELETING"
+	RepairingState = "REPAIRING"
+	sc500          = conversion.IntPtr(500)
+	sc200          = conversion.IntPtr(200)
+	sc404          = conversion.IntPtr(404)
+	clusterName    = "clusterName"
+	requestParams  = &admin.GetFlexClusterApiParams{
+		GroupId: "groupId",
+		Name:    clusterName,
+	}
+)
+
+type testCase struct {
+	expectedState *string
+	name          string
+	mockResponses []response
+	desiredStates []string
+	pendingStates []string
+	expectedError bool
+}
+
+func TestFlexClusterStateTransition(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "Successful transition to IDLE",
+			mockResponses: []response{
+				{state: &CreatingState, statusCode: sc200},
+				{state: &IdleState, statusCode: sc200},
+			},
+			expectedState: &IdleState,
+			expectedError: false,
+			desiredStates: []string{IdleState},
+			pendingStates: []string{CreatingState},
+		},
+		{
+			name: "Error when API returns 5XX",
+			mockResponses: []response{
+				{statusCode: sc500, err: errors.New("Internal server error")},
+			},
+			expectedState: nil,
+			expectedError: true,
+			desiredStates: []string{IdleState},
+			pendingStates: []string{CreatingState},
+		},
+		{
+			name: "Error when API returns 404",
+			mockResponses: []response{
+				{statusCode: sc404, err: errors.New("Not found")},
+			},
+			expectedState: nil,
+			expectedError: true,
+			desiredStates: []string{IdleState},
+			pendingStates: []string{UpdatingState},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mockadmin.NewFlexClustersApi(t)
+			m.EXPECT().GetFlexClusterWithParams(mock.Anything, mock.Anything).Return(admin.GetFlexClusterApiRequest{ApiService: m})
+
+			for _, resp := range tc.mockResponses {
+				modelResp, httpResp, err := resp.get()
+				m.EXPECT().GetFlexClusterExecute(mock.Anything).Return(modelResp, httpResp, err).Once()
+			}
+			resp, err := flexcluster.WaitStateTransition(context.Background(), requestParams, m, tc.pendingStates, tc.desiredStates)
+			assert.Equal(t, tc.expectedError, err != nil)
+			if resp != nil {
+				assert.Equal(t, *tc.expectedState, *resp.StateName)
+			}
+		})
+	}
+}
+
+type response struct {
+	state      *string
+	statusCode *int
+	err        error
+}
+
+func (r *response) get() (*admin.FlexClusterDescription20250101, *http.Response, error) {
+	var httpResp *http.Response
+	if r.statusCode != nil {
+		httpResp = &http.Response{
+			StatusCode: *r.statusCode,
+		}
+	}
+	return responseWithState(r.state), httpResp, r.err
+}
+
+func responseWithState(state *string) *admin.FlexClusterDescription20250101 {
+	if state == nil {
+		return nil
+	}
+	return &admin.FlexClusterDescription20250101{
+		Name:      &clusterName,
+		StateName: state,
+	}
+}

--- a/internal/service/flexcluster/state_transition_test.go
+++ b/internal/service/flexcluster/state_transition_test.go
@@ -63,14 +63,15 @@ func TestFlexClusterStateTransition(t *testing.T) {
 			pendingStates: []string{CreatingState},
 		},
 		{
-			name: "Error when API returns 404",
+			name: "Deleted state when API returns 404",
 			mockResponses: []response{
+				{state: &DeletingState, statusCode: sc200},
 				{statusCode: sc404, err: errors.New("Not found")},
 			},
 			expectedState: nil,
 			expectedError: true,
 			desiredStates: []string{IdleState},
-			pendingStates: []string{UpdatingState},
+			pendingStates: []string{UpdatingState, DeletingState},
 		},
 	}
 


### PR DESCRIPTION
## Description

Adds state transition logic to mongodbatlas_flex_cluster resource

Link to any related issue(s): CLOUDP-279544

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
