### PR TITLE
feat: Implements and tests `mongodbatlas_flex_cluster` data source

### DIFF
--- a/.changelog/2738.txt
+++ b/.changelog/2738.txt
@@ -1,0 +1,3 @@
+```release-note:new-datasource
+data-source/mongodbatlas_flex_cluster
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -450,6 +450,7 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 	previewDataSources := []func() datasource.DataSource{
 		resourcepolicy.DataSource,
 		resourcepolicy.PluralDataSource,
+		flexcluster.DataSource,
 	} // Data sources not yet in GA
 	if providerEnablePreview {
 		dataSources = append(dataSources, previewDataSources...)

--- a/internal/service/flexcluster/data_source.go
+++ b/internal/service/flexcluster/data_source.go
@@ -2,7 +2,6 @@ package flexcluster
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -37,17 +36,13 @@ func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasou
 	}
 
 	connV2 := d.Client.AtlasV2
-	flexCluster, apiResp, err := connV2.FlexClustersApi.GetFlexCluster(ctx, tfModel.ProjectId.ValueString(), tfModel.Name.ValueString()).Execute()
+	apiResp, _, err := connV2.FlexClustersApi.GetFlexCluster(ctx, tfModel.ProjectId.ValueString(), tfModel.Name.ValueString()).Execute()
 	if err != nil {
-		if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		resp.Diagnostics.AddError("error reading data source", err.Error())
 		return
 	}
 
-	newFlexClusterModel, diags := NewTFModel(ctx, flexCluster)
+	newFlexClusterModel, diags := NewTFModel(ctx, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -111,6 +111,10 @@ func configBasic(projectID, clusterName, provider, region string, terminationPro
 				region_name           = %[4]q
 			}
 			termination_protection_enabled = %[5]t
+		}
+		data "mongodbatlas_flex_cluster" "test" {
+			project_id = mongodbatlas_flex_cluster.test.project_id
+			name       = mongodbatlas_flex_cluster.test.name
 		}`, projectID, clusterName, provider, region, terminationProtectionEnabled)
 }
 

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 var (
-	resourceType = "mongodbatlas_flex_cluster"
-	resourceName = "mongodbatlas_flex_cluster.flex_cluster"
+	resourceType   = "mongodbatlas_flex_cluster"
+	resourceName   = "mongodbatlas_flex_cluster.test"
+	dataSourceName = "data.mongodbatlas_flex_cluster.test"
 )
 
 func TestAccFlexClusterRS_basic(t *testing.T) {
@@ -102,7 +103,7 @@ func failedUpdateTestCase(t *testing.T) *resource.TestCase {
 
 func configBasic(projectID, clusterName, provider, region string, terminationProtectionEnabled bool) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_flex_cluster" "flex_cluster" {
+		resource "mongodbatlas_flex_cluster" "test" {
 			project_id = %[1]q
 			name       = %[2]q
 			provider_settings = {
@@ -121,6 +122,7 @@ func checksFlexCluster(projectID, clusterName string, terminationProtectionEnabl
 		"termination_protection_enabled": fmt.Sprintf("%v", terminationProtectionEnabled),
 	}
 	checks = acc.AddAttrChecks(resourceName, checks, attributes)
+	checks = acc.AddAttrChecks(dataSourceName, checks, attributes)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -116,13 +116,26 @@ func configBasic(projectID, clusterName, provider, region string, terminationPro
 
 func checksFlexCluster(projectID, clusterName string, terminationProtectionEnabled bool) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{checkExists()}
-	attributes := map[string]string{
+	attrMap := map[string]string{
 		"project_id":                     projectID,
 		"name":                           clusterName,
 		"termination_protection_enabled": fmt.Sprintf("%v", terminationProtectionEnabled),
 	}
-	checks = acc.AddAttrChecks(resourceName, checks, attributes)
-	checks = acc.AddAttrChecks(dataSourceName, checks, attributes)
+	attrSet := []string{
+		"backup_settings.enabled",
+		"cluster_type",
+		"connection_strings.standard",
+		"create_date",
+		"id",
+		"mongo_db_version",
+		"state_name",
+		"version_release_system",
+		"provider_settings.provider_name",
+	}
+	checks = acc.AddAttrChecks(resourceName, checks, attrMap)
+	checks = acc.AddAttrChecks(dataSourceName, checks, attrMap)
+	checks = acc.AddAttrSetChecks(resourceName, checks, attrSet...)
+	checks = acc.AddAttrSetChecks(dataSourceName, checks, attrSet...)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 


### PR DESCRIPTION
## Description

Implements `mongodbatlas_flex_cluster` singular data source and includes coverage for new data source in acceptance tests. Note that plural data source schema is implemented as a part of this PR, but further implementation and testing of plural data source is left for a separate ticket, [CLOUDP-278906](https://jira.mongodb.org/browse/CLOUDP-278906).

Link to any related issue(s): [CLOUDP-278905](https://jira.mongodb.org/browse/CLOUDP-278905).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
