### PR TITLE
chore: Refactor read operation in 'mongodb_advanced_cluster'

### DIFF
--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -514,6 +514,7 @@ func flattenProcessArgs(p20240530 *admin20240530.ClusterDescriptionProcessArgs, 
 	return flattenedProcessArgs
 }
 
+// This function is untilised by DS read which still uses the old API and will be removed when refactor to DS read operation is implemented.
 func FlattenAdvancedReplicationSpecsOldSDK(ctx context.Context, apiObjects []admin20240530.ReplicationSpec, zoneNameToZoneIDs map[string]string, rootDiskSizeGB float64, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
 	// for flattening old model we need information of value defined at root disk_size_gb so we set the value in new location under hardware specs
@@ -544,7 +545,7 @@ func flattenAdvancedReplicationSpecs(ctx context.Context, apiObjects []admin.Rep
 		doesAdvancedReplicationSpecMatchAPI, replicationSpecFlattener, connV2)
 }
 
-// Compresses an array of Replication Specs from all shards to only one shard per zoneName
+// compressAPIObjectList returns an array of ReplicationSpec20240805. The input array is reduced from all shards to only one shard per zoneName
 func compressAPIObjectList(apiObjects []admin.ReplicationSpec20240805) []admin.ReplicationSpec20240805 {
 	var compressedAPIObjectList []admin.ReplicationSpec20240805
 	wasZoneNameUsed := populateZoneNameMap(apiObjects)
@@ -557,7 +558,7 @@ func compressAPIObjectList(apiObjects []admin.ReplicationSpec20240805) []admin.R
 	return compressedAPIObjectList
 }
 
-// Populates map with zoneNames and initializes all keys to false
+// populateZoneNameMap returns a map of zoneNames and initializes all keys to false.
 func populateZoneNameMap(apiObjects []admin.ReplicationSpec20240805) map[string]bool {
 	zoneNames := make(map[string]bool)
 	for _, apiObject := range apiObjects {
@@ -632,6 +633,7 @@ func flattenAdvancedReplicationSpecsLogic[T ReplicationSpecSDKModel](
 	return tfList, nil
 }
 
+// This function is untilised by DS read which still uses the old API and will be removed when refactor to DS read operation is implemented.
 func doesAdvancedReplicationSpecMatchAPIOldSDK(tfObject map[string]any, apiObject *admin20240530.ReplicationSpec) bool {
 	return tfObject["id"] == apiObject.GetId() || (tfObject["id"] == nil && tfObject["zone_name"] == apiObject.GetZoneName())
 }
@@ -1148,8 +1150,7 @@ func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.Replic
 	return tfMap, nil
 }
 
-// flattenAdvancedReplicationSpecOldSDK returns a map populated with ReplicationSpec attributes. This function is untilised by DS read which still uses the old API.
-// This function will be removed when refactor to DS read operation is implemented.
+// This function is untilised by DS read which still uses the old API and will be removed when refactor to DS read operation is implemented.
 func flattenAdvancedReplicationSpecOldSDK(ctx context.Context, apiObject *admin20240530.ReplicationSpec, zoneNameToZoneIDs map[string]string, rootDiskSizeGB float64, tfMapObject map[string]any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
 	if apiObject == nil {

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -566,11 +566,9 @@ func flattenAdvancedReplicationSpecsLogic[T ReplicationSpecSDKModel](
 	for i := 0; i < len(tfList); i++ {
 		var tfMapObject map[string]any
 
-		// *** if we haven't gone thru the whole list, assign the object at [i] to tfMapObject
 		if len(tfMapObjects) > i {
 			tfMapObject = tfMapObjects[i].(map[string]any)
 		}
-		// ** here I will want to add logic to check if this zoneName has already been logged
 		for j := 0; j < len(apiObjects); j++ {
 			if wasAPIObjectUsed[j] || !tfModelWithSDKMatcher(tfMapObject, &apiObjects[j]) {
 				continue

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -25,6 +25,11 @@ import (
 
 const minVersionForChangeStreamOptions = 6.0
 
+type OldShardConfigMeta struct {
+	ID       string
+	NumShard int
+}
+
 var (
 	DSTagsSchema = schema.Schema{
 		Type:     schema.TypeSet,

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -524,7 +524,7 @@ func FlattenAdvancedReplicationSpecsOldSDK(ctx context.Context, apiObjects []adm
 		doesAdvancedReplicationSpecMatchAPIOldSDK, replicationSpecFlattener, connV2)
 }
 
-func FlattenAdvancedReplicationSpecsOldShardConfig(ctx context.Context, apiObjects []admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecMeta map[string]OldShardConfigMeta, tfMapObjects []any,
+func FlattenAdvancedReplicationSpecsOldShardingConfig(ctx context.Context, apiObjects []admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecMeta map[string]OldShardConfigMeta, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
 	replicationSpecFlattener := func(ctx context.Context, sdkModel *admin.ReplicationSpec20240805, tfModel map[string]any, resourceData *schema.ResourceData, client *admin.APIClient) (map[string]any, error) {
 		return flattenAdvancedReplicationSpecOldShardingConfig(ctx, sdkModel, zoneNameToOldReplicationSpecMeta, tfModel, resourceData, connV2)
@@ -1102,7 +1102,7 @@ func flattenAdvancedReplicationSpecsDS(ctx context.Context, apiRepSpecs []admin.
 	tfList := make([]map[string]any, len(apiRepSpecs))
 
 	for i, apiRepSpec := range apiRepSpecs {
-		tfReplicationSpec, err := flattenAdvancedReplicationSpecDS(ctx, &apiRepSpec, zoneNameToOldReplicationSpecIDs, nil, d, connV2)
+		tfReplicationSpec, err := flattenAdvancedReplicationSpec(ctx, &apiRepSpec, zoneNameToOldReplicationSpecIDs, nil, d, connV2)
 		if err != nil {
 			return nil, err
 		}
@@ -1111,7 +1111,7 @@ func flattenAdvancedReplicationSpecsDS(ctx context.Context, apiRepSpecs []admin.
 	return tfList, nil
 }
 
-func flattenAdvancedReplicationSpecDS(ctx context.Context, apiObject *admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecIDs map[string]string, tfMapObject map[string]any,
+func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecIDs map[string]string, tfMapObject map[string]any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
 	if apiObject == nil {
 		return nil, nil
@@ -1121,43 +1121,6 @@ func flattenAdvancedReplicationSpecDS(ctx context.Context, apiObject *admin.Repl
 	tfMap["external_id"] = apiObject.GetId()
 
 	if oldID, ok := zoneNameToOldReplicationSpecIDs[apiObject.GetZoneName()]; ok {
-		tfMap["id"] = oldID // replicationSpecs.*.id stores value associated to old cluster API (2023-02-01)
-	}
-
-	// define num_shards for backwards compatibility as this attribute has default value of 1.
-	tfMap["num_shards"] = 1
-
-	if tfMapObject != nil {
-		object, containerIDs, err := flattenAdvancedReplicationSpecRegionConfigs(ctx, apiObject.GetRegionConfigs(), tfMapObject["region_configs"].([]any), d, connV2)
-		if err != nil {
-			return nil, err
-		}
-		tfMap["region_configs"] = object
-		tfMap["container_id"] = containerIDs
-	} else {
-		object, containerIDs, err := flattenAdvancedReplicationSpecRegionConfigs(ctx, apiObject.GetRegionConfigs(), nil, d, connV2)
-		if err != nil {
-			return nil, err
-		}
-		tfMap["region_configs"] = object
-		tfMap["container_id"] = containerIDs
-	}
-	tfMap["zone_name"] = apiObject.GetZoneName()
-	tfMap["zone_id"] = apiObject.GetZoneId()
-
-	return tfMap, nil
-}
-
-func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecMeta map[string]string, tfMapObject map[string]any,
-	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
-	if apiObject == nil {
-		return nil, nil
-	}
-
-	tfMap := map[string]any{}
-	tfMap["external_id"] = apiObject.GetId()
-
-	if oldID, ok := zoneNameToOldReplicationSpecMeta[apiObject.GetZoneName()]; ok {
 		tfMap["id"] = oldID // replicationSpecs.*.id stores value associated to old cluster API (2023-02-01)
 	}
 

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -527,7 +527,7 @@ func FlattenAdvancedReplicationSpecsOldSDK(ctx context.Context, apiObjects []adm
 func FlattenAdvancedReplicationSpecsOldShardConfig(ctx context.Context, apiObjects []admin.ReplicationSpec20240805, zoneNameToOldReplicationSpecMeta map[string]OldShardConfigMeta, tfMapObjects []any,
 	d *schema.ResourceData, connV2 *admin.APIClient) ([]map[string]any, error) {
 	replicationSpecFlattener := func(ctx context.Context, sdkModel *admin.ReplicationSpec20240805, tfModel map[string]any, resourceData *schema.ResourceData, client *admin.APIClient) (map[string]any, error) {
-		return flattenAdvancedReplicationSpecOldShardConfig(ctx, sdkModel, zoneNameToOldReplicationSpecMeta, tfModel, resourceData, connV2)
+		return flattenAdvancedReplicationSpecOldShardingConfig(ctx, sdkModel, zoneNameToOldReplicationSpecMeta, tfModel, resourceData, connV2)
 	}
 	compressedAPIObjects := compressAPIObjectList(apiObjects)
 	return flattenAdvancedReplicationSpecsLogic[admin.ReplicationSpec20240805](ctx, compressedAPIObjects, tfMapObjects, d,
@@ -1185,6 +1185,8 @@ func flattenAdvancedReplicationSpec(ctx context.Context, apiObject *admin.Replic
 	return tfMap, nil
 }
 
+// flattenAdvancedReplicationSpecOldSDK returns a map populated with ReplicationSpec attributes. This function is untilised by DS read which still uses the old API.
+// This function will be removed when refactor to DS read operation is implemented.
 func flattenAdvancedReplicationSpecOldSDK(ctx context.Context, apiObject *admin20240530.ReplicationSpec, zoneNameToZoneIDs map[string]string, rootDiskSizeGB float64, tfMapObject map[string]any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
 	if apiObject == nil {
@@ -1217,7 +1219,7 @@ func flattenAdvancedReplicationSpecOldSDK(ctx context.Context, apiObject *admin2
 	return tfMap, nil
 }
 
-func flattenAdvancedReplicationSpecOldShardConfig(ctx context.Context, apiObject *admin.ReplicationSpec20240805, zoneNameToOldShardConfigMeta map[string]OldShardConfigMeta, tfMapObject map[string]any,
+func flattenAdvancedReplicationSpecOldShardingConfig(ctx context.Context, apiObject *admin.ReplicationSpec20240805, zoneNameToOldShardConfigMeta map[string]OldShardConfigMeta, tfMapObject map[string]any,
 	d *schema.ResourceData, connV2 *admin.APIClient) (map[string]any, error) {
 	if apiObject == nil {
 		return nil, nil

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -268,7 +268,7 @@ func TestFlattenAdvancedReplicationSpecOldSDK(t *testing.T) {
 			}
 			resourceData := schema.TestResourceDataRaw(t, testSchema, map[string]any{"project_id": "p1"})
 
-			tfOutputSpecs, err := advancedcluster.FlattenAdvancedReplicationSpecsOldShardConfig(context.Background(), tc.adminSpecs, tc.zoneNameToOldReplicationSpecMeta, tc.tfInputSpecs, resourceData, client)
+			tfOutputSpecs, err := advancedcluster.FlattenAdvancedReplicationSpecsOldShardingConfig(context.Background(), tc.adminSpecs, tc.zoneNameToOldReplicationSpecMeta, tc.tfInputSpecs, resourceData, client)
 
 			require.NoError(t, err)
 			assert.Len(t, tfOutputSpecs, tc.expectedLen)

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -149,7 +149,7 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 	}
 }
 
-func TestFlattenAdvancedReplicationSpecOldSDK(t *testing.T) {
+func TestFlattenAdvancedReplicationSpecsOldShardingConfig(t *testing.T) {
 	var (
 		regionName         = "EU_WEST_1"
 		providerName       = "AWS"

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -149,6 +149,137 @@ func TestFlattenReplicationSpecs(t *testing.T) {
 	}
 }
 
+func TestFlattenAdvancedReplicationSpecOldSDK(t *testing.T) {
+	var (
+		regionName         = "EU_WEST_1"
+		providerName       = "AWS"
+		expectedID         = "id1"
+		unexpectedID       = "id2"
+		expectedZoneName   = "z1"
+		unexpectedZoneName = "z2"
+		regionConfigAdmin  = []admin.CloudRegionConfig20240805{{
+			ProviderName: &providerName,
+			RegionName:   &regionName,
+		}}
+		regionConfigTfSameZone = map[string]any{
+			"provider_name": "AWS",
+			"region_name":   regionName,
+		}
+		regionConfigTfDiffZone = map[string]any{
+			"provider_name": "AWS",
+			"region_name":   regionName,
+			"zone_name":     unexpectedZoneName,
+		}
+		apiSpecExpected  = admin.ReplicationSpec20240805{Id: &expectedID, ZoneName: &expectedZoneName, RegionConfigs: &regionConfigAdmin}
+		apiSpecDifferent = admin.ReplicationSpec20240805{Id: &unexpectedID, ZoneName: &unexpectedZoneName, RegionConfigs: &regionConfigAdmin}
+		testSchema       = map[string]*schema.Schema{
+			"project_id": {Type: schema.TypeString},
+		}
+		tfSameIDSameZone = map[string]any{
+			"id":             expectedID,
+			"num_shards":     1,
+			"region_configs": []any{regionConfigTfSameZone},
+			"zone_name":      expectedZoneName,
+		}
+		tfNoIDSameZone = map[string]any{
+			"id":             nil,
+			"num_shards":     1,
+			"region_configs": []any{regionConfigTfSameZone},
+			"zone_name":      expectedZoneName,
+		}
+		tfNoIDDiffZone = map[string]any{
+			"id":             nil,
+			"num_shards":     1,
+			"region_configs": []any{regionConfigTfDiffZone},
+			"zone_name":      unexpectedZoneName,
+		}
+		tfdiffIDDiffZone = map[string]any{
+			"id":             "unique",
+			"num_shards":     1,
+			"region_configs": []any{regionConfigTfDiffZone},
+			"zone_name":      unexpectedZoneName,
+		}
+	)
+	testCases := map[string]struct {
+		adminSpecs                       []admin.ReplicationSpec20240805
+		tfInputSpecs                     []any
+		zoneNameToOldReplicationSpecMeta map[string]advancedcluster.OldShardConfigMeta
+		expectedLen                      int
+	}{
+		"empty admin spec should return empty list": {
+			[]admin.ReplicationSpec20240805{},
+			[]any{tfSameIDSameZone},
+			map[string]advancedcluster.OldShardConfigMeta{},
+			0,
+		},
+		"existing id, should match admin": {
+			[]admin.ReplicationSpec20240805{apiSpecExpected},
+			[]any{tfSameIDSameZone},
+			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			1,
+		},
+		"existing different id, should change to admin spec": {
+			[]admin.ReplicationSpec20240805{apiSpecExpected},
+			[]any{tfdiffIDDiffZone},
+			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			1,
+		},
+		"missing id, should be set when zone_name matches": {
+			[]admin.ReplicationSpec20240805{apiSpecExpected},
+			[]any{tfNoIDSameZone},
+			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			1,
+		},
+		"missing id and diff zone, should change to admin spec": {
+			[]admin.ReplicationSpec20240805{apiSpecExpected},
+			[]any{tfNoIDDiffZone},
+			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			1,
+		},
+		"existing id, should match correct api spec using `id` and extra api spec added": {
+			[]admin.ReplicationSpec20240805{apiSpecDifferent, apiSpecExpected},
+			[]any{tfSameIDSameZone},
+			map[string]advancedcluster.OldShardConfigMeta{unexpectedZoneName: {unexpectedID, 1}, expectedZoneName: {expectedID, 1}},
+			2,
+		},
+		"missing id, should match correct api spec using `zone_name` and extra api spec added": {
+			[]admin.ReplicationSpec20240805{apiSpecDifferent, apiSpecExpected},
+			[]any{tfNoIDSameZone},
+			map[string]advancedcluster.OldShardConfigMeta{unexpectedZoneName: {unexpectedID, 1}, expectedZoneName: {expectedID, 1}},
+			2,
+		},
+		"two matching specs should be set to api specs": {
+			[]admin.ReplicationSpec20240805{apiSpecExpected, apiSpecDifferent},
+			[]any{tfSameIDSameZone, tfdiffIDDiffZone},
+			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}, unexpectedZoneName: {unexpectedID, 1}},
+			2,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			peeringAPI := mockadmin.NetworkPeeringApi{}
+
+			peeringAPI.EXPECT().ListPeeringContainerByCloudProviderWithParams(mock.Anything, mock.Anything).Return(admin.ListPeeringContainerByCloudProviderApiRequest{ApiService: &peeringAPI})
+			containerResult := []admin.CloudProviderContainer{{Id: conversion.StringPtr("c1"), RegionName: &regionName, ProviderName: &providerName}}
+			peeringAPI.EXPECT().ListPeeringContainerByCloudProviderExecute(mock.Anything).Return(&admin.PaginatedCloudProviderContainer{Results: &containerResult}, nil, nil)
+
+			client := &admin.APIClient{
+				NetworkPeeringApi: &peeringAPI,
+			}
+			resourceData := schema.TestResourceDataRaw(t, testSchema, map[string]any{"project_id": "p1"})
+
+			tfOutputSpecs, err := advancedcluster.FlattenAdvancedReplicationSpecsOldShardConfig(context.Background(), tc.adminSpecs, tc.zoneNameToOldReplicationSpecMeta, tc.tfInputSpecs, resourceData, client)
+
+			require.NoError(t, err)
+			assert.Len(t, tfOutputSpecs, tc.expectedLen)
+			if tc.expectedLen != 0 {
+				assert.Equal(t, expectedID, tfOutputSpecs[0]["id"])
+				assert.Equal(t, expectedZoneName, tfOutputSpecs[0]["zone_name"])
+			}
+		})
+	}
+}
+
 func TestGetDiskSizeGBFromReplicationSpec(t *testing.T) {
 	diskSizeGBValue := 40.0
 

--- a/internal/service/advancedcluster/model_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/model_advanced_cluster_test.go
@@ -202,56 +202,56 @@ func TestFlattenAdvancedReplicationSpecOldSDK(t *testing.T) {
 	)
 	testCases := map[string]struct {
 		adminSpecs                       []admin.ReplicationSpec20240805
-		tfInputSpecs                     []any
 		zoneNameToOldReplicationSpecMeta map[string]advancedcluster.OldShardConfigMeta
+		tfInputSpecs                     []any
 		expectedLen                      int
 	}{
 		"empty admin spec should return empty list": {
 			[]admin.ReplicationSpec20240805{},
-			[]any{tfSameIDSameZone},
 			map[string]advancedcluster.OldShardConfigMeta{},
+			[]any{tfSameIDSameZone},
 			0,
 		},
 		"existing id, should match admin": {
 			[]admin.ReplicationSpec20240805{apiSpecExpected},
-			[]any{tfSameIDSameZone},
 			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			[]any{tfSameIDSameZone},
 			1,
 		},
 		"existing different id, should change to admin spec": {
 			[]admin.ReplicationSpec20240805{apiSpecExpected},
-			[]any{tfdiffIDDiffZone},
 			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			[]any{tfdiffIDDiffZone},
 			1,
 		},
 		"missing id, should be set when zone_name matches": {
 			[]admin.ReplicationSpec20240805{apiSpecExpected},
-			[]any{tfNoIDSameZone},
 			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			[]any{tfNoIDSameZone},
 			1,
 		},
 		"missing id and diff zone, should change to admin spec": {
 			[]admin.ReplicationSpec20240805{apiSpecExpected},
-			[]any{tfNoIDDiffZone},
 			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}},
+			[]any{tfNoIDDiffZone},
 			1,
 		},
 		"existing id, should match correct api spec using `id` and extra api spec added": {
 			[]admin.ReplicationSpec20240805{apiSpecDifferent, apiSpecExpected},
-			[]any{tfSameIDSameZone},
 			map[string]advancedcluster.OldShardConfigMeta{unexpectedZoneName: {unexpectedID, 1}, expectedZoneName: {expectedID, 1}},
+			[]any{tfSameIDSameZone},
 			2,
 		},
 		"missing id, should match correct api spec using `zone_name` and extra api spec added": {
 			[]admin.ReplicationSpec20240805{apiSpecDifferent, apiSpecExpected},
-			[]any{tfNoIDSameZone},
 			map[string]advancedcluster.OldShardConfigMeta{unexpectedZoneName: {unexpectedID, 1}, expectedZoneName: {expectedID, 1}},
+			[]any{tfNoIDSameZone},
 			2,
 		},
 		"two matching specs should be set to api specs": {
 			[]admin.ReplicationSpec20240805{apiSpecExpected, apiSpecDifferent},
-			[]any{tfSameIDSameZone, tfdiffIDDiffZone},
 			map[string]advancedcluster.OldShardConfigMeta{expectedZoneName: {expectedID, 1}, unexpectedZoneName: {unexpectedID, 1}},
+			[]any{tfSameIDSameZone, tfdiffIDDiffZone},
 			2,
 		},
 	}

--- a/internal/service/advancedcluster/model_sdk_version_conversion.go
+++ b/internal/service/advancedcluster/model_sdk_version_conversion.go
@@ -298,9 +298,6 @@ func convertRegionConfigSliceToLatest(slice *[]admin20240530.CloudRegionConfig, 
 	return &results
 }
 
-// Essentially, AdvancedClusterDescription is totally same and copied over bar diskSizeGb (which is held in rep spec for latestSDK),
-// replication spec,(which we deal w elsewhere), and links (which are dismissed)
-// That is to say, not lossing anything here by just using latestSDK
 func convertClusterDescToLatestExcludeRepSpecs(oldClusterDesc *admin20240530.AdvancedClusterDescription) *admin.ClusterDescription20240805 {
 	return &admin.ClusterDescription20240805{
 		BackupEnabled: oldClusterDesc.BackupEnabled,

--- a/internal/service/advancedcluster/model_sdk_version_conversion.go
+++ b/internal/service/advancedcluster/model_sdk_version_conversion.go
@@ -298,6 +298,9 @@ func convertRegionConfigSliceToLatest(slice *[]admin20240530.CloudRegionConfig, 
 	return &results
 }
 
+// Essentially, AdvancedClusterDescription is totally same and copied over bar diskSizeGb (which is held in rep spec for latestSDK),
+// replication spec,(which we deal w elsewhere), and links (which are dismissed)
+// That is to say, not lossing anything here by just using latestSDK
 func convertClusterDescToLatestExcludeRepSpecs(oldClusterDesc *admin20240530.AdvancedClusterDescription) *admin.ClusterDescription20240805 {
 	return &admin.ClusterDescription20240805{
 		BackupEnabled: oldClusterDesc.BackupEnabled,

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -609,8 +609,8 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	return nil
 }
 
-// GetReplicationSpecAttributesFromOldAPI returns the id and num shard values of replication specs coming from old API. This is used to populate replication_specs.*.id and replication_specs.*.num_shard attributes for old shard confirguration.
-// In the old API each replications spec has a 1:1 relation with each zone, so ids and num shards are stored in a struct oldShardConfigMeta and are returned in a map from zoneName to oldShardConfigMeta.
+// GetReplicationSpecAttributesFromOldAPI returns the id and num shard values of replication specs coming from old API. This is used to populate replication_specs.*.id and replication_specs.*.num_shard attributes for old sharding confirgurations.
+// In the old API, each replications spec has a 1:1 relation with each zone, so ids and num shards are stored in a struct oldShardConfigMeta and are returned in a map from zoneName to oldShardConfigMeta.
 func GetReplicationSpecAttributesFromOldAPI(ctx context.Context, projectID, clusterName string, client20240530 admin20240530.ClustersApi) (map[string]OldShardConfigMeta, error) {
 	clusterOldAPI, _, err := client20240530.GetCluster(ctx, projectID, clusterName).Execute()
 	if err != nil {
@@ -631,7 +631,7 @@ func getReplicationSpecIDsFromOldAPI(ctx context.Context, projectID, clusterName
 	clusterOldAPI, _, err := connV220240530.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
 	if apiError, ok := admin20240530.AsError(err); ok {
 		if apiError.GetErrorCode() == "ASYMMETRIC_SHARD_UNSUPPORTED" {
-			return nil, nil // if it's the case of an asymmetric shard, an error is expected in old API and replication_specs.*.id attribute will not be populated
+			return nil, nil // If it is the case of an asymmetric shard, an error is expected in old API and replication_specs.*.id attribute will not be populated.
 		}
 		readErrorMsg := "error reading advanced cluster with 2023-02-01 API (%s): %s"
 		return nil, fmt.Errorf(readErrorMsg, clusterName, err)
@@ -644,7 +644,7 @@ func getReplicationSpecIDsFromOldAPI(ctx context.Context, projectID, clusterName
 	return result, nil
 }
 
-// getZoneIDsFromNewAPI returns the zone id values of replication specs coming from new API. This is used to populate zone_id when old API is called in the read.
+// getZoneIDsFromNewAPI returns the zone id values of replication specs coming from new API. This is used to populate zone_id when old API is called in DS read.
 func getZoneIDsFromNewAPI(cluster *admin.ClusterDescription20240805) (map[string]string, error) {
 	specs := cluster.GetReplicationSpecs()
 	result := make(map[string]string, len(specs))

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -554,8 +554,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	// var clusterResp *admin.ClusterDescription20240805
-
 	var replicationSpecs []map[string]any
 
 	cluster, resp, err := connV2.ClustersApi.GetCluster(ctx, projectID, clusterName).Execute()
@@ -594,9 +592,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 		}
 	}
-	// clusterResp = cluster
-
-	// *** KEEP AS IS!! ----------------------------
 	diags := setRootFields(d, cluster, true)
 	if diags.HasError() {
 		return diags
@@ -620,7 +615,6 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 
 	return nil
-	// *** -----------------------------------------
 }
 
 // getReplicationSpecAttributesFromOldAPI returns the id values of replication specs coming from old API. This is used to populate old replication_specs.*.id attribute avoiding breaking changes.

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -570,7 +570,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		replicationSpecs, err = FlattenAdvancedReplicationSpecsOldShardConfig(ctx, cluster.GetReplicationSpecs(), zoneNameToOldReplicationSpecMeta, d.Get("replication_specs").([]any), d, connV2)
+		replicationSpecs, err = FlattenAdvancedReplicationSpecsOldShardingConfig(ctx, cluster.GetReplicationSpecs(), zoneNameToOldReplicationSpecMeta, d.Get("replication_specs").([]any), d, connV2)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(ErrorClusterAdvancedSetting, "replication_specs", clusterName, err))
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -46,11 +46,6 @@ const (
 
 var DeprecationMsgOldSchema = fmt.Sprintf("%s %s", constant.DeprecationParam, DeprecationOldSchemaAction)
 
-type OldShardConfigMeta struct {
-	ID       string
-	NumShard int
-}
-
 func Resource() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCreate,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -40,7 +40,7 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 		projectID   = "11111"
 		clusterName = "testCluster"
 		ID          = "111111"
-		num_shard   = 2
+		numShard    = 2
 		zoneName    = "ZoneName managed by Terraform"
 	)
 
@@ -58,11 +58,11 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 			expectedError:  errors.New("error reading advanced cluster with 2023-02-01 API (testCluster): generic"),
 			expectedResult: nil,
 		},
-		"Successfull": {
+		"Successful": {
 			mockCluster: &admin20240530.AdvancedClusterDescription{
 				ReplicationSpecs: &[]admin20240530.ReplicationSpec{
 					{
-						NumShards: &num_shard,
+						NumShards: &numShard,
 						Id:        &ID,
 						ZoneName:  &zoneName,
 					},
@@ -72,7 +72,7 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 			mockError:     nil,
 			expectedError: nil,
 			expectedResult: map[string]advancedcluster.OldShardConfigMeta{
-				zoneName: {ID: ID, NumShard: num_shard},
+				zoneName: {ID: ID, NumShard: numShard},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Refactors resource read operation in 'mongodb_advanced_cluster' such that the operation relies as much as possible on latest API version. The old API must still be called to obtain `advanced_configuration` attributes, `replication_spec.id` and `num_shard`, whether old or new shard configuration is used.

Link to any related issue(s): [CLOUDP-286227](https://jira.mongodb.org/browse/CLOUDP-286227)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
