### PR TITLE
chore: Adjusts default timeout of flexCluster to 3 hours

### DIFF
--- a/internal/service/flexcluster/state_transition.go
+++ b/internal/service/flexcluster/state_transition.go
@@ -15,7 +15,7 @@ func WaitStateTransition(ctx context.Context, requestParams *admin.GetFlexCluste
 		Pending:    pendingStates,
 		Target:     desiredStates,
 		Refresh:    refreshFunc(ctx, requestParams, client),
-		Timeout:    5 * time.Minute,
+		Timeout:    3 * time.Hour,
 		MinTimeout: 3 * time.Second,
 		Delay:      0,
 	}
@@ -37,7 +37,7 @@ func WaitStateTransitionDelete(ctx context.Context, requestParams *admin.GetFlex
 		Pending:    []string{retrystrategy.RetryStrategyDeletingState},
 		Target:     []string{retrystrategy.RetryStrategyDeletedState},
 		Refresh:    refreshFunc(ctx, requestParams, client),
-		Timeout:    5 * time.Minute,
+		Timeout:    3 * time.Hour,
 		MinTimeout: 3 * time.Second,
 		Delay:      0,
 	}


### PR DESCRIPTION
## Description

Adjusts flex_cluster default timeout for state transitions to 3 hours

Link to any related issue(s): [CLOUDP-281414](https://jira.mongodb.org/browse/CLOUDP-281414)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ x If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
