### PR TITLE
fix: Fixes change assigments in `mongodbatlas_project_api_key`

### DIFF
--- a/.changelog/2737.txt
+++ b/.changelog/2737.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_project_api_key: Fixes some issues when updating the resource
+```

--- a/.changelog/2737.txt
+++ b/.changelog/2737.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_project_api_key: Validates `projectID` are unique across `project_assignment` blocks, fixes Update issues with error `API_KEY_ALREADY_IN_GROUP`
+resource/mongodbatlas_project_api_key: Validates `project_id` are unique across `project_assignment` blocks and fixes update issues with error `API_KEY_ALREADY_IN_GROUP`
 ```

--- a/.changelog/2737.txt
+++ b/.changelog/2737.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_project_api_key: Fixes multiple issues
+resource/mongodbatlas_project_api_key: Validates `projectID` are unique across `project_assignment` blocks, fixes Update issues with error `API_KEY_ALREADY_IN_GROUP`
 ```

--- a/.changelog/2737.txt
+++ b/.changelog/2737.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_project_api_key: Fixes some issues when updating the resource
+resource/mongodbatlas_project_api_key: Fixes multiple issues
 ```

--- a/docs/resources/project_api_key.md
+++ b/docs/resources/project_api_key.md
@@ -56,9 +56,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-API Keys must be imported using API Key ID e.g.
+API Keys must be imported using project ID, API Key ID e.g.
 
 ```
-$ terraform import mongodbatlas_project_api_key.test 671c13c6ccbe4c3ac90e6184
+$ terraform import mongodbatlas_project_api_key.test 5d09d6a59ccf6445652a444a-6576974933969669
 ```
 See [MongoDB Atlas API - API Key](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Programmatic-API-Keys/operation/createProjectApiKey) - Documentation for more information.

--- a/docs/resources/project_api_key.md
+++ b/docs/resources/project_api_key.md
@@ -56,9 +56,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-API Keys must be imported using project ID, API Key ID e.g.
+API Keys must be imported using API Key ID e.g.
 
 ```
-$ terraform import mongodbatlas_project_api_key.test 5d09d6a59ccf6445652a444a-6576974933969669
+$ terraform import mongodbatlas_project_api_key.test 671c13c6ccbe4c3ac90e6184
 ```
 See [MongoDB Atlas API - API Key](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Programmatic-API-Keys/operation/createProjectApiKey) - Documentation for more information.

--- a/internal/service/projectapikey/data_source_project_api_key.go
+++ b/internal/service/projectapikey/data_source_project_api_key.go
@@ -88,7 +88,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error getting api key information: %s", err))
 		}
-		if err := d.Set("project_assignment", flattenProjectAssignmentsFromRoles(details.GetRoles())); err != nil {
+		if err := d.Set("project_assignment", flattenProjectAssignments(details.GetRoles())); err != nil {
 			return diag.Errorf(ErrorProjectSetting, `project_assignment`, projectID, err)
 		}
 	}

--- a/internal/service/projectapikey/data_source_project_api_key.go
+++ b/internal/service/projectapikey/data_source_project_api_key.go
@@ -84,10 +84,12 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf("error setting `private_key`: %s", err))
 		}
 
-		if projectAssignments, err := newProjectAssignment(ctx, connV2, apiKeyID); err == nil {
-			if err := d.Set("project_assignment", projectAssignments); err != nil {
-				return diag.Errorf(ErrorProjectSetting, `project_assignment`, projectID, err)
-			}
+		apiAssigments, err := getAPIProjectAssignments(ctx, connV2, apiKeyID)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error getting api key information: %s", err))
+		}
+		if err := d.Set("project_assignment", flattenProjectAssignments(apiAssigments)); err != nil {
+			return diag.Errorf(ErrorProjectSetting, `project_assignment`, projectID, err)
 		}
 	}
 

--- a/internal/service/projectapikey/data_source_project_api_key.go
+++ b/internal/service/projectapikey/data_source_project_api_key.go
@@ -89,7 +89,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf("error getting api key information: %s", err))
 		}
 		if err := d.Set("project_assignment", flattenProjectAssignments(details.GetRoles())); err != nil {
-			return diag.Errorf(ErrorProjectSetting, `project_assignment`, projectID, err)
+			return diag.FromErr(fmt.Errorf("error setting `project_assignment`: %s", err))
 		}
 	}
 

--- a/internal/service/projectapikey/data_source_project_api_key.go
+++ b/internal/service/projectapikey/data_source_project_api_key.go
@@ -84,11 +84,11 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf("error setting `private_key`: %s", err))
 		}
 
-		apiAssigments, err := getAPIProjectAssignments(ctx, connV2, apiKeyID)
+		details, _, err := getKeyDetails(ctx, connV2, apiKeyID)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error getting api key information: %s", err))
 		}
-		if err := d.Set("project_assignment", flattenProjectAssignments(apiAssigments)); err != nil {
+		if err := d.Set("project_assignment", flattenProjectAssignmentsFromRoles(details.GetRoles())); err != nil {
 			return diag.Errorf(ErrorProjectSetting, `project_assignment`, projectID, err)
 		}
 	}

--- a/internal/service/projectapikey/data_source_project_api_keys.go
+++ b/internal/service/projectapikey/data_source_project_api_keys.go
@@ -121,7 +121,7 @@ func flattenProjectAPIKeys(ctx context.Context, connV2 *admin.APIClient, apiKeys
 		if err != nil {
 			return nil, err
 		}
-		results[k]["project_assignment"] = flattenProjectAssignmentsFromRoles(details.GetRoles())
+		results[k]["project_assignment"] = flattenProjectAssignments(details.GetRoles())
 	}
 	return results, nil
 }

--- a/internal/service/projectapikey/data_source_project_api_keys.go
+++ b/internal/service/projectapikey/data_source_project_api_keys.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20240805005/admin"
 )
@@ -76,12 +77,12 @@ func PluralDataSource() *schema.Resource {
 
 func pluralDataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
-	pageNum := d.Get("page_num").(int)
-	itemsPerPage := d.Get("items_per_page").(int)
-
-	projectID := d.Get("project_id").(string)
-
-	apiKeys, _, err := connV2.ProgrammaticAPIKeysApi.ListProjectApiKeys(ctx, projectID).PageNum(pageNum).ItemsPerPage(itemsPerPage).Execute()
+	params := &admin.ListProjectApiKeysApiParams{
+		GroupId:      d.Get("project_id").(string),
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+	}
+	apiKeys, _, err := connV2.ProgrammaticAPIKeysApi.ListProjectApiKeysWithParams(ctx, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting api keys information: %s", err))
 	}

--- a/internal/service/projectapikey/data_source_project_api_keys.go
+++ b/internal/service/projectapikey/data_source_project_api_keys.go
@@ -116,11 +116,11 @@ func flattenProjectAPIKeys(ctx context.Context, connV2 *admin.APIClient, apiKeys
 			"private_key": apiKey.GetPrivateKey(),
 		}
 
-		apiAssigments, err := getAPIProjectAssignments(ctx, connV2, apiKey.GetId())
+		details, _, err := getKeyDetails(ctx, connV2, apiKey.GetId())
 		if err != nil {
 			return nil, err
 		}
-		results[k]["project_assignment"] = flattenProjectAssignments(apiAssigments)
+		results[k]["project_assignment"] = flattenProjectAssignmentsFromRoles(details.GetRoles())
 	}
 	return results, nil
 }

--- a/internal/service/projectapikey/data_source_project_api_keys.go
+++ b/internal/service/projectapikey/data_source_project_api_keys.go
@@ -116,12 +116,11 @@ func flattenProjectAPIKeys(ctx context.Context, connV2 *admin.APIClient, apiKeys
 			"private_key": apiKey.GetPrivateKey(),
 		}
 
-		projectAssignment, err := newProjectAssignment(ctx, connV2, apiKey.GetId())
+		apiAssigments, err := getAPIProjectAssignments(ctx, connV2, apiKey.GetId())
 		if err != nil {
 			return nil, err
 		}
-
-		results[k]["project_assignment"] = projectAssignment
+		results[k]["project_assignment"] = flattenProjectAssignments(apiAssigments)
 	}
 	return results, nil
 }

--- a/internal/service/projectapikey/model_project_api_key.go
+++ b/internal/service/projectapikey/model_project_api_key.go
@@ -1,0 +1,101 @@
+package projectapikey
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20240805005/admin"
+)
+
+func expandProjectAssignments(projectAssignments *schema.Set) map[string][]string {
+	results := make(map[string][]string)
+	for _, val := range projectAssignments.List() {
+		results[val.(map[string]any)["project_id"].(string)] = conversion.ExpandStringList(val.(map[string]any)["role_names"].(*schema.Set).List())
+	}
+	return results
+}
+
+func flattenProjectAssignments(roles []admin.CloudAccessRoleAssignment) []map[string]any {
+	assignments := make(map[string][]string)
+	for _, role := range roles {
+		if groupID := role.GetGroupId(); groupID != "" {
+			assignments[groupID] = append(assignments[groupID], role.GetRoleName())
+		}
+	}
+	var results []map[string]any
+	for projectID, roles := range assignments {
+		results = append(results, map[string]any{
+			"project_id": projectID,
+			"role_names": roles,
+		})
+	}
+	return results
+}
+
+func getAssignmentChanges(d *schema.ResourceData) (add, remove, update map[string][]string) {
+	before, after := d.GetChange("project_assignment")
+	add = expandProjectAssignments(after.(*schema.Set))
+	remove = expandProjectAssignments(before.(*schema.Set))
+	update = make(map[string][]string)
+
+	for projectID, rolesAfter := range add {
+		if rolesBefore, ok := remove[projectID]; ok {
+			if !sameRoles(rolesBefore, rolesAfter) {
+				update[projectID] = rolesAfter
+			}
+			delete(remove, projectID)
+			delete(add, projectID)
+		}
+	}
+	return
+}
+
+func sameRoles(roles1, roles2 []string) bool {
+	set1 := make(map[string]struct{})
+	for _, role := range roles1 {
+		set1[role] = struct{}{}
+	}
+	set2 := make(map[string]struct{})
+	for _, role := range roles2 {
+		set2[role] = struct{}{}
+	}
+	return reflect.DeepEqual(set1, set2)
+}
+
+// getKeyDetails returns nil error and nil details if not found as it's not considered an error
+func getKeyDetails(ctx context.Context, connV2 *admin.APIClient, apiKeyID string) (*admin.ApiKeyUserDetails, string, error) {
+	root, _, err := connV2.RootApi.GetSystemStatus(ctx).Execute()
+	if err != nil {
+		return nil, "", err
+	}
+	for _, role := range root.ApiKey.GetRoles() {
+		if orgID := role.GetOrgId(); orgID != "" {
+			key, _, err := connV2.ProgrammaticAPIKeysApi.GetApiKey(ctx, orgID, apiKeyID).Execute()
+			if err != nil {
+				if admin.IsErrorCode(err, "API_KEY_NOT_FOUND") {
+					return nil, orgID, nil
+				}
+				return nil, orgID, fmt.Errorf("error getting api key information: %s", err)
+			}
+			return key, orgID, nil
+		}
+	}
+	return nil, "", nil
+}
+
+func validateUniqueProjectIDs(d *schema.ResourceData) error {
+	if projectAssignments, ok := d.GetOk("project_assignment"); ok {
+		uniqueIDs := make(map[string]bool)
+		for _, val := range projectAssignments.(*schema.Set).List() {
+			projectID := val.(map[string]any)["project_id"].(string)
+			if uniqueIDs[projectID] {
+				return fmt.Errorf("duplicated projectID in assignments: %s", projectID)
+			}
+			uniqueIDs[projectID] = true
+		}
+	}
+	return nil
+}

--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -214,8 +215,16 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "-", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("import format error: to import a api key use the format {project_id}-{api_key_id}")
+	}
+
+	// projectID is not needed for import any more, but kept to maintain import format and avoid breaking changes
+	apiKeyID := parts[1]
+
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"api_key_id": d.Id(),
+		"api_key_id": apiKeyID,
 	}))
 	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -217,8 +217,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		for _, apiKey := range changedAssignments {
 			projectID := apiKey.(map[string]any)["project_id"].(string)
 			roles := conversion.ExpandStringList(apiKey.(map[string]any)["role_names"].(*schema.Set).List())
-			assignment := []admin.UserAccessRoleAssignment{{Roles: &roles}}
-			_, _, err := connV2.ProgrammaticAPIKeysApi.AddProjectApiKey(ctx, projectID, apiKeyID, &assignment).Execute()
+			assignment := admin.UpdateAtlasProjectApiKey{Roles: &roles}
+			_, _, err := connV2.ProgrammaticAPIKeysApi.UpdateApiKeyRoles(ctx, projectID, apiKeyID, &assignment).Execute()
 			if err != nil {
 				return diag.Errorf("error updating role names for the api_key(%s): %s", apiKey, err)
 			}

--- a/internal/service/projectapikey/resource_project_api_key.go
+++ b/internal/service/projectapikey/resource_project_api_key.go
@@ -4,17 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20240805005/admin"
-)
-
-const (
-	ErrorProjectSetting = "error setting `%s` for project (%s): %s"
 )
 
 func Resource() *schema.Resource {
@@ -223,94 +218,4 @@ func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) 
 		"api_key_id": d.Id(),
 	}))
 	return []*schema.ResourceData{d}, nil
-}
-
-func expandProjectAssignments(projectAssignments *schema.Set) map[string][]string {
-	results := make(map[string][]string)
-	for _, val := range projectAssignments.List() {
-		results[val.(map[string]any)["project_id"].(string)] = conversion.ExpandStringList(val.(map[string]any)["role_names"].(*schema.Set).List())
-	}
-	return results
-}
-
-func flattenProjectAssignments(roles []admin.CloudAccessRoleAssignment) []map[string]any {
-	assignments := make(map[string][]string)
-	for _, role := range roles {
-		if groupID := role.GetGroupId(); groupID != "" {
-			assignments[groupID] = append(assignments[groupID], role.GetRoleName())
-		}
-	}
-	var results []map[string]any
-	for projectID, roles := range assignments {
-		results = append(results, map[string]any{
-			"project_id": projectID,
-			"role_names": roles,
-		})
-	}
-	return results
-}
-
-func getAssignmentChanges(d *schema.ResourceData) (add, remove, update map[string][]string) {
-	before, after := d.GetChange("project_assignment")
-	add = expandProjectAssignments(after.(*schema.Set))
-	remove = expandProjectAssignments(before.(*schema.Set))
-	update = make(map[string][]string)
-
-	for projectID, rolesAfter := range add {
-		if rolesBefore, ok := remove[projectID]; ok {
-			if !sameRoles(rolesBefore, rolesAfter) {
-				update[projectID] = rolesAfter
-			}
-			delete(remove, projectID)
-			delete(add, projectID)
-		}
-	}
-	return
-}
-
-func sameRoles(roles1, roles2 []string) bool {
-	set1 := make(map[string]struct{})
-	for _, role := range roles1 {
-		set1[role] = struct{}{}
-	}
-	set2 := make(map[string]struct{})
-	for _, role := range roles2 {
-		set2[role] = struct{}{}
-	}
-	return reflect.DeepEqual(set1, set2)
-}
-
-// getKeyDetails returns nil error and nil details if not found as it's not considered an error
-func getKeyDetails(ctx context.Context, connV2 *admin.APIClient, apiKeyID string) (*admin.ApiKeyUserDetails, string, error) {
-	root, _, err := connV2.RootApi.GetSystemStatus(ctx).Execute()
-	if err != nil {
-		return nil, "", err
-	}
-	for _, role := range root.ApiKey.GetRoles() {
-		if orgID := role.GetOrgId(); orgID != "" {
-			key, _, err := connV2.ProgrammaticAPIKeysApi.GetApiKey(ctx, orgID, apiKeyID).Execute()
-			if err != nil {
-				if admin.IsErrorCode(err, "API_KEY_NOT_FOUND") {
-					return nil, orgID, nil
-				}
-				return nil, orgID, fmt.Errorf("error getting api key information: %s", err)
-			}
-			return key, orgID, nil
-		}
-	}
-	return nil, "", nil
-}
-
-func validateUniqueProjectIDs(d *schema.ResourceData) error {
-	if projectAssignments, ok := d.GetOk("project_assignment"); ok {
-		uniqueIDs := make(map[string]bool)
-		for _, val := range projectAssignments.(*schema.Set).List() {
-			projectID := val.(map[string]any)["project_id"].(string)
-			if uniqueIDs[projectID] {
-				return fmt.Errorf("duplicated projectID in assignments: %s", projectID)
-			}
-			uniqueIDs[projectID] = true
-		}
-	}
-	return nil
 }

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -315,7 +315,7 @@ func checkDestroy(projectID string) resource.TestCheckFunc {
 			ids := conversion.DecodeStateID(rs.Primary.ID)
 			for _, val := range projectAPIKeys.GetResults() {
 				if val.GetId() == ids["api_key_id"] {
-					return fmt.Errorf("Project API Key (%s) still exists", ids["role_name"])
+					return fmt.Errorf("Project API Key (%s) still exists", ids["api_key_id"])
 				}
 			}
 		}

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -85,25 +85,6 @@ func TestAccProjectAPIKey_changingSingleProject(t *testing.T) {
 	})
 }
 
-func TestAccProjectAPIKey_dataSources(t *testing.T) {
-	var (
-		projectID   = acc.ProjectIDExecution(t)
-		description = acc.RandomName()
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy(projectID),
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(description, projectID, roleName),
-				Check:  checkAggr(description, projectID, roleName),
-			},
-		},
-	})
-}
-
 func TestAccProjectAPIKey_updateDescription(t *testing.T) {
 	var (
 		projectID          = acc.ProjectIDExecution(t)

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -296,7 +296,6 @@ func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
 			if _, _, err := acc.ConnV2().ProgrammaticAPIKeysApi.DeleteApiKey(context.Background(), orgID, key.GetId()).Execute(); err != nil {
 				return err
 			}
-			return nil
 		}
 	}
 	return nil

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -43,7 +43,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 			},
 			{
 				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportStateIdFunc:       importStateIDFunc(resourceName, projectID),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"private_key"},
@@ -287,13 +287,13 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func importStateIDFunc(resourceName, projectID string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-		return rs.Primary.Attributes["api_key_id"], nil
+		return fmt.Sprintf("%s-%s", projectID, rs.Primary.Attributes["api_key_id"]), nil
 	}
 }
 

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -208,9 +208,8 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 		projectID         = acc.ProjectIDExecution(t)
 		descriptionPrefix = acc.RandomName()
 		description       = descriptionPrefix + "-" + acc.RandomName()
+		config            = configBasic(projectID, description, roleName, false)
 	)
-
-	projectAPIKeyConfig := configBasic(projectID, description, roleName, false)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -218,7 +217,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 		CheckDestroy:             checkDestroy(projectID),
 		Steps: []resource.TestStep{
 			{
-				Config: projectAPIKeyConfig,
+				Config: config,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 				),
@@ -229,7 +228,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 						t.Fatalf("failed to manually delete API key resource: %s", err)
 					}
 				},
-				Config:             projectAPIKeyConfig,
+				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true, // should detect that api key has to be recreated
 			},
@@ -297,6 +296,7 @@ func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
 			if _, _, err := acc.ConnV2().ProgrammaticAPIKeysApi.DeleteApiKey(context.Background(), orgID, key.GetId()).Execute(); err != nil {
 				return err
 			}
+			return nil
 		}
 	}
 	return nil

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -164,21 +164,19 @@ func TestAccProjectAPIKey_updateRole(t *testing.T) {
 			{
 				Config: configBasic(projectID, description, roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.#", "1"),
-					// resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.0", roleName),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.0.role_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.0.role_names.0", roleName),
 				),
 			},
 			{
 				Config: configBasic(projectID, description, updatedRoleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
 					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.0", updatedRoleName),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.0.role_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.0.role_names.0", updatedRoleName),
 				),
 			},
 		},

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -144,7 +144,7 @@ func TestAccProjectAPIKey_duplicateProject(t *testing.T) {
 		CheckDestroy:             checkDestroy(projectID),
 		Steps: []resource.TestStep{
 			{
-				Config:      configTwoAssignments(description, projectID, roleName, projectID, updatedRoleName),
+				Config:      configDuplicatedProject(description, projectID, roleName, updatedRoleName),
 				ExpectError: regexp.MustCompile("duplicated projectID in assignments: " + projectID),
 			},
 		},
@@ -217,7 +217,6 @@ func TestAccProjectAPIKey_invalidRole(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		description = fmt.Sprintf("desc-%s", projectID)
-		roleName    = "INVALID_ROLE"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -226,7 +225,7 @@ func TestAccProjectAPIKey_invalidRole(t *testing.T) {
 		CheckDestroy:             checkDestroy(projectID),
 		Steps: []resource.TestStep{
 			{
-				Config:      configBasic(description, projectID, roleName),
+				Config:      configBasic(description, projectID, "INVALID_ROLE"),
 				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
 			},
 		},
@@ -313,7 +312,7 @@ func configBasic(description, projectID, roleNames string) string {
 	`, description, projectID, roleNames, configDataSources(projectID))
 }
 
-func configTwoAssignments(description, projectID1, roleNames1, projectID2, roleName2 string) string {
+func configDuplicatedProject(description, projectID, roleNames1, roleName2 string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project_api_key" "test" {
 			description  = %[1]q
@@ -322,11 +321,11 @@ func configTwoAssignments(description, projectID1, roleNames1, projectID2, roleN
 				role_names = [%[3]q]
 			}
 			project_assignment  {
-				project_id = %[4]q
-				role_names = [%[5]q]
+				project_id = %[2]q
+				role_names = [%[4]q]
 			}
 		}
-	`, description, projectID1, roleNames1, projectID2, roleName2)
+	`, description, projectID, roleNames1, roleName2)
 }
 
 func configChangingProject(orgID, projectName2, description, assignedProject string) string {

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -26,12 +26,10 @@ func TestAccProjectAPIKey_basic(t *testing.T) {
 
 func basicTestCase(tb testing.TB) *resource.TestCase {
 	tb.Helper()
-
 	var (
 		projectID   = acc.ProjectIDExecution(tb)
 		description = acc.RandomName()
 	)
-
 	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -46,10 +44,11 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: false,
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       importStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_key"},
 			},
 		},
 	}
@@ -328,10 +327,7 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-
-		projectID := rs.Primary.Attributes["project_assignment.0.project_id"]
-
-		return fmt.Sprintf("%s-%s", projectID, rs.Primary.Attributes["api_key_id"]), nil
+		return rs.Primary.Attributes["api_key_id"], nil
 	}
 }
 

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -339,16 +339,17 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 func configBasic(projectID, description, roleNames string, includeDataSources bool) string {
 	var dataSourcesStr string
 	if includeDataSources {
-		dataSourcesStr = `
+		dataSourcesStr = fmt.Sprintf(`
 			data "mongodbatlas_project_api_key" "test" {
-				project_id      = mongodbatlas_project_api_key.test.project_assignment.0.project_id
+				project_id      = %[1]q
 				api_key_id  = mongodbatlas_project_api_key.test.api_key_id
 			}
 			
 			data "mongodbatlas_project_api_keys" "test" {
-				project_id      = mongodbatlas_project_api_key.test.project_assignment.0.project_id
+				project_id      = %[1]q
+				depends_on = [mongodbatlas_project_api_key.test]
 			}
-		`
+		`, projectID)
 	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project_api_key" "test" {

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -149,6 +149,42 @@ func TestAccProjectAPIKey_updateDescription(t *testing.T) {
 	})
 }
 
+func TestAccProjectAPIKey_updateRole(t *testing.T) {
+	var (
+		projectID       = acc.ProjectIDExecution(t)
+		description     = acc.RandomName()
+		updatedRoleName = "GROUP_READ_ONLY"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy(projectID),
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(projectID, description, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.#", "1"),
+					// resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.0", roleName),
+				),
+			},
+			{
+				Config: configBasic(projectID, description, updatedRoleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "project_assignment[0].roles_names.0", updatedRoleName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 	var (
 		orgID             = os.Getenv("MONGODB_ATLAS_ORG_ID")

--- a/internal/testutil/acc/attribute_checks.go
+++ b/internal/testutil/acc/attribute_checks.go
@@ -66,6 +66,7 @@ func JSONEquals(expected string) resource.CheckResourceAttrWithFunc {
 	}
 }
 
+// IsProjectNameOrID accepts a project id or name and checks if the input project id matches the expected project
 func IsProjectNameOrID(expected string) resource.CheckResourceAttrWithFunc {
 	return func(input string) error {
 		projectID := expected

--- a/internal/testutil/acc/attribute_checks.go
+++ b/internal/testutil/acc/attribute_checks.go
@@ -1,6 +1,7 @@
 package acc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -60,6 +61,23 @@ func JSONEquals(expected string) resource.CheckResourceAttrWithFunc {
 
 		if !reflect.DeepEqual(expectedAny, inputAny) {
 			return fmt.Errorf("expected `%v`, got `%v`", expected, input)
+		}
+		return nil
+	}
+}
+
+func IsProjectNameOrID(expected string) resource.CheckResourceAttrWithFunc {
+	return func(input string) error {
+		projectID := expected
+		if startNumber, _ := regexp.MatchString(`^\d`, expected); !startNumber {
+			resp, _, _ := ConnV2().ProjectsApi.GetProjectByName(context.Background(), expected).Execute()
+			projectID = resp.GetId()
+			if projectID == "" {
+				return fmt.Errorf("project not found %q", expected)
+			}
+		}
+		if projectID != input {
+			return fmt.Errorf("project expected %q but got %q", projectID, input)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

Fixes several issues in `mongodbatlas_project_api_key`. It also addresses HELP-66460

- Fixes error `API_KEY_ALREADY_IN_GROUP ` when Updating roles in an existing `project_assignment`
- Doesn't allow duplicated `project_id` between different `project_assignment`. All `role_names` for a specific `project_id` must be in the same `assignment`
- Fixes plural data source when `page_num` or `items_per_page` are not provided
- Improve tests adding more test cases, and more checks including checkExists
- Some refactors to simplify code, for example:
  - Get the `orgID`  in order to simplify operations
  - Use internally `map[string][]string` for assigments, i.e. a map from `projectID` to its list of `role names`


Link to any related issue(s): CLOUDP-280725

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
