### PR TITLE
chore: Generate Flex Cluster data source file and schemas

### DIFF
--- a/internal/service/flexcluster/data_source.go
+++ b/internal/service/flexcluster/data_source.go
@@ -1,0 +1,55 @@
+//nolint:gocritic
+package flexcluster
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	// "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	// "github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+var _ datasource.DataSource = &ds{}
+var _ datasource.DataSourceWithConfigure = &ds{}
+
+func DataSource() datasource.DataSource {
+	return &ds{
+		DSCommon: config.DSCommon{
+			DataSourceName: resourceName,
+		},
+	}
+}
+
+type ds struct {
+	config.DSCommon
+}
+
+func (d *ds) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	// TODO: Schema and model must be defined in data_source_schema.go. Details on scaffolding this file found in contributing/development-best-practices.md under "Scaffolding Schema and Model Definitions"
+	resp.Schema = DataSourceSchema(ctx)
+}
+
+func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	// var tfModel TFModel
+	// resp.Diagnostics.Append(req.Config.Get(ctx, &tfModel)...)
+	// if resp.Diagnostics.HasError() {
+	// 	return
+	// }
+
+	// TODO: make get request to resource
+
+	// connV2 := d.Client.AtlasV2
+	//if err != nil {
+	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	// newFlexClusterModel, diags := NewTFModel(ctx, apiResp)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+	// resp.Diagnostics.Append(resp.State.Set(ctx, newFlexClusterModel)...)
+}

--- a/internal/service/flexcluster/data_source_schema.go
+++ b/internal/service/flexcluster/data_source_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func DataSourceSchema(ctx context.Context) schema.Schema {
@@ -45,6 +46,11 @@ func dataSourceSchema(isPlural bool) map[string]schema.Attribute {
 			},
 			Computed:            true,
 			MarkdownDescription: "Group of cloud provider settings that configure the provisioned MongoDB flex cluster.",
+		},
+		"tags": schema.MapAttribute{
+			ElementType:         types.StringType,
+			Computed:            true,
+			MarkdownDescription: "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the instance.",
 		},
 		"backup_settings": schema.SingleNestedAttribute{
 			Attributes: map[string]schema.Attribute{
@@ -89,22 +95,6 @@ func dataSourceSchema(isPlural bool) map[string]schema.Attribute {
 		"state_name": schema.StringAttribute{
 			Computed:            true,
 			MarkdownDescription: "Human-readable label that indicates the current operating condition of this instance.",
-		},
-		"tags": schema.ListNestedAttribute{
-			NestedObject: schema.NestedAttributeObject{
-				Attributes: map[string]schema.Attribute{
-					"key": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
-					},
-					"value": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
-					},
-				},
-			},
-			Computed:            true,
-			MarkdownDescription: "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the instance.",
 		},
 		"termination_protection_enabled": schema.BoolAttribute{
 			Computed:            true,

--- a/internal/service/flexcluster/data_source_schema.go
+++ b/internal/service/flexcluster/data_source_schema.go
@@ -1,0 +1,118 @@
+package flexcluster
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+)
+
+func DataSourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: dataSourceSchema(false),
+	}
+}
+
+func dataSourceSchema(isPlural bool) map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"project_id": schema.StringAttribute{
+			Required:            !isPlural,
+			Computed:            isPlural,
+			MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+		},
+		"name": schema.StringAttribute{
+			Required:            !isPlural,
+			Computed:            isPlural,
+			MarkdownDescription: "Human-readable label that identifies the flex cluster.",
+		},
+		"provider_settings": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"backing_provider_name": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the flex cluster.",
+				},
+				"disk_size_gb": schema.Float64Attribute{
+					Computed:            true,
+					MarkdownDescription: "Storage capacity available to the flex cluster expressed in gigabytes.",
+				},
+				"provider_name": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Human-readable label that identifies the cloud service provider.",
+				},
+				"region_name": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Human-readable label that identifies the geographic location of your MongoDB flex cluster. The region you choose can affect network latency for clients accessing your databases. For a complete list of region names, see [AWS](https://docs.atlas.mongodb.com/reference/amazon-aws/#std-label-amazon-aws), [GCP](https://docs.atlas.mongodb.com/reference/google-gcp/), and [Azure](https://docs.atlas.mongodb.com/reference/microsoft-azure/).",
+				},
+			},
+			Computed:            true,
+			MarkdownDescription: "Group of cloud provider settings that configure the provisioned MongoDB flex cluster.",
+		},
+		"backup_settings": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"enabled": schema.BoolAttribute{
+					Computed:            true,
+					MarkdownDescription: "Flag that indicates whether backups are performed for this flex cluster. Backup uses [TODO](TODO) for flex clusters.",
+				},
+			},
+			Computed:            true,
+			MarkdownDescription: "Flex backup configuration",
+		},
+		"cluster_type": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Flex cluster topology.",
+		},
+		"connection_strings": schema.SingleNestedAttribute{
+			Attributes: map[string]schema.Attribute{
+				"standard": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Public connection string that you can use to connect to this cluster. This connection string uses the mongodb:// protocol.",
+				},
+				"standard_srv": schema.StringAttribute{
+					Computed:            true,
+					MarkdownDescription: "Public connection string that you can use to connect to this flex cluster. This connection string uses the `mongodb+srv://` protocol.",
+				},
+			},
+			Computed:            true,
+			MarkdownDescription: "Collection of Uniform Resource Locators that point to the MongoDB database.",
+		},
+		"create_date": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Date and time when MongoDB Cloud created this instance. This parameter expresses its value in ISO 8601 format in UTC.",
+		},
+		"id": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the instance.",
+		},
+		"mongo_dbversion": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Version of MongoDB that the instance runs.",
+		},
+		"state_name": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Human-readable label that indicates the current operating condition of this instance.",
+		},
+		"tags": schema.ListNestedAttribute{
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"key": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
+					},
+					"value": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
+					},
+				},
+			},
+			Computed:            true,
+			MarkdownDescription: "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the instance.",
+		},
+		"termination_protection_enabled": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.",
+		},
+		"version_release_system": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Method by which the cluster maintains the MongoDB versions.",
+		},
+	}
+}

--- a/internal/service/flexcluster/data_source_schema.go
+++ b/internal/service/flexcluster/data_source_schema.go
@@ -88,7 +88,7 @@ func dataSourceSchema(isPlural bool) map[string]schema.Attribute {
 			Computed:            true,
 			MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the instance.",
 		},
-		"mongo_dbversion": schema.StringAttribute{
+		"mongo_db_version": schema.StringAttribute{
 			Computed:            true,
 			MarkdownDescription: "Version of MongoDB that the instance runs.",
 		},

--- a/internal/service/flexcluster/plural_data_source_schema.go
+++ b/internal/service/flexcluster/plural_data_source_schema.go
@@ -1,0 +1,31 @@
+package flexcluster
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func DataSourcePluralSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+			},
+			"flex_clusters": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: dataSourceSchema(true),
+				},
+				MarkdownDescription: "List of returned documents that MongoDB Cloud provides when completing this request.",
+			},
+		},
+	}
+}
+
+type TFModelDSP struct {
+	ProjectId    types.String `tfsdk:"project_id"`
+	FlexClusters []TFModel    `tfsdk:"flex_clusters"`
+}

--- a/internal/service/flexcluster/tfplugingen/generator_config.yml
+++ b/internal/service/flexcluster/tfplugingen/generator_config.yml
@@ -9,3 +9,13 @@ resources:
     create:
       path: /api/atlas/v2/groups/{groupId}/flexClusters
       method: POST
+
+data_sources:
+  flex_cluster:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/flexClusters/{name}
+      method: GET
+  flex_clusters:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/flexClusters
+      method: GET


### PR DESCRIPTION
## Description

Generate Flex Cluster data source file and schemas.

File `data_source.go` has been primarily commented out and will be properly implemented in a following ticket. 

Link to any related issue(s): [CLOUDP-278904](https://jira.mongodb.org/browse/CLOUDP-278904)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
