### PR TITLE
chore: Implements no-op resource and run test with resource

### DIFF
--- a/internal/common/conversion/string_framework.go
+++ b/internal/common/conversion/string_framework.go
@@ -24,6 +24,15 @@ func ToTFMapOfSlices(ctx context.Context, values map[string][]string) (basetypes
 	return types.MapValueFrom(ctx, types.ListType{ElemType: types.StringType}, values)
 }
 
+func ToTFMapOfString(ctx context.Context, diags *diag.Diagnostics, values *map[string]string) basetypes.MapValue{
+	if values == nil {
+		return basetypes.NewMapNull(types.StringType)
+	}
+	mapValue, localDiags := types.MapValueFrom(context.Background(), types.StringType, values)
+	diags.Append(localDiags...)
+	return mapValue
+}
+
 // StringNullIfEmpty converts a string value to a Framework String value.
 // An empty string is converted to a null String. Useful for optional attributes.
 func StringNullIfEmpty(v string) types.String {

--- a/internal/common/conversion/string_framework.go
+++ b/internal/common/conversion/string_framework.go
@@ -24,7 +24,7 @@ func ToTFMapOfSlices(ctx context.Context, values map[string][]string) (basetypes
 	return types.MapValueFrom(ctx, types.ListType{ElemType: types.StringType}, values)
 }
 
-func ToTFMapOfString(ctx context.Context, diags *diag.Diagnostics, values *map[string]string) basetypes.MapValue{
+func ToTFMapOfString(ctx context.Context, diags *diag.Diagnostics, values *map[string]string) basetypes.MapValue { //nolint:gocritic // easy usage from sdk fields
 	if values == nil {
 		return basetypes.NewMapNull(types.StringType)
 	}

--- a/internal/service/advancedclustertpf/model.go
+++ b/internal/service/advancedclustertpf/model.go
@@ -4,48 +4,9 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
-
-// NewTFModel temporarily creates a fake model to be able to run the tests
-func NewTFModel(ctx context.Context, apiResp *admin.ClusterDescription20240805, diags *diag.Diagnostics) *TFModel {
-	model := &TFModel{
-		BiConnector: NewObjectTF(ctx, diags, BiConnectorObjType, TFBiConnectorModel{
-			ReadPreference: types.StringValue("PREFERENCE"),
-			Enabled:        types.BoolValue(false),
-		}),
-		ConnectionStrings: NewObjectTF(ctx, diags, ConnectionStringsObjType, TFConnectionStringsModel{
-			AwsPrivateLink:    types.MapNull(types.StringType),
-			AwsPrivateLinkSrv: types.MapNull(types.StringType),
-			Private:           types.StringValue("Private"),
-			PrivateEndpoint:   types.ListNull(types.StringType),
-			PrivateSrv:        types.StringValue("PrivateSrv"),
-			Standard:          types.StringValue("Standard"),
-			StandardSrv:       types.StringValue("StandardSrv"),
-		}),
-		MongoDBEmployeeAccessGrant: NewObjectTF(ctx, diags, MongoDbemployeeAccessGrantObjType, TFMongoDbemployeeAccessGrantModel{
-			ExpirationTime: types.StringValue("2024-10-31T00:00:00Z"),
-			GrantType:      types.StringValue("TYPE"),
-		}),
-		ReplicationSpecs: types.ListNull(ReplicationSpecsObjType),
-		Tags:             types.MapNull(types.StringType),
-		Labels:           types.ListNull(LabelsObjType),
-	}
-
-	if diags.HasError() {
-		return nil
-	}
-	return model
-}
-
-func NewObjectTF(ctx context.Context, diags *diag.Diagnostics, objectType types.ObjectType, model any) types.Object {
-	object, moreDiags := types.ObjectValueFrom(ctx, objectType.AttributeTypes(), &model)
-	diags.Append(moreDiags...)
-	if diags.HasError() {
-		return types.ObjectNull(objectType.AttributeTypes())
-	}
-	return object
-}
 
 func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.ClusterDescription20240805, diag.Diagnostics) {
 	return &admin.ClusterDescription20240805{}, nil

--- a/internal/service/advancedclustertpf/model.go
+++ b/internal/service/advancedclustertpf/model.go
@@ -7,8 +7,44 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
 
+// NewTFModel temporarily creates a fake model to be able to run the tests
 func NewTFModel(ctx context.Context, apiResp *admin.ClusterDescription20240805, diags *diag.Diagnostics) *TFModel {
-	return &TFModel{}
+	model := &TFModel{
+		BiConnector: NewObjectTF(ctx, diags, BiConnectorObjType, TFBiConnectorModel{
+			ReadPreference: types.StringValue("PREFERENCE"),
+			Enabled:        types.BoolValue(false),
+		}),
+		ConnectionStrings: NewObjectTF(ctx, diags, ConnectionStringsObjType, TFConnectionStringsModel{
+			AwsPrivateLink:    types.MapNull(types.StringType),
+			AwsPrivateLinkSrv: types.MapNull(types.StringType),
+			Private:           types.StringValue("Private"),
+			PrivateEndpoint:   types.ListNull(types.StringType),
+			PrivateSrv:        types.StringValue("PrivateSrv"),
+			Standard:          types.StringValue("Standard"),
+			StandardSrv:       types.StringValue("StandardSrv"),
+		}),
+		MongoDBEmployeeAccessGrant: NewObjectTF(ctx, diags, MongoDbemployeeAccessGrantObjType, TFMongoDbemployeeAccessGrantModel{
+			ExpirationTime: types.StringValue("2024-10-31T00:00:00Z"),
+			GrantType:      types.StringValue("TYPE"),
+		}),
+		ReplicationSpecs: types.ListNull(ReplicationSpecsObjType),
+		Tags:             types.MapNull(types.StringType),
+		Labels:           types.ListNull(LabelsObjType),
+	}
+
+	if diags.HasError() {
+		return nil
+	}
+	return model
+}
+
+func NewObjectTF(ctx context.Context, diags *diag.Diagnostics, objectType types.ObjectType, model any) types.Object {
+	object, moreDiags := types.ObjectValueFrom(ctx, objectType.AttributeTypes(), &model)
+	diags.Append(moreDiags...)
+	if diags.HasError() {
+		return types.ObjectNull(objectType.AttributeTypes())
+	}
+	return object
 }
 
 func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.ClusterDescription20240805, diag.Diagnostics) {

--- a/internal/service/advancedclustertpf/model.go
+++ b/internal/service/advancedclustertpf/model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
 

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -129,7 +129,7 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            types.StringPointerValue(item.Id),
 			ExternalId:    types.StringValue("TODO_STATIC"),
-			NumShards:     types.Int64Value(1),
+			NumShards:     types.Int64Value(1), //TODO: Static
 			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &todoContainerID),
 			RegionConfigs: regionConfigs,
 			ZoneId:        types.StringPointerValue(item.ZoneId),

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -87,9 +87,9 @@ func NewConnectionStringsObjType(ctx context.Context, input *admin.ClusterConnec
 	return objType
 }
 
-func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags *diag.Diagnostics) types.List {
+func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags *diag.Diagnostics) types.Set {
 	if input == nil {
-		return types.ListNull(LabelsObjType)
+		return types.SetNull(LabelsObjType)
 	}
 	tfModels := make([]TFLabelsModel, len(*input))
 	for i, item := range *input {
@@ -98,9 +98,9 @@ func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags 
 			Value: types.StringPointerValue(item.Value),
 		}
 	}
-	listType, diagsLocal := types.ListValueFrom(ctx, LabelsObjType, tfModels)
+	setType, diagsLocal := types.SetValueFrom(ctx, LabelsObjType, tfModels)
 	diags.Append(diagsLocal...)
-	return listType
+	return setType
 }
 
 func NewMongoDBEmployeeAccessGrantObjType(ctx context.Context, input *admin.EmployeeAccessGrant, diags *diag.Diagnostics) types.Object {
@@ -141,9 +141,9 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 	return listType
 }
 
-func NewTagsObjType(ctx context.Context, input *[]admin.ResourceTag, diags *diag.Diagnostics) types.List {
+func NewTagsObjType(ctx context.Context, input *[]admin.ResourceTag, diags *diag.Diagnostics) types.Set {
 	if input == nil {
-		return types.ListNull(TagsObjType)
+		return types.SetNull(TagsObjType)
 	}
 	tfModels := make([]TFTagsModel, len(*input))
 	for i, item := range *input {
@@ -152,9 +152,9 @@ func NewTagsObjType(ctx context.Context, input *[]admin.ResourceTag, diags *diag
 			Value: types.StringValue(item.Value),
 		}
 	}
-	listType, diagsLocal := types.ListValueFrom(ctx, TagsObjType, tfModels)
+	setType, diagsLocal := types.SetValueFrom(ctx, TagsObjType, tfModels)
 	diags.Append(diagsLocal...)
-	return listType
+	return setType
 }
 
 func NewPrivateEndpointObjType(ctx context.Context, input *[]admin.ClusterDescriptionConnectionStringsPrivateEndpoint, diags *diag.Diagnostics) types.List {

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
 
 func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, timeout timeouts.Value, diags *diag.Diagnostics) *TFModel {

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -14,7 +14,6 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 	biConnector := NewBiConnectorObjType(ctx, input.BiConnector, diags)
 	connectionStrings := NewConnectionStringsObjType(ctx, input.ConnectionStrings, diags)
 	labels := NewLabelsObjType(ctx, input.Labels, diags)
-	mongoDBEmployeeAccessGrant := NewMongoDBEmployeeAccessGrantObjType(ctx, input.MongoDBEmployeeAccessGrant, diags)
 	replicationSpecs := NewReplicationSpecsObjType(ctx, input.ReplicationSpecs, diags)
 	tags := NewTagsObjType(ctx, input.Tags, diags)
 	if diags.HasError() {
@@ -37,7 +36,6 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 		ProjectID:                                 types.StringPointerValue(input.GroupId),
 		ClusterID:                                 types.StringPointerValue(input.Id),
 		Labels:                                    labels,
-		MongoDBEmployeeAccessGrant:                mongoDBEmployeeAccessGrant,
 		MongoDBMajorVersion:                       types.StringPointerValue(input.MongoDBMajorVersion),
 		MongoDBVersion:                            types.StringPointerValue(input.MongoDBVersion),
 		Name:                                      types.StringPointerValue(input.Name),
@@ -101,19 +99,6 @@ func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags 
 	setType, diagsLocal := types.SetValueFrom(ctx, LabelsObjType, tfModels)
 	diags.Append(diagsLocal...)
 	return setType
-}
-
-func NewMongoDBEmployeeAccessGrantObjType(ctx context.Context, input *admin.EmployeeAccessGrant, diags *diag.Diagnostics) types.Object {
-	if input == nil {
-		return types.ObjectNull(MongoDbEmployeeAccessGrantObjType.AttrTypes)
-	}
-	tfModel := TFMongoDbEmployeeAccessGrantModel{
-		ExpirationTime: types.StringValue(conversion.TimeToString(input.ExpirationTime)),
-		GrantType:      types.StringValue(input.GrantType),
-	}
-	objType, diagsLocal := types.ObjectValueFrom(ctx, MongoDbEmployeeAccessGrantObjType.AttrTypes, tfModel)
-	diags.Append(diagsLocal...)
-	return objType
 }
 
 func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationSpec20240805, diags *diag.Diagnostics) types.List {

--- a/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
@@ -1,0 +1,37 @@
+package advancedclustertpf
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+)
+
+func AddAdvancedConfig(ctx context.Context, tfModel *TFModel, input *admin.ClusterDescriptionProcessArgs20240805, diags *diag.Diagnostics) {
+	var advancedConfig TFAdvancedConfigurationModel
+	if input != nil {
+		advancedConfig = TFAdvancedConfigurationModel{
+			ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds: types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds)),
+			ChunkMigrationConcurrency:                             types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.ChunkMigrationConcurrency)),
+			DefaultMaxTimeMs:                                      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DefaultMaxTimeMS)),
+			DefaultWriteConcern:                                   types.StringPointerValue(input.DefaultWriteConcern),
+			DefaultReadConcern:                                    types.StringNull(), // TODO: static
+			FailIndexKeyTooLong:                                   types.BoolNull(),   // TODO: static,
+			JavascriptEnabled:                                     types.BoolPointerValue(input.JavascriptEnabled),
+			MinimumEnabledTlsProtocol:                             types.StringPointerValue(input.MinimumEnabledTlsProtocol),
+			NoTableScan:                                           types.BoolPointerValue(input.NoTableScan),
+			OplogMinRetentionHours:                                types.Float64PointerValue(input.OplogMinRetentionHours),
+			OplogSizeMb:                                           types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.OplogSizeMB)),
+			QueryStatsLogVerbosity:                                types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.QueryStatsLogVerbosity)),
+			SampleSizeBiconnector:                                 types.Int64Null(), // TODO: static
+			SampleRefreshIntervalBiconnector:                      types.Int64Null(), // TODO: static
+			TransactionLifetimeLimitSeconds:                       types.Int64PointerValue(input.TransactionLifetimeLimitSeconds),
+		}
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, AdvancedConfigurationObjType.AttrTypes, advancedConfig)
+	diags.Append(diagsLocal...)
+	tfModel.AdvancedConfiguration = objType
+
+}

--- a/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
-	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
 
 func AddAdvancedConfig(ctx context.Context, tfModel *TFModel, input *admin.ClusterDescriptionProcessArgs20240805, diags *diag.Diagnostics) {

--- a/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
@@ -33,5 +33,4 @@ func AddAdvancedConfig(ctx context.Context, tfModel *TFModel, input *admin.Clust
 	objType, diagsLocal := types.ObjectValueFrom(ctx, AdvancedConfigurationObjType.AttrTypes, advancedConfig)
 	diags.Append(diagsLocal...)
 	tfModel.AdvancedConfiguration = objType
-
 }

--- a/internal/service/advancedclustertpf/model_from_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_from_ClusterDescription20240805.go
@@ -121,10 +121,16 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		return types.ListNull(ReplicationSpecsObjType)
 	}
 	tfModels := make([]TFReplicationSpecsModel, len(*input))
+	todoContainerID := map[string]string{
+		"AWS:US_EAST_1": "6728c725e12c976e3a21e204",
+	}
 	for i, item := range *input {
 		regionConfigs := NewRegionConfigsObjType(ctx, item.RegionConfigs, diags)
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            types.StringPointerValue(item.Id),
+			ExternalId:    types.StringValue("TODO_STATIC"),
+			NumShards:     types.Int64Value(1),
+			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &todoContainerID),
 			RegionConfigs: regionConfigs,
 			ZoneId:        types.StringPointerValue(item.ZoneId),
 			ZoneName:      types.StringPointerValue(item.ZoneName),

--- a/internal/service/advancedclustertpf/model_from_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_from_ClusterDescription20240805.go
@@ -1,0 +1,270 @@
+package advancedclustertpf
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+)
+
+func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, timeout timeouts.Value, diags *diag.Diagnostics) *TFModel {
+	biConnector := NewBiConnectorObjType(ctx, input.BiConnector, diags)
+	connectionStrings := NewConnectionStringsObjType(ctx, input.ConnectionStrings, diags)
+	labels := NewLabelsObjType(ctx, input.Labels, diags)
+	mongoDBEmployeeAccessGrant := NewMongoDBEmployeeAccessGrantObjType(ctx, input.MongoDBEmployeeAccessGrant, diags)
+	replicationSpecs := NewReplicationSpecsObjType(ctx, input.ReplicationSpecs, diags)
+	tags := NewTagsObjType(ctx, input.Tags, diags)
+	if diags.HasError() {
+		return nil
+	}
+	return &TFModel{
+		AcceptDataRisksAndForceReplicaSetReconfig: types.StringPointerValue(conversion.TimePtrToStringPtr(input.AcceptDataRisksAndForceReplicaSetReconfig)),
+		BackupEnabled:               types.BoolPointerValue(input.BackupEnabled),
+		BiConnector:                 biConnector,
+		ClusterType:                 types.StringPointerValue(input.ClusterType),
+		ConfigServerManagementMode:  types.StringPointerValue(input.ConfigServerManagementMode),
+		ConfigServerType:            types.StringPointerValue(input.ConfigServerType),
+		ConnectionStrings:           connectionStrings,
+		CreateDate:                  types.StringPointerValue(conversion.TimePtrToStringPtr(input.CreateDate)),
+		DiskWarmingMode:             types.StringPointerValue(input.DiskWarmingMode),
+		EncryptionAtRestProvider:    types.StringPointerValue(input.EncryptionAtRestProvider),
+		FeatureCompatibilityVersion: types.StringPointerValue(input.FeatureCompatibilityVersion),
+		FeatureCompatibilityVersionExpirationDate: types.StringPointerValue(conversion.TimePtrToStringPtr(input.FeatureCompatibilityVersionExpirationDate)),
+		GlobalClusterSelfManagedSharding:          types.BoolPointerValue(input.GlobalClusterSelfManagedSharding),
+		ProjectID:                                 types.StringPointerValue(input.GroupId),
+		ClusterID:                                 types.StringPointerValue(input.Id),
+		Labels:                                    labels,
+		MongoDBEmployeeAccessGrant:                mongoDBEmployeeAccessGrant,
+		MongoDBMajorVersion:                       types.StringPointerValue(input.MongoDBMajorVersion),
+		MongoDBVersion:                            types.StringPointerValue(input.MongoDBVersion),
+		Name:                                      types.StringPointerValue(input.Name),
+		Paused:                                    types.BoolPointerValue(input.Paused),
+		PitEnabled:                                types.BoolPointerValue(input.PitEnabled),
+		RedactClientLogData:                       types.BoolPointerValue(input.RedactClientLogData),
+		ReplicaSetScalingStrategy:                 types.StringPointerValue(input.ReplicaSetScalingStrategy),
+		ReplicationSpecs:                          replicationSpecs,
+		RootCertType:                              types.StringPointerValue(input.RootCertType),
+		StateName:                                 types.StringPointerValue(input.StateName),
+		Tags:                                      tags,
+		TerminationProtectionEnabled:              types.BoolPointerValue(input.TerminationProtectionEnabled),
+		VersionReleaseSystem:                      types.StringPointerValue(input.VersionReleaseSystem),
+		Timeouts:                                  timeout,
+	}
+}
+
+func NewBiConnectorObjType(ctx context.Context, input *admin.BiConnector, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(BiConnectorObjType.AttrTypes)
+	}
+	tfModel := TFBiConnectorModel{
+		Enabled:        types.BoolPointerValue(input.Enabled),
+		ReadPreference: types.StringPointerValue(input.ReadPreference),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, BiConnectorObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func NewConnectionStringsObjType(ctx context.Context, input *admin.ClusterConnectionStrings, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(ConnectionStringsObjType.AttrTypes)
+	}
+	privateEndpoint := NewPrivateEndpointObjType(ctx, input.PrivateEndpoint, diags)
+	tfModel := TFConnectionStringsModel{
+		AwsPrivateLink:    conversion.ToTFMapOfString(ctx, diags, input.AwsPrivateLink),
+		AwsPrivateLinkSrv: conversion.ToTFMapOfString(ctx, diags, input.AwsPrivateLinkSrv),
+		Private:           types.StringPointerValue(input.Private),
+		PrivateEndpoint:   privateEndpoint,
+		PrivateSrv:        types.StringPointerValue(input.PrivateSrv),
+		Standard:          types.StringPointerValue(input.Standard),
+		StandardSrv:       types.StringPointerValue(input.StandardSrv),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, ConnectionStringsObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(LabelsObjType)
+	}
+	tfModels := make([]TFLabelsModel, len(*input))
+	for i, item := range *input {
+		tfModels[i] = TFLabelsModel{
+			Key:   types.StringPointerValue(item.Key),
+			Value: types.StringPointerValue(item.Value),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, LabelsObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewMongoDBEmployeeAccessGrantObjType(ctx context.Context, input *admin.EmployeeAccessGrant, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(MongoDbEmployeeAccessGrantObjType.AttrTypes)
+	}
+	tfModel := TFMongoDbEmployeeAccessGrantModel{
+		ExpirationTime: types.StringValue(conversion.TimeToString(input.ExpirationTime)),
+		GrantType:      types.StringValue(input.GrantType),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, MongoDbEmployeeAccessGrantObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationSpec20240805, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(ReplicationSpecsObjType)
+	}
+	tfModels := make([]TFReplicationSpecsModel, len(*input))
+	for i, item := range *input {
+		regionConfigs := NewRegionConfigsObjType(ctx, item.RegionConfigs, diags)
+		tfModels[i] = TFReplicationSpecsModel{
+			Id:            types.StringPointerValue(item.Id),
+			RegionConfigs: regionConfigs,
+			ZoneId:        types.StringPointerValue(item.ZoneId),
+			ZoneName:      types.StringPointerValue(item.ZoneName),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, ReplicationSpecsObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewTagsObjType(ctx context.Context, input *[]admin.ResourceTag, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(TagsObjType)
+	}
+	tfModels := make([]TFTagsModel, len(*input))
+	for i, item := range *input {
+		tfModels[i] = TFTagsModel{
+			Key:   types.StringValue(item.Key),
+			Value: types.StringValue(item.Value),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, TagsObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewPrivateEndpointObjType(ctx context.Context, input *[]admin.ClusterDescriptionConnectionStringsPrivateEndpoint, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(PrivateEndpointObjType)
+	}
+	tfModels := make([]TFPrivateEndpointModel, len(*input))
+	for i, item := range *input {
+		endpoints := NewEndpointsObjType(ctx, item.Endpoints, diags)
+		tfModels[i] = TFPrivateEndpointModel{
+			ConnectionString:                  types.StringPointerValue(item.ConnectionString),
+			Endpoints:                         endpoints,
+			SrvConnectionString:               types.StringPointerValue(item.SrvConnectionString),
+			SrvShardOptimizedConnectionString: types.StringPointerValue(item.SrvShardOptimizedConnectionString),
+			Type:                              types.StringPointerValue(item.Type),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, PrivateEndpointObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewRegionConfigsObjType(ctx context.Context, input *[]admin.CloudRegionConfig20240805, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(RegionConfigsObjType)
+	}
+	tfModels := make([]TFRegionConfigsModel, len(*input))
+	for i, item := range *input {
+		analyticsAutoScaling := NewAutoScalingObjType(ctx, item.AnalyticsAutoScaling, diags)
+		analyticsSpecs := NewSpecsObjType(ctx, item.AnalyticsSpecs, diags)
+		autoScaling := NewAutoScalingObjType(ctx, item.AutoScaling, diags)
+		electableSpecs := NewSpecsFromHwObjType(ctx, item.ElectableSpecs, diags)
+		readOnlySpecs := NewSpecsObjType(ctx, item.ReadOnlySpecs, diags)
+		tfModels[i] = TFRegionConfigsModel{
+			AnalyticsAutoScaling: analyticsAutoScaling,
+			AnalyticsSpecs:       analyticsSpecs,
+			AutoScaling:          autoScaling,
+			BackingProviderName:  types.StringPointerValue(item.BackingProviderName),
+			ElectableSpecs:       electableSpecs,
+			Priority:             types.Int64PointerValue(conversion.IntPtrToInt64Ptr(item.Priority)),
+			ProviderName:         types.StringPointerValue(item.ProviderName),
+			ReadOnlySpecs:        readOnlySpecs,
+			RegionName:           types.StringPointerValue(item.RegionName),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, RegionConfigsObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewEndpointsObjType(ctx context.Context, input *[]admin.ClusterDescriptionConnectionStringsPrivateEndpointEndpoint, diags *diag.Diagnostics) types.List {
+	if input == nil {
+		return types.ListNull(EndpointsObjType)
+	}
+	tfModels := make([]TFEndpointsModel, len(*input))
+	for i, item := range *input {
+		tfModels[i] = TFEndpointsModel{
+			EndpointId:   types.StringPointerValue(item.EndpointId),
+			ProviderName: types.StringPointerValue(item.ProviderName),
+			Region:       types.StringPointerValue(item.Region),
+		}
+	}
+	listType, diagsLocal := types.ListValueFrom(ctx, EndpointsObjType, tfModels)
+	diags.Append(diagsLocal...)
+	return listType
+}
+
+func NewSpecsObjType(ctx context.Context, input *admin.DedicatedHardwareSpec20240805, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(SpecsObjType.AttrTypes)
+	}
+	tfModel := TFSpecsModel{
+		DiskIops:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
+		DiskSizeGb:    types.Float64PointerValue(input.DiskSizeGB),
+		EbsVolumeType: types.StringPointerValue(input.EbsVolumeType),
+		InstanceSize:  types.StringPointerValue(input.InstanceSize),
+		NodeCount:     types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, SpecsObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func NewSpecsFromHwObjType(ctx context.Context, input *admin.HardwareSpec20240805, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(SpecsObjType.AttrTypes)
+	}
+	tfModel := TFSpecsModel{
+		DiskIops:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
+		DiskSizeGb:    types.Float64PointerValue(input.DiskSizeGB),
+		EbsVolumeType: types.StringPointerValue(input.EbsVolumeType),
+		InstanceSize:  types.StringPointerValue(input.InstanceSize),
+		NodeCount:     types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, SpecsObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}
+
+func NewAutoScalingObjType(ctx context.Context, input *admin.AdvancedAutoScalingSettings, diags *diag.Diagnostics) types.Object {
+	if input == nil {
+		return types.ObjectNull(AutoScalingObjType.AttrTypes)
+	}
+	compute := input.Compute
+	tfModel := TFAutoScalingModel{}
+	if compute != nil {
+		tfModel.ComputeMaxInstanceSize = types.StringPointerValue(compute.MaxInstanceSize)
+		tfModel.ComputeMinInstanceSize = types.StringPointerValue(compute.MinInstanceSize)
+		tfModel.ComputeEnabled = types.BoolPointerValue(compute.Enabled)
+		tfModel.ComputeScaleDownEnabled = types.BoolPointerValue(compute.ScaleDownEnabled)
+	}
+	diskGB := input.DiskGB
+	if diskGB != nil {
+		tfModel.DiskGBEnabled = types.BoolPointerValue(diskGB.Enabled)
+	}
+	objType, diagsLocal := types.ObjectValueFrom(ctx, AutoScalingObjType.AttrTypes, tfModel)
+	diags.Append(diagsLocal...)
+	return objType
+}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -70,6 +70,12 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 }
 
 func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state TFModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -51,13 +51,18 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	sdkResp, err := ReadResponse(1)
+	sdkResp, err := ReadClusterResponse(1)
 	if err != nil {
 		resp.Diagnostics.AddError("errorCreate", fmt.Sprintf(errorCreate, err.Error()))
 		return
 	}
-
 	tfNewModel := NewTFModel(ctx, sdkResp, tfModel.Timeouts, &resp.Diagnostics)
+	sdkAdvConfig, err := ReadClusterProcessArgsResponse(1)
+	if err != nil {
+		resp.Diagnostics.AddError("errorCreateAdvConfig", fmt.Sprintf(errorCreate, err.Error()))
+	}
+
+	AddAdvancedConfig(ctx, tfNewModel, sdkAdvConfig, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -2,6 +2,7 @@ package advancedclustertpf
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -10,6 +11,22 @@ import (
 
 var _ resource.ResourceWithConfigure = &rs{}
 var _ resource.ResourceWithImportState = &rs{}
+
+const (
+	errorCreate                    = "error creating advanced cluster: %s"
+	errorRead                      = "error reading  advanced cluster (%s): %s"
+	errorDelete                    = "error deleting advanced cluster (%s): %s"
+	errorUpdate                    = "error updating advanced cluster (%s): %s"
+	errorConfigUpdate              = "error updating advanced cluster configuration options (%s): %s"
+	errorConfigRead                = "error reading advanced cluster configuration options (%s): %s"
+	ErrorClusterSetting            = "error setting `%s` for MongoDB Cluster (%s): %s"
+	ErrorAdvancedConfRead          = "error reading Advanced Configuration Option form MongoDB Cluster (%s): %s"
+	ErrorClusterAdvancedSetting    = "error setting `%s` for MongoDB ClusterAdvanced (%s): %s"
+	ErrorAdvancedClusterListStatus = "error awaiting MongoDB ClusterAdvanced List IDLE: %s"
+	ErrorOperationNotPermitted     = "error operation not permitted"
+	ignoreLabel                    = "Infrastructure Tool"
+	DeprecationOldSchemaAction     = "Please refer to our examples, documentation, and 1.18.0 migration guide for more details at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
+)
 
 func Resource() resource.Resource {
 	return &rs{
@@ -34,7 +51,13 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tfNewModel := NewTFModel(ctx, nil, &resp.Diagnostics)
+	sdkResp, err := ReadResponse(1)
+	if err != nil {
+		resp.Diagnostics.AddError("errorCreate", fmt.Sprintf(errorCreate, err.Error()))
+		return
+	}
+
+	tfNewModel := NewTFModel(ctx, sdkResp, tfModel.Timeouts, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -543,6 +543,7 @@ type TFModel struct {
 	RetainBackupsEnabled                      types.Bool     `tfsdk:"retain_backups_enabled"`
 	BackupEnabled                             types.Bool     `tfsdk:"backup_enabled"`
 	GlobalClusterSelfManagedSharding          types.Bool     `tfsdk:"global_cluster_self_managed_sharding"`
+	AdvancedConfiguration                     types.Object   `tfsdk:"advanced_configuration"`
 }
 
 type TFBiConnectorModel struct {
@@ -720,3 +721,7 @@ type TFAdvancedConfigurationModel struct {
 	JavascriptEnabled                                     types.Bool    `tfsdk:"javascript_enabled"`
 	NoTableScan                                           types.Bool    `tfsdk:"no_table_scan"`
 }
+
+var TFAdvancedConfigurationObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	// TODO: to be implemented
+}}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -315,10 +315,21 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this cluster.",
 			},
-			"tags": schema.MapAttribute{ // TODO: was ListNestedAttribute, changed to align with flex cluster, might be breaking change
-				ElementType:         types.StringType,
+			"tags": schema.ListNestedAttribute{
 				Optional:            true,
-				MarkdownDescription: "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the instance.",
+				MarkdownDescription: "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"key": schema.StringAttribute{
+							Required:            true,
+							MarkdownDescription: "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
+						},
+						"value": schema.StringAttribute{
+							Required:            true,
+							MarkdownDescription: "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
+						},
+					},
+				},
 			},
 			"termination_protection_enabled": schema.BoolAttribute{
 				Computed:            true,
@@ -513,7 +524,7 @@ type TFModel struct {
 	DiskSizeGB                                types.Float64  `tfsdk:"disk_size_gb"`
 	Labels                                    types.List     `tfsdk:"labels"`
 	ReplicationSpecs                          types.List     `tfsdk:"replication_specs"`
-	Tags                                      types.Map      `tfsdk:"tags"`
+	Tags                                      types.List     `tfsdk:"tags"`
 	DiskWarmingMode                           types.String   `tfsdk:"disk_warming_mode"`
 	StateName                                 types.String   `tfsdk:"state_name"`
 	ConnectionStrings                         types.Object   `tfsdk:"connection_strings"`
@@ -614,12 +625,12 @@ var LabelsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"value": types.StringType,
 }}
 
-type TFMongoDbemployeeAccessGrantModel struct {
+type TFMongoDbEmployeeAccessGrantModel struct {
 	ExpirationTime types.String `tfsdk:"expiration_time"`
 	GrantType      types.String `tfsdk:"grant_type"`
 }
 
-var MongoDbemployeeAccessGrantObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
+var MongoDbEmployeeAccessGrantObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"expiration_time": types.StringType,
 	"grant_type":      types.StringType,
 }}
@@ -663,10 +674,10 @@ var RegionConfigsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 }}
 
 type TFAutoScalingModel struct {
-	ComputeMaxInstanceSize  types.String `tfsdk:"max_instance_size"`
-	ComputeMinInstanceSize  types.String `tfsdk:"min_instance_size"`
-	ComputeEnabled          types.Bool   `tfsdk:"enabled"`
-	ComputeScaleDownEnabled types.Bool   `tfsdk:"scale_down_enabled"`
+	ComputeMaxInstanceSize  types.String `tfsdk:"compute_max_instance_size"`
+	ComputeMinInstanceSize  types.String `tfsdk:"compute_min_instance_size"`
+	ComputeEnabled          types.Bool   `tfsdk:"compute_enabled"`
+	ComputeScaleDownEnabled types.Bool   `tfsdk:"compute_scale_down_enabled"`
 	DiskGBEnabled           types.Bool   `tfsdk:"disk_gb_enabled"`
 }
 

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -315,6 +317,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this cluster.",
 			},
+			// TODO: We want to avoid breaking changes even though it is incompatible with flex cluster and project resource
 			"tags": schema.ListNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.",
@@ -439,6 +442,9 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 	return schema.SingleNestedAttribute{
 		Computed: true,
 		Optional: true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 		// TODO: MaxItems: 1,
 		MarkdownDescription: "advanced_configuration", // TODO: add description
 		Attributes: map[string]schema.Attribute{
@@ -723,22 +729,36 @@ var TagsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 
 type TFAdvancedConfigurationModel struct {
 	OplogMinRetentionHours                                types.Float64 `tfsdk:"oplog_min_retention_hours"`
-	ProjectId                                             types.String  `tfsdk:"project_id"`
-	ClusterName                                           types.String  `tfsdk:"cluster_name"`
 	MinimumEnabledTlsProtocol                             types.String  `tfsdk:"minimum_enabled_tls_protocol"`
 	DefaultWriteConcern                                   types.String  `tfsdk:"default_write_concern"`
+	DefaultReadConcern                                    types.String  `tfsdk:"default_read_concern"`
 	DefaultMaxTimeMs                                      types.Int64   `tfsdk:"default_max_time_ms"`
 	ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds types.Int64   `tfsdk:"change_stream_options_pre_and_post_images_expire_after_seconds"`
 	ChunkMigrationConcurrency                             types.Int64   `tfsdk:"chunk_migration_concurrency"`
 	OplogSizeMb                                           types.Int64   `tfsdk:"oplog_size_mb"`
 	QueryStatsLogVerbosity                                types.Int64   `tfsdk:"query_stats_log_verbosity"`
-	SampleRefreshIntervalBiconnector                      types.Int64   `tfsdk:"sample_refresh_interval_biconnector"`
-	SampleSizeBiconnector                                 types.Int64   `tfsdk:"sample_size_biconnector"`
+	SampleRefreshIntervalBiconnector                      types.Int64   `tfsdk:"sample_refresh_interval_bi_connector"`
+	SampleSizeBiconnector                                 types.Int64   `tfsdk:"sample_size_bi_connector"`
 	TransactionLifetimeLimitSeconds                       types.Int64   `tfsdk:"transaction_lifetime_limit_seconds"`
 	JavascriptEnabled                                     types.Bool    `tfsdk:"javascript_enabled"`
 	NoTableScan                                           types.Bool    `tfsdk:"no_table_scan"`
+	FailIndexKeyTooLong                                   types.Bool    `tfsdk:"fail_index_key_too_long"`
 }
 
-var TFAdvancedConfigurationObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	// TODO: to be implemented
+var AdvancedConfigurationObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"change_stream_options_pre_and_post_images_expire_after_seconds": types.Int64Type,
+	"chunk_migration_concurrency":                                    types.Int64Type,
+	"default_max_time_ms":                                            types.Int64Type,
+	"default_read_concern":                                           types.StringType,
+	"default_write_concern":                                          types.StringType,
+	"fail_index_key_too_long":                                        types.BoolType,
+	"javascript_enabled":                                             types.BoolType,
+	"minimum_enabled_tls_protocol":                                   types.StringType,
+	"no_table_scan":                                                  types.BoolType,
+	"oplog_min_retention_hours":                                      types.Float64Type,
+	"oplog_size_mb":                                                  types.Int64Type,
+	"query_stats_log_verbosity":                                      types.Int64Type,
+	"sample_refresh_interval_bi_connector":                           types.Int64Type,
+	"sample_size_bi_connector":                                       types.Int64Type,
+	"transaction_lifetime_limit_seconds":                             types.Int64Type,
 }}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -236,8 +236,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Set this field to configure the replica set scaling mode for your cluster.\n\nBy default, Atlas scales under WORKLOAD_TYPE. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.\n\nWhen configured as SEQUENTIAL, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.\n\nWhen configured as NODE_TYPE, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.",
 			},
 			"replication_specs": schema.ListNestedAttribute{
-				Computed:            true,
-				Optional:            true,
+				Required:            true, // TODO: wrong computability
 				MarkdownDescription: "List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -249,6 +248,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"container_id": schema.MapAttribute{ // TODO: added as in current resource
 							ElementType:         types.StringType,
 							Optional:            true,
+							Computed:            true,
 							MarkdownDescription: "container_id", // TODO: add description
 						},
 						"external_id": schema.StringAttribute{ // TODO: added as in current resource
@@ -264,8 +264,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "num_shards", // TODO: add description
 						},
 						"region_configs": schema.ListNestedAttribute{
-							Computed:            true,
-							Optional:            true,
+							Required:            true, // TODO: wrong computability
 							MarkdownDescription: "Hardware specifications for nodes set for a given region. Each **regionConfigs** object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each **regionConfigs** object must have either an **analyticsSpecs** object, **electableSpecs** object, or **readOnlySpecs** object. Tenant clusters only require **electableSpecs. Dedicated** clusters can specify any of these specifications, but must have at least one **electableSpecs** object within a **replicationSpec**.\n\n**Example:**\n\nIf you set `\"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize\" : \"M30\"`, set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : `\"M30\"` if you have electable nodes and `\"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize\" : `\"M30\"` if you have read-only nodes.",
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -205,7 +205,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the cluster.",
 			},
 			"labels": schema.ListNestedAttribute{ // TODO: database_user is using SetNestedBlock, probably better to align
-				Computed:            true, // TODO: not sure if it should be computed
+				Computed:            true, // TODO: must be computed since backend returns "[]" when it is not specified using "Default" to avoid plan changes
 				Optional:            true,
 				Default:             listdefault.StaticValue(types.ListValueMust(LabelsObjType, nil)),
 				MarkdownDescription: "Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.\n\nCluster labels are deprecated and will be removed in a future release. We strongly recommend that you use [resource tags](https://dochub.mongodb.org/core/add-cluster-tag-atlas) instead.",

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -581,7 +581,7 @@ var ConnectionStringsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"aws_private_link":     types.MapType{ElemType: types.StringType},
 	"aws_private_link_srv": types.MapType{ElemType: types.StringType},
 	"private":              types.StringType,
-	"private_endpoint":     types.ListType{ElemType: types.StringType},
+	"private_endpoint":     types.ListType{ElemType: PrivateEndpointObjType},
 	"private_srv":          types.StringType,
 	"standard":             types.StringType,
 	"standard_srv":         types.StringType,
@@ -597,7 +597,7 @@ type TFPrivateEndpointModel struct {
 
 var PrivateEndpointObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"connection_string":                     types.StringType,
-	"endpoints":                             types.ListType{ElemType: types.StringType},
+	"endpoints":                             types.ListType{ElemType: EndpointsObjType},
 	"srv_connection_string":                 types.StringType,
 	"srv_shard_optimized_connection_string": types.StringType,
 	"type":                                  types.StringType,
@@ -637,6 +637,9 @@ var MongoDbEmployeeAccessGrantObjType = types.ObjectType{AttrTypes: map[string]a
 
 type TFReplicationSpecsModel struct {
 	Id            types.String `tfsdk:"id"`
+	ContainerId   types.Map    `tfsdk:"container_id"`
+	ExternalId    types.String `tfsdk:"external_id"`
+	NumShards     types.Int64  `tfsdk:"num_shards"`
 	RegionConfigs types.List   `tfsdk:"region_configs"`
 	ZoneId        types.String `tfsdk:"zone_id"`
 	ZoneName      types.String `tfsdk:"zone_name"`
@@ -644,7 +647,10 @@ type TFReplicationSpecsModel struct {
 
 var ReplicationSpecsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"id":             types.StringType,
-	"region_configs": types.ListType{ElemType: types.StringType},
+	"container_id":   types.MapType{ElemType: types.StringType},
+	"external_id":    types.StringType,
+	"num_shards":     types.Int64Type,
+	"region_configs": types.ListType{ElemType: RegionConfigsObjType},
 	"zone_id":        types.StringType,
 	"zone_name":      types.StringType,
 }}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -204,10 +204,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the cluster.",
 			},
-			"labels": schema.ListNestedAttribute{ // TODO: database_user is using SetNestedBlock, probably better to align
+			"labels": schema.SetNestedAttribute{ // TODO: database_user is using SetNestedBlock, probably better to align
 				Computed:            true, // TODO: must be computed since backend returns "[]" when it is not specified using "Default" to avoid plan changes
 				Optional:            true,
-				Default:             listdefault.StaticValue(types.ListValueMust(LabelsObjType, nil)),
+				Default:             setdefault.StaticValue(types.SetValueMust(LabelsObjType, nil)),
 				MarkdownDescription: "Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.\n\nCluster labels are deprecated and will be removed in a future release. We strongly recommend that you use [resource tags](https://dochub.mongodb.org/core/add-cluster-tag-atlas) instead.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -390,7 +390,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this cluster.",
 			},
 			// TODO: We want to avoid breaking changes even though it is incompatible with flex cluster and project resource
-			"tags": schema.ListNestedAttribute{
+			"tags": schema.SetNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.",
 				NestedObject: schema.NestedAttributeObject{
@@ -619,9 +619,9 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 
 type TFModel struct {
 	DiskSizeGB                                types.Float64  `tfsdk:"disk_size_gb"`
-	Labels                                    types.List     `tfsdk:"labels"`
+	Labels                                    types.Set      `tfsdk:"labels"`
 	ReplicationSpecs                          types.List     `tfsdk:"replication_specs"`
-	Tags                                      types.List     `tfsdk:"tags"`
+	Tags                                      types.Set      `tfsdk:"tags"`
 	DiskWarmingMode                           types.String   `tfsdk:"disk_warming_mode"`
 	StateName                                 types.String   `tfsdk:"state_name"`
 	ConnectionStrings                         types.Object   `tfsdk:"connection_strings"`

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -6,10 +6,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -22,14 +27,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set **acceptDataRisksAndForceReplicaSetReconfig** to the current date.",
 			},
 			"backup_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/) for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.",
 			},
 			"bi_connector": schema.SingleNestedAttribute{
 				// TODO: MaxItems: 1
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Settings needed to configure the MongoDB Connector for Business Intelligence for this cluster.",
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
@@ -49,7 +60,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Configuration of nodes that comprise the cluster.",
 			},
 			"config_server_management_mode": schema.StringAttribute{
-				Computed:            true,
+				// Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Config Server Management Mode for creating or updating a sharded cluster.\n\nWhen configured as ATLAS_MANAGED, atlas may automatically switch the cluster's config server type for optimal performance and savings.\n\nWhen configured as FIXED_TO_DEDICATED, the cluster will always use a dedicated config server.",
 			},
@@ -60,6 +71,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"connection_strings": schema.SingleNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Collection of Uniform Resource Locators that point to the MongoDB database.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"aws_private_link": schema.MapAttribute{ // TODO: not in current resource, decide if keep
 						Computed:            true,
@@ -134,29 +148,49 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"create_date": schema.StringAttribute{
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.",
 			},
 			"disk_warming_mode": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Disk warming mode selection.",
 			},
 			"encryption_at_rest_provider": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster **replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize** setting must be `M10` or higher and `\"backupEnabled\" : false` or omitted entirely.",
 			},
 			"feature_compatibility_version": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Computed:            true,
+				Optional: true,
+				// Computed:            true,
+				// PlanModifiers: []planmodifier.String{
+				// 	stringplanmodifier.UseStateForUnknown(),
+				// },
 				MarkdownDescription: "Feature compatibility version of the cluster.",
 			},
 			"feature_compatibility_version_expiration_date": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Computed:            true,
+				// Computed:            true,
+				Optional: true,
+				// PlanModifiers: []planmodifier.String{
+				// 	stringplanmodifier.UseStateForUnknown(),
+				// },
 				MarkdownDescription: "Feature compatibility version expiration date.",
 			},
 			"global_cluster_self_managed_sharding": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Set this field to configure the Sharding Management Mode when creating a new Global Cluster.\n\nWhen set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.\n\nWhen set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.\n\nThis setting cannot be changed once the cluster is deployed.",
 			},
 			"project_id": schema.StringAttribute{ // TODO: fail if trying to update
@@ -164,12 +198,16 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
 			},
 			"cluster_id": schema.StringAttribute{ // TODO: was generated as id
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the cluster.",
 			},
 			"labels": schema.ListNestedAttribute{ // TODO: database_user is using SetNestedBlock, probably better to align
 				Computed:            true, // TODO: not sure if it should be computed
 				Optional:            true,
+				Default:             listdefault.StaticValue(types.ListValueMust(LabelsObjType, nil)),
 				MarkdownDescription: "Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.\n\nCluster labels are deprecated and will be removed in a future release. We strongly recommend that you use [resource tags](https://dochub.mongodb.org/core/add-cluster-tag-atlas) instead.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -187,7 +225,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"mongo_db_employee_access_grant": schema.SingleNestedAttribute{ // TODO: not in current resource, already in mongodbemployeeaccessgrant, will probably delete, was generated as mongo_dbemployee_access_grant
-				Computed:            true,
+				Optional: true,
+				// Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "MongoDB employee granted access level and expiration for a cluster.",
 				Attributes: map[string]schema.Attribute{
 					"expiration_time": schema.StringAttribute{
@@ -204,11 +246,17 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				// TODO: watch out new error, Error code: "ATLAS_CLUSTER_VERSION_DEPRECATED") Detail: MongoDB version is deprecated in Atlas. Reason: Bad Request. Params: [], BadRequestDetail:
 				Computed: true,
 				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				// TODO: StateFunc: FormatMongoDBMajorVersion,
 				MarkdownDescription: "MongoDB major version of the cluster.\n\nOn creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLTSVersions).\n\n On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.",
 			},
 			"mongo_db_version": schema.StringAttribute{ // TODO: was generated as mongo_dbversion
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Version of MongoDB that the cluster runs.",
 			},
 			"name": schema.StringAttribute{ // TODO: fail if trying to update
@@ -216,22 +264,30 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Human-readable label that identifies this cluster.",
 			},
 			"paused": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Flag that indicates whether the cluster is paused.",
 			},
 			"pit_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Flag that indicates whether the cluster uses continuous cloud backups.",
 			},
 			"redact_client_log_data": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Enable or disable log redaction.\n\nThis setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.\n\nUse ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.\n\n*Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.",
 			},
 			"replica_set_scaling_strategy": schema.StringAttribute{
-				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Set this field to configure the replica set scaling mode for your cluster.\n\nBy default, Atlas scales under WORKLOAD_TYPE. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.\n\nWhen configured as SEQUENTIAL, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.\n\nWhen configured as NODE_TYPE, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.",
 			},
@@ -242,18 +298,26 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							// TODO: Deprecated: DeprecationMsgOldSchema,
-							Computed:            true,
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the replication object for a shard in a Cluster. If you include existing shard replication configurations in the request, you must specify this parameter. If you add a new shard to an existing Cluster, you may specify this parameter. The request deletes any existing shards  in the Cluster that you exclude from the request. This corresponds to Shard ID displayed in the UI.",
 						},
 						"container_id": schema.MapAttribute{ // TODO: added as in current resource
-							ElementType:         types.StringType,
-							Optional:            true,
-							Computed:            true,
+							ElementType: types.StringType,
+							Computed:    true,
+							PlanModifiers: []planmodifier.Map{
+								mapplanmodifier.UseStateForUnknown(),
+							},
 							MarkdownDescription: "container_id", // TODO: add description
 						},
 						"external_id": schema.StringAttribute{ // TODO: added as in current resource
 							Computed:            true,
 							MarkdownDescription: "external_id", // TODO: add description
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"num_shards": schema.Int64Attribute{ // TODO: added as in current resource
 							// TODO: Deprecated: DeprecationMsgOldSchema,
@@ -268,9 +332,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Hardware specifications for nodes set for a given region. Each **regionConfigs** object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each **regionConfigs** object must have either an **analyticsSpecs** object, **electableSpecs** object, or **readOnlySpecs** object. Tenant clusters only require **electableSpecs. Dedicated** clusters can specify any of these specifications, but must have at least one **electableSpecs** object within a **replicationSpec**.\n\n**Example:**\n\nIf you set `\"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize\" : \"M30\"`, set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : `\"M30\"` if you have electable nodes and `\"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize\" : `\"M30\"` if you have read-only nodes.",
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
-									"analytics_auto_scaling": AutoScalingSchema(),
+									"analytics_auto_scaling": AutoScalingSchema(false),
 									"analytics_specs":        SpecsSchema("Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region."),
-									"auto_scaling":           AutoScalingSchema(),
+									"auto_scaling":           AutoScalingSchema(true),
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
 										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when **providerName** is `TENANT` and **electableSpecs.instanceSize** is `M0`, `M2` or `M5`.",
@@ -295,7 +359,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 						"zone_id": schema.StringAttribute{
-							Computed:            true,
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the zone in a Global Cluster. This value can be used to configure Global Cluster backup policies.",
 						},
 						"zone_name": schema.StringAttribute{
@@ -308,12 +375,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"root_cert_type": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Root Certificate Authority that MongoDB Cloud cluster uses. MongoDB Cloud supports Internet Security Research Group.",
 			},
 			"state_name": schema.StringAttribute{
-				Computed:            true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this cluster.",
 			},
 			// TODO: We want to avoid breaking changes even though it is incompatible with flex cluster and project resource
@@ -334,14 +407,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"termination_protection_enabled": schema.BoolAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.",
 			},
 			"version_release_system": schema.StringAttribute{
 				// TODO: probably leave validation just in the server, ValidateFunc: validation.StringInSlice([]string{"LTS", "CONTINUOUS"}, false),
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify **mongoDBMajorVersion**.",
 			},
 			"retain_backups_enabled": schema.BoolAttribute{ // TODO: not exposed in API, used in Delete operation
@@ -350,7 +429,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"disk_size_gb": schema.Float64Attribute{ // TODO: not exposed in latest API, deprecated in root in current resource
 				// Deprecated: DeprecationMsgOldSchema,
-				Computed:            true,
+				// Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
 			},
@@ -364,11 +443,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-func AutoScalingSchema() schema.SingleNestedAttribute {
+func AutoScalingSchema(computed bool) schema.SingleNestedAttribute {
+	// todo: computed, analytics_auto_scaling is not returned by default, so it cannot be computed
 	return schema.SingleNestedAttribute{
 		// TODO: MaxItems: 1
-		Computed:            true,
-		Optional:            true,
+		Computed: computed,
+		Optional: true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 		MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
 		Attributes: map[string]schema.Attribute{
 			"compute_enabled": schema.BoolAttribute{ // TODO: was nested in compute
@@ -403,13 +486,19 @@ func AutoScalingSchema() schema.SingleNestedAttribute {
 func SpecsSchema(markdownDescription string) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
 		// TODO: MaxItems: 1
-		Computed:            true,
-		Optional:            true,
+		Computed: true,
+		Optional: true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 		MarkdownDescription: markdownDescription,
 		Attributes: map[string]schema.Attribute{
 			"disk_iops": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
 			},
 			"disk_size_gb": schema.Float64Attribute{
@@ -418,8 +507,11 @@ func SpecsSchema(markdownDescription string) schema.SingleNestedAttribute {
 				MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
 			},
 			"ebs_volume_type": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
 			},
 			"instance_size": schema.StringAttribute{

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -60,7 +60,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Configuration of nodes that comprise the cluster.",
 			},
 			"config_server_management_mode": schema.StringAttribute{
-				// Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Config Server Management Mode for creating or updating a sharded cluster.\n\nWhen configured as ATLAS_MANAGED, atlas may automatically switch the cluster's config server type for optimal performance and savings.\n\nWhen configured as FIXED_TO_DEDICATED, the cluster will always use a dedicated config server.",
 			},
@@ -170,19 +169,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster **replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize** setting must be `M10` or higher and `\"backupEnabled\" : false` or omitted entirely.",
 			},
 			"feature_compatibility_version": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Optional: true,
-				// Computed:            true,
-				// PlanModifiers: []planmodifier.String{
-				// 	stringplanmodifier.UseStateForUnknown(),
-				// },
+				Optional:            true,
 				MarkdownDescription: "Feature compatibility version of the cluster.",
 			},
 			"feature_compatibility_version_expiration_date": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				// Computed:            true,
-				Optional: true,
-				// PlanModifiers: []planmodifier.String{
-				// 	stringplanmodifier.UseStateForUnknown(),
-				// },
+				Optional:            true,
 				MarkdownDescription: "Feature compatibility version expiration date.",
 			},
 			"global_cluster_self_managed_sharding": schema.BoolAttribute{
@@ -221,24 +212,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Optional:            true,
 							MarkdownDescription: "Value set to the Key applied to tag and categorize this component.",
 						},
-					},
-				},
-			},
-			"mongo_db_employee_access_grant": schema.SingleNestedAttribute{ // TODO: not in current resource, already in mongodbemployeeaccessgrant, will probably delete, was generated as mongo_dbemployee_access_grant
-				Optional: true,
-				// Computed: true,
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
-				MarkdownDescription: "MongoDB employee granted access level and expiration for a cluster.",
-				Attributes: map[string]schema.Attribute{
-					"expiration_time": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Expiration date for the employee access grant.",
-					},
-					"grant_type": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Level of access to grant to MongoDB Employees.",
 					},
 				},
 			},
@@ -634,7 +607,6 @@ type TFModel struct {
 	ProjectID                                 types.String   `tfsdk:"project_id"`
 	ClusterID                                 types.String   `tfsdk:"cluster_id"`
 	ConfigServerManagementMode                types.String   `tfsdk:"config_server_management_mode"`
-	MongoDBEmployeeAccessGrant                types.Object   `tfsdk:"mongo_db_employee_access_grant"`
 	MongoDBMajorVersion                       types.String   `tfsdk:"mongo_db_major_version"`
 	MongoDBVersion                            types.String   `tfsdk:"mongo_db_version"`
 	Name                                      types.String   `tfsdk:"name"`
@@ -720,16 +692,6 @@ type TFLabelsModel struct {
 var LabelsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"key":   types.StringType,
 	"value": types.StringType,
-}}
-
-type TFMongoDbEmployeeAccessGrantModel struct {
-	ExpirationTime types.String `tfsdk:"expiration_time"`
-	GrantType      types.String `tfsdk:"grant_type"`
-}
-
-var MongoDbEmployeeAccessGrantObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"expiration_time": types.StringType,
-	"grant_type":      types.StringType,
 }}
 
 type TFReplicationSpecsModel struct {

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -195,7 +195,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the cluster.",
 			},
-			"labels": schema.SetNestedAttribute{ // TODO: database_user is using SetNestedBlock, probably better to align
+			"labels": schema.SetNestedAttribute{
 				Computed:            true, // TODO: must be computed since backend returns "[]" when it is not specified using "Default" to avoid plan changes
 				Optional:            true,
 				Default:             setdefault.StaticValue(types.SetValueMust(LabelsObjType, nil)),

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -21,25 +21,22 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 
 func configBasic() string {
 	return `
-	 /*	
-	 // TODO: resource not used yet until we have a fake model so test can run
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id = "111111111111111111111111"
 			name = "test"
 			cluster_type = "TYPE"
 		}
-	*/
 		data "mongodbatlas_advanced_cluster" "test" {
 			project_id = "111111111111111111111111"
 			name = "test"
 
-			// depends_on = [mongodbatlas_advanced_cluster.test]	
+			depends_on = [mongodbatlas_advanced_cluster.test]	
 		}
 
 		data "mongodbatlas_advanced_clusters" "tests" {
 				project_id = "111111111111111111111111"
 
-				// depends_on = [mongodbatlas_advanced_cluster.test]	
+				depends_on = [mongodbatlas_advanced_cluster.test]	
 		}
 	`
 }

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -25,6 +25,18 @@ func configBasic() string {
 			project_id = "111111111111111111111111"
 			name = "test"
 			cluster_type = "REPLICASET"
+			replication_specs = [{
+				region_configs = [{
+					priority        = 7
+					provider_name = "AWS"
+					region_name     = "US_EAST_1"
+					electable_specs = {
+						node_count = 3
+						instance_size = "M10"
+						disk_size_gb = 10
+					}
+				}]
+			}]
 		}
 	`
 }

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -24,19 +24,7 @@ func configBasic() string {
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id = "111111111111111111111111"
 			name = "test"
-			cluster_type = "TYPE"
-		}
-		data "mongodbatlas_advanced_cluster" "test" {
-			project_id = "111111111111111111111111"
-			name = "test"
-
-			depends_on = [mongodbatlas_advanced_cluster.test]	
-		}
-
-		data "mongodbatlas_advanced_clusters" "tests" {
-				project_id = "111111111111111111111111"
-
-				depends_on = [mongodbatlas_advanced_cluster.test]	
+			cluster_type = "REPLICASET"
 		}
 	`
 }

--- a/internal/service/advancedclustertpf/responses.go
+++ b/internal/service/advancedclustertpf/responses.go
@@ -1,0 +1,37 @@
+package advancedclustertpf
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+)
+
+var (
+	//go:embed testdata/create_1.json
+	create1 string
+	//go:embed testdata/create_2.json
+	create2 string
+	//go:embed testdata/create_3.json
+	create3         string
+	responsesCreate = map[int]string{
+		1: create1,
+		2: create2,
+		3: create3,
+	}
+)
+
+func ReadResponse(number int) (*admin.ClusterDescription20240805, error) {
+	responseJSON, ok := responsesCreate[number]
+	if !ok {
+		return nil, fmt.Errorf("unknown response number %d", number)
+	}
+	return parseReadResponse(responseJSON)
+}
+
+func parseReadResponse(data string) (*admin.ClusterDescription20240805, error) {
+	var SDKModel admin.ClusterDescription20240805
+	err := json.Unmarshal([]byte(data), &SDKModel)
+	return &SDKModel, err
+}

--- a/internal/service/advancedclustertpf/responses.go
+++ b/internal/service/advancedclustertpf/responses.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"go.mongodb.org/atlas-sdk/v20241023001/admin"
+	"go.mongodb.org/atlas-sdk/v20241023002/admin"
 )
 
 var (

--- a/internal/service/advancedclustertpf/responses.go
+++ b/internal/service/advancedclustertpf/responses.go
@@ -20,18 +20,29 @@ var (
 		2: create2,
 		3: create3,
 	}
+	//go:embed testdata/process_args_1.json
+	processArgs1         string
+	responsesProcessArgs = map[int]string{
+		1: processArgs1,
+	}
 )
 
-func ReadResponse(number int) (*admin.ClusterDescription20240805, error) {
+func ReadClusterResponse(number int) (*admin.ClusterDescription20240805, error) {
 	responseJSON, ok := responsesCreate[number]
 	if !ok {
 		return nil, fmt.Errorf("unknown response number %d", number)
 	}
-	return parseReadResponse(responseJSON)
+	var SDKModel admin.ClusterDescription20240805
+	err := json.Unmarshal([]byte(responseJSON), &SDKModel)
+	return &SDKModel, err
 }
 
-func parseReadResponse(data string) (*admin.ClusterDescription20240805, error) {
-	var SDKModel admin.ClusterDescription20240805
-	err := json.Unmarshal([]byte(data), &SDKModel)
+func ReadClusterProcessArgsResponse(number int) (*admin.ClusterDescriptionProcessArgs20240805, error) {
+	responseJSON, ok := responsesProcessArgs[number]
+	if !ok {
+		return nil, fmt.Errorf("unknown response number %d", number)
+	}
+	var SDKModel admin.ClusterDescriptionProcessArgs20240805
+	err := json.Unmarshal([]byte(responseJSON), &SDKModel)
 	return &SDKModel, err
 }

--- a/internal/service/advancedclustertpf/testdata/create_1.json
+++ b/internal/service/advancedclustertpf/testdata/create_1.json
@@ -1,0 +1,84 @@
+{
+    "backupEnabled": true,
+    "biConnector": {
+        "enabled": false,
+        "readPreference": "secondary"
+    },
+    "clusterType": "REPLICASET",
+    "connectionStrings": {},
+    "createDate": "2024-11-06T06:52:28Z",
+    "diskWarmingMode": "FULLY_WARMED",
+    "encryptionAtRestProvider": "NONE",
+    "globalClusterSelfManagedSharding": false,
+    "groupId": "111111111111111111111111",
+    "id": "672b122c5ed804369706f178",
+    "labels": [],
+    "links": [
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init",
+            "rel": "self"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/restoreJobs",
+            "rel": "https://cloud.mongodb.com/restoreJobs"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/snapshots",
+            "rel": "https://cloud.mongodb.com/snapshots"
+        }
+    ],
+    "mongoDBMajorVersion": "7.0",
+    "mongoDBVersion": "7.0.15",
+    "name": "test",
+    "paused": false,
+    "pitEnabled": false,
+    "redactClientLogData": false,
+    "replicationSpecs": [
+        {
+            "id": "672b122c5ed804369706f16e",
+            "regionConfigs": [
+                {
+                    "analyticsSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "autoScaling": {
+                        "compute": {
+                            "enabled": false,
+                            "scaleDownEnabled": false
+                        },
+                        "diskGB": {
+                            "enabled": false
+                        }
+                    },
+                    "electableSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 3
+                    },
+                    "priority": 7,
+                    "providerName": "AWS",
+                    "readOnlySpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "regionName": "US_EAST_1"
+                }
+            ],
+            "zoneId": "672b122c5ed804369706f16c",
+            "zoneName": "ZoneName managed by Terraform"
+        }
+    ],
+    "rootCertType": "ISRGROOTX1",
+    "stateName": "CREATING",
+    "terminationProtectionEnabled": false,
+    "versionReleaseSystem": "LTS"
+}

--- a/internal/service/advancedclustertpf/testdata/create_2.json
+++ b/internal/service/advancedclustertpf/testdata/create_2.json
@@ -1,0 +1,85 @@
+{
+    "backupEnabled": true,
+    "biConnector": {
+        "enabled": false,
+        "readPreference": "secondary"
+    },
+    "clusterType": "REPLICASET",
+    "connectionStrings": {},
+    "createDate": "2024-11-06T06:52:28Z",
+    "diskWarmingMode": "FULLY_WARMED",
+    "encryptionAtRestProvider": "NONE",
+    "globalClusterSelfManagedSharding": false,
+    "groupId": "111111111111111111111111",
+    "id": "672b122c5ed804369706f178",
+    "labels": [],
+    "links": [
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init",
+            "rel": "self"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/restoreJobs",
+            "rel": "https://cloud.mongodb.com/restoreJobs"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/snapshots",
+            "rel": "https://cloud.mongodb.com/snapshots"
+        }
+    ],
+    "mongoDBMajorVersion": "7.0",
+    "mongoDBVersion": "7.0.15",
+    "name": "test",
+    "paused": false,
+    "pitEnabled": false,
+    "redactClientLogData": false,
+    "replicationSpecs": [
+        {
+            "id": "672b122c5ed804369706f16e",
+            "regionConfigs": [
+                {
+                    "analyticsSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "autoScaling": {
+                        "compute": {
+                            "enabled": false,
+                            "scaleDownEnabled": false
+                        },
+                        "diskGB": {
+                            "enabled": false
+                        }
+                    },
+                    "electableSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 3
+                    },
+                    "priority": 7,
+                    "providerName": "AWS",
+                    "readOnlySpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "diskSizeGB": 10.0,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "regionName": "US_EAST_1"
+                }
+            ],
+            "zoneId": "672b122c5ed804369706f16c",
+            "zoneName": "ZoneName managed by Terraform"
+        }
+    ],
+    "rootCertType": "ISRGROOTX1",
+    "stateName": "CREATING",
+    "tags": [],
+    "terminationProtectionEnabled": false,
+    "versionReleaseSystem": "LTS"
+}

--- a/internal/service/advancedclustertpf/testdata/create_3.json
+++ b/internal/service/advancedclustertpf/testdata/create_3.json
@@ -1,0 +1,86 @@
+{
+    "backupEnabled": true,
+    "biConnector": {
+        "enabled": false,
+        "readPreference": "secondary"
+    },
+    "clusterType": "REPLICASET",
+    "connectionStrings": {
+        "standard": "mongodb://atlas-init-shard-00-00.jciib.mongodb-dev.net:27017,atlas-init-shard-00-01.jciib.mongodb-dev.net:27017,atlas-init-shard-00-02.jciib.mongodb-dev.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-v8ck2g-shard-0",
+        "standardSrv": "mongodb+srv://atlas-init.jciib.mongodb-dev.net"
+    },
+    "createDate": "2024-11-06T06:52:28Z",
+    "diskSizeGB": 10.0,
+    "diskWarmingMode": "FULLY_WARMED",
+    "encryptionAtRestProvider": "NONE",
+    "globalClusterSelfManagedSharding": false,
+    "groupId": "111111111111111111111111",
+    "id": "672b122c5ed804369706f178",
+    "labels": [],
+    "links": [
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init",
+            "rel": "self"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/restoreJobs",
+            "rel": "https://cloud.mongodb.com/restoreJobs"
+        },
+        {
+            "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/111111111111111111111111/clusters/atlas-init/backup/snapshots",
+            "rel": "https://cloud.mongodb.com/snapshots"
+        }
+    ],
+    "mongoDBMajorVersion": "7.0",
+    "mongoDBVersion": "7.0.15",
+    "name": "test",
+    "paused": false,
+    "pitEnabled": false,
+    "replicationSpecs": [
+        {
+            "id": "672b122c5ed804369706f16d",
+            "numShards": 1,
+            "regionConfigs": [
+                {
+                    "analyticsSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "autoScaling": {
+                        "compute": {
+                            "enabled": false,
+                            "scaleDownEnabled": false
+                        },
+                        "diskGB": {
+                            "enabled": false
+                        }
+                    },
+                    "electableSpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 3
+                    },
+                    "priority": 7,
+                    "providerName": "AWS",
+                    "readOnlySpecs": {
+                        "instanceSize": "M10",
+                        "diskIOPS": 3000,
+                        "ebsVolumeType": "STANDARD",
+                        "nodeCount": 0
+                    },
+                    "regionName": "US_EAST_1"
+                }
+            ],
+            "zoneId": "672b122c5ed804369706f16c",
+            "zoneName": "ZoneName managed by Terraform"
+        }
+    ],
+    "rootCertType": "ISRGROOTX1",
+    "stateName": "IDLE",
+    "tags": [],
+    "terminationProtectionEnabled": false,
+    "versionReleaseSystem": "LTS"
+}

--- a/internal/service/advancedclustertpf/testdata/create_payload.json
+++ b/internal/service/advancedclustertpf/testdata/create_payload.json
@@ -1,0 +1,22 @@
+{
+    "backupEnabled": true,
+    "clusterType": "REPLICASET",
+    "name": "test",
+    "replicationSpecs": [
+        {
+            "regionConfigs": [
+                {
+                    "electableSpecs": {
+                        "diskSizeGB": 10,
+                        "instanceSize": "M10",
+                        "nodeCount": 3
+                    },
+                    "priority": 7,
+                    "providerName": "AWS",
+                    "regionName": "US_EAST_1"
+                }
+            ],
+            "zoneName": "ZoneName managed by Terraform"
+        }
+    ]
+}

--- a/internal/service/advancedclustertpf/testdata/process_args_1.json
+++ b/internal/service/advancedclustertpf/testdata/process_args_1.json
@@ -1,0 +1,15 @@
+{
+    "changeStreamOptionsPreAndPostImagesExpireAfterSeconds": null,
+    "chunkMigrationConcurrency": null,
+    "defaultMaxTimeMS": null,
+    "defaultWriteConcern": null,
+    "javascriptEnabled": true,
+    "minimumEnabledTlsProtocol": "TLS1_2",
+    "noTableScan": false,
+    "oplogMinRetentionHours": null,
+    "oplogSizeMB": null,
+    "queryStatsLogVerbosity": null,
+    "sampleRefreshIntervalBIConnector": null,
+    "sampleSizeBIConnector": null,
+    "transactionLifetimeLimitSeconds": null
+}


### PR DESCRIPTION
## Description

- Implements no-op resource and run test with resource.
- Using static `.json` files in `testdata` to simulate a real response and avoid hard-coding too many values (will be removed in later PRs)
- resource_schema.go is still a WIP with a lot of TODOs. Changes are tracked [here](https://docs.google.com/document/d/1QxrB1BOiMCvUjwAsllG0M3rHKl6ymKJOEF6L5aNYJmE/edit?tab=t.0#heading=h.yvdfy3rjivp)
- experimenting with new naming format for converting `model_xxx`
- only includes conversions from `sdk` -> `TFModel` follow up [issue](https://jira.mongodb.org/browse/CLOUDP-283042) for update and more conversions

In order to run tests locally:
```
make enable-advancedclustertpf   # only once

ACCTEST_PACKAGES=./internal/service/advancedclustertpf ACCTEST_REGEX_RUN='TestAccAdvancedCluster_basic' make testacc          
```

Link to any related issue(s): CLOUDP-281930

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
