### PR TITLE
fix: Improve error message when networking peering reaches a failed status

### DIFF
--- a/.changelog/2766.txt
+++ b/.changelog/2766.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_network_peering: Improve error message when networking peering reaches a failed status
+```

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -324,11 +324,11 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 func errorIfFailedStatusIsPresent(peer *admin.BaseNetworkPeeringConnectionSettings) diag.Diagnostics {
 	// for azure/gcp "status" and "errorState" is returned, for aws "statusName" and "errorStateName" :-/
 	if peer.GetStatus() == "FAILED" || peer.GetStatusName() == "FAILED" {
-		statusName := peer.GetStatus()
-		if peer.GetStatusName() != "" {
-			statusName = peer.GetStatusName()
+		errorState := peer.GetErrorState()
+		if peer.GetErrorStateName() != "" {
+			errorState = peer.GetErrorStateName()
 		}
-		return diag.FromErr(fmt.Errorf("peer networking is in a failed state: %s", statusName))
+		return diag.FromErr(fmt.Errorf("peer networking is in a failed state: %s", errorState))
 	}
 	return nil
 }

--- a/internal/service/networkpeering/resource_network_peering.go
+++ b/internal/service/networkpeering/resource_network_peering.go
@@ -322,7 +322,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func errorIfFailedStatusIsPresent(peer *admin.BaseNetworkPeeringConnectionSettings) diag.Diagnostics {
-	// for azure/gcp "status" and "errorState" is returned, for aws "statusName" and "errorStateName" :-/
+	// for Azure/GCP "status" and "errorState" is returned, for AWS "statusName" and "errorStateName" :-/
 	if peer.GetStatus() == "FAILED" || peer.GetStatusName() == "FAILED" {
 		errorState := peer.GetErrorState()
 		if peer.GetErrorStateName() != "" {

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -69,6 +70,28 @@ func TestAccNetworkRSNetworkPeering_Azure(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"container_id"},
+			},
+		},
+	})
+}
+
+func TestAccNetworkRSNetworkPeering_AzureFailedStatus(t *testing.T) {
+	var (
+		directoryID       = os.Getenv("AZURE_DIRECTORY_ID")
+		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
+		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+		vNetName          = os.Getenv("AZURE_VNET_NAME")
+		providerName      = "AZURE"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAzure(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyNetworkPeering,
+		Steps: []resource.TestStep{
+			{
+				Config:      configAzureTwoPeeringSameCIDR(providerName, directoryID, subscriptionID, resourceGroupName, vNetName),
+				ExpectError: regexp.MustCompile("peer networking is in a failed state:"),
 			},
 		},
 	})
@@ -310,6 +333,45 @@ func configAzure(projectID, providerName, directoryID, subscriptionID, resourceG
 			vnet_name	          = %[6]q
 		}
 	`, projectID, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
+}
+
+func configAzureTwoPeeringSameCIDR(providerName, directoryID, subscriptionID, resourceGroupName, vNetName string) string {
+	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
+	firstProjName := acc.RandomProjectName()
+	secondProjName := acc.RandomProjectName()
+	cidrBlock := "192.164.0.0/21" // failure expected as 2 peering connections use same cidr block range in same azure account
+	firstAzureConfig := configAzureWithProject("first", orgID, firstProjName, cidrBlock, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
+	secondAzureConfig := configAzureWithProject("second", orgID, secondProjName, cidrBlock, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
+	return fmt.Sprintf(`
+		%[1]s
+		%[2]s
+	`, firstAzureConfig, secondAzureConfig)
+}
+
+func configAzureWithProject(rsName, orgID, projectName, cidrBlock, providerName, directoryID, subscriptionID, resourceGroupName, vNetName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project" "%[8]s" {
+			org_id 			 = %[1]q
+			name   			 = %[2]q
+		}
+
+		resource "mongodbatlas_network_container" "%[8]s" {
+			project_id   		  = mongodbatlas_project.%[8]s.id
+			atlas_cidr_block  = %[9]q
+			provider_name		  = %[3]q
+			region    			  = "US_EAST_2"
+		}
+
+		resource "mongodbatlas_network_peering" "%[8]s" {
+			project_id   		  = mongodbatlas_project.%[8]s.id
+			container_id          = mongodbatlas_network_container.%[8]s.container_id
+			provider_name         = %[3]q
+			azure_directory_id    = %[4]q
+			azure_subscription_id = %[5]q
+			resource_group_name   = %[6]q
+			vnet_name	          = %[7]q
+		}
+	`, orgID, projectName, providerName, directoryID, subscriptionID, resourceGroupName, vNetName, rsName, cidrBlock)
 }
 
 func configGCP(projectID, providerName, gcpProjectID, networkName string) string {

--- a/internal/service/networkpeering/resource_network_peering_test.go
+++ b/internal/service/networkpeering/resource_network_peering_test.go
@@ -339,7 +339,7 @@ func configAzureTwoPeeringSameCIDR(providerName, directoryID, subscriptionID, re
 	orgID := os.Getenv("MONGODB_ATLAS_ORG_ID")
 	firstProjName := acc.RandomProjectName()
 	secondProjName := acc.RandomProjectName()
-	cidrBlock := "192.164.0.0/21" // failure expected as 2 peering connections use same cidr block range in same azure account
+	cidrBlock := "172.16.0.0/21" // failure expected as 2 peering connections use same cidr block range in same azure account
 	firstAzureConfig := configAzureWithProject("first", orgID, firstProjName, cidrBlock, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
 	secondAzureConfig := configAzureWithProject("second", orgID, secondProjName, cidrBlock, providerName, directoryID, subscriptionID, resourceGroupName, vNetName)
 	return fmt.Sprintf(`


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-268949

Reproduced a FAILED status by creating 2 network_peering resources with same azure account and cidr block range (using separate projects).

### Before

```
mongodbatlas_network_peering.other: Still creating... [40s elapsed]
╷
│ Error: error creating MongoDB Network Peering Connection: unexpected state 'FAILED', wanted target 'AVAILABLE, PENDING_ACCEPTANCE'. last error: %!s(<nil>)
│ 
│   with mongodbatlas_network_peering.other,
│   on main.tf line 53, in resource "mongodbatlas_network_peering" "other":
│   53: resource "mongodbatlas_network_peering" "other" {
│ 
```

### After

```
mongodbatlas_network_peering.other: Still creating... [40s elapsed]
╷
│ Error: Peer networking is in a failed state: Could not create peering connection in Atlas Azure account because a peer with an overlapping CIDR block already exists.
│ 
│   with mongodbatlas_network_peering.other,
│   on main.tf line 53, in resource "mongodbatlas_network_peering" "other":
│   53: resource "mongodbatlas_network_peering" "other" {
│ 
```


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
