### PR TITLE
deprecate: Deprecates Serverless functionality

### DIFF
--- a/.changelog/2742.txt
+++ b/.changelog/2742.txt
@@ -1,0 +1,27 @@
+```release-note:note
+resource/mongodbatlas_serverless_instance: Deprecates `continuous_backup_enabled` attribute
+```
+
+```release-note:note
+resource/mongodbatlas_serverless_instance: Deprecates `auto_indexing` attribute
+```
+
+```release-note:note
+resource/mongodbatlas_privatelink_endpoint_serverless: Deprecates resource
+```
+
+```release-note:note
+resource/mongodbatlas_privatelink_endpoint_serverless: Deprecates resource
+```
+
+```release-note:note
+resource/mongodbatlas_privatelink_endpoint_service_serverless: Deprecates resource
+```
+
+```release-note:note
+data-source/mongodbatlas_privatelink_endpoint_service_serverless: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_privatelink_endpoints_service_serverless: Deprecates data source
+```

--- a/.changelog/2742.txt
+++ b/.changelog/2742.txt
@@ -7,6 +7,22 @@ resource/mongodbatlas_serverless_instance: Deprecates `auto_indexing` attribute
 ```
 
 ```release-note:note
+data-source/mongodbatlas_serverless_instance: Deprecates `continuous_backup_enabled` attribute
+```
+
+```release-note:note
+data-source/mongodbatlas_serverless_instance: Deprecates `auto_indexing` attribute
+```
+
+```release-note:note
+data-source/mongodbatlas_serverless_instances: Deprecates `continuous_backup_enabled` attribute
+```
+
+```release-note:note
+data-source/mongodbatlas_serverless_instances: Deprecates `auto_indexing` attribute
+```
+
+```release-note:note
 resource/mongodbatlas_privatelink_endpoint_serverless: Deprecates resource
 ```
 

--- a/.changelog/2742.txt
+++ b/.changelog/2742.txt
@@ -11,10 +11,6 @@ resource/mongodbatlas_privatelink_endpoint_serverless: Deprecates resource
 ```
 
 ```release-note:note
-resource/mongodbatlas_privatelink_endpoint_serverless: Deprecates resource
-```
-
-```release-note:note
 resource/mongodbatlas_privatelink_endpoint_service_serverless: Deprecates resource
 ```
 

--- a/docs/data-sources/privatelink_endpoint_service_serverless.md
+++ b/docs/data-sources/privatelink_endpoint_service_serverless.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
 
 # Data Source: privatelink_endpoint_service_serverless
 

--- a/docs/data-sources/privatelink_endpoint_service_serverless.md
+++ b/docs/data-sources/privatelink_endpoint_service_serverless.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+
 # Data Source: privatelink_endpoint_service_serverless
 
 `privatelink_endpoint_service_serverless` provides a Serverless PrivateLink Endpoint Service resource.

--- a/docs/data-sources/privatelink_endpoints_service_serverless.md
+++ b/docs/data-sources/privatelink_endpoints_service_serverless.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+
 # Data Source: privatelink_endpoints_service_serverless
 
 `privatelink_endpoints_service_serverless` describes the list of all Serverless PrivateLink Endpoint Service resource.

--- a/docs/data-sources/privatelink_endpoints_service_serverless.md
+++ b/docs/data-sources/privatelink_endpoints_service_serverless.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+**WARNING:** This data source is deprecated and will be removed in March 2025. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
 
 # Data Source: privatelink_endpoints_service_serverless
 

--- a/docs/data-sources/serverless_instance.md
+++ b/docs/data-sources/serverless_instance.md
@@ -43,9 +43,9 @@ Follow this example to [setup private connection to a serverless instance using 
 * `provider_settings_provider_name` - Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
 * `state_name` - Stage of deployment of this serverless instance when the resource made its request.
-* `continuous_backup_enabled` - Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
+* `continuous_backup_enabled` - (Deprecated) Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
 * `termination_protection_enabled` - Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.
-* `auto_indexing` - Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/).
+* `auto_indexing` - (Deprecated) Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/).
 * `tags` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 
 ### Tags

--- a/docs/data-sources/serverless_instances.md
+++ b/docs/data-sources/serverless_instances.md
@@ -34,9 +34,9 @@ data "mongodbatlas_serverless_instances" "data_serverless" {
 * `provider_settings_provider_name` - Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
 * `state_name` - Stage of deployment of this serverless instance when the resource made its request.
-* `continuous_backup_enabled` - Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
+* `continuous_backup_enabled` - (Deprecated) Flag that indicates whether the serverless instance uses Serverless Continuous Backup.
 * `termination_protection_enabled` - Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.
-* `auto_indexing` - Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/).
+* `auto_indexing` - (Deprecated) Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/).
 * `tags` - Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 
 ### Tags

--- a/docs/resources/privatelink_endpoint_serverless.md
+++ b/docs/resources/privatelink_endpoint_serverless.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
 
 # Resource: privatelink_endpoint_serverless
 

--- a/docs/resources/privatelink_endpoint_serverless.md
+++ b/docs/resources/privatelink_endpoint_serverless.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+
 # Resource: privatelink_endpoint_serverless
 
 `privatelink_endpoint_serverless` Provides a Serverless PrivateLink Endpoint resource.

--- a/docs/resources/privatelink_endpoint_service_serverless.md
+++ b/docs/resources/privatelink_endpoint_service_serverless.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+
 # Resource: privatelink_endpoint_service_serverless
 
 `privatelink_endpoint_service_serverless` Provides a Serverless PrivateLink Endpoint Service resource.

--- a/docs/resources/privatelink_endpoint_service_serverless.md
+++ b/docs/resources/privatelink_endpoint_service_serverless.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see placeholder-serverless-deprecation-url
+**WARNING:** This resource is deprecated and will be removed in March 2025. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
 
 # Resource: privatelink_endpoint_service_serverless
 

--- a/docs/resources/serverless_instance.md
+++ b/docs/resources/serverless_instance.md
@@ -36,9 +36,9 @@ Follow this example to [setup private connection to a serverless instance using 
 * `provider_settings_provider_name` - (Required) Cloud service provider that applies to the provisioned the serverless instance.
 * `provider_settings_region_name` - (Required) 	
   Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
-* `continuous_backup_enabled` - (Optional) Flag that indicates whether the serverless instance uses [Serverless Continuous Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup). If this parameter is false or not used, the serverless instance uses [Basic Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup).  
+* `continuous_backup_enabled` - (Deprecated, Optional) Flag that indicates whether the serverless instance uses [Serverless Continuous Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup). If this parameter is false or not used, the serverless instance uses [Basic Backup](https://www.mongodb.com/docs/atlas/configure-serverless-backup).  
 * `termination_protection_enabled` - Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.
-* `auto_indexing` - (Optional) Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/). This parameter defaults to true.
+* `auto_indexing` - (Deprecated, Optional) Flag that indicates whether the serverless instance uses [Serverless Auto Indexing](https://www.mongodb.com/docs/atlas/performance-advisor/auto-index-serverless/). This parameter defaults to true.
 * `tags` - (Optional) Set that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. See [below](#tags).
 
 ### Tags

--- a/internal/common/constant/deprecation.go
+++ b/internal/common/constant/deprecation.go
@@ -1,11 +1,14 @@
 package constant
 
 const (
-	DeprecationParam                           = "This parameter is deprecated."
-	DeprecationParamWithReplacement            = "This parameter is deprecated. Please transition to %s."
-	DeprecationParamByVersion                  = "This parameter is deprecated and will be removed in version %s."
-	DeprecationParamByVersionWithReplacement   = "This parameter is deprecated and will be removed in version %s. Please transition to %s."
-	DeprecationParamFutureWithReplacement      = "This parameter is deprecated and will be removed in the future. Please transition to %s"
-	DeprecationResourceByDateWithReplacement   = "This resource is deprecated and will be removed in %s. Please transition to %s."
-	DeprecationDataSourceByDateWithReplacement = "This data source is deprecated and will be removed in %s. Please transition to %s."
+	DeprecationParam                            = "This parameter is deprecated."
+	DeprecationParamWithReplacement             = "This parameter is deprecated. Please transition to %s."
+	DeprecationParamByVersion                   = "This parameter is deprecated and will be removed in version %s."
+	DeprecationParamByVersionWithReplacement    = "This parameter is deprecated and will be removed in version %s. Please transition to %s."
+	DeprecationParamFutureWithReplacement       = "This parameter is deprecated and will be removed in the future. Please transition to %s"
+	DeprecationResourceByDateWithReplacement    = "This resource is deprecated and will be removed in %s. Please transition to %s."
+	DeprecationDataSourceByDateWithReplacement  = "This data source is deprecated and will be removed in %s. Please transition to %s."
+	DeprecationResourceByDateWithExternalLink   = "This resource is deprecated and will be removed in %s. For more details see %s."
+	DeprecationDataSourceByDateWithExternalLink = "This data source is deprecated and will be removed in %s. For more details see %s."
+	DeprecatioParamByDateWithExternalLink       = "This parameter is deprecated and will be removed in %s. For more details see %s."
 )

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -35,7 +35,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -35,7 +35,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "url"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
+++ b/internal/service/privatelinkendpointserverless/resource_privatelink_endpoint_serverless.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/privatelinkendpoint"
@@ -34,6 +35,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "url"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
@@ -15,7 +15,7 @@ import (
 func DataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext:        dataSourceRead,
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoint_service_serverless.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/privatelinkendpointservice"
@@ -13,7 +14,8 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRead,
+		ReadContext:        dataSourceRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -15,7 +15,7 @@ import (
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext:        dataSourcePluralRead,
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/data_source_privatelink_endpoints_service_serverless.go
@@ -2,17 +2,20 @@ package privatelinkendpointserviceserverless
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20241023001/admin"
 )
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourcePluralRead,
+		ReadContext:        dataSourcePluralRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
@@ -35,7 +35,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
+++ b/internal/service/privatelinkendpointserviceserverless/resource_privatelink_endpoint_service_serverless.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -34,6 +35,7 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/serverlessinstance/data_source_serverless_instance.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instance.go
@@ -2,9 +2,11 @@ package serverlessinstance
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
@@ -88,14 +90,16 @@ func dataSourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Computed:   true,
 		},
 		"auto_indexing": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Computed:   true,
 		},
 		"tags": &advancedcluster.DSTagsSchema,
 	}

--- a/internal/service/serverlessinstance/data_source_serverless_instance.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instance.go
@@ -90,13 +90,13 @@ func dataSourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,
 		},
 		"auto_indexing": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/serverlessinstance/resource_serverless_instance.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
@@ -110,14 +111,16 @@ func resourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Computed:   true,
 		},
 		"auto_indexing": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Type:       schema.TypeBool,
+			Optional:   true,
+			Computed:   true,
 		},
 		"tags": &advancedcluster.RSTagsSchema,
 	}

--- a/internal/service/serverlessinstance/resource_serverless_instance.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance.go
@@ -111,13 +111,13 @@ func resourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,
 		},
 		"auto_indexing": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "placeholder-serverless-deprecation-url"),
+			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,


### PR DESCRIPTION
## Description

Deprecates Serverless functionality
- mongodbatlas_privatelink_endpoint_serverless resource.
- mongodbatlas_privatelink_endpoint_service_serverless resource and data source.
- Serverless Continuous Cloud Backup Parameter in mongodbatlas_serverless_instance
- Serverless Auto-Indexing Parameter in mongodbatlas_serverless_instance

Link to any related issue(s): CLOUDP-280719

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
