### PR TITLE
chore: Initial implementation of Move State

### DIFF
--- a/internal/service/advancedclustertpf/move_state.go
+++ b/internal/service/advancedclustertpf/move_state.go
@@ -2,36 +2,123 @@ package advancedclustertpf
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
+// TODO: We temporarily use mongodbatlas_database_user instead of mongodbatlas_cluster to set up the initial environment
 func (r *rs) MoveState(context.Context) []resource.StateMover {
 	return []resource.StateMover{
 		{
-			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
-				timeout := timeouts.Value{
-					Object: types.ObjectValueMust(
-						map[string]attr.Type{
-							"create": types.StringType,
-							"update": types.StringType,
-							"delete": types.StringType,
-						},
-						map[string]attr.Value{
-							"create": types.StringValue("30m"),
-							"update": types.StringValue("30m"),
-							"delete": types.StringValue("30m"),
-						}),
-				}
-				tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, timeout)
-				if shouldReturn {
-					return
-				}
-				resp.Diagnostics.Append(resp.TargetState.Set(ctx, tfNewModel)...)
-			},
+			StateMover: stateMoverTemporaryTPFDatabaseUser,
+		},
+		{
+			StateMover: stateMoverTemporaryV2,
+		},
+		{
+			StateMover: stateMoverCluster,
 		},
 	}
+}
+
+func stateMoverTemporaryTPFDatabaseUser(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	if !isSource(req, "database_user") {
+		return
+	}
+	rawStateValue, err := req.SourceRawState.Unmarshal(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id":                 tftypes.String,
+			"project_id":         tftypes.String,
+			"auth_database_name": tftypes.String,
+			"username":           tftypes.String,
+			"password":           tftypes.String,
+			"x509_type":          tftypes.String,
+			"oidc_auth_type":     tftypes.String,
+			"ldap_auth_type":     tftypes.String,
+			"aws_iam_type":       tftypes.String,
+			"roles": tftypes.Set{ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"collection_name": tftypes.String,
+					"database_name":   tftypes.String,
+					"role_name":       tftypes.String,
+				},
+			}},
+			"labels": tftypes.Set{ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"key":   tftypes.String,
+					"value": tftypes.String,
+				},
+			}},
+			"scopes": tftypes.Set{ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"name": tftypes.String,
+					"type": tftypes.String,
+				},
+			}},
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to Unmarshal Source State", err.Error())
+		return
+	}
+	var rawState map[string]tftypes.Value
+	if err := rawStateValue.As(&rawState); err != nil {
+		resp.Diagnostics.AddError("Unable to Convert Source State", err.Error())
+		return
+	}
+	var projectID *string // TODO: take username as the cluster name
+	if err := rawState["project_id"].As(&projectID); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("project_id"), "Unable to Convert Source State", err.Error())
+		return
+	}
+	var clusterName *string // TODO: take username as the cluster name
+	if err := rawState["username"].As(&clusterName); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("username"), "Unable to Convert Source State", err.Error())
+		return
+	}
+	setMoveState(ctx, *projectID, *clusterName, resp)
+}
+
+func stateMoverTemporaryV2(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+}
+
+func stateMoverCluster(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+}
+
+func isSource(req resource.MoveStateRequest, resourceName string) bool {
+	return req.SourceTypeName == "mongodbatlas_"+resourceName &&
+		req.SourceSchemaVersion == 0 &&
+		strings.HasSuffix(req.SourceProviderAddress, "/mongodbatlas")
+}
+
+func setMoveState(ctx context.Context, projectID, clusterName string, resp *resource.MoveStateResponse) {
+	// TODO: timeout should be read from source if provided
+	timeout := timeouts.Value{
+		Object: types.ObjectValueMust(
+			map[string]attr.Type{
+				"create": types.StringType,
+				"update": types.StringType,
+				"delete": types.StringType,
+			},
+			map[string]attr.Value{
+				"create": types.StringValue("30m"),
+				"update": types.StringValue("30m"),
+				"delete": types.StringValue("30m"),
+			}),
+	}
+	// TODO: we need to have a good state (all attributes known or null) but not need to be the final ones as Reas is called after
+	tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, timeout)
+	if shouldReturn {
+		return
+	}
+	// TODO: setting attributed needed by Read, confirm if ClusterID is needed
+	tfNewModel.ProjectID = types.StringValue(projectID)
+	tfNewModel.Name = types.StringValue(clusterName)
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, tfNewModel)...)
 }

--- a/internal/service/advancedclustertpf/move_state.go
+++ b/internal/service/advancedclustertpf/move_state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
@@ -146,7 +147,8 @@ func stateMoverTemporaryRawState(ctx context.Context, req resource.MoveStateRequ
 	if !isSource(req, "database_user", MoveModeValRawState) {
 		return
 	}
-	rawStateValue, err := req.SourceRawState.Unmarshal(tftypes.Object{
+	// TODO: not need to define the full model if using IgnoreUndefinedAttributes, as in JSON case
+	rawStateValue, err := req.SourceRawState.UnmarshalWithOpts(tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
 			"id":                 tftypes.String,
 			"project_id":         tftypes.String,
@@ -177,7 +179,7 @@ func stateMoverTemporaryRawState(ctx context.Context, req resource.MoveStateRequ
 				},
 			}},
 		},
-	})
+	}, tfprotov6.UnmarshalOpts{ValueFromJSONOpts: tftypes.ValueFromJSONOpts{IgnoreUndefinedAttributes: true}})
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Unmarshal Source State", err.Error())
 		return

--- a/internal/service/advancedclustertpf/move_state.go
+++ b/internal/service/advancedclustertpf/move_state.go
@@ -18,7 +18,7 @@ import (
 const (
 	MoveModeEnvVarName   = "MONGODB_ATLAS_TEST_MOVE_MODE"
 	MoveModeValPreferred = "preferred"
-	MoveModeValLowlevel  = "lowlevel"
+	MoveModeValRawState  = "rawstate"
 	MoveModeValJSON      = "json"
 )
 
@@ -108,7 +108,7 @@ func (r *rs) MoveState(context.Context) []resource.StateMover {
 			StateMover: stateMoverTemporaryPreferred,
 		},
 		{
-			StateMover: stateMoverTemporaryLowLevel,
+			StateMover: stateMoverTemporaryRawState,
 		},
 		{
 			StateMover: stateMoverTemporaryJSON,
@@ -142,8 +142,8 @@ func stateMoverTemporaryPreferred(ctx context.Context, req resource.MoveStateReq
 	setMoveState(ctx, state.ProjectID.String(), state.Username.String(), resp)
 }
 
-func stateMoverTemporaryLowLevel(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
-	if !isSource(req, "database_user", MoveModeValLowlevel) {
+func stateMoverTemporaryRawState(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+	if !isSource(req, "database_user", MoveModeValRawState) {
 		return
 	}
 	rawStateValue, err := req.SourceRawState.Unmarshal(tftypes.Object{

--- a/internal/service/advancedclustertpf/move_state.go
+++ b/internal/service/advancedclustertpf/move_state.go
@@ -1,0 +1,37 @@
+package advancedclustertpf
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (r *rs) MoveState(context.Context) []resource.StateMover {
+	return []resource.StateMover{
+		{
+			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+				timeout := timeouts.Value{
+					Object: types.ObjectValueMust(
+						map[string]attr.Type{
+							"create": types.StringType,
+							"update": types.StringType,
+							"delete": types.StringType,
+						},
+						map[string]attr.Value{
+							"create": types.StringValue("30m"),
+							"update": types.StringValue("30m"),
+							"delete": types.StringValue("30m"),
+						}),
+				}
+				tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, timeout)
+				if shouldReturn {
+					return
+				}
+				resp.Diagnostics.Append(resp.TargetState.Set(ctx, tfNewModel)...)
+			},
+		},
+	}
+}

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -16,6 +16,7 @@ func TestAccAdvancedCluster_move_preferred(t *testing.T) {
 		clusterName = acc.RandomClusterName()
 	)
 	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValPreferred)
+	// TODO: temporary no parallel tests so t.Setenv can be used
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -10,13 +10,12 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func TestAccAdvancedCluster_move_basic(t *testing.T) {
+func TestAccAdvancedCluster_move_lowelevel(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
-	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValPreferred)
-	// TODO: temporarily not parallel tests so t.Setenv can be called
+	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValLowlevel)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
@@ -40,7 +39,6 @@ func TestAccAdvancedCluster_move_json(t *testing.T) {
 		clusterName = acc.RandomClusterName()
 	)
 	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValJSON)
-	// TODO: temporarily not parallel tests so t.Setenv can be called
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -2,9 +2,11 @@ package advancedclustertpf_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -13,7 +15,9 @@ func TestAccAdvancedCluster_move_basic(t *testing.T) {
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValPreferred)
+	// TODO: temporarily not parallel tests so t.Setenv can be called
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
@@ -30,12 +34,58 @@ func TestAccAdvancedCluster_move_basic(t *testing.T) {
 	})
 }
 
+func TestAccAdvancedCluster_move_json(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+	)
+	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValJSON)
+	// TODO: temporarily not parallel tests so t.Setenv can be called
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configMoveFirst(projectID, clusterName),
+			},
+			{
+				Config: configMoveSecond(projectID, clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAdvancedCluster_move_invalid(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+	)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configMoveFirst(projectID, clusterName),
+			},
+			{
+				Config:      configMoveSecond(projectID, clusterName),
+				ExpectError: regexp.MustCompile("Unable to Move Resource State"),
+			},
+			{
+				Config: configMoveFirst(projectID, clusterName),
+			},
+		},
+	})
+}
+
 // TODO: We temporarily use mongodbatlas_database_user instead of mongodbatlas_cluster to set up the initial environment
 func configMoveFirst(projectID, clusterName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_database_user" "oldtpf" {
 			project_id         = %[1]q
-			username           = %[2]q
+			username           = %[2]q # TODO: temporarily we use the username in database_user source as the cluster name in destination
 			password           = "test-acc-password"
 			auth_database_name = "admin"
 			roles {

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -10,6 +10,29 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
+func TestAccAdvancedCluster_move_preferred(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+	)
+	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValPreferred)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configMoveFirst(projectID, clusterName),
+			},
+			{
+				Config: configMoveSecond(projectID, clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAdvancedCluster_move_rawstate(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -1,0 +1,23 @@
+package advancedclustertpf_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestAccAdvancedCluster_move_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configMoveBasic(),
+			},
+		},
+	})
+}
+
+func configMoveBasic() string {
+	return ""
+}

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -1,6 +1,7 @@
 package advancedclustertpf_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -8,16 +9,49 @@ import (
 )
 
 func TestAccAdvancedCluster_move_basic(t *testing.T) {
+	var (
+		projectID   = acc.ProjectIDExecution(t)
+		clusterName = acc.RandomClusterName()
+	)
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configMoveBasic(),
+				Config: configMoveFirst(projectID, clusterName),
+			},
+			{
+				Config:   configMoveSecond(projectID, clusterName),
+				PlanOnly: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+				),
 			},
 		},
 	})
 }
 
-func configMoveBasic() string {
-	return ""
+// TODO: We temporarily use mongodbatlas_database_user instead of mongodbatlas_cluster to set up the initial environment
+func configMoveFirst(projectID, clusterName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_database_user" "oldtpf" {
+			project_id         = %[1]q
+			username           = %[2]q
+			password           = "test-acc-password"
+			auth_database_name = "admin"
+			roles {
+				role_name     = "atlasAdmin"
+				database_name = "admin"
+			}
+		}
+	`, projectID, clusterName)
+}
+
+func configMoveSecond(projectID, clusterName string) string {
+	return `
+		moved {
+			from = mongodbatlas_database_user.oldtpf
+			to   = mongodbatlas_advanced_cluster.test
+		}
+	` + configBasic(projectID, clusterName, "")
 }

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func TestAccAdvancedCluster_move_lowelevel(t *testing.T) {
+func TestAccAdvancedCluster_move_rawstate(t *testing.T) {
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
 	)
-	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValLowlevel)
+	t.Setenv(advancedclustertpf.MoveModeEnvVarName, advancedclustertpf.MoveModeValRawState)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{

--- a/internal/service/advancedclustertpf/move_state_test.go
+++ b/internal/service/advancedclustertpf/move_state_test.go
@@ -20,8 +20,7 @@ func TestAccAdvancedCluster_move_basic(t *testing.T) {
 				Config: configMoveFirst(projectID, clusterName),
 			},
 			{
-				Config:   configMoveSecond(projectID, clusterName),
-				PlanOnly: true,
+				Config: configMoveSecond(projectID, clusterName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -13,6 +13,7 @@ import (
 
 var _ resource.ResourceWithConfigure = &rs{}
 var _ resource.ResourceWithImportState = &rs{}
+var _ resource.ResourceWithMoveState = &rs{}
 
 const (
 	errorCreate                    = "error creating advanced cluster: %s"

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -88,6 +88,9 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 	tfNewModel, shouldReturn := mockedSDK(ctx, &resp.Diagnostics, plan.Timeouts)
+	// TODO: keep project_id and name from plan to avoid overwriting for move_state tests. We should probably do the same with the rest of attributes
+	tfNewModel.Name = plan.Name
+	tfNewModel.ProjectID = plan.ProjectID
 	if shouldReturn {
 		return
 	}

--- a/internal/service/advancedclustertpf/resource_test.go
+++ b/internal/service/advancedclustertpf/resource_test.go
@@ -24,14 +24,18 @@ func ChangeReponseNumber(responseNumber int) resource.TestCheckFunc {
 }
 
 func TestAccAdvancedCluster_basic(t *testing.T) {
+	var (
+		projectID   = "111111111111111111111111"
+		clusterName = "test"
+	)
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(""),
+				Config: configBasic(projectID, clusterName, ""),
 			},
 			{
-				Config: configBasic("accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
+				Config: configBasic(projectID, "test", "accept_data_risks_and_force_replica_set_reconfig = \"2006-01-02T15:04:05Z\""),
 				Check:  resource.ComposeTestCheckFunc(ChangeReponseNumber(2)),
 			},
 			{
@@ -45,12 +49,11 @@ func TestAccAdvancedCluster_basic(t *testing.T) {
 	})
 }
 
-func configBasic(extra string) string {
+func configBasic(projectID, clusterName, extra string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = "111111111111111111111111"
-			%[1]s
-			name = "test"
+			project_id = %[1]q
+			name = %[2]q
 			cluster_type = "REPLICASET"
 			replication_specs = [{
 				region_configs = [{
@@ -64,6 +67,7 @@ func configBasic(extra string) string {
 					}
 				}]
 			}]
+			%[3]s
 		}
-	`, extra)
+	`, projectID, clusterName, extra)
 }


### PR DESCRIPTION
## Description

Initial implementation of Move State.  Three approaches are shown so the best one can be chosen:
- Preferred: This is the recommended way by Hashicorp. Schema and model must be defined in TFP format. They can be reused if source resource is in TPF, if not, they must be created. It's more work but it has safer types so it can be a good option if full transformation logic is needed.
- Raw state: Only the model needs to be done (not full model, only attributes we want to read), but access to attributes is a bit harder as it has to be done individually. It can be a good alternative if we only need to extract project_id and cluster_name and leave the state creation to Read operation.
- JSON: Similar to previous approach, we only need to define model for project_id and cluster_name fields if we only need those. It's a bit more convenient to access the fields but problem is according to JSON attribute doc:  "it is not safe to assume that all states written by 0.12.0 or higher will be in JSON format; future versions may switch to an alternate encoding for states."


Link to any related issue(s): CLOUDP-283855

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
