### PR TITLE
doc: Clarify in new sharding configuration migration guide that two way transition is not supported 

### DIFF
--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -6,7 +6,7 @@ page_title: "Migration Guide: Advanced Cluster New Sharding Configurations"
 
 **Objective**: Use this guide to migrate your existing `advanced_cluster` resources to support new sharding configurations introduced in version 1.18.0. The new sharding configurations allow you to scale shards independently. Existing sharding configurations continue to work, but you will receive deprecation messages if you continue to use them.
 
-Note: Once applied, `advanced_cluster` resource making use of the new sharding configuration will not be able to transition back to the old sharding configuration.
+Note: Once applied, the `advanced_cluster` resource making use of the new sharding configuration will not be able to transition back to the old sharding configuration.
 
 - [Migration Guide: Advanced Cluster New Sharding Configurations](#migration-guide-advanced-cluster-new-sharding-schema)
   - [Changes Overview](#changes-overview)

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -6,7 +6,7 @@ page_title: "Migration Guide: Advanced Cluster New Sharding Configurations"
 
 **Objective**: Use this guide to migrate your existing `advanced_cluster` resources to support new sharding configurations introduced in version 1.18.0. The new sharding configurations allow you to scale shards independently. Existing sharding configurations continue to work, but you will receive deprecation messages if you continue to use them.
 
-Note: `advanced_cluster` resource making use of new sharding configuration will not be able to transition back to the old sharding configuration.
+Note: Once applied, `advanced_cluster` resource making use of the new sharding configuration will not be able to transition back to the old sharding configuration.
 
 - [Migration Guide: Advanced Cluster New Sharding Configurations](#migration-guide-advanced-cluster-new-sharding-schema)
   - [Changes Overview](#changes-overview)

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -6,6 +6,8 @@ page_title: "Migration Guide: Advanced Cluster New Sharding Configurations"
 
 **Objective**: Use this guide to migrate your existing `advanced_cluster` resources to support new sharding configurations introduced in version 1.18.0. The new sharding configurations allow you to scale shards independently. Existing sharding configurations continue to work, but you will receive deprecation messages if you continue to use them.
 
+Note: `advanced_cluster` resource making use of new sharding configuration will not be able to transition back to the old sharding configuration.
+
 - [Migration Guide: Advanced Cluster New Sharding Configurations](#migration-guide-advanced-cluster-new-sharding-schema)
   - [Changes Overview](#changes-overview)
     - [Migrate advanced\_cluster type `SHARDED`](#migrate-advanced_cluster-type-sharded)


### PR DESCRIPTION
## Description

Spotted by @Zuhairahmed, mentioned in a PD comment.

We currently having an error validation not allowing transition from new to old sharding configuration, but missing clarification in the migration guide.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
