### PR TITLE
chore: Improvements to SDK version update

### DIFF
--- a/internal/service/atlasuser/data_source_atlas_user.go
+++ b/internal/service/atlasuser/data_source_atlas_user.go
@@ -10,9 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin" // Using older version of API as lastest version with preview enabled includes breaking changes in AtlasUser. To be changed to lastest version when flexCluster is in prod and preview is no longer used.
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
 )
 
 const (

--- a/internal/service/atlasuser/data_source_atlas_user_test.go
+++ b/internal/service/atlasuser/data_source_atlas_user_test.go
@@ -89,8 +89,7 @@ func TestAccConfigDSAtlasUser_InvalidAttrCombination(t *testing.T) {
 
 func fetchUser(t *testing.T, userID string) *admin20240805.CloudAppUser {
 	t.Helper()
-	connV220240805 := acc.MongoDBClient.AtlasV220240805
-	userResp, _, err := connV220240805.MongoDBCloudUsersApi.GetUser(context.Background(), userID).Execute()
+	userResp, _, err := acc.ConnV220240805().MongoDBCloudUsersApi.GetUser(context.Background(), userID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas User (%s) could not be fetched: %v", userID, err)
 	}
@@ -99,8 +98,7 @@ func fetchUser(t *testing.T, userID string) *admin20240805.CloudAppUser {
 
 func fetchUserByUsername(t *testing.T, username string) *admin20240805.CloudAppUser {
 	t.Helper()
-	connV220240805 := acc.MongoDBClient.AtlasV220240805
-	userResp, _, err := connV220240805.MongoDBCloudUsersApi.GetUserByUsername(context.Background(), username).Execute()
+	userResp, _, err := acc.ConnV220240805().MongoDBCloudUsersApi.GetUserByUsername(context.Background(), username).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas User (%s) could not be fetched: %v", username, err)
 	}

--- a/internal/service/atlasuser/data_source_atlas_user_test.go
+++ b/internal/service/atlasuser/data_source_atlas_user_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
+	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin" // Using older version of API as lastest version with preview enabled includes breaking changes in AtlasUser. To be changed to lastest version when flexCluster is in prod and preview is no longer used.
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"

--- a/internal/service/atlasuser/data_source_atlas_users.go
+++ b/internal/service/atlasuser/data_source_atlas_users.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
+	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin" // Using older version of API as lastest version with preview enabled includes breaking changes in AtlasUser. To be changed to lastest version when flexCluster is in prod and preview is no longer used.
 )
 
 const (

--- a/internal/service/atlasuser/data_source_atlas_users_test.go
+++ b/internal/service/atlasuser/data_source_atlas_users_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
+	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin" // Using older version of API as lastest version with preview enabled includes breaking changes in AtlasUser. To be changed to lastest version when flexCluster is in prod and preview is no longer used.
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/atlasuser"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"

--- a/internal/service/atlasuser/data_source_atlas_users_test.go
+++ b/internal/service/atlasuser/data_source_atlas_users_test.go
@@ -203,8 +203,7 @@ func TestAccConfigDSAtlasUsers_InvalidAttrCombinations(t *testing.T) {
 
 func fetchOrgUsers(t *testing.T, orgID string) *admin20240805.PaginatedAppUser {
 	t.Helper()
-	connV220240805 := acc.MongoDBClient.AtlasV220240805
-	users, _, err := connV220240805.OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
+	users, _, err := acc.ConnV220240805().OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
 	if err != nil {
 		t.Fatalf("the Atlas Users for Org(%s) could not be fetched: %v", orgID, err)
 	}
@@ -295,8 +294,7 @@ func testAccCheckMongoDBAtlasOrgWithUsersExists(dataSourceName string) resource.
 			return fmt.Errorf("org_id not defined in data source: %s", dataSourceName)
 		}
 
-		connV220240805 := acc.MongoDBClient.AtlasV220240805
-		apiResp, _, err := connV220240805.OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
+		apiResp, _, err := acc.ConnV220240805().OrganizationsApi.ListOrganizationUsers(context.Background(), orgID).Execute()
 
 		if err != nil {
 			return fmt.Errorf("unable to determine if users exist in org: %s", orgID)

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
+	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
 	"go.mongodb.org/atlas-sdk/v20241023001/admin"
 )
 
@@ -37,6 +38,11 @@ func Conn() *matlas.Client {
 
 func ConnV2() *admin.APIClient {
 	return MongoDBClient.AtlasV2
+}
+
+// For temporary use in atlas_user as workaround for lastest preview containing breaking changes in atlas_user.
+func ConnV220240805() *admin20240805.APIClient {
+	return MongoDBClient.AtlasV220240805
 }
 
 func ConnV2UsingProxy(proxyPort *int) *admin.APIClient {


### PR DESCRIPTION
## Description

Improvements to SDK version update
- In-code comment outlining the necessity for the older version of SDK to be used within atlasUser.
- Define ConnV220240805() for altasUser within factory.go
These improvements are part of temporary fixes to atlas_user while SDK preview is in use for flex_cluster and can all be reverted after API for flex_cluster is in prod.

Link to any related issue(s): [CLOUDP-281945](https://jira.mongodb.org/browse/CLOUDP-281945)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
