### PR TITLE
chore: Reverts changes to project data source

### DIFF
--- a/.changelog/2815.txt
+++ b/.changelog/2815.txt
@@ -1,7 +1,0 @@
-```release-note:note
-data-source/mongodbatlas_project: Changes `role_names` from a list to a set as in the resource
-```
-
-```release-note:note
-data-source/mongodbatlas_projects: Changes `role_names` from a list to a set as in the resource
-```

--- a/internal/service/project/data_source_project.go
+++ b/internal/service/project/data_source_project.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -32,44 +33,155 @@ type projectDS struct {
 }
 
 type TFProjectDSModel struct {
-	IPAddresses                                 types.Object    `tfsdk:"ip_addresses"`
-	Created                                     types.String    `tfsdk:"created"`
-	OrgID                                       types.String    `tfsdk:"org_id"`
-	RegionUsageRestrictions                     types.String    `tfsdk:"region_usage_restrictions"`
-	ID                                          types.String    `tfsdk:"id"`
-	Name                                        types.String    `tfsdk:"name"`
-	ProjectID                                   types.String    `tfsdk:"project_id"`
-	Tags                                        types.Map       `tfsdk:"tags"`
-	Teams                                       []*TFTeamModel  `tfsdk:"teams"`
-	Limits                                      []*TFLimitModel `tfsdk:"limits"`
-	ClusterCount                                types.Int64     `tfsdk:"cluster_count"`
-	IsCollectDatabaseSpecificsStatisticsEnabled types.Bool      `tfsdk:"is_collect_database_specifics_statistics_enabled"`
-	IsRealtimePerformancePanelEnabled           types.Bool      `tfsdk:"is_realtime_performance_panel_enabled"`
-	IsSchemaAdvisorEnabled                      types.Bool      `tfsdk:"is_schema_advisor_enabled"`
-	IsPerformanceAdvisorEnabled                 types.Bool      `tfsdk:"is_performance_advisor_enabled"`
-	IsExtendedStorageSizesEnabled               types.Bool      `tfsdk:"is_extended_storage_sizes_enabled"`
-	IsDataExplorerEnabled                       types.Bool      `tfsdk:"is_data_explorer_enabled"`
-	IsSlowOperationThresholdingEnabled          types.Bool      `tfsdk:"is_slow_operation_thresholding_enabled"`
+	IPAddresses                                 types.Object     `tfsdk:"ip_addresses"`
+	Created                                     types.String     `tfsdk:"created"`
+	OrgID                                       types.String     `tfsdk:"org_id"`
+	RegionUsageRestrictions                     types.String     `tfsdk:"region_usage_restrictions"`
+	ID                                          types.String     `tfsdk:"id"`
+	Name                                        types.String     `tfsdk:"name"`
+	ProjectID                                   types.String     `tfsdk:"project_id"`
+	Tags                                        types.Map        `tfsdk:"tags"`
+	Teams                                       []*TFTeamDSModel `tfsdk:"teams"`
+	Limits                                      []*TFLimitModel  `tfsdk:"limits"`
+	ClusterCount                                types.Int64      `tfsdk:"cluster_count"`
+	IsCollectDatabaseSpecificsStatisticsEnabled types.Bool       `tfsdk:"is_collect_database_specifics_statistics_enabled"`
+	IsRealtimePerformancePanelEnabled           types.Bool       `tfsdk:"is_realtime_performance_panel_enabled"`
+	IsSchemaAdvisorEnabled                      types.Bool       `tfsdk:"is_schema_advisor_enabled"`
+	IsPerformanceAdvisorEnabled                 types.Bool       `tfsdk:"is_performance_advisor_enabled"`
+	IsExtendedStorageSizesEnabled               types.Bool       `tfsdk:"is_extended_storage_sizes_enabled"`
+	IsDataExplorerEnabled                       types.Bool       `tfsdk:"is_data_explorer_enabled"`
+	IsSlowOperationThresholdingEnabled          types.Bool       `tfsdk:"is_slow_operation_thresholding_enabled"`
+}
+
+type TFTeamDSModel struct {
+	TeamID    types.String `tfsdk:"team_id"`
+	RoleNames types.List   `tfsdk:"role_names"`
 }
 
 func (d *projectDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	overridenFields := map[string]schema.Attribute{
-		"project_id": schema.StringAttribute{
-			Optional: true,
-			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("name")),
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"project_id": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("name")),
+				},
+			},
+			"name": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("project_id")),
+				},
+			},
+			"org_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"cluster_count": schema.Int64Attribute{
+				Computed: true,
+			},
+			"created": schema.StringAttribute{
+				Computed: true,
+			},
+			"is_collect_database_specifics_statistics_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_data_explorer_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_extended_storage_sizes_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_performance_advisor_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_realtime_performance_panel_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_schema_advisor_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"is_slow_operation_thresholding_enabled": schema.BoolAttribute{
+				Computed:           true,
+				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByVersion, "1.24.0"),
+			},
+			"region_usage_restrictions": schema.StringAttribute{
+				Computed: true,
+			},
+			"teams": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"team_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"role_names": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+			"limits": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"value": schema.Int64Attribute{
+							Computed: true,
+						},
+						"current_usage": schema.Int64Attribute{
+							Computed: true,
+						},
+						"default_limit": schema.Int64Attribute{
+							Computed: true,
+						},
+						"maximum_limit": schema.Int64Attribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ip_addresses": schema.SingleNestedAttribute{
+				Computed:           true,
+				DeprecationMessage: fmt.Sprintf(constant.DeprecationParamByVersionWithReplacement, "1.21.0", "mongodbatlas_project_ip_addresses data source"),
+				Attributes: map[string]schema.Attribute{
+					"services": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"clusters": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"cluster_name": schema.StringAttribute{
+											Computed: true,
+										},
+										"inbound": schema.ListAttribute{
+											ElementType: types.StringType,
+											Computed:    true,
+										},
+										"outbound": schema.ListAttribute{
+											ElementType: types.StringType,
+											Computed:    true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags": schema.MapAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
 			},
 		},
-		"name": schema.StringAttribute{
-			Optional: true,
-			Validators: []validator.String{
-				stringvalidator.ConflictsWith(path.MatchRoot("project_id")),
-			},
-		},
-		"project_owner_id":             nil,
-		"with_default_alerts_settings": nil,
 	}
-	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(ctx), nil, overridenFields)
+	conversion.UpdateSchemaDescription(&resp.Schema)
 }
 
 func (d *projectDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/service/project/data_source_projects.go
+++ b/internal/service/project/data_source_projects.go
@@ -111,7 +111,7 @@ func (d *ProjectsDS) Schema(ctx context.Context, req datasource.SchemaRequest, r
 									"team_id": schema.StringAttribute{
 										Computed: true,
 									},
-									"role_names": schema.SetAttribute{
+									"role_names": schema.ListAttribute{
 										Computed:    true,
 										ElementType: types.StringType,
 									},

--- a/internal/service/project/model_project.go
+++ b/internal/service/project/model_project.go
@@ -40,15 +40,15 @@ func NewTFProjectDataSourceModel(ctx context.Context, project *admin.Group, proj
 	}, nil
 }
 
-func NewTFTeamsDataSourceModel(ctx context.Context, atlasTeams *admin.PaginatedTeamRole) []*TFTeamModel {
+func NewTFTeamsDataSourceModel(ctx context.Context, atlasTeams *admin.PaginatedTeamRole) []*TFTeamDSModel {
 	if atlasTeams.GetTotalCount() == 0 {
 		return nil
 	}
 	results := atlasTeams.GetResults()
-	teams := make([]*TFTeamModel, len(results))
+	teams := make([]*TFTeamDSModel, len(results))
 	for i, atlasTeam := range results {
-		roleNames, _ := types.SetValueFrom(ctx, types.StringType, atlasTeam.RoleNames)
-		teams[i] = &TFTeamModel{
+		roleNames, _ := types.ListValueFrom(ctx, types.StringType, atlasTeam.RoleNames)
+		teams[i] = &TFTeamDSModel{
 			TeamID:    types.StringValue(atlasTeam.GetTeamId()),
 			RoleNames: roleNames,
 		}

--- a/internal/service/project/model_project_test.go
+++ b/internal/service/project/model_project_test.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	roles              = []string{"GROUP_DATA_ACCESS_READ_ONLY", "GROUP_CLUSTER_MANAGER"}
+	roleList, _        = types.ListValueFrom(context.Background(), types.StringType, roles)
 	roleSet, _         = types.SetValueFrom(context.Background(), types.StringType, roles)
 	ipAddresses        = []string{"13.13.13.13"}
 	ipAddressesList, _ = types.ListValueFrom(context.Background(), types.StringType, ipAddresses)
@@ -40,10 +41,10 @@ var (
 			RoleNames: &roles,
 		},
 	}
-	teamsDSTF = []*project.TFTeamModel{
+	teamsDSTF = []*project.TFTeamDSModel{
 		{
 			TeamID:    types.StringValue("teamId"),
-			RoleNames: roleSet,
+			RoleNames: roleList,
 		},
 	}
 	teamsTFSet, _ = types.SetValueFrom(context.Background(), project.TfTeamObjectType, []project.TFTeamModel{
@@ -151,7 +152,7 @@ func TestTeamsDataSourceSDKToTFModel(t *testing.T) {
 	testCases := []struct {
 		name              string
 		paginatedTeamRole *admin.PaginatedTeamRole
-		expectedTFModel   []*project.TFTeamModel
+		expectedTFModel   []*project.TFTeamDSModel
 	}{
 		{
 			name: "TeamRole",


### PR DESCRIPTION
## Description

Reverts changes to project data source done in: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2815 so `role_names` is kept as a list.


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
