### PR TITLE
fix: Adds new attribute `results` and deprecates `resource_policies` for `mongodbatlas_resource_policies` data source

### DIFF
--- a/.changelog/2740.txt
+++ b/.changelog/2740.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+mongodbatlas_resource_policies: Adds `results` attribute and deprecates `resource_policies`
+```

--- a/.changelog/2740.txt
+++ b/.changelog/2740.txt
@@ -2,6 +2,6 @@
 data-source/mongodbatlas_resource_policies: Adds `results` attribute
 ```
 
-```release-note:enhancement
+```release-note:note
 data-source/mongodbatlas_resource_policies: Deprecates `resource_policies` attribute
 ```

--- a/.changelog/2740.txt
+++ b/.changelog/2740.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-mongodbatlas_resource_policies: Adds `results` attribute and deprecates `resource_policies`
+data-source/mongodbatlas_resource_policies: Adds `results` attribute and deprecates `resource_policies`
 ```

--- a/.changelog/2740.txt
+++ b/.changelog/2740.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-data-source/mongodbatlas_resource_policies: Adds `results` attribute and deprecates `resource_policies`
+data-source/mongodbatlas_resource_policies: Adds `results` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_resource_policies: Deprecates `resource_policies` attribute
 ```

--- a/docs/data-sources/resource_policies.md
+++ b/docs/data-sources/resource_policies.md
@@ -84,7 +84,7 @@ data "mongodbatlas_resource_policies" "this" {
 
 
 output "policy_ids" {
-  value = { for policy in data.mongodbatlas_resource_policies.this.resource_policies : policy.name => policy.id }
+  value = { for policy in data.mongodbatlas_resource_policies.this.results : policy.name => policy.id }
 }
 ```
 
@@ -97,7 +97,8 @@ output "policy_ids" {
 
 ### Read-Only
 
-- `resource_policies` (Attributes List) (see [below for nested schema](#nestedatt--resource_policies))
+- `resource_policies` (Attributes List, Deprecated) (see [below for nested schema](#nestedatt--resource_policies))
+- `results` (Attributes List) (see [below for nested schema](#nestedatt--results))
 
 <a id="nestedatt--resource_policies"></a>
 ### Nested Schema for `resource_policies`
@@ -134,6 +135,49 @@ Read-Only:
 
 <a id="nestedatt--resource_policies--policies"></a>
 ### Nested Schema for `resource_policies.policies`
+
+Read-Only:
+
+- `body` (String) A string that defines the permissions for the policy. The syntax used is the Cedar Policy language.
+- `id` (String) Unique 24-hexadecimal character string that identifies the policy.
+
+
+
+<a id="nestedatt--results"></a>
+### Nested Schema for `results`
+
+Read-Only:
+
+- `created_by_user` (Attributes) The user that last updated the Atlas resource policy. (see [below for nested schema](#nestedatt--results--created_by_user))
+- `created_date` (String) Date and time in UTC when the Atlas resource policy was created.
+- `id` (String) Unique 24-hexadecimal digit string that identifies an Atlas resource policy.
+- `last_updated_by_user` (Attributes) The user that last updated the Atlas resource policy. (see [below for nested schema](#nestedatt--results--last_updated_by_user))
+- `last_updated_date` (String) Date and time in UTC when the Atlas resource policy was last updated.
+- `name` (String) Human-readable label that describes the Atlas resource policy.
+- `org_id` (String) Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
+- `policies` (Attributes List) List of policies that make up the Atlas resource policy. (see [below for nested schema](#nestedatt--results--policies))
+- `version` (String) A string that identifies the version of the Atlas resource policy.
+
+<a id="nestedatt--results--created_by_user"></a>
+### Nested Schema for `results.created_by_user`
+
+Read-Only:
+
+- `id` (String) Unique 24-hexadecimal character string that identifies a user.
+- `name` (String) Human-readable label that describes a user.
+
+
+<a id="nestedatt--results--last_updated_by_user"></a>
+### Nested Schema for `results.last_updated_by_user`
+
+Read-Only:
+
+- `id` (String) Unique 24-hexadecimal character string that identifies a user.
+- `name` (String) Human-readable label that describes a user.
+
+
+<a id="nestedatt--results--policies"></a>
+### Nested Schema for `results.policies`
 
 Read-Only:
 

--- a/docs/data-sources/resource_policy.md
+++ b/docs/data-sources/resource_policy.md
@@ -84,7 +84,7 @@ data "mongodbatlas_resource_policies" "this" {
 
 
 output "policy_ids" {
-  value = { for policy in data.mongodbatlas_resource_policies.this.resource_policies : policy.name => policy.id }
+  value = { for policy in data.mongodbatlas_resource_policies.this.results : policy.name => policy.id }
 }
 ```
 

--- a/docs/resources/resource_policy.md
+++ b/docs/resources/resource_policy.md
@@ -86,7 +86,7 @@ data "mongodbatlas_resource_policies" "this" {
 
 
 output "policy_ids" {
-  value = { for policy in data.mongodbatlas_resource_policies.this.resource_policies : policy.name => policy.id }
+  value = { for policy in data.mongodbatlas_resource_policies.this.results : policy.name => policy.id }
 }
 ```
 

--- a/examples/mongodbatlas_resource_policy/main.tf
+++ b/examples/mongodbatlas_resource_policy/main.tf
@@ -74,5 +74,5 @@ data "mongodbatlas_resource_policies" "this" {
 
 
 output "policy_ids" {
-  value = { for policy in data.mongodbatlas_resource_policies.this.resource_policies : policy.name => policy.id }
+  value = { for policy in data.mongodbatlas_resource_policies.this.results : policy.name => policy.id }
 }

--- a/internal/service/resourcepolicy/model.go
+++ b/internal/service/resourcepolicy/model.go
@@ -82,6 +82,7 @@ func NewTFModelDSP(ctx context.Context, orgID string, input []admin.ApiAtlasReso
 	}
 	return &TFModelDSP{
 		ResourcePolicies: tfModels,
+		Results:          tfModels,
 		OrgID:            types.StringValue(orgID),
 	}, *diags
 }

--- a/internal/service/resourcepolicy/plural_data_source_schema.go
+++ b/internal/service/resourcepolicy/plural_data_source_schema.go
@@ -2,8 +2,10 @@ package resourcepolicy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 )
@@ -18,6 +20,13 @@ func DataSourcePluralSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.",
 			},
 			"resource_policies": schema.ListNestedAttribute{
+				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamWithReplacement, "`results`"),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: dsAttributes,
+				},
+				Computed: true,
+			},
+			"results": schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: dsAttributes,
 				},
@@ -30,4 +39,5 @@ func DataSourcePluralSchema(ctx context.Context) schema.Schema {
 type TFModelDSP struct {
 	OrgID            types.String `tfsdk:"org_id"`
 	ResourcePolicies []TFModel    `tfsdk:"resource_policies"`
+	Results          []TFModel    `tfsdk:"results"`
 }

--- a/internal/service/resourcepolicy/resource_migration_test.go
+++ b/internal/service/resourcepolicy/resource_migration_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestMigResourcePolicy_basic(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.21.3") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.21.3
+	mig.SkipIfVersionBelow(t, "1.22.0") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.21.3
 	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }

--- a/internal/service/resourcepolicy/resource_migration_test.go
+++ b/internal/service/resourcepolicy/resource_migration_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestMigResourcePolicy_basic(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.22.0") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.21.3
+	mig.SkipIfVersionBelow(t, "1.22.0") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.22.0
 	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }

--- a/internal/service/resourcepolicy/resource_migration_test.go
+++ b/internal/service/resourcepolicy/resource_migration_test.go
@@ -7,6 +7,6 @@ import (
 )
 
 func TestMigResourcePolicy_basic(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.21.0") // this feature was introduced in provider version 1.21.0
+	mig.SkipIfVersionBelow(t, "1.21.3") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.21.3
 	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }

--- a/internal/service/resourcepolicy/resource_test.go
+++ b/internal/service/resourcepolicy/resource_test.go
@@ -158,15 +158,15 @@ func checksResourcePolicy(orgID, name string, policyCount int) resource.TestChec
 		"version",
 	}
 	pluralMap := map[string]string{
-		"org_id":              orgID,
-		"resource_policies.#": "1",
+		"org_id":    orgID,
+		"results.#": "1",
 	}
 	checks := []resource.TestCheckFunc{checkExists()}
 	checks = acc.AddAttrChecks(dataSourcePluralID, checks, pluralMap)
 	for i := 0; i < policyCount; i++ {
 		checks = acc.AddAttrSetChecks(resourceID, checks, fmt.Sprintf("policies.%d.body", i), fmt.Sprintf("policies.%d.id", i))
 		checks = acc.AddAttrSetChecks(dataSourceID, checks, fmt.Sprintf("policies.%d.body", i), fmt.Sprintf("policies.%d.id", i))
-		checks = acc.AddAttrSetChecks(dataSourcePluralID, checks, fmt.Sprintf("resource_policies.0.policies.%d.body", i), fmt.Sprintf("resource_policies.0.policies.%d.id", i))
+		checks = acc.AddAttrSetChecks(dataSourcePluralID, checks, fmt.Sprintf("results.0.policies.%d.body", i), fmt.Sprintf("results.0.policies.%d.id", i))
 	}
 	// cannot use dataSourcePluralID as it doesn't have the `results` attribute
 	return acc.CheckRSAndDS(resourceID, &dataSourceID, nil, attrSet, attrMap, resource.ComposeAggregateTestCheckFunc(checks...))


### PR DESCRIPTION
## Description

Adds new attribute `results` and deprecates `resource_policies` for `mongodbatlas_resource_policies` data source

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
