### PR TITLE
feat: Implements `mongodbatlas_flex_cluster` plural data source

### DIFF
--- a/.changelog/2767.txt
+++ b/.changelog/2767.txt
@@ -1,0 +1,3 @@
+```release-note:new-datasource
+mongodbatlas_flex_clusters
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -451,6 +451,7 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 		resourcepolicy.DataSource,
 		resourcepolicy.PluralDataSource,
 		flexcluster.DataSource,
+		flexcluster.PluralDataSource,
 	} // Data sources not yet in GA
 	if providerEnablePreview {
 		dataSources = append(dataSources, previewDataSources...)

--- a/internal/service/flexcluster/model.go
+++ b/internal/service/flexcluster/model.go
@@ -41,11 +41,11 @@ func NewTFModel(ctx context.Context, apiResp *admin.FlexClusterDescription202411
 	}, nil
 }
 
-func NewTFModelDSP(ctx context.Context, projectID string, input *admin.PaginatedFlexClusters20250101) (*TFModelDSP, diag.Diagnostics) {
+func NewTFModelDSP(ctx context.Context, projectID string, input *admin.PaginatedFlexClusters20241113) (*TFModelDSP, diag.Diagnostics) {
 	diags := &diag.Diagnostics{}
 	tfModels := make([]TFModel, len(input.GetResults()))
 	for i, item := range input.GetResults() {
-		tfModel, diagsLocal := NewTFModel(ctx, &item) // currently complains that item is of type *any
+		tfModel, diagsLocal := NewTFModel(ctx, &item)
 		diags.Append(diagsLocal...)
 		tfModels[i] = *tfModel
 	}
@@ -58,7 +58,7 @@ func NewTFModelDSP(ctx context.Context, projectID string, input *admin.Paginated
 	}, *diags
 }
 
-func NewAtlasCreateReq(ctx context.Context, plan *TFModel) (*admin.FlexClusterDescriptionCreate20250101, diag.Diagnostics) {
+func NewAtlasCreateReq(ctx context.Context, plan *TFModel) (*admin.FlexClusterDescriptionCreate20241113, diag.Diagnostics) {
 	providerSettings := &TFProviderSettings{}
 	if diags := plan.ProviderSettings.As(ctx, providerSettings, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags

--- a/internal/service/flexcluster/model.go
+++ b/internal/service/flexcluster/model.go
@@ -41,7 +41,24 @@ func NewTFModel(ctx context.Context, apiResp *admin.FlexClusterDescription202411
 	}, nil
 }
 
-func NewAtlasCreateReq(ctx context.Context, plan *TFModel) (*admin.FlexClusterDescriptionCreate20241113, diag.Diagnostics) {
+func NewTFModelDSP(ctx context.Context, projectID string, input []admin.FlexClusterDescription20250101) (*TFModelDSP, diag.Diagnostics) {
+	diags := &diag.Diagnostics{}
+	tfModels := make([]TFModel, len(input))
+	for i, item := range input {
+		tfModel, diagsLocal := NewTFModel(ctx, &item)
+		diags.Append(diagsLocal...)
+		tfModels[i] = *tfModel
+	}
+	if diags.HasError() {
+		return nil, *diags
+	}
+	return &TFModelDSP{
+		ProjectId: types.StringValue(projectID),
+		Results:   tfModels,
+	}, *diags
+}
+
+func NewAtlasCreateReq(ctx context.Context, plan *TFModel) (*admin.FlexClusterDescriptionCreate20250101, diag.Diagnostics) {
 	providerSettings := &TFProviderSettings{}
 	if diags := plan.ProviderSettings.As(ctx, providerSettings, basetypes.ObjectAsOptions{}); diags.HasError() {
 		return nil, diags

--- a/internal/service/flexcluster/model.go
+++ b/internal/service/flexcluster/model.go
@@ -43,9 +43,11 @@ func NewTFModel(ctx context.Context, apiResp *admin.FlexClusterDescription202411
 
 func NewTFModelDSP(ctx context.Context, projectID string, input *admin.PaginatedFlexClusters20241113) (*TFModelDSP, diag.Diagnostics) {
 	diags := &diag.Diagnostics{}
-	tfModels := make([]TFModel, len(input.GetResults()))
-	for i, item := range input.GetResults() {
-		tfModel, diagsLocal := NewTFModel(ctx, &item)
+	results := input.GetResults()
+	tfModels := make([]TFModel, len(results))
+	for i := range results {
+		item := &results[i]
+		tfModel, diagsLocal := NewTFModel(ctx, item)
 		diags.Append(diagsLocal...)
 		tfModels[i] = *tfModel
 	}

--- a/internal/service/flexcluster/model.go
+++ b/internal/service/flexcluster/model.go
@@ -41,11 +41,11 @@ func NewTFModel(ctx context.Context, apiResp *admin.FlexClusterDescription202411
 	}, nil
 }
 
-func NewTFModelDSP(ctx context.Context, projectID string, input []admin.FlexClusterDescription20250101) (*TFModelDSP, diag.Diagnostics) {
+func NewTFModelDSP(ctx context.Context, projectID string, input *admin.PaginatedFlexClusters20250101) (*TFModelDSP, diag.Diagnostics) {
 	diags := &diag.Diagnostics{}
-	tfModels := make([]TFModel, len(input))
-	for i, item := range input {
-		tfModel, diagsLocal := NewTFModel(ctx, &item)
+	tfModels := make([]TFModel, len(input.GetResults()))
+	for i, item := range input.GetResults() {
+		tfModel, diagsLocal := NewTFModel(ctx, &item) // currently complains that item is of type *any
 		diags.Append(diagsLocal...)
 		tfModels[i] = *tfModel
 	}

--- a/internal/service/flexcluster/model.go
+++ b/internal/service/flexcluster/model.go
@@ -41,15 +41,16 @@ func NewTFModel(ctx context.Context, apiResp *admin.FlexClusterDescription202411
 	}, nil
 }
 
-func NewTFModelDSP(ctx context.Context, projectID string, input *admin.PaginatedFlexClusters20241113) (*TFModelDSP, diag.Diagnostics) {
+func NewTFModelDSP(ctx context.Context, projectID string, input []admin.FlexClusterDescription20241113) (*TFModelDSP, diag.Diagnostics) {
 	diags := &diag.Diagnostics{}
-	results := input.GetResults()
-	tfModels := make([]TFModel, len(results))
-	for i := range results {
-		item := &results[i]
+	tfModels := make([]TFModel, len(input))
+	for i := range input {
+		item := &input[i]
 		tfModel, diagsLocal := NewTFModel(ctx, item)
 		diags.Append(diagsLocal...)
-		tfModels[i] = *tfModel
+		if tfModel != nil {
+			tfModels[i] = *tfModel
+		}
 	}
 	if diags.HasError() {
 		return nil, *diags

--- a/internal/service/flexcluster/model_test.go
+++ b/internal/service/flexcluster/model_test.go
@@ -47,13 +47,13 @@ var (
 )
 
 type NewTFModelTestCase struct {
-	input           *admin.FlexClusterDescription20241113
 	expectedTFModel *flexcluster.TFModel
+	input           *admin.FlexClusterDescription20241113
 }
 
 type NewTFModelDSPTestCase struct {
-	input              []admin.FlexClusterDescription20241113
 	expectedTFModelDSP *flexcluster.TFModelDSP
+	input              []admin.FlexClusterDescription20241113
 }
 
 type NewAtlasCreateReqTestCase struct {

--- a/internal/service/flexcluster/model_test.go
+++ b/internal/service/flexcluster/model_test.go
@@ -52,7 +52,7 @@ type NewTFModelTestCase struct {
 }
 
 type NewTFModelDSPTestCase struct {
-	input              *admin.PaginatedFlexClusters20241113
+	input              []admin.FlexClusterDescription20241113
 	expectedTFModelDSP *flexcluster.TFModelDSP
 }
 
@@ -211,68 +211,66 @@ func TestNewTFModelDSP(t *testing.T) {
 					},
 				},
 			},
-			input: &admin.PaginatedFlexClusters20241113{
-				Results: &[]admin.FlexClusterDescription20241113{
-					{
-						GroupId: &projectID,
-						Id:      &id,
-						Tags: &[]admin.ResourceTag{
-							{
-								Key:   key1,
-								Value: value1,
-							},
+			input: []admin.FlexClusterDescription20241113{
+				{
+					GroupId: &projectID,
+					Id:      &id,
+					Tags: &[]admin.ResourceTag{
+						{
+							Key:   key1,
+							Value: value1,
 						},
-						ProviderSettings: admin.FlexProviderSettings20241113{
-							ProviderName:        &providerName,
-							RegionName:          &regionName,
-							BackingProviderName: &backingProviderName,
-							DiskSizeGB:          &diskSizeGb,
-						},
-						ConnectionStrings: &admin.FlexConnectionStrings20241113{
-							Standard:    &standardConnectionString,
-							StandardSrv: &standardSrvConnectionString,
-						},
-						CreateDate:           &createDateTime,
-						MongoDBVersion:       &mongoDBVersion,
-						Name:                 &name,
-						ClusterType:          &clusterType,
-						StateName:            &stateName,
-						VersionReleaseSystem: &versionReleaseSystem,
-						BackupSettings: &admin.FlexBackupSettings20241113{
-							Enabled: conversion.Pointer(true),
-						},
-						TerminationProtectionEnabled: &terminationProtectionEnabled,
 					},
-					{
-						GroupId: &projectID,
-						Id:      conversion.StringPtr("id-2"),
-						Tags: &[]admin.ResourceTag{
-							{
-								Key:   key1,
-								Value: value1,
-							},
-						},
-						ProviderSettings: admin.FlexProviderSettings20241113{
-							ProviderName:        &providerName,
-							RegionName:          &regionName,
-							BackingProviderName: &backingProviderName,
-							DiskSizeGB:          &diskSizeGb,
-						},
-						ConnectionStrings: &admin.FlexConnectionStrings20241113{
-							Standard:    &standardConnectionString,
-							StandardSrv: &standardSrvConnectionString,
-						},
-						CreateDate:           &createDateTime,
-						MongoDBVersion:       &mongoDBVersion,
-						Name:                 &name,
-						ClusterType:          &clusterType,
-						StateName:            &stateName,
-						VersionReleaseSystem: &versionReleaseSystem,
-						BackupSettings: &admin.FlexBackupSettings20241113{
-							Enabled: conversion.Pointer(true),
-						},
-						TerminationProtectionEnabled: &terminationProtectionEnabled,
+					ProviderSettings: admin.FlexProviderSettings20241113{
+						ProviderName:        &providerName,
+						RegionName:          &regionName,
+						BackingProviderName: &backingProviderName,
+						DiskSizeGB:          &diskSizeGb,
 					},
+					ConnectionStrings: &admin.FlexConnectionStrings20241113{
+						Standard:    &standardConnectionString,
+						StandardSrv: &standardSrvConnectionString,
+					},
+					CreateDate:           &createDateTime,
+					MongoDBVersion:       &mongoDBVersion,
+					Name:                 &name,
+					ClusterType:          &clusterType,
+					StateName:            &stateName,
+					VersionReleaseSystem: &versionReleaseSystem,
+					BackupSettings: &admin.FlexBackupSettings20241113{
+						Enabled: conversion.Pointer(true),
+					},
+					TerminationProtectionEnabled: &terminationProtectionEnabled,
+				},
+				{
+					GroupId: &projectID,
+					Id:      conversion.StringPtr("id-2"),
+					Tags: &[]admin.ResourceTag{
+						{
+							Key:   key1,
+							Value: value1,
+						},
+					},
+					ProviderSettings: admin.FlexProviderSettings20241113{
+						ProviderName:        &providerName,
+						RegionName:          &regionName,
+						BackingProviderName: &backingProviderName,
+						DiskSizeGB:          &diskSizeGb,
+					},
+					ConnectionStrings: &admin.FlexConnectionStrings20241113{
+						Standard:    &standardConnectionString,
+						StandardSrv: &standardSrvConnectionString,
+					},
+					CreateDate:           &createDateTime,
+					MongoDBVersion:       &mongoDBVersion,
+					Name:                 &name,
+					ClusterType:          &clusterType,
+					StateName:            &stateName,
+					VersionReleaseSystem: &versionReleaseSystem,
+					BackupSettings: &admin.FlexBackupSettings20241113{
+						Enabled: conversion.Pointer(true),
+					},
+					TerminationProtectionEnabled: &terminationProtectionEnabled,
 				},
 			},
 		},
@@ -281,9 +279,7 @@ func TestNewTFModelDSP(t *testing.T) {
 				ProjectId: types.StringValue(projectID),
 				Results:   []flexcluster.TFModel{},
 			},
-			input: &admin.PaginatedFlexClusters20241113{
-				Results: &[]admin.FlexClusterDescription20241113{},
-			},
+			input: []admin.FlexClusterDescription20241113{},
 		},
 	}
 	for testName, tc := range testCases {

--- a/internal/service/flexcluster/model_test.go
+++ b/internal/service/flexcluster/model_test.go
@@ -170,7 +170,6 @@ func TestNewTFModel(t *testing.T) {
 }
 
 func TestNewTFModelDSP(t *testing.T) {
-	// projectID :=
 	testCases := map[string]NewTFModelDSPTestCase{
 		"Complete TF state": {
 			expectedTFModelDSP: &flexcluster.TFModelDSP{

--- a/internal/service/flexcluster/model_test.go
+++ b/internal/service/flexcluster/model_test.go
@@ -51,6 +51,11 @@ type NewTFModelTestCase struct {
 	expectedTFModel *flexcluster.TFModel
 }
 
+type NewTFModelDSPTestCase struct {
+	input              *admin.PaginatedFlexClusters20241113
+	expectedTFModelDSP *flexcluster.TFModelDSP
+}
+
 type NewAtlasCreateReqTestCase struct {
 	input          *flexcluster.TFModel
 	expectedSDKReq *admin.FlexClusterDescriptionCreate20241113
@@ -160,6 +165,135 @@ func TestNewTFModel(t *testing.T) {
 				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}
 			assert.Equal(t, tc.expectedTFModel, tfModel, "created TF model did not match expected output")
+		})
+	}
+}
+
+func TestNewTFModelDSP(t *testing.T) {
+	// projectID :=
+	testCases := map[string]NewTFModelDSPTestCase{
+		"Complete TF state": {
+			expectedTFModelDSP: &flexcluster.TFModelDSP{
+				ProjectId: types.StringValue(projectID),
+				Results: []flexcluster.TFModel{
+					{
+						ProjectId: types.StringValue(projectID),
+						Id:        types.StringValue(id),
+						Tags: types.MapValueMust(types.StringType, map[string]attr.Value{
+							key1: types.StringValue(value1),
+						}),
+						ProviderSettings:             *providerSettingsObject,
+						ConnectionStrings:            *connectionStringsObject,
+						CreateDate:                   types.StringValue(createDate),
+						MongoDbversion:               types.StringValue(mongoDBVersion),
+						Name:                         types.StringValue(name),
+						ClusterType:                  types.StringValue(clusterType),
+						StateName:                    types.StringValue(stateName),
+						VersionReleaseSystem:         types.StringValue(versionReleaseSystem),
+						BackupSettings:               *backupSettingsObject,
+						TerminationProtectionEnabled: types.BoolValue(terminationProtectionEnabled),
+					},
+					{
+						ProjectId: types.StringValue(projectID),
+						Id:        types.StringValue("id-2"),
+						Tags: types.MapValueMust(types.StringType, map[string]attr.Value{
+							key1: types.StringValue(value1),
+						}),
+						ProviderSettings:             *providerSettingsObject,
+						ConnectionStrings:            *connectionStringsObject,
+						CreateDate:                   types.StringValue(createDate),
+						MongoDbversion:               types.StringValue(mongoDBVersion),
+						Name:                         types.StringValue(name),
+						ClusterType:                  types.StringValue(clusterType),
+						StateName:                    types.StringValue(stateName),
+						VersionReleaseSystem:         types.StringValue(versionReleaseSystem),
+						BackupSettings:               *backupSettingsObject,
+						TerminationProtectionEnabled: types.BoolValue(terminationProtectionEnabled),
+					},
+				},
+			},
+			input: &admin.PaginatedFlexClusters20241113{
+				Results: &[]admin.FlexClusterDescription20241113{
+					{
+						GroupId: &projectID,
+						Id:      &id,
+						Tags: &[]admin.ResourceTag{
+							{
+								Key:   key1,
+								Value: value1,
+							},
+						},
+						ProviderSettings: admin.FlexProviderSettings20241113{
+							ProviderName:        &providerName,
+							RegionName:          &regionName,
+							BackingProviderName: &backingProviderName,
+							DiskSizeGB:          &diskSizeGb,
+						},
+						ConnectionStrings: &admin.FlexConnectionStrings20241113{
+							Standard:    &standardConnectionString,
+							StandardSrv: &standardSrvConnectionString,
+						},
+						CreateDate:           &createDateTime,
+						MongoDBVersion:       &mongoDBVersion,
+						Name:                 &name,
+						ClusterType:          &clusterType,
+						StateName:            &stateName,
+						VersionReleaseSystem: &versionReleaseSystem,
+						BackupSettings: &admin.FlexBackupSettings20241113{
+							Enabled: conversion.Pointer(true),
+						},
+						TerminationProtectionEnabled: &terminationProtectionEnabled,
+					},
+					{
+						GroupId: &projectID,
+						Id:      conversion.StringPtr("id-2"),
+						Tags: &[]admin.ResourceTag{
+							{
+								Key:   key1,
+								Value: value1,
+							},
+						},
+						ProviderSettings: admin.FlexProviderSettings20241113{
+							ProviderName:        &providerName,
+							RegionName:          &regionName,
+							BackingProviderName: &backingProviderName,
+							DiskSizeGB:          &diskSizeGb,
+						},
+						ConnectionStrings: &admin.FlexConnectionStrings20241113{
+							Standard:    &standardConnectionString,
+							StandardSrv: &standardSrvConnectionString,
+						},
+						CreateDate:           &createDateTime,
+						MongoDBVersion:       &mongoDBVersion,
+						Name:                 &name,
+						ClusterType:          &clusterType,
+						StateName:            &stateName,
+						VersionReleaseSystem: &versionReleaseSystem,
+						BackupSettings: &admin.FlexBackupSettings20241113{
+							Enabled: conversion.Pointer(true),
+						},
+						TerminationProtectionEnabled: &terminationProtectionEnabled,
+					},
+				},
+			},
+		},
+		"No Flex Clusters": {
+			expectedTFModelDSP: &flexcluster.TFModelDSP{
+				ProjectId: types.StringValue(projectID),
+				Results:   []flexcluster.TFModel{},
+			},
+			input: &admin.PaginatedFlexClusters20241113{
+				Results: &[]admin.FlexClusterDescription20241113{},
+			},
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			tfModelDSP, diags := flexcluster.NewTFModelDSP(context.Background(), projectID, tc.input)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedTFModelDSP, tfModelDSP, "created TF model DSP did not match expected output")
 		})
 	}
 }

--- a/internal/service/flexcluster/plural_data_source.go
+++ b/internal/service/flexcluster/plural_data_source.go
@@ -42,7 +42,7 @@ func (d *pluralDS) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 		return
 	}
 
-	newFlexClustersModel, diags := NewTFModelDSP(ctx, tfModel.ProjectId.ValueString(), apiResp) //apiResp will
+	newFlexClustersModel, diags := NewTFModelDSP(ctx, tfModel.ProjectId.ValueString(), apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/flexcluster/plural_data_source.go
+++ b/internal/service/flexcluster/plural_data_source.go
@@ -1,0 +1,70 @@
+package flexcluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20240805004/admin"
+)
+
+var _ datasource.DataSource = &pluralDS{}
+var _ datasource.DataSourceWithConfigure = &pluralDS{}
+
+func PluralDataSource() datasource.DataSource {
+	return &pluralDS{
+		DSCommon: config.DSCommon{
+			DataSourceName: fmt.Sprintf("%ss", resourceName),
+		},
+	}
+}
+
+type pluralDS struct {
+	config.DSCommon
+}
+
+func (d *pluralDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = PluralDataSourceSchema(ctx)
+}
+
+func (d *pluralDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var tfModel TFModelDSP
+	resp.Diagnostics.Append(req.Config.Get(ctx, &tfModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	connV2 := d.Client.AtlasV2
+	apiResp, err := getFlexClusterList(ctx, connV2, tfModel.ProjectId.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError("error reading plural data source", err.Error())
+		return
+	}
+
+	newFlexClustersModel, diags := NewTFModelDSP(ctx, tfModel.ProjectId.ValueString(), apiResp)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newFlexClustersModel)...)
+}
+
+func getFlexClusterList(ctx context.Context, connV2 *admin.APIClient, projectId string) ([]admin.FlexClusterDescription20250101, error) {
+	var list []admin.FlexClusterDescription20250101
+	apiResp, _, err := connV2.FlexClustersApi.ListFlexClusters(ctx, projectId).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("error reading plural data source: %s", err)
+	}
+
+	for _, result := range apiResp.GetResults() {
+		if cluster, ok := result.(admin.FlexClusterDescription20250101); ok {
+			list = append(list, cluster)
+		} else {
+			return nil, fmt.Errorf("error reading plural data source: %s", err)
+		}
+	}
+
+	return list, nil
+}

--- a/internal/service/flexcluster/plural_data_source_schema.go
+++ b/internal/service/flexcluster/plural_data_source_schema.go
@@ -26,6 +26,6 @@ func PluralDataSourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModelDSP struct {
-	ProjectId    types.String `tfsdk:"project_id"`
-	FlexClusters []TFModel    `tfsdk:"flex_clusters"`
+	ProjectId types.String `tfsdk:"project_id"`
+	Results   []TFModel    `tfsdk:"results"`
 }

--- a/internal/service/flexcluster/plural_data_source_schema.go
+++ b/internal/service/flexcluster/plural_data_source_schema.go
@@ -7,14 +7,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func DataSourcePluralSchema(ctx context.Context) schema.Schema {
+func PluralDataSourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
 			},
-			"flex_clusters": schema.ListNestedAttribute{
+			"results": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: dataSourceSchema(true),

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -119,7 +119,7 @@ func configBasic(projectID, clusterName, provider, region string, terminationPro
 		}
 		data "mongodbatlas_flex_clusters" "test" {
 			project_id = mongodbatlas_flex_cluster.test.project_id
-		}`, projectID, clusterName, terminationProtectionEnabled)
+		}`, projectID, clusterName, provider, region, terminationProtectionEnabled)
 }
 
 func checksFlexCluster(projectID, clusterName string, terminationProtectionEnabled bool) resource.TestCheckFunc {


### PR DESCRIPTION
## Description

Implements `mongodbatlas_flex_cluster` plural data source and testing.

Link to any related issue(s): [CLOUDP-278906](https://jira.mongodb.org/browse/CLOUDP-278906)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
