### PR TITLE
chore: Aligns schema with existing SDKv2 adv_cluster except Type and PlanModifications

### DIFF
--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, timeout timeouts.Value, diags *diag.Diagnostics) *TFModel {
-	biConnector := NewBiConnectorObjType(ctx, input.BiConnector, diags)
+	biConnector := NewBiConnectorConfigObjType(ctx, input.BiConnector, diags)
 	connectionStrings := NewConnectionStringsObjType(ctx, input.ConnectionStrings, diags)
 	labels := NewLabelsObjType(ctx, input.Labels, diags)
 	replicationSpecs := NewReplicationSpecsObjType(ctx, input.ReplicationSpecs, diags)
@@ -22,7 +22,7 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 	return &TFModel{
 		AcceptDataRisksAndForceReplicaSetReconfig: types.StringPointerValue(conversion.TimePtrToStringPtr(input.AcceptDataRisksAndForceReplicaSetReconfig)),
 		BackupEnabled:                    types.BoolPointerValue(input.BackupEnabled),
-		BiConnector:                      biConnector,
+		BiConnectorConfig:                biConnector,
 		ClusterType:                      types.StringPointerValue(input.ClusterType),
 		ConfigServerManagementMode:       types.StringPointerValue(input.ConfigServerManagementMode),
 		ConfigServerType:                 types.StringPointerValue(input.ConfigServerType),
@@ -50,15 +50,15 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 	}
 }
 
-func NewBiConnectorObjType(ctx context.Context, input *admin.BiConnector, diags *diag.Diagnostics) types.Object {
+func NewBiConnectorConfigObjType(ctx context.Context, input *admin.BiConnector, diags *diag.Diagnostics) types.Object {
 	if input == nil {
-		return types.ObjectNull(BiConnectorObjType.AttrTypes)
+		return types.ObjectNull(BiConnectorConfigObjType.AttrTypes)
 	}
 	tfModel := TFBiConnectorModel{
 		Enabled:        types.BoolPointerValue(input.Enabled),
 		ReadPreference: types.StringPointerValue(input.ReadPreference),
 	}
-	objType, diagsLocal := types.ObjectValueFrom(ctx, BiConnectorObjType.AttrTypes, tfModel)
+	objType, diagsLocal := types.ObjectValueFrom(ctx, BiConnectorConfigObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)
 	return objType
 }

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -21,35 +21,32 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 	}
 	return &TFModel{
 		AcceptDataRisksAndForceReplicaSetReconfig: types.StringPointerValue(conversion.TimePtrToStringPtr(input.AcceptDataRisksAndForceReplicaSetReconfig)),
-		BackupEnabled:               types.BoolPointerValue(input.BackupEnabled),
-		BiConnector:                 biConnector,
-		ClusterType:                 types.StringPointerValue(input.ClusterType),
-		ConfigServerManagementMode:  types.StringPointerValue(input.ConfigServerManagementMode),
-		ConfigServerType:            types.StringPointerValue(input.ConfigServerType),
-		ConnectionStrings:           connectionStrings,
-		CreateDate:                  types.StringPointerValue(conversion.TimePtrToStringPtr(input.CreateDate)),
-		DiskWarmingMode:             types.StringPointerValue(input.DiskWarmingMode),
-		EncryptionAtRestProvider:    types.StringPointerValue(input.EncryptionAtRestProvider),
-		FeatureCompatibilityVersion: types.StringPointerValue(input.FeatureCompatibilityVersion),
-		FeatureCompatibilityVersionExpirationDate: types.StringPointerValue(conversion.TimePtrToStringPtr(input.FeatureCompatibilityVersionExpirationDate)),
-		GlobalClusterSelfManagedSharding:          types.BoolPointerValue(input.GlobalClusterSelfManagedSharding),
-		ProjectID:                                 types.StringPointerValue(input.GroupId),
-		ClusterID:                                 types.StringPointerValue(input.Id),
-		Labels:                                    labels,
-		MongoDBMajorVersion:                       types.StringPointerValue(input.MongoDBMajorVersion),
-		MongoDBVersion:                            types.StringPointerValue(input.MongoDBVersion),
-		Name:                                      types.StringPointerValue(input.Name),
-		Paused:                                    types.BoolPointerValue(input.Paused),
-		PitEnabled:                                types.BoolPointerValue(input.PitEnabled),
-		RedactClientLogData:                       types.BoolPointerValue(input.RedactClientLogData),
-		ReplicaSetScalingStrategy:                 types.StringPointerValue(input.ReplicaSetScalingStrategy),
-		ReplicationSpecs:                          replicationSpecs,
-		RootCertType:                              types.StringPointerValue(input.RootCertType),
-		StateName:                                 types.StringPointerValue(input.StateName),
-		Tags:                                      tags,
-		TerminationProtectionEnabled:              types.BoolPointerValue(input.TerminationProtectionEnabled),
-		VersionReleaseSystem:                      types.StringPointerValue(input.VersionReleaseSystem),
-		Timeouts:                                  timeout,
+		BackupEnabled:                    types.BoolPointerValue(input.BackupEnabled),
+		BiConnector:                      biConnector,
+		ClusterType:                      types.StringPointerValue(input.ClusterType),
+		ConfigServerManagementMode:       types.StringPointerValue(input.ConfigServerManagementMode),
+		ConfigServerType:                 types.StringPointerValue(input.ConfigServerType),
+		ConnectionStrings:                connectionStrings,
+		CreateDate:                       types.StringPointerValue(conversion.TimePtrToStringPtr(input.CreateDate)),
+		EncryptionAtRestProvider:         types.StringPointerValue(input.EncryptionAtRestProvider),
+		GlobalClusterSelfManagedSharding: types.BoolPointerValue(input.GlobalClusterSelfManagedSharding),
+		ProjectID:                        types.StringPointerValue(input.GroupId),
+		ClusterID:                        types.StringPointerValue(input.Id),
+		Labels:                           labels,
+		MongoDBMajorVersion:              types.StringPointerValue(input.MongoDBMajorVersion),
+		MongoDBVersion:                   types.StringPointerValue(input.MongoDBVersion),
+		Name:                             types.StringPointerValue(input.Name),
+		Paused:                           types.BoolPointerValue(input.Paused),
+		PitEnabled:                       types.BoolPointerValue(input.PitEnabled),
+		RedactClientLogData:              types.BoolPointerValue(input.RedactClientLogData),
+		ReplicaSetScalingStrategy:        types.StringPointerValue(input.ReplicaSetScalingStrategy),
+		ReplicationSpecs:                 replicationSpecs,
+		RootCertType:                     types.StringPointerValue(input.RootCertType),
+		StateName:                        types.StringPointerValue(input.StateName),
+		Tags:                             tags,
+		TerminationProtectionEnabled:     types.BoolPointerValue(input.TerminationProtectionEnabled),
+		VersionReleaseSystem:             types.StringPointerValue(input.VersionReleaseSystem),
+		Timeouts:                         timeout,
 	}
 }
 
@@ -72,13 +69,11 @@ func NewConnectionStringsObjType(ctx context.Context, input *admin.ClusterConnec
 	}
 	privateEndpoint := NewPrivateEndpointObjType(ctx, input.PrivateEndpoint, diags)
 	tfModel := TFConnectionStringsModel{
-		AwsPrivateLink:    conversion.ToTFMapOfString(ctx, diags, input.AwsPrivateLink),
-		AwsPrivateLinkSrv: conversion.ToTFMapOfString(ctx, diags, input.AwsPrivateLinkSrv),
-		Private:           types.StringPointerValue(input.Private),
-		PrivateEndpoint:   privateEndpoint,
-		PrivateSrv:        types.StringPointerValue(input.PrivateSrv),
-		Standard:          types.StringPointerValue(input.Standard),
-		StandardSrv:       types.StringPointerValue(input.StandardSrv),
+		Private:         types.StringPointerValue(input.Private),
+		PrivateEndpoint: privateEndpoint,
+		PrivateSrv:      types.StringPointerValue(input.PrivateSrv),
+		Standard:        types.StringPointerValue(input.Standard),
+		StandardSrv:     types.StringPointerValue(input.StandardSrv),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, ConnectionStringsObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)
@@ -106,16 +101,13 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		return types.ListNull(ReplicationSpecsObjType)
 	}
 	tfModels := make([]TFReplicationSpecsModel, len(*input))
-	todoContainerID := map[string]string{
-		"AWS:US_EAST_1": "6728c725e12c976e3a21e204",
-	}
 	for i, item := range *input {
 		regionConfigs := NewRegionConfigsObjType(ctx, item.RegionConfigs, diags)
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            types.StringPointerValue(item.Id),
-			ExternalId:    types.StringValue("TODO_STATIC"),
-			NumShards:     types.Int64Value(1), //TODO: Static
-			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &todoContainerID),
+			ExternalId:    types.StringNull(),                          // TODO: Static
+			NumShards:     types.Int64Null(),                           // TODO: Static
+			ContainerId:   conversion.ToTFMapOfString(ctx, diags, nil), // TODO: Static
 			RegionConfigs: regionConfigs,
 			ZoneId:        types.StringPointerValue(item.ZoneId),
 			ZoneName:      types.StringPointerValue(item.ZoneName),

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -106,7 +106,7 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            types.StringPointerValue(item.Id),
 			ExternalId:    types.StringNull(),                          // TODO: Static
-			NumShards:     types.Int64Null(),                           // TODO: Static
+			NumShards:     types.Int64Value(1),                         // TODO: Static
 			ContainerId:   conversion.ToTFMapOfString(ctx, diags, nil), // TODO: Static
 			RegionConfigs: regionConfigs,
 			ZoneId:        types.StringPointerValue(item.ZoneId),

--- a/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescriptionProcessArgs20240805.go
@@ -14,20 +14,17 @@ func AddAdvancedConfig(ctx context.Context, tfModel *TFModel, input *admin.Clust
 	if input != nil {
 		advancedConfig = TFAdvancedConfigurationModel{
 			ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds: types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds)),
-			ChunkMigrationConcurrency:                             types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.ChunkMigrationConcurrency)),
-			DefaultMaxTimeMs:                                      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DefaultMaxTimeMS)),
-			DefaultWriteConcern:                                   types.StringPointerValue(input.DefaultWriteConcern),
-			DefaultReadConcern:                                    types.StringNull(), // TODO: static
-			FailIndexKeyTooLong:                                   types.BoolNull(),   // TODO: static,
-			JavascriptEnabled:                                     types.BoolPointerValue(input.JavascriptEnabled),
-			MinimumEnabledTlsProtocol:                             types.StringPointerValue(input.MinimumEnabledTlsProtocol),
-			NoTableScan:                                           types.BoolPointerValue(input.NoTableScan),
-			OplogMinRetentionHours:                                types.Float64PointerValue(input.OplogMinRetentionHours),
-			OplogSizeMb:                                           types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.OplogSizeMB)),
-			QueryStatsLogVerbosity:                                types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.QueryStatsLogVerbosity)),
-			SampleSizeBiconnector:                                 types.Int64Null(), // TODO: static
-			SampleRefreshIntervalBiconnector:                      types.Int64Null(), // TODO: static
-			TransactionLifetimeLimitSeconds:                       types.Int64PointerValue(input.TransactionLifetimeLimitSeconds),
+			DefaultWriteConcern:              types.StringPointerValue(input.DefaultWriteConcern),
+			DefaultReadConcern:               types.StringNull(), // TODO: static
+			FailIndexKeyTooLong:              types.BoolNull(),   // TODO: static,
+			JavascriptEnabled:                types.BoolPointerValue(input.JavascriptEnabled),
+			MinimumEnabledTlsProtocol:        types.StringPointerValue(input.MinimumEnabledTlsProtocol),
+			NoTableScan:                      types.BoolPointerValue(input.NoTableScan),
+			OplogMinRetentionHours:           types.Float64PointerValue(input.OplogMinRetentionHours),
+			OplogSizeMb:                      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.OplogSizeMB)),
+			SampleSizeBiconnector:            types.Int64Null(), // TODO: static
+			SampleRefreshIntervalBiconnector: types.Int64Null(), // TODO: static
+			TransactionLifetimeLimitSeconds:  types.Int64PointerValue(input.TransactionLifetimeLimitSeconds),
 		}
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, AdvancedConfigurationObjType.AttrTypes, advancedConfig)

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -29,6 +30,8 @@ const (
 	ignoreLabel                    = "Infrastructure Tool"
 	DeprecationOldSchemaAction     = "Please refer to our examples, documentation, and 1.18.0 migration guide for more details at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
 )
+
+var DeprecationMsgOldSchema = fmt.Sprintf("%s %s", constant.DeprecationParam, DeprecationOldSchemaAction)
 
 func Resource() resource.Resource {
 	return &rs{

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -83,7 +83,11 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, plan.Timeouts)
+	if shouldReturn {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, tfNewModel)...)
 }
 
 func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -7,10 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -27,20 +23,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set **acceptDataRisksAndForceReplicaSetReconfig** to the current date.",
 			},
 			"backup_enabled": schema.BoolAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/) for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.",
 			},
 			"bi_connector": schema.SingleNestedAttribute{
 				// TODO: MaxItems: 1
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Settings needed to configure the MongoDB Connector for Business Intelligence for this cluster.",
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
@@ -60,30 +50,18 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Configuration of nodes that comprise the cluster.",
 			},
 			"config_server_management_mode": schema.StringAttribute{
+				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Config Server Management Mode for creating or updating a sharded cluster.\n\nWhen configured as ATLAS_MANAGED, atlas may automatically switch the cluster's config server type for optimal performance and savings.\n\nWhen configured as FIXED_TO_DEDICATED, the cluster will always use a dedicated config server.",
 			},
 			"config_server_type": schema.StringAttribute{
-				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: "Describes a sharded cluster's config server type.",
 			},
 			"connection_strings": schema.SingleNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Collection of Uniform Resource Locators that point to the MongoDB database.",
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
-				},
 				Attributes: map[string]schema.Attribute{
-					"aws_private_link": schema.MapAttribute{ // TODO: not in current resource, decide if keep
-						Computed:            true,
-						MarkdownDescription: "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to MongoDB Cloud through the interface endpoint that the key names.",
-						ElementType:         types.StringType,
-					},
-					"aws_private_link_srv": schema.MapAttribute{ // TODO: not in current resource, decide if keep
-						Computed:            true,
-						MarkdownDescription: "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to Atlas through the interface endpoint that the key names. If the cluster uses an optimized connection string, `awsPrivateLinkSrv` contains the optimized connection string. If the cluster has the non-optimized (legacy) connection string, `awsPrivateLinkSrv` contains the non-optimized connection string even if an optimized connection string is also present.",
-						ElementType:         types.StringType,
-					},
 					"private": schema.StringAttribute{
 						Computed:            true,
 						MarkdownDescription: "Network peering connection strings for each interface Virtual Private Cloud (VPC) endpoint that you configured to connect to this cluster. This connection string uses the `mongodb+srv://` protocol. The resource returns this parameter once someone creates a network peering connection to this cluster. This protocol tells the application to look up the host seed list in the Domain Name System (DNS). This list synchronizes with the nodes in a cluster. If the connection string uses this Uniform Resource Identifier (URI) format, you don't need to append the seed list or change the URI if the nodes change. Use this URI format if your driver supports it. If it doesn't, use connectionStrings.private. For Amazon Web Services (AWS) clusters, this resource returns this parameter only if you enable custom DNS.",
@@ -153,35 +131,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 				MarkdownDescription: "Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.",
 			},
-			"disk_warming_mode": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				MarkdownDescription: "Disk warming mode selection.",
-			},
 			"encryption_at_rest_provider": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster **replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize** setting must be `M10` or higher and `\"backupEnabled\" : false` or omitted entirely.",
 			},
-			"feature_compatibility_version": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Optional:            true,
-				MarkdownDescription: "Feature compatibility version of the cluster.",
-			},
-			"feature_compatibility_version_expiration_date": schema.StringAttribute{ // TODO: not in current resource, decide if keep
-				Optional:            true,
-				MarkdownDescription: "Feature compatibility version expiration date.",
-			},
 			"global_cluster_self_managed_sharding": schema.BoolAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Set this field to configure the Sharding Management Mode when creating a new Global Cluster.\n\nWhen set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.\n\nWhen set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.\n\nThis setting cannot be changed once the cluster is deployed.",
 			},
 			"project_id": schema.StringAttribute{ // TODO: fail if trying to update
@@ -216,7 +173,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"mongo_db_major_version": schema.StringAttribute{ // TODO: was generated as mongo_dbmajor_version
-				// TODO: watch out new error, Error code: "ATLAS_CLUSTER_VERSION_DEPRECATED") Detail: MongoDB version is deprecated in Atlas. Reason: Bad Request. Params: [], BadRequestDetail:
 				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
@@ -226,10 +182,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "MongoDB major version of the cluster.\n\nOn creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLTSVersions).\n\n On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.",
 			},
 			"mongo_db_version": schema.StringAttribute{ // TODO: was generated as mongo_dbversion
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
 				MarkdownDescription: "Version of MongoDB that the cluster runs.",
 			},
 			"name": schema.StringAttribute{ // TODO: fail if trying to update
@@ -237,30 +190,22 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Human-readable label that identifies this cluster.",
 			},
 			"paused": schema.BoolAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether the cluster is paused.",
 			},
 			"pit_enabled": schema.BoolAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether the cluster uses continuous cloud backups.",
 			},
 			"redact_client_log_data": schema.BoolAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Enable or disable log redaction.\n\nThis setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.\n\nUse ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.\n\n*Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.",
 			},
 			"replica_set_scaling_strategy": schema.StringAttribute{
+				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Set this field to configure the replica set scaling mode for your cluster.\n\nBy default, Atlas scales under WORKLOAD_TYPE. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.\n\nWhen configured as SEQUENTIAL, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.\n\nWhen configured as NODE_TYPE, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.",
 			},
@@ -271,33 +216,24 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
 							// TODO: Deprecated: DeprecationMsgOldSchema,
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
+							Computed:            true,
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the replication object for a shard in a Cluster. If you include existing shard replication configurations in the request, you must specify this parameter. If you add a new shard to an existing Cluster, you may specify this parameter. The request deletes any existing shards  in the Cluster that you exclude from the request. This corresponds to Shard ID displayed in the UI.",
 						},
 						"container_id": schema.MapAttribute{ // TODO: added as in current resource
-							ElementType: types.StringType,
-							Computed:    true,
-							PlanModifiers: []planmodifier.Map{
-								mapplanmodifier.UseStateForUnknown(),
-							},
+							ElementType:         types.StringType,
+							Computed:            true,
 							MarkdownDescription: "container_id", // TODO: add description
 						},
 						"external_id": schema.StringAttribute{ // TODO: added as in current resource
 							Computed:            true,
 							MarkdownDescription: "external_id", // TODO: add description
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
 						},
 						"num_shards": schema.Int64Attribute{ // TODO: added as in current resource
 							// TODO: Deprecated: DeprecationMsgOldSchema,
 							// TODO: not sure if add valitadation here: ValidateFunc: validation.IntBetween(1, 50),
-							Computed:            true,
+							// Default:             int64default.StaticInt64(1),
+							Computed:            true, // must be computed to allow default 1
 							Optional:            true,
-							Default:             int64default.StaticInt64(1),
 							MarkdownDescription: "num_shards", // TODO: add description
 						},
 						"region_configs": schema.ListNestedAttribute{
@@ -305,9 +241,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Hardware specifications for nodes set for a given region. Each **regionConfigs** object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each **regionConfigs** object must have either an **analyticsSpecs** object, **electableSpecs** object, or **readOnlySpecs** object. Tenant clusters only require **electableSpecs. Dedicated** clusters can specify any of these specifications, but must have at least one **electableSpecs** object within a **replicationSpec**.\n\n**Example:**\n\nIf you set `\"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize\" : \"M30\"`, set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : `\"M30\"` if you have electable nodes and `\"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize\" : `\"M30\"` if you have read-only nodes.",
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
-									"analytics_auto_scaling": AutoScalingSchema(false),
+									"analytics_auto_scaling": AutoScalingSchema(),
 									"analytics_specs":        SpecsSchema("Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region."),
-									"auto_scaling":           AutoScalingSchema(true),
+									"auto_scaling":           AutoScalingSchema(),
 									"backing_provider_name": schema.StringAttribute{
 										Optional:            true,
 										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when **providerName** is `TENANT` and **electableSpecs.instanceSize** is `M0`, `M2` or `M5`.",
@@ -332,14 +268,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 						"zone_id": schema.StringAttribute{
-							Computed: true,
-							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
-							},
+							Computed:            true,
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the zone in a Global Cluster. This value can be used to configure Global Cluster backup policies.",
 						},
 						"zone_name": schema.StringAttribute{
-							Computed:            true,
+							Computed:            true, // must be computed to have a Default
 							Optional:            true,
 							Default:             stringdefault.StaticString("ZoneName managed by Terraform"), // TODO: as in current resource
 							MarkdownDescription: "Human-readable label that describes the zone this shard belongs to in a Global Cluster. Provide this value only if \"clusterType\" : \"GEOSHARDED\" but not \"selfManagedSharding\" : true.",
@@ -348,18 +281,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"root_cert_type": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Root Certificate Authority that MongoDB Cloud cluster uses. MongoDB Cloud supports Internet Security Research Group.",
 			},
 			"state_name": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this cluster.",
 			},
 			// TODO: We want to avoid breaking changes even though it is incompatible with flex cluster and project resource
@@ -402,7 +329,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"disk_size_gb": schema.Float64Attribute{ // TODO: not exposed in latest API, deprecated in root in current resource
 				// Deprecated: DeprecationMsgOldSchema,
-				// Computed:            true,
+				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
 			},
@@ -416,15 +343,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 	}
 }
 
-func AutoScalingSchema(computed bool) schema.SingleNestedAttribute {
+func AutoScalingSchema() schema.SingleNestedAttribute {
 	// todo: computed, analytics_auto_scaling is not returned by default, so it cannot be computed
 	return schema.SingleNestedAttribute{
 		// TODO: MaxItems: 1
-		Computed: computed,
-		Optional: true,
-		PlanModifiers: []planmodifier.Object{
-			objectplanmodifier.UseStateForUnknown(),
-		},
+		Computed:            true,
+		Optional:            true,
 		MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
 		Attributes: map[string]schema.Attribute{
 			"compute_enabled": schema.BoolAttribute{ // TODO: was nested in compute
@@ -459,19 +383,13 @@ func AutoScalingSchema(computed bool) schema.SingleNestedAttribute {
 func SpecsSchema(markdownDescription string) schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
 		// TODO: MaxItems: 1
-		Computed: true,
-		Optional: true,
-		PlanModifiers: []planmodifier.Object{
-			objectplanmodifier.UseStateForUnknown(),
-		},
+		Computed:            true,
+		Optional:            true,
 		MarkdownDescription: markdownDescription,
 		Attributes: map[string]schema.Attribute{
 			"disk_iops": schema.Int64Attribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
 			},
 			"disk_size_gb": schema.Float64Attribute{
@@ -480,11 +398,8 @@ func SpecsSchema(markdownDescription string) schema.SingleNestedAttribute {
 				MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
 			},
 			"ebs_volume_type": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
 			},
 			"instance_size": schema.StringAttribute{
@@ -506,27 +421,13 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 	return schema.SingleNestedAttribute{
 		Computed: true,
 		Optional: true,
-		PlanModifiers: []planmodifier.Object{
-			objectplanmodifier.UseStateForUnknown(),
-		},
 		// TODO: MaxItems: 1,
 		MarkdownDescription: "advanced_configuration", // TODO: add description
 		Attributes: map[string]schema.Attribute{
 			"change_stream_options_pre_and_post_images_expire_after_seconds": schema.Int64Attribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             int64default.StaticInt64(-1), // TODO: think if default in the server only
+				Optional: true,
+				// Default:             int64default.StaticInt64(-1), // TODO: think if default in the server only
 				MarkdownDescription: "The minimum pre- and post-image retention time in seconds.",
-			},
-			"chunk_migration_concurrency": schema.Int64Attribute{ // TODO: not in current resource, decide if keep
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Number of threads on the source shard and the receiving shard for chunk migration. The number of threads should not exceed the half the total number of CPU cores in the sharded cluster.",
-			},
-			"default_max_time_ms": schema.Int64Attribute{ // TODO: not in current resource, decide if keep
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Default time limit in milliseconds for individual read operations to complete.",
 			},
 			"default_write_concern": schema.StringAttribute{
 				Computed:            true,
@@ -544,6 +445,7 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 				MarkdownDescription: "Minimum Transport Layer Security (TLS) version that the cluster accepts for incoming connections. Clusters using TLS 1.0 or 1.1 should consider setting TLS 1.2 as the minimum TLS protocol version.",
 			},
 			"no_table_scan": schema.BoolAttribute{
+				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether the cluster disables executing any query that requires a collection scan to return results.",
 			},
@@ -553,11 +455,8 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 			},
 			"oplog_size_mb": schema.Int64Attribute{
 				Optional:            true,
+				Computed:            true,
 				MarkdownDescription: "Storage limit of cluster's oplog expressed in megabytes. A value of null indicates that the cluster uses the default oplog size that MongoDB Cloud calculates.",
-			},
-			"query_stats_log_verbosity": schema.Int64Attribute{ // TODO: not in current resource, decide if keep
-				Optional:            true,
-				MarkdownDescription: "May be set to 1 (disabled) or 3 (enabled). When set to 3, Atlas will include redacted and anonymized $queryStats output in MongoDB logs. $queryStats output does not contain literals or field values. Enabling this setting might impact the performance of your cluster.",
 			},
 			"sample_refresh_interval_bi_connector": schema.Int64Attribute{ // TODO was sample_refresh_interval_biconnector
 				Computed:            true,
@@ -595,14 +494,11 @@ type TFModel struct {
 	Labels                                    types.Set      `tfsdk:"labels"`
 	ReplicationSpecs                          types.List     `tfsdk:"replication_specs"`
 	Tags                                      types.Set      `tfsdk:"tags"`
-	DiskWarmingMode                           types.String   `tfsdk:"disk_warming_mode"`
 	StateName                                 types.String   `tfsdk:"state_name"`
 	ConnectionStrings                         types.Object   `tfsdk:"connection_strings"`
 	CreateDate                                types.String   `tfsdk:"create_date"`
 	AcceptDataRisksAndForceReplicaSetReconfig types.String   `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
 	EncryptionAtRestProvider                  types.String   `tfsdk:"encryption_at_rest_provider"`
-	FeatureCompatibilityVersion               types.String   `tfsdk:"feature_compatibility_version"`
-	FeatureCompatibilityVersionExpirationDate types.String   `tfsdk:"feature_compatibility_version_expiration_date"`
 	Timeouts                                  timeouts.Value `tfsdk:"timeouts"`
 	ProjectID                                 types.String   `tfsdk:"project_id"`
 	ClusterID                                 types.String   `tfsdk:"cluster_id"`
@@ -637,23 +533,19 @@ var BiConnectorObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 }}
 
 type TFConnectionStringsModel struct {
-	AwsPrivateLink    types.Map    `tfsdk:"aws_private_link"`
-	AwsPrivateLinkSrv types.Map    `tfsdk:"aws_private_link_srv"`
-	Private           types.String `tfsdk:"private"`
-	PrivateEndpoint   types.List   `tfsdk:"private_endpoint"`
-	PrivateSrv        types.String `tfsdk:"private_srv"`
-	Standard          types.String `tfsdk:"standard"`
-	StandardSrv       types.String `tfsdk:"standard_srv"`
+	Private         types.String `tfsdk:"private"`
+	PrivateEndpoint types.List   `tfsdk:"private_endpoint"`
+	PrivateSrv      types.String `tfsdk:"private_srv"`
+	Standard        types.String `tfsdk:"standard"`
+	StandardSrv     types.String `tfsdk:"standard_srv"`
 }
 
 var ConnectionStringsObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"aws_private_link":     types.MapType{ElemType: types.StringType},
-	"aws_private_link_srv": types.MapType{ElemType: types.StringType},
-	"private":              types.StringType,
-	"private_endpoint":     types.ListType{ElemType: PrivateEndpointObjType},
-	"private_srv":          types.StringType,
-	"standard":             types.StringType,
-	"standard_srv":         types.StringType,
+	"private":          types.StringType,
+	"private_endpoint": types.ListType{ElemType: PrivateEndpointObjType},
+	"private_srv":      types.StringType,
+	"standard":         types.StringType,
+	"standard_srv":     types.StringType,
 }}
 
 type TFPrivateEndpointModel struct {
@@ -785,11 +677,8 @@ type TFAdvancedConfigurationModel struct {
 	MinimumEnabledTlsProtocol                             types.String  `tfsdk:"minimum_enabled_tls_protocol"`
 	DefaultWriteConcern                                   types.String  `tfsdk:"default_write_concern"`
 	DefaultReadConcern                                    types.String  `tfsdk:"default_read_concern"`
-	DefaultMaxTimeMs                                      types.Int64   `tfsdk:"default_max_time_ms"`
 	ChangeStreamOptionsPreAndPostImagesExpireAfterSeconds types.Int64   `tfsdk:"change_stream_options_pre_and_post_images_expire_after_seconds"`
-	ChunkMigrationConcurrency                             types.Int64   `tfsdk:"chunk_migration_concurrency"`
 	OplogSizeMb                                           types.Int64   `tfsdk:"oplog_size_mb"`
-	QueryStatsLogVerbosity                                types.Int64   `tfsdk:"query_stats_log_verbosity"`
 	SampleRefreshIntervalBiconnector                      types.Int64   `tfsdk:"sample_refresh_interval_bi_connector"`
 	SampleSizeBiconnector                                 types.Int64   `tfsdk:"sample_size_bi_connector"`
 	TransactionLifetimeLimitSeconds                       types.Int64   `tfsdk:"transaction_lifetime_limit_seconds"`
@@ -800,18 +689,15 @@ type TFAdvancedConfigurationModel struct {
 
 var AdvancedConfigurationObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"change_stream_options_pre_and_post_images_expire_after_seconds": types.Int64Type,
-	"chunk_migration_concurrency":                                    types.Int64Type,
-	"default_max_time_ms":                                            types.Int64Type,
-	"default_read_concern":                                           types.StringType,
-	"default_write_concern":                                          types.StringType,
-	"fail_index_key_too_long":                                        types.BoolType,
-	"javascript_enabled":                                             types.BoolType,
-	"minimum_enabled_tls_protocol":                                   types.StringType,
-	"no_table_scan":                                                  types.BoolType,
-	"oplog_min_retention_hours":                                      types.Float64Type,
-	"oplog_size_mb":                                                  types.Int64Type,
-	"query_stats_log_verbosity":                                      types.Int64Type,
-	"sample_refresh_interval_bi_connector":                           types.Int64Type,
-	"sample_size_bi_connector":                                       types.Int64Type,
-	"transaction_lifetime_limit_seconds":                             types.Int64Type,
+	"default_read_concern":                 types.StringType,
+	"default_write_concern":                types.StringType,
+	"fail_index_key_too_long":              types.BoolType,
+	"javascript_enabled":                   types.BoolType,
+	"minimum_enabled_tls_protocol":         types.StringType,
+	"no_table_scan":                        types.BoolType,
+	"oplog_min_retention_hours":            types.Float64Type,
+	"oplog_size_mb":                        types.Int64Type,
+	"sample_refresh_interval_bi_connector": types.Int64Type,
+	"sample_size_bi_connector":             types.Int64Type,
+	"transaction_lifetime_limit_seconds":   types.Int64Type,
 }}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -215,7 +215,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							// TODO: Deprecated: DeprecationMsgOldSchema,
+							DeprecationMessage:  DeprecationMsgOldSchema,
 							Computed:            true,
 							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the replication object for a shard in a Cluster. If you include existing shard replication configurations in the request, you must specify this parameter. If you add a new shard to an existing Cluster, you may specify this parameter. The request deletes any existing shards  in the Cluster that you exclude from the request. This corresponds to Shard ID displayed in the UI.",
 						},
@@ -229,7 +229,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "external_id", // TODO: add description
 						},
 						"num_shards": schema.Int64Attribute{ // TODO: added as in current resource
-							// TODO: Deprecated: DeprecationMsgOldSchema,
+							DeprecationMessage: DeprecationMsgOldSchema,
 							// TODO: not sure if add valitadation here: ValidateFunc: validation.IntBetween(1, 50),
 							// Default:             int64default.StaticInt64(1),
 							Computed:            true, // must be computed to allow default 1
@@ -328,7 +328,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Flag that indicates whether to retain backup snapshots for the deleted dedicated cluster.",
 			},
 			"disk_size_gb": schema.Float64Attribute{ // TODO: not exposed in latest API, deprecated in root in current resource
-				// Deprecated: DeprecationMsgOldSchema,
+				DeprecationMessage:  DeprecationMsgOldSchema,
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
@@ -474,13 +474,13 @@ func AdvancedConfigurationSchema(ctx context.Context) schema.SingleNestedAttribu
 				MarkdownDescription: "Lifetime, in seconds, of multi-document transactions. Atlas considers the transactions that exceed this limit as expired and so aborts them through a periodic cleanup process.",
 			},
 			"default_read_concern": schema.StringAttribute{ // TODO: not exposed in latest API, deprecated in current resource
-				// TODO: Deprecated: DeprecationMsgOldSchema,
+				DeprecationMessage:  DeprecationMsgOldSchema,
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "default_read_concern", // TODO: add description
 			},
 			"fail_index_key_too_long": schema.BoolAttribute{ // TODO: not exposed in latest API, deprecated in current resource
-				// TODO: Deprecated: DeprecationMsgOldSchema,
+				DeprecationMessage:  DeprecationMsgOldSchema,
 				Computed:            true,
 				Optional:            true,
 				MarkdownDescription: "fail_index_key_too_long", // TODO: add description

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -27,7 +27,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/) for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.",
 			},
-			"bi_connector": schema.SingleNestedAttribute{
+			"bi_connector_config": schema.SingleNestedAttribute{
 				// TODO: MaxItems: 1
 				Computed:            true,
 				Optional:            true,
@@ -507,7 +507,7 @@ type TFModel struct {
 	MongoDBVersion                            types.String   `tfsdk:"mongo_db_version"`
 	Name                                      types.String   `tfsdk:"name"`
 	VersionReleaseSystem                      types.String   `tfsdk:"version_release_system"`
-	BiConnector                               types.Object   `tfsdk:"bi_connector"`
+	BiConnectorConfig                         types.Object   `tfsdk:"bi_connector_config"`
 	ConfigServerType                          types.String   `tfsdk:"config_server_type"`
 	ReplicaSetScalingStrategy                 types.String   `tfsdk:"replica_set_scaling_strategy"`
 	ClusterType                               types.String   `tfsdk:"cluster_type"`
@@ -527,7 +527,7 @@ type TFBiConnectorModel struct {
 	Enabled        types.Bool   `tfsdk:"enabled"`
 }
 
-var BiConnectorObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
+var BiConnectorConfigObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"enabled":         types.BoolType,
 	"read_preference": types.StringType,
 }}

--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -231,7 +232,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"num_shards": schema.Int64Attribute{ // TODO: added as in current resource
 							DeprecationMessage: DeprecationMsgOldSchema,
 							// TODO: not sure if add valitadation here: ValidateFunc: validation.IntBetween(1, 50),
-							// Default:             int64default.StaticInt64(1),
+							Default:             int64default.StaticInt64(1),
 							Computed:            true, // must be computed to allow default 1
 							Optional:            true,
 							MarkdownDescription: "num_shards", // TODO: add description

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -29,10 +29,16 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state_name", "CREATING"),
+					ChangeReponseNumber(2),
+				),
 			},
 			{
 				Config: configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
-				Check:  resource.ComposeTestCheckFunc(ChangeReponseNumber(2)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "accept_data_risks_and_force_replica_set_reconfig", "2006-01-02T15:04:05Z"),
+				),
 			},
 			{
 				ResourceName:                         resourceName,

--- a/internal/service/advancedclustertpf/testdata/create_2.json
+++ b/internal/service/advancedclustertpf/testdata/create_2.json
@@ -80,7 +80,6 @@
     ],
     "rootCertType": "ISRGROOTX1",
     "stateName": "CREATING",
-    "tags": [],
     "terminationProtectionEnabled": false,
     "versionReleaseSystem": "LTS"
 }


### PR DESCRIPTION
## Description

- Aligns schema with existing SDKv2 adv_cluster except **Type** and **PlanModifications**

- [x] Align computability, [not fully possible](https://docs.google.com/document/d/1QxrB1BOiMCvUjwAsllG0M3rHKl6ymKJOEF6L5aNYJmE/edit?tab=t.0#bookmark=id.ksuhoa86ti30)
- [x] Deprecation messages updated
- [x] New attributes will be removed


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
