### PR TITLE
test: Supports running `advanced_cluster_tpf` resource with tests in `advancedcluster` package

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -233,8 +233,7 @@ jobs:
       with:
         filters: |
           advanced_cluster:
-            - 'internal/service/advancedcluster/!(*_test).go' # matches any adv_cluster file change except test files  
-
+            - 'internal/service/advancedcluster/!(*_test).go' # matches any adv_cluster file change except test files
           advanced_cluster_tpf:
             - 'internal/service/advancedclustertpf/*.go'
             - 'internal/service/advancedcluster/*_test.go'

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -362,7 +362,9 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/service/advancedclustertpf
+          ACCTEST_PACKAGES: |
+            ./internal/service/advancedcluster
+            ./internal/service/advancedclustertpf
           MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS: "true"
         run: make testacc
 

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -233,9 +233,10 @@ jobs:
       with:
         filters: |
           advanced_cluster:
-            - 'internal/service/advancedcluster/*.go'
+            - 'internal/service/advancedcluster/!(*_test).go'
           advanced_cluster_tpf:
             - 'internal/service/advancedclustertpf/*.go'
+            - 'internal/service/advancedcluster/*_test.go'
           assume_role:
             - 'internal/provider/*.go'
           backup:
@@ -362,6 +363,7 @@ jobs:
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/advancedclustertpf
+          MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS: "true"
         run: make testacc
 
   assume_role:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -233,7 +233,8 @@ jobs:
       with:
         filters: |
           advanced_cluster:
-            - 'internal/service/advancedcluster/!(*_test).go'
+            - 'internal/service/advancedcluster/!(*_test).go' # matches any adv_cluster file change except test files  
+
           advanced_cluster_tpf:
             - 'internal/service/advancedclustertpf/*.go'
             - 'internal/service/advancedcluster/*_test.go'
@@ -362,10 +363,10 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS: "true"
           ACCTEST_PACKAGES: |
             ./internal/service/advancedcluster
             ./internal/service/advancedclustertpf
-          MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS: "true"
         run: make testacc
 
   assume_role:

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -72,7 +72,7 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -97,7 +97,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -127,7 +127,7 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -16,38 +16,44 @@ import (
 const versionBeforeISSRelease = "1.17.6"
 
 func TestMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	testCase := replicaSetAWSProviderTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	testCase := replicaSetMultiCloudTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	testCase := singleShardedMultiCloudTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_symmetricGeoShardedOldSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	testCase := symmetricGeoShardedOldSchemaTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_asymmetricShardedNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	testCase := asymmetricShardedNewSchemaTestCase(t)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, mig.PreCheckBasicSleep(t)),
+		PreCheck:     mig.PreCheckBasicSleep(t),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -65,6 +71,7 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -72,7 +79,7 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -90,6 +97,7 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -97,7 +105,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -120,6 +128,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -127,7 +136,7 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() { mig.PreCheckBasic(t) }),
+		PreCheck:     func() { mig.PreCheckBasic(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -150,6 +159,7 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 }
 
 func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	mig.SkipIfVersionBelow(t, "1.19.0") // version where change_stream_options_pre_and_post_images_expire_after_seconds was introduced
 	var (
 		projectID   = acc.ProjectIDExecution(t)
@@ -192,7 +202,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, mig.PreCheckBasicSleep(t)),
+		PreCheck:     mig.PreCheckBasicSleep(t),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -47,7 +47,7 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     mig.PreCheckBasicSleep(t),
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, mig.PreCheckBasicSleep(t)),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -72,7 +72,7 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -97,7 +97,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -127,7 +127,7 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t) },
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, func() {mig.PreCheckBasic(t)} ),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -192,7 +192,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     mig.PreCheckBasicSleep(t),
+		PreCheck:     acc.SkipIfTPFAdvancedCluster(t, mig.PreCheckBasicSleep(t)),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestMigAdvancedCluster_empty_advancedConfig(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t, func() {})()
 	acc.SkipInUnitTest(t) // needed because TF test infra is not used
 	v0State := map[string]any{
 		"project_id":   "test-id",
@@ -63,6 +64,7 @@ func TestMigAdvancedCluster_empty_advancedConfig(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_v0StateUpgrade_ReplicationSpecs(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t, func() {})()
 	acc.SkipInUnitTest(t) // needed because TF test infra is not used
 	v0State := map[string]any{
 		"project_id":     "test-id",

--- a/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_state_upgrader_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMigAdvancedCluster_empty_advancedConfig(t *testing.T) {
-	acc.SkipIfTPFAdvancedCluster(t, func() {})()
+	acc.SkipIfTPFAdvancedCluster(t)
 	acc.SkipInUnitTest(t) // needed because TF test infra is not used
 	v0State := map[string]any{
 		"project_id":   "test-id",
@@ -64,7 +64,7 @@ func TestMigAdvancedCluster_empty_advancedConfig(t *testing.T) {
 }
 
 func TestMigAdvancedCluster_v0StateUpgrade_ReplicationSpecs(t *testing.T) {
-	acc.SkipIfTPFAdvancedCluster(t, func() {})()
+	acc.SkipIfTPFAdvancedCluster(t)
 	acc.SkipInUnitTest(t) // needed because TF test infra is not used
 	v0State := map[string]any{
 		"project_id":     "test-id",

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -30,13 +30,14 @@ var (
 )
 
 func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
 		clusterNameUpdated = acc.RandomClusterName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -59,6 +60,7 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	resource.ParallelTest(t, replicaSetAWSProviderTestCase(t))
 }
 func replicaSetAWSProviderTestCase(t *testing.T) resource.TestCase {
@@ -69,7 +71,7 @@ func replicaSetAWSProviderTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -93,6 +95,7 @@ func replicaSetAWSProviderTestCase(t *testing.T) resource.TestCase {
 }
 
 func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	resource.ParallelTest(t, replicaSetMultiCloudTestCase(t))
 }
 func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
@@ -105,7 +108,7 @@ func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -129,6 +132,7 @@ func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
 }
 
 func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	resource.ParallelTest(t, singleShardedMultiCloudTestCase(t))
 }
 
@@ -142,7 +146,7 @@ func singleShardedMultiCloudTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -166,6 +170,7 @@ func singleShardedMultiCloudTestCase(t *testing.T) resource.TestCase {
 }
 
 func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID           = acc.ProjectIDExecution(t)
 		clusterName         = acc.RandomClusterName()
@@ -174,7 +179,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -202,6 +207,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID    = acc.ProjectIDExecution(t)
 		clusterName  = acc.RandomClusterName()
@@ -209,7 +215,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -240,6 +246,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -271,7 +278,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -288,6 +295,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -316,7 +324,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -333,6 +341,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 }
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -348,7 +357,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -376,6 +385,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 }
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -391,7 +401,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -418,6 +428,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 }
 
 func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpectsError(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -425,7 +436,7 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -442,6 +453,7 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 }
 
 func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to check correctly plural data source in the different test steps
@@ -449,7 +461,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -470,6 +482,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 }
 
 func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -477,7 +490,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -498,13 +511,14 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 }
 
 func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -517,6 +531,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -524,7 +539,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -541,6 +556,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	resource.ParallelTest(t, symmetricGeoShardedOldSchemaTestCase(t))
 }
 
@@ -553,7 +569,7 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -570,6 +586,7 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T) resource.TestCase {
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -577,7 +594,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -594,6 +611,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAddingRemovingShard(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -601,7 +619,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -622,6 +640,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	resource.ParallelTest(t, asymmetricShardedNewSchemaTestCase(t))
 }
 
@@ -634,7 +653,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -647,6 +666,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T) resource.TestCase {
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemovingShard(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -654,7 +674,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -675,6 +695,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 }
 
 func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -682,7 +703,7 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -699,6 +720,7 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 }
 
 func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -706,7 +728,7 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -723,6 +745,7 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -730,7 +753,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -755,6 +778,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()
@@ -762,7 +786,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -784,6 +808,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 
 // TestAccClusterAdvancedCluster_priorityOldSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -791,7 +816,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -813,6 +838,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 
 // TestAccClusterAdvancedCluster_priorityNewSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
@@ -820,7 +846,7 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -36,7 +36,7 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 		clusterNameUpdated = acc.RandomClusterName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -69,7 +69,7 @@ func replicaSetAWSProviderTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -105,7 +105,7 @@ func replicaSetMultiCloudTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -142,7 +142,7 @@ func singleShardedMultiCloudTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -174,7 +174,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -209,7 +209,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -271,7 +271,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -316,7 +316,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -348,7 +348,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -391,7 +391,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -425,7 +425,7 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -449,7 +449,7 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -477,7 +477,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -504,7 +504,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, acc.PreCheckBasicSleep(t, nil, projectID, clusterName)),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -524,7 +524,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -553,7 +553,7 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -577,7 +577,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -601,7 +601,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -634,7 +634,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T) resource.TestCase {
 	)
 
 	return resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -654,7 +654,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -682,7 +682,7 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -706,7 +706,7 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -730,7 +730,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -762,7 +762,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -791,7 +791,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
@@ -820,7 +820,7 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		PreCheck:                 acc.SkipIfTPFAdvancedCluster(t, func() { acc.PreCheckBasic(t) }),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -18,7 +18,7 @@ func PreCheckBasic(tb testing.TB) {
 	}
 }
 
-func SkipIfTPFAdvancedCluster(tb testing.TB, existingPreCheck func()) func(){
+func SkipIfTPFAdvancedCluster(tb testing.TB, existingPreCheck func()) func() {
 	tb.Helper()
 	return func() {
 		if os.Getenv("MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS") == "true" {
@@ -26,9 +26,7 @@ func SkipIfTPFAdvancedCluster(tb testing.TB, existingPreCheck func()) func(){
 		}
 		existingPreCheck()
 	}
-
 }
-
 
 // PreCheckBasicSleep is a helper function to call SerialSleep, see its help for more info.
 // Some examples of use are when the test is calling ProjectIDExecution or GetClusterInfo to create clusters.

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -18,6 +18,18 @@ func PreCheckBasic(tb testing.TB) {
 	}
 }
 
+func SkipIfTPFAdvancedCluster(tb testing.TB, existingPreCheck func()) func(){
+	tb.Helper()
+	return func() {
+		if os.Getenv("MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS") == "true" {
+			tb.Skip("Skipping TPF Advanced Cluster tests")
+		}
+		existingPreCheck()
+	}
+
+}
+
+
 // PreCheckBasicSleep is a helper function to call SerialSleep, see its help for more info.
 // Some examples of use are when the test is calling ProjectIDExecution or GetClusterInfo to create clusters.
 func PreCheckBasicSleep(tb testing.TB, clusterInfo *ClusterInfo, projectID, clusterName string) func() {

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -18,13 +18,10 @@ func PreCheckBasic(tb testing.TB) {
 	}
 }
 
-func SkipIfTPFAdvancedCluster(tb testing.TB, existingPreCheck func()) func() {
+func SkipIfTPFAdvancedCluster(tb testing.TB) {
 	tb.Helper()
-	return func() {
-		if os.Getenv("MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS") == "true" {
-			tb.Skip("Skipping TPF Advanced Cluster tests")
-		}
-		existingPreCheck()
+	if os.Getenv("MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS") == "true" {
+		tb.Skip("Skipping tests as resource is TPF Advanced Cluster and implementation is pending")
 	}
 }
 


### PR DESCRIPTION
## Description

Supports running `advanced_cluster_tpf` resource with tests in `advancedcluster` package.
Uses a new flag `MONGODB_ATLAS_TPF_ADV_CLUSTER_TESTS` to determine if we are in the tpf job

Link to any related issue(s): CLOUDP-283271

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments (screenshots of runs in a different testing repo)





<img width="1082" alt="image" src="https://github.com/user-attachments/assets/ed587960-1f3b-4626-a0d3-409f5a964be1">
<img width="987" alt="image" src="https://github.com/user-attachments/assets/4b2c2368-837a-4d36-ba8f-efb6060d118f">
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/9bb26981-8a56-46a9-81bc-b852d12ef899">
<img width="985" alt="image" src="https://github.com/user-attachments/assets/263e526d-09a1-4977-89ae-d129c9391ab1">