### PR TITLE
chore: Implements no-op CRUD operations

### DIFF
--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -10,7 +10,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+type ClusterImportAttrNames struct {
+	ProjectID   string
+	ClusterName string
+}
+
+func (c *ClusterImportAttrNames) GetProjectID() string {
+	if c != nil && c.ProjectID != "" {
+		return c.ProjectID
+	}
+	return "project_id"
+}
+
+func (c *ClusterImportAttrNames) GetClusterName() string {
+	if c != nil && c.ClusterName != "" {
+		return c.ClusterName
+	}
+	return "cluster_name"
+}
+
+func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, names *ClusterImportAttrNames) {
 	parts := strings.SplitN(req.ID, "-", 2)
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("invalid import ID", "expected 2 parts with project_id and cluster_name: "+req.ID)
@@ -26,8 +45,8 @@ func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportSta
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cluster_name"), clusterName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.GetProjectID()), projectID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.GetClusterName()), clusterName)...)
 }
 
 func ValidateProjectID(projectID string) error {

--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -13,7 +13,7 @@ import (
 func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, attrNameProjectID, attrNameClusterName string) {
 	parts := strings.SplitN(req.ID, "-", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("invalid import ID", "expected 2 parts with project_id and cluster_name: "+req.ID)
+		resp.Diagnostics.AddError("invalid import ID", fmt.Sprintf("expected 2 parts with %s and %s: %s",  attrNameProjectID, attrNameClusterName, req.ID,))
 		return
 	}
 	projectID, clusterName := parts[0], parts[1]

--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -10,26 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-type ClusterImportAttrNames struct {
-	ProjectID   string
-	ClusterName string
-}
-
-func (c *ClusterImportAttrNames) GetProjectID() string {
-	if c != nil && c.ProjectID != "" {
-		return c.ProjectID
-	}
-	return "project_id"
-}
-
-func (c *ClusterImportAttrNames) GetClusterName() string {
-	if c != nil && c.ClusterName != "" {
-		return c.ClusterName
-	}
-	return "cluster_name"
-}
-
-func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, names *ClusterImportAttrNames) {
+func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, attrNameProjectID, attrNameClusterName string) {
 	parts := strings.SplitN(req.ID, "-", 2)
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("invalid import ID", "expected 2 parts with project_id and cluster_name: "+req.ID)
@@ -45,8 +26,8 @@ func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportSta
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.GetProjectID()), projectID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.GetClusterName()), clusterName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(attrNameProjectID), projectID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(attrNameClusterName), clusterName)...)
 }
 
 func ValidateProjectID(projectID string) error {

--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -13,7 +13,7 @@ import (
 func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, attrNameProjectID, attrNameClusterName string) {
 	parts := strings.SplitN(req.ID, "-", 2)
 	if len(parts) != 2 {
-		resp.Diagnostics.AddError("invalid import ID", fmt.Sprintf("expected 2 parts with %s and %s: %s",  attrNameProjectID, attrNameClusterName, req.ID,))
+		resp.Diagnostics.AddError("invalid import ID", fmt.Sprintf("expected 2 parts with %s and %s: %s", attrNameProjectID, attrNameClusterName, req.ID))
 		return
 	}
 	projectID, clusterName := parts[0], parts[1]

--- a/internal/common/conversion/import_state_test.go
+++ b/internal/common/conversion/import_state_test.go
@@ -23,21 +23,3 @@ func TestValidateClusterName(t *testing.T) {
 	assert.Contains(t, err.Error(), "_invalidClusterName")
 	assert.Contains(t, err.Error(), "cluster_name must be a string with length between 1 and 64, starting and ending with an alphanumeric character, and containing only alphanumeric characters and hyphens")
 }
-
-func TestGetProjectID(t *testing.T) {
-	c := &conversion.ClusterImportAttrNames{
-		ProjectID:   "test_project_id",
-		ClusterName: "test_cluster_name",
-	}
-	assert.Equal(t, "test_project_id", c.GetProjectID())
-	assert.Equal(t, "test_cluster_name", c.GetClusterName())
-
-	getProjectID := func(names *conversion.ClusterImportAttrNames) string {
-		return names.GetProjectID()
-	}
-	assert.Equal(t, "project_id", getProjectID(nil))
-	getClusterName := func(names *conversion.ClusterImportAttrNames) string {
-		return names.GetClusterName()
-	}
-	assert.Equal(t, "cluster_name", getClusterName(nil))
-}

--- a/internal/common/conversion/import_state_test.go
+++ b/internal/common/conversion/import_state_test.go
@@ -23,3 +23,21 @@ func TestValidateClusterName(t *testing.T) {
 	assert.Contains(t, err.Error(), "_invalidClusterName")
 	assert.Contains(t, err.Error(), "cluster_name must be a string with length between 1 and 64, starting and ending with an alphanumeric character, and containing only alphanumeric characters and hyphens")
 }
+
+func TestGetProjectID(t *testing.T) {
+	c := &conversion.ClusterImportAttrNames{
+		ProjectID:   "test_project_id",
+		ClusterName: "test_cluster_name",
+	}
+	assert.Equal(t, "test_project_id", c.GetProjectID())
+	assert.Equal(t, "test_cluster_name", c.GetClusterName())
+
+	getProjectID := func(names *conversion.ClusterImportAttrNames) string {
+		return names.GetProjectID()
+	}
+	assert.Equal(t, "project_id", getProjectID(nil))
+	getClusterName := func(names *conversion.ClusterImportAttrNames) string {
+		return names.GetClusterName()
+	}
+	assert.Equal(t, "cluster_name", getClusterName(nil))
+}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -101,9 +101,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	conversion.ImportStateProjectIDClusterName(ctx, req, resp, &conversion.ClusterImportAttrNames{
-		ClusterName: "name",
-	})
+	conversion.ImportStateProjectIDClusterName(ctx, req, resp, "project_id", "name")
 }
 
 func mockedSDK(ctx context.Context, diags *diag.Diagnostics, timeout timeouts.Value) (*TFModel, bool) {

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -46,24 +48,13 @@ func (r *rs) Schema(ctx context.Context, req resource.SchemaRequest, resp *resou
 }
 
 func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var tfModel TFModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfModel)...)
+	var plan TFModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	sdkResp, err := ReadClusterResponse(1)
-	if err != nil {
-		resp.Diagnostics.AddError("errorCreate", fmt.Sprintf(errorCreate, err.Error()))
-		return
-	}
-	tfNewModel := NewTFModel(ctx, sdkResp, tfModel.Timeouts, &resp.Diagnostics)
-	sdkAdvConfig, err := ReadClusterProcessArgsResponse(1)
-	if err != nil {
-		resp.Diagnostics.AddError("errorCreateAdvConfig", fmt.Sprintf(errorCreate, err.Error()))
-	}
-
-	AddAdvancedConfig(ctx, tfNewModel, sdkAdvConfig, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
+	tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, plan.Timeouts)
+	if shouldReturn {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, tfNewModel)...)
@@ -75,14 +66,61 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	if state.ClusterID.IsNull() {
+		tfModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, state.Timeouts)
+		if shouldReturn {
+			return
+		}
+		resp.Diagnostics.Append(resp.State.Set(ctx, tfModel)...)
+	} else {
+		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	}
 }
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan TFModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state TFModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	name := state.Name.ValueString()
+	clusterID := state.ClusterID.ValueString()
+	if clusterID == "" {
+		resp.Diagnostics.AddError("errorDelete", fmt.Sprintf(errorDelete, name, "clusterID is empty"))
+		return
+	}
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	conversion.ImportStateProjectIDClusterName(ctx, req, resp, &conversion.ClusterImportAttrNames{
+		ClusterName: "name",
+	})
+}
+
+func mockedSDK(ctx context.Context, diags *diag.Diagnostics, timeout timeouts.Value) (*TFModel, bool) {
+	sdkResp, err := ReadClusterResponse()
+	if err != nil {
+		diags.AddError("errorCreate", fmt.Sprintf(errorCreate, err.Error()))
+		return nil, true
+	}
+	tfNewModel := NewTFModel(ctx, sdkResp, timeout, diags)
+	sdkAdvConfig, err := ReadClusterProcessArgsResponse()
+	if err != nil {
+		diags.AddError("errorCreateAdvConfig", fmt.Sprintf(errorCreate, err.Error()))
+		return nil, true
+	}
+	AddAdvancedConfig(ctx, tfNewModel, sdkAdvConfig, diags)
+	if diags.HasError() {
+		return nil, true
+	}
+	return tfNewModel, false
 }

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -35,7 +35,6 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 				Check:  resource.ComposeTestCheckFunc(ChangeReponseNumber(2)),
 			},
 			{
-				Config:                               configBasic(""),
 				ResourceName:                         resourceName,
 				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, "project_id", "name"),
 				ImportState:                          true,

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -35,7 +35,7 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 				Check:  resource.ComposeTestCheckFunc(ChangeReponseNumber(2)),
 			},
 			{
-				Config:                               configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
+				Config:                               configBasic(""),
 				ResourceName:                         resourceName,
 				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, "project_id", "name"),
 				ImportState:                          true,

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -38,7 +37,7 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 			{
 				Config:                               configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
 				ResourceName:                         resourceName,
-				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, &conversion.ClusterImportAttrNames{ClusterName: "name"}),
+				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, "project_id", "name"),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "name",

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -1,28 +1,57 @@
 package advancedclustertpf_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
+
+const (
+	resourceName = "mongodbatlas_advanced_cluster.test"
+)
+
+func ChangeReponseNumber(responseNumber int) resource.TestCheckFunc {
+	changer := func(*terraform.State) error {
+		advancedclustertpf.SetCurrentClusterResponse(responseNumber)
+		return nil
+	}
+	return changer
+}
 
 func TestAccAdvancedCluster_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(),
+				Config: configBasic(""),
+			},
+			{
+				Config: configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
+				Check:  resource.ComposeTestCheckFunc(ChangeReponseNumber(2)),
+			},
+			{
+				Config:                               configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
+				ResourceName:                         resourceName,
+				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, &conversion.ClusterImportAttrNames{ClusterName: "name"}),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
 			},
 		},
 	})
 }
 
-func configBasic() string {
-	return `
+func configBasic(extra string) string {
+	return fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id = "111111111111111111111111"
+			%[1]s
 			name = "test"
 			cluster_type = "REPLICASET"
 			replication_specs = [{
@@ -38,5 +67,5 @@ func configBasic() string {
 				}]
 			}]
 		}
-	`
+	`, extra)
 }

--- a/internal/service/advancedclustertpf/responses.go
+++ b/internal/service/advancedclustertpf/responses.go
@@ -25,22 +25,28 @@ var (
 	responsesProcessArgs = map[int]string{
 		1: processArgs1,
 	}
+	currentClusterResponse     = 1
+	currentProcessArgsResponse = 1
 )
 
-func ReadClusterResponse(number int) (*admin.ClusterDescription20240805, error) {
-	responseJSON, ok := responsesCreate[number]
+func SetCurrentClusterResponse(responseNumber int) {
+	currentClusterResponse = responseNumber
+}
+
+func ReadClusterResponse() (*admin.ClusterDescription20240805, error) {
+	responseJSON, ok := responsesCreate[currentClusterResponse]
 	if !ok {
-		return nil, fmt.Errorf("unknown response number %d", number)
+		return nil, fmt.Errorf("unknown cluster response number %d", currentClusterResponse)
 	}
 	var SDKModel admin.ClusterDescription20240805
 	err := json.Unmarshal([]byte(responseJSON), &SDKModel)
 	return &SDKModel, err
 }
 
-func ReadClusterProcessArgsResponse(number int) (*admin.ClusterDescriptionProcessArgs20240805, error) {
-	responseJSON, ok := responsesProcessArgs[number]
+func ReadClusterProcessArgsResponse() (*admin.ClusterDescriptionProcessArgs20240805, error) {
+	responseJSON, ok := responsesProcessArgs[currentProcessArgsResponse]
 	if !ok {
-		return nil, fmt.Errorf("unknown response number %d", number)
+		return nil, fmt.Errorf("unknown process args response number %d", currentProcessArgsResponse)
 	}
 	var SDKModel admin.ClusterDescriptionProcessArgs20240805
 	err := json.Unmarshal([]byte(responseJSON), &SDKModel)

--- a/internal/service/advancedclustertpf/testdata/create_2.json
+++ b/internal/service/advancedclustertpf/testdata/create_2.json
@@ -1,4 +1,5 @@
 {
+    "acceptDataRisksAndForceReplicaSetReconfig": "2006-01-02T15:04:05Z",
     "backupEnabled": true,
     "biConnector": {
         "enabled": false,

--- a/internal/service/mongodbemployeeaccessgrant/resource.go
+++ b/internal/service/mongodbemployeeaccessgrant/resource.go
@@ -91,7 +91,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	conversion.ImportStateProjectIDClusterName(ctx, req, resp, nil)
+	conversion.ImportStateProjectIDClusterName(ctx, req, resp, "project_id", "cluster_name")
 }
 
 func (r *rs) createOrUpdate(ctx context.Context, tfModelFunc func(context.Context, any) diag.Diagnostics, diagnostics *diag.Diagnostics, state *tfsdk.State) {

--- a/internal/service/mongodbemployeeaccessgrant/resource.go
+++ b/internal/service/mongodbemployeeaccessgrant/resource.go
@@ -91,7 +91,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	conversion.ImportStateProjectIDClusterName(ctx, req, resp)
+	conversion.ImportStateProjectIDClusterName(ctx, req, resp, nil)
 }
 
 func (r *rs) createOrUpdate(ctx context.Context, tfModelFunc func(context.Context, any) diag.Diagnostics, diagnostics *diag.Diagnostics, state *tfsdk.State) {

--- a/internal/service/mongodbemployeeaccessgrant/resource_test.go
+++ b/internal/service/mongodbemployeeaccessgrant/resource_test.go
@@ -53,7 +53,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			{
 				Config:                               configBasic(projectID, clusterName, grantType, expirationTime),
 				ResourceName:                         resourceName,
-				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName),
+				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, nil),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "cluster_name",

--- a/internal/service/mongodbemployeeaccessgrant/resource_test.go
+++ b/internal/service/mongodbemployeeaccessgrant/resource_test.go
@@ -53,7 +53,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 			{
 				Config:                               configBasic(projectID, clusterName, grantType, expirationTime),
 				ResourceName:                         resourceName,
-				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, nil),
+				ImportStateIdFunc:                    acc.ImportStateIDFuncProjectIDClusterName(resourceName, "project_id", "cluster_name"),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "cluster_name",

--- a/internal/testutil/acc/import_state.go
+++ b/internal/testutil/acc/import_state.go
@@ -8,13 +8,13 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 )
 
-func ImportStateIDFuncProjectIDClusterName(resourceName string, nameOverrides *conversion.ClusterImportAttrNames) resource.ImportStateIdFunc {
+func ImportStateIDFuncProjectIDClusterName(resourceName, attrNameProjectID, attrNameClusterName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-		return IDWithProjectIDClusterName(rs.Primary.Attributes[nameOverrides.GetProjectID()], rs.Primary.Attributes[nameOverrides.GetClusterName()])
+		return IDWithProjectIDClusterName(rs.Primary.Attributes[attrNameProjectID], rs.Primary.Attributes[attrNameClusterName])
 	}
 }
 

--- a/internal/testutil/acc/import_state.go
+++ b/internal/testutil/acc/import_state.go
@@ -8,13 +8,13 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 )
 
-func ImportStateIDFuncProjectIDClusterName(resourceName string) resource.ImportStateIdFunc {
+func ImportStateIDFuncProjectIDClusterName(resourceName string, nameOverrides *conversion.ClusterImportAttrNames) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return "", fmt.Errorf("not found: %s", resourceName)
 		}
-		return IDWithProjectIDClusterName(rs.Primary.Attributes["project_id"], rs.Primary.Attributes["cluster_name"])
+		return IDWithProjectIDClusterName(rs.Primary.Attributes[nameOverrides.GetProjectID()], rs.Primary.Attributes[nameOverrides.GetClusterName()])
 	}
 }
 


### PR DESCRIPTION
## Description

- Implements no-op CRUD operations and full acceptance test
- support overriding ClusterImportAttrNames

Link to any related issue(s): CLOUDP-283042

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
