### PR TITLE
feat: Add `failed` attribute to `mongodbatlas_cloud_backup_snapshot_restore_job`

### DIFF
--- a/.changelog/2771.tx
+++ b/.changelog/2771.tx
@@ -1,0 +1,11 @@
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_snapshot_restore_job: Adds `failed` attribute
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_cloud_backup_snapshot_restore_jobs: Adds `failed` attribute
+```
+
+```release-note:enhancement
+resource/mongodbatlas_cloud_backup_snapshot_restore_job: Adds `failed` attribute
+```

--- a/docs/data-sources/cloud_backup_snapshot_restore_job.md
+++ b/docs/data-sources/cloud_backup_snapshot_restore_job.md
@@ -49,6 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 * `delivery_url` -	One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
 * `expired` -	Indicates whether the restore job expired.
 * `expires_at` -	UTC ISO 8601 formatted point in time when the restore job expires.
+* `failed` -     Indicates whether the restore job failed.
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
@@ -56,7 +57,7 @@ In addition to all arguments above, the following attributes are exported:
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
-* `oplogInc` - Oplog operation number from which to you want to restore this snapshot. 
+* `oplogInc` - Oplog operation number from which to you want to restore this snapshot.
 * `pointInTimeUTCSeconds` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/restore/get-one-restore-job/)

--- a/docs/data-sources/cloud_backup_snapshot_restore_jobs.md
+++ b/docs/data-sources/cloud_backup_snapshot_restore_jobs.md
@@ -56,6 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 * `delivery_url` -	One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
 * `expired` -	Indicates whether the restore job expired.
 * `expires_at` -	UTC ISO 8601 formatted point in time when the restore job expires.
+* `failed` -     Indicates whether the restore job failed.
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The unique identifier of the restore job.
 * `snapshot_id` -	Unique identifier of the source snapshot ID of the restore job.
@@ -63,7 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 * `target_cluster_name` -	Name of the target Atlas cluster to which the restore job restores the snapshot. Only visible if deliveryType is automated.
 * `timestamp` - Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
 * `oplogTs` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
-* `oplogInc` - Oplog operation number from which to you want to restore this snapshot. 
+* `oplogInc` - Oplog operation number from which to you want to restore this snapshot.
 * `pointInTimeUTCSeconds` - Timestamp in the number of seconds that have elapsed since the UNIX epoch.
 
 

--- a/docs/resources/cloud_backup_snapshot_restore_job.md
+++ b/docs/resources/cloud_backup_snapshot_restore_job.md
@@ -1,6 +1,6 @@
 # Resource: mongodbatlas_cloud_backup_snapshot_restore_job
 
-`mongodbatlas_cloud_backup_snapshot_restore_job` provides a resource to create a new restore job from a cloud backup snapshot of a specified cluster. The restore job must define one of three delivery types: 
+`mongodbatlas_cloud_backup_snapshot_restore_job` provides a resource to create a new restore job from a cloud backup snapshot of a specified cluster. The restore job must define one of three delivery types:
 * **automated:** Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetGroupId.
 
 * **download:** Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. The contents of the archive contain the data files for your Atlas cluster.
@@ -9,7 +9,7 @@
 
 -> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your request body to create an automated restore job, Atlas removes all existing data on the target cluster prior to the restore.
 
--> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your 
+-> **Important:** If you specify `deliveryType` : `automated` or `deliveryType` : `pointInTime` in your
 `mongodbatlas_cloud_backup_snapshot_restore_job` resource, you won't be able to delete the snapshot resource in MongoDB Atlas as the Atlas Admin API doesn't support this. The provider will remove the Terraform resource from the state file but won't destroy the MongoDB Atlas resource.
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
@@ -156,10 +156,10 @@ resource "mongodbatlas_cloud_backup_snapshot_restore_job" "test" {
 * `delivery_type_config.oplog_ts` - Optional setting for **pointInTime** configuration. Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
 * `delivery_type_config.oplog_inc` - Optional setting for **pointInTime** configuration. Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp. Used in conjunction with `oplog_ts`.
 * `delivery_type_config.point_in_time_utc_seconds` - Optional setting for **pointInTime** configuration. Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot. Used instead of oplog settings.
-* `snapshot_id` - Optional setting for **pointInTime** configuration. Unique identifier of the snapshot to restore. 
+* `snapshot_id` - Optional setting for **pointInTime** configuration. Unique identifier of the snapshot to restore.
 
 ### Download
-Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId. 
+Atlas provides a URL to download a .tar.gz of the snapshot with snapshotId.
 
 ### Automated
 Atlas automatically restores the snapshot with snapshotId to the Atlas cluster with name targetClusterName in the Atlas project with targetProjectId. if you want to use automated delivery type, you must to set the arguments for the afformentioned properties.
@@ -177,6 +177,7 @@ In addition to all arguments above, the following attributes are exported:
 * `delivery_url` -	One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
 * `expired` -	Indicates whether the restore job expired.
 * `expires_at` -	UTC ISO 8601 formatted point in time when the restore job expires.
+* `failed` -     Indicates whether the restore job failed.
 * `finished_at` -	UTC ISO 8601 formatted point in time when the restore job completed.
 * `id` -	The Terraform's unique identifier used internally for state management.
 * `links` -	One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_job.go
@@ -50,6 +50,10 @@ func DataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"failed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"finished_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -100,6 +104,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if err = d.Set("delivery_type", snapshotRes.GetDeliveryType()); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `delivery_type` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
+	}
+
+	if err = d.Set("failed", snapshotRes.GetFailed()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `failed` for cloudProviderSnapshotRestoreJob (%s): %s", d.Id(), err))
 	}
 
 	if err = d.Set("snapshot_id", snapshotRes.GetSnapshotId()); err != nil {

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
@@ -64,6 +64,10 @@ func PluralDataSource() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"failed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 						"finished_at": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -148,6 +152,7 @@ func flattenCloudProviderSnapshotRestoreJobs(cloudProviderSnapshotRestoreJobs []
 				"delivery_url":              cloudProviderSnapshotRestoreJob.GetDeliveryUrl(),
 				"expired":                   cloudProviderSnapshotRestoreJob.GetExpired(),
 				"expires_at":                conversion.TimePtrToStringPtr(cloudProviderSnapshotRestoreJob.ExpiresAt),
+				"failed":                    cloudProviderSnapshotRestoreJob.GetFailed(),
 				"finished_at":               conversion.TimePtrToStringPtr(cloudProviderSnapshotRestoreJob.FinishedAt),
 				"snapshot_id":               cloudProviderSnapshotRestoreJob.GetSnapshotId(),
 				"target_project_id":         cloudProviderSnapshotRestoreJob.GetTargetGroupId(),

--- a/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/resource_cloud_backup_snapshot_restore_job.go
@@ -108,6 +108,10 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"failed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"finished_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -189,6 +193,10 @@ func setCommonFields(d *schema.ResourceData, snapshotReq *admin.DiskBackupSnapsh
 
 	if err = d.Set("expires_at", conversion.TimePtrToStringPtr(snapshotReq.ExpiresAt)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `expires_at` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
+	}
+
+	if err = d.Set("failed", snapshotReq.GetFailed()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `failed` for cloudProviderSnapshotRestoreJob (%s): %s", restoreID, err))
 	}
 
 	if err = d.Set("finished_at", conversion.TimePtrToStringPtr(snapshotReq.FinishedAt)); err != nil {


### PR DESCRIPTION
## Description

`failed` attribute is missing from resource/data-source representing snapshot restore job. It would be useful to have it so that we can see the full picture of the restore job from within terraform representation. 

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
