### PR TITLE
fix: Provide err when error message populated in `mongodbatlas_privatelink_endpoint` and `mongodbatlas_privatelink_endpoint_service`

### DIFF
--- a/.changelog/2803.txt
+++ b/.changelog/2803.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-Improve error message when privatelink endpoint returns error after POST
+resource/mongodbatlas_privatelink_endpoint: Improve error message when privatelink endpoint returns error after POST
 ```
 
 ```release-note:enhancement
-Improve error message when privatelink endpoint service returns error after POST
+resource/mongodbatlas_privatelink_endpoint_service: Improve error message when privatelink endpoint service returns error after POST
 ```

--- a/.changelog/2803.txt
+++ b/.changelog/2803.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/mongodbatlas_privatelink_endpoint: Improve error message when privatelink endpoint returns error after POST
+resource/mongodbatlas_privatelink_endpoint: Improves error message when privatelink endpoint returns error after POST
 ```
 
 ```release-note:enhancement
-resource/mongodbatlas_privatelink_endpoint_service: Improve error message when privatelink endpoint service returns error after POST
+resource/mongodbatlas_privatelink_endpoint_service: Improves error message when privatelink endpoint service returns error after POST
 ```

--- a/.changelog/2803.txt
+++ b/.changelog/2803.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+Improve error message when privatelink endpoint returns error after POST
+```
+
+```release-note:enhancement
+Improve error message when privatelink endpoint service returns error after POST
+```

--- a/internal/service/privatelinkendpoint/resource_privatelink_endpoint.go
+++ b/internal/service/privatelinkendpoint/resource_privatelink_endpoint.go
@@ -170,7 +170,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			d.SetId("")
 			return nil
 		}
-
 		return diag.FromErr(fmt.Errorf(errorPrivateLinkEndpointsRead, privateLinkID, err))
 	}
 
@@ -226,6 +225,9 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.FromErr(fmt.Errorf(ErrorPrivateLinkEndpointsSetting, "service_attachment_names", privateLinkID, err))
 	}
 
+	if privateEndpoint.GetErrorMessage() != "" {
+		return diag.FromErr(fmt.Errorf("privatelink endpoint is in a failed state: %s", privateEndpoint.GetErrorMessage()))
+	}
 	return nil
 }
 

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service.go
@@ -222,7 +222,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			d.SetId("")
 			return nil
 		}
-
 		return diag.FromErr(fmt.Errorf(ErrorServiceEndpointRead, endpointServiceID, err))
 	}
 
@@ -274,6 +273,9 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		}
 	}
 
+	if privateEndpoint.GetErrorMessage() != "" {
+		return diag.FromErr(fmt.Errorf("privatelink endpoint is in a failed state: %s", privateEndpoint.GetErrorMessage()))
+	}
 	return nil
 }
 

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service.go
@@ -274,7 +274,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 
 	if privateEndpoint.GetErrorMessage() != "" {
-		return diag.FromErr(fmt.Errorf("privatelink endpoint is in a failed state: %s", privateEndpoint.GetErrorMessage()))
+		return diag.FromErr(fmt.Errorf("privatelink endpoint service is in a failed state: %s", privateEndpoint.GetErrorMessage()))
 	}
 	return nil
 }

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -24,15 +24,14 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
 		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
 
 		providerName = "AWS"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID    = acc.ProjectIDExecution(t)
 		region       = os.Getenv("AWS_REGION")
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckAwsEnvPrivateLinkEndpointService(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		CheckDestroy:             checkDestroy,
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		Steps: []resource.TestStep{
 			{
 				Config: configFailAWS(

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -178,16 +178,16 @@ func configCompleteAWS(awsAccessKey, awsSecretKey, projectID, providerName, regi
 func configFailAWS(projectID, providerName, region, resourceSuffix string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_privatelink_endpoint" "test" {
-			project_id    = "%[1]s"
-			provider_name = "%[2]s"
-			region        = "%[3]s"
+			project_id    = %[1]q
+			provider_name = %[2]q
+			region        = %[3]q
 		}
 
 		resource "mongodbatlas_privatelink_endpoint_service" %[4]q {
 			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
 			endpoint_service_id   = "vpce-11111111111111111"
 			private_link_id       = mongodbatlas_privatelink_endpoint.test.id
-			provider_name         = "%[2]s"
+			provider_name         = %[2]q
 		}
 	`, projectID, providerName, region, resourceSuffix)
 }

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -19,13 +19,9 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
 }
 
 func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
-	acc.SkipTestForCI(t) // needs AWS configuration
 	var (
 		resourceSuffix = "test"
 		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
-
-		awsAccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
-		awsSecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 
 		providerName = "AWS"
 		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -40,7 +36,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configFailAWS(
-					awsAccessKey, awsSecretKey, projectID, providerName, region, resourceSuffix,
+					projectID, providerName, region, resourceSuffix,
 				),
 				Check:       resource.TestCheckResourceAttr(resourceName, "error_message", "privatelink endpoint is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
 				ExpectError: regexp.MustCompile("privatelink endpoint service is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
@@ -180,25 +176,19 @@ func configCompleteAWS(awsAccessKey, awsSecretKey, projectID, providerName, regi
 	`, awsAccessKey, awsSecretKey, projectID, providerName, region, vpcID, subnetID, securityGroupID, resourceSuffix)
 }
 
-func configFailAWS(awsAccessKey, awsSecretKey, projectID, providerName, region, resourceSuffix string) string {
+func configFailAWS(projectID, providerName, region, resourceSuffix string) string {
 	return fmt.Sprintf(`
-		provider "aws" {
-			region        = "%[5]s"
-			access_key = "%[1]s"
-			secret_key = "%[2]s"
-		}
-
 		resource "mongodbatlas_privatelink_endpoint" "test" {
-			project_id    = "%[3]s"
-			provider_name = "%[4]s"
-			region        = "%[5]s"
+			project_id    = "%[1]s"
+			provider_name = "%[2]s"
+			region        = "%[3]s"
 		}
 
-		resource "mongodbatlas_privatelink_endpoint_service" %[6]q {
+		resource "mongodbatlas_privatelink_endpoint_service" %[4]q {
 			project_id            = mongodbatlas_privatelink_endpoint.test.project_id
 			endpoint_service_id   = "vpce-11111111111111111"
 			private_link_id       = mongodbatlas_privatelink_endpoint.test.id
-			provider_name         = "%[4]s"
+			provider_name         = "%[2]s"
 		}
-	`, awsAccessKey, awsSecretKey, projectID, providerName, region, resourceSuffix)
+	`, projectID, providerName, region, resourceSuffix)
 }

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -21,7 +21,6 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Complete(t *testing.T) {
 func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
 	var (
 		resourceSuffix = "test"
-		resourceName   = fmt.Sprintf("mongodbatlas_privatelink_endpoint_service.%s", resourceSuffix)
 
 		providerName = "AWS"
 		projectID    = acc.ProjectIDExecution(t)
@@ -37,7 +36,6 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
 				Config: configFailAWS(
 					projectID, providerName, region, resourceSuffix,
 				),
-				Check:       resource.TestCheckResourceAttr(resourceName, "error_message", "privatelink endpoint is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
 				ExpectError: regexp.MustCompile("privatelink endpoint service is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
 			},
 		},

--- a/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
+++ b/internal/service/privatelinkendpointservice/resource_privatelink_endpoint_service_test.go
@@ -43,7 +43,7 @@ func TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed(t *testing.T) {
 					awsAccessKey, awsSecretKey, projectID, providerName, region, resourceSuffix,
 				),
 				Check:       resource.TestCheckResourceAttr(resourceName, "error_message", "privatelink endpoint is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
-				ExpectError: regexp.MustCompile("privatelink endpoint is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
+				ExpectError: regexp.MustCompile("privatelink endpoint service is in a failed state: Interface endpoint vpce-11111111111111111 was not found."),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Both mongodbatlas_privatelink_endpoint_service and mongodbatlas_privatelink_endpoint have a error_message computed attribute (present in GET response), however no error message is being created to make users aware of the error when it is present. This PR adds the necessary logic to inform the user when an error is present.

- Within the `mongodbatlas_privatelink_endpoint_service`, a testcase, `TestAccNetworkRSPrivateLinkEndpointServiceAWS_Failed`, has been added to verify error is now received.
This test passes an invalid vcpe id to a `mongodbatlas_privatelink_endpoint_service` resource. Creation will succeed but GET requests will fail with `Interface endpoint <invalid_vcpe_id> was not found`

- A testcase within `mongodbatlas_privatelink_endpoint` was not found and, hence, no test has been added.

Link to any related issue(s): [CLOUDP-282564](https://jira.mongodb.org/browse/CLOUDP-282564)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
