### PR TITLE
fix: Returns MapNull when tags is not set

### DIFF
--- a/internal/common/conversion/tags.go
+++ b/internal/common/conversion/tags.go
@@ -25,6 +25,9 @@ func NewResourceTags(ctx context.Context, tags types.Map) *[]admin.ResourceTag {
 }
 
 func NewTFTags(tags []admin.ResourceTag) types.Map {
+	if len(tags) == 0 {
+		return types.MapNull(types.StringType)
+	}
 	typesTags := make(map[string]attr.Value, len(tags))
 	for _, tag := range tags {
 		typesTags[tag.Key] = types.StringValue(tag.Value)

--- a/internal/common/conversion/tags_test.go
+++ b/internal/common/conversion/tags_test.go
@@ -33,7 +33,7 @@ func TestNewResourceTags(t *testing.T) {
 
 func TestNewTFTags(t *testing.T) {
 	var (
-		tfMapEmpty     = types.MapValueMust(types.StringType, map[string]attr.Value{})
+		tfMapNull      = types.MapNull(types.StringType)
 		apiListEmpty   = []admin.ResourceTag{}
 		apiSingleTag   = []admin.ResourceTag{*admin.NewResourceTag("key1", "value1")}
 		tfMapSingleTag = types.MapValueMust(types.StringType, map[string]attr.Value{"key1": types.StringValue("value1")})
@@ -42,7 +42,7 @@ func TestNewTFTags(t *testing.T) {
 		expected  types.Map
 		adminTags []admin.ResourceTag
 	}{
-		"api empty list tf null should give map null":      {tfMapEmpty, apiListEmpty},
+		"api empty list tf null should give map null":      {tfMapNull, apiListEmpty},
 		"tags single value tf null should give map single": {tfMapSingleTag, apiSingleTag},
 	}
 	for name, tc := range testCases {

--- a/internal/service/flexcluster/model_test.go
+++ b/internal/service/flexcluster/model_test.go
@@ -128,7 +128,7 @@ func TestNewTFModel(t *testing.T) {
 			expectedTFModel: &flexcluster.TFModel{
 				ProjectId:                    types.StringNull(),
 				Id:                           types.StringNull(),
-				Tags:                         types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				Tags:                         types.MapNull(types.StringType),
 				ProviderSettings:             nilProviderSettingsObject,
 				ConnectionStrings:            types.ObjectNull(flexcluster.ConnectionStringsType.AttrTypes),
 				CreateDate:                   types.StringNull(),

--- a/internal/service/flexcluster/resource_test.go
+++ b/internal/service/flexcluster/resource_test.go
@@ -44,15 +44,15 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, provider, region, true),
-				Check:  checksFlexCluster(projectID, clusterName, true),
+				Config: configBasic(projectID, clusterName, provider, region, true, false),
+				Check:  checksFlexCluster(projectID, clusterName, true, false),
 			},
 			{
-				Config: configBasic(projectID, clusterName, provider, region, false),
-				Check:  checksFlexCluster(projectID, clusterName, false),
+				Config: configBasic(projectID, clusterName, provider, region, false, true),
+				Check:  checksFlexCluster(projectID, clusterName, false, false),
 			},
 			{
-				Config:            configBasic(projectID, clusterName, provider, region, true),
+				Config:            configBasic(projectID, clusterName, provider, region, true, true),
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
@@ -80,30 +80,37 @@ func failedUpdateTestCase(t *testing.T) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, provider, region, false),
-				Check:  checksFlexCluster(projectID, clusterName, false),
+				Config: configBasic(projectID, clusterName, provider, region, false, false),
+				Check:  checksFlexCluster(projectID, clusterName, false, false),
 			},
 			{
-				Config:      configBasic(projectID, clusterNameUpdated, provider, region, false),
+				Config:      configBasic(projectID, clusterNameUpdated, provider, region, false, false),
 				ExpectError: regexp.MustCompile("name cannot be updated"),
 			},
 			{
-				Config:      configBasic(projectIDUpdated, clusterName, provider, region, false),
+				Config:      configBasic(projectIDUpdated, clusterName, provider, region, false, false),
 				ExpectError: regexp.MustCompile("project_id cannot be updated"),
 			},
 			{
-				Config:      configBasic(projectID, clusterName, providerUpdated, region, false),
+				Config:      configBasic(projectID, clusterName, providerUpdated, region, false, false),
 				ExpectError: regexp.MustCompile("provider_settings.backing_provider_name cannot be updated"),
 			},
 			{
-				Config:      configBasic(projectID, clusterName, provider, regionUpdated, false),
+				Config:      configBasic(projectID, clusterName, provider, regionUpdated, false, false),
 				ExpectError: regexp.MustCompile("provider_settings.region_name cannot be updated"),
 			},
 		},
 	}
 }
 
-func configBasic(projectID, clusterName, provider, region string, terminationProtectionEnabled bool) string {
+func configBasic(projectID, clusterName, provider, region string, terminationProtectionEnabled, tags bool) string {
+	tagsConfig := ""
+	if tags {
+		tagsConfig = `
+			tags = {
+				testKey = "testValue"
+			}`
+	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_flex_cluster" "test" {
 			project_id = %[1]q
@@ -113,9 +120,7 @@ func configBasic(projectID, clusterName, provider, region string, terminationPro
 				region_name           = %[4]q
 			}
 			termination_protection_enabled = %[5]t
-			tags = {
-				testKey = "testValue"
-			}
+			%[6]s
 		}
 		data "mongodbatlas_flex_cluster" "test" {
 			project_id = mongodbatlas_flex_cluster.test.project_id
@@ -123,16 +128,18 @@ func configBasic(projectID, clusterName, provider, region string, terminationPro
 		}
 		data "mongodbatlas_flex_clusters" "test" {
 			project_id = mongodbatlas_flex_cluster.test.project_id
-		}`, projectID, clusterName, provider, region, terminationProtectionEnabled)
+		}`, projectID, clusterName, provider, region, terminationProtectionEnabled, tagsConfig)
 }
 
-func checksFlexCluster(projectID, clusterName string, terminationProtectionEnabled bool) resource.TestCheckFunc {
+func checksFlexCluster(projectID, clusterName string, terminationProtectionEnabled, tagsCheck bool) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{checkExists()}
 	attrMap := map[string]string{
 		"project_id":                     projectID,
 		"name":                           clusterName,
 		"termination_protection_enabled": fmt.Sprintf("%v", terminationProtectionEnabled),
-		"tags.testKey":                   "testValue",
+	}
+	if tagsCheck {
+		attrMap["tags.testKey"] = "testValue"
 	}
 	pluralMap := map[string]string{
 		"project_id": projectID,

--- a/internal/service/project/model_project_test.go
+++ b/internal/service/project/model_project_test.go
@@ -6,7 +6,6 @@ import (
 
 	"go.mongodb.org/atlas-sdk/v20241113001/admin"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 
@@ -236,7 +235,7 @@ func TestProjectDataSourceSDKToDataSourceTFModel(t *testing.T) {
 				Limits:                                      limitsTF,
 				IPAddresses:                                 ipAddressesTF,
 				Created:                                     types.StringValue("0001-01-01T00:00:00Z"),
-				Tags:                                        types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				Tags:                                        types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -271,7 +270,7 @@ func TestProjectDataSourceSDKToDataSourceTFModel(t *testing.T) {
 				Limits:                                      limitsTF,
 				IPAddresses:                                 ipAddressesTF,
 				Created:                                     types.StringValue("0001-01-01T00:00:00Z"),
-				Tags:                                        types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				Tags:                                        types.MapNull(types.StringType),
 			},
 		},
 	}
@@ -323,7 +322,7 @@ func TestProjectDataSourceSDKToResourceTFModel(t *testing.T) {
 				Limits:                                      limitsTFSet,
 				IPAddresses:                                 ipAddressesTF,
 				Created:                                     types.StringValue("0001-01-01T00:00:00Z"),
-				Tags:                                        types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				Tags:                                        types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -356,7 +355,7 @@ func TestProjectDataSourceSDKToResourceTFModel(t *testing.T) {
 				Limits:                                      limitsTFSet,
 				IPAddresses:                                 ipAddressesTF,
 				Created:                                     types.StringValue("0001-01-01T00:00:00Z"),
-				Tags:                                        types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				Tags:                                        types.MapNull(types.StringType),
 			},
 		},
 	}

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1011,7 +1011,6 @@ func TestAccProject_withTags(t *testing.T) {
 		projectName  = acc.RandomProjectName()
 		nameUpdated  = "my-tag-name-updated"
 		envUnchanged = "unchanged"
-		tagsEmpty    = map[string]string{}
 		tags1        = map[string]string{
 			"Name":        "my-tag-name",
 			"Environment": envUnchanged,
@@ -1051,7 +1050,7 @@ func TestAccProject_withTags(t *testing.T) {
 				ExpectError: regexp.MustCompile(`exceeded the maximum allowed length of \d+ characters`),
 			},
 			{
-				Config: configWithTags(orgID, projectName, tagsEmpty),
+				Config: configWithTags(orgID, projectName, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceNameByID, "tags.#", "0"),


### PR DESCRIPTION
## Description

When creating a flex cluster without tags, the creation was successful, but the provider returned an error:

```
Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mongodbatlas_flex_cluster.example-cluster, provider "provider[\"registry.terraform.io/mongodb/mongodbatlas\"]" produced an unexpected new value: .tags: was null,
│ but now cty.MapValEmpty(cty.String).
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
Tests have been added to the flex cluster acceptance tests that cover the case where `tags` are null


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
