### PR TITLE
chore: Avoid calling new 2024-10-23 API version in POST and PATCH cluster operations

### DIFF
--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -31,6 +31,7 @@ const (
 type MongoDBClient struct {
 	Atlas           *matlasClient.Client
 	AtlasV2         *admin.APIClient
+	AtlasV220240805 *admin.APIClient         // used in advanced_cluster to avoid adopting 2024-10-23 release with ISS autoscaling
 	AtlasV220240530 *admin20240530.APIClient // used in advanced_cluster and cloud_backup_schedule for avoiding breaking changes
 	Config          *Config
 }

--- a/internal/service/cluster/new_atlas.go
+++ b/internal/service/cluster/new_atlas.go
@@ -19,6 +19,7 @@ func newAtlasUpdate(ctx context.Context, timeout time.Duration, connV2 *admin.AP
 	req := &admin.ClusterDescription20240805{
 		RedactClientLogData: &redactClientLogData,
 	}
+	// can call latest API as autoscaling property is not specified
 	if _, _, err = connV2.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-281272

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
