### PR TITLE
chore: Includes the rest of blocks in TPF test converter

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -210,6 +210,9 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 }
 
 func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
+	// TODO: Already prepared for TPF but getting this error:
+	//  unexpected new value: .advanced_configuration.fail_index_key_too_long: was cty.False, but now null
+	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -874,7 +877,6 @@ func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 				Config: acc.ConvertAdvancedClusterToTPF(t, configBiConnectorConfig(projectID, clusterName, true)),
 				Check:  checkTenantBiConnectorConfig(projectID, clusterName, true),
 			},
-			acc.TestStepImportCluster(resourceName),
 		},
 	})
 }
@@ -2337,7 +2339,7 @@ func configBiConnectorConfig(projectID, name string, enabled bool) string {
 					}
 					provider_name = "AWS"
 					priority      = 7
-					region_name   = "US_EAST_1"
+					region_name   = "US_WEST_2"
 				}
 			}
 

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -417,7 +417,6 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 }
 
 func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
-	acc.SkipIfTPFAdvancedCluster(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to check correctly plural data source in the different test steps
@@ -430,15 +429,15 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithTags(orgID, projectName, clusterName),
+				Config: acc.ConvertAdvancedClusterToTPF(t, configWithTags(orgID, projectName, clusterName)),
 				Check:  checkTags(clusterName),
 			},
 			{
-				Config: configWithTags(orgID, projectName, clusterName, acc.ClusterTagsMap1, acc.ClusterTagsMap2),
+				Config: acc.ConvertAdvancedClusterToTPF(t, configWithTags(orgID, projectName, clusterName, acc.ClusterTagsMap1, acc.ClusterTagsMap2)),
 				Check:  checkTags(clusterName, acc.ClusterTagsMap1, acc.ClusterTagsMap2),
 			},
 			{
-				Config: configWithTags(orgID, projectName, clusterName, acc.ClusterTagsMap3),
+				Config: acc.ConvertAdvancedClusterToTPF(t, configWithTags(orgID, projectName, clusterName, acc.ClusterTagsMap3)),
 				Check:  checkTags(clusterName, acc.ClusterTagsMap3),
 			},
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2349,10 +2349,12 @@ func configBiConnectorConfig(projectID, name string, enabled bool) string {
 		data "mongodbatlas_advanced_cluster" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
+			depends_on = [mongodbatlas_advanced_cluster.test]
 		}
 
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
+			depends_on = [mongodbatlas_advanced_cluster.test]
 		}
 	`, projectID, name, additionalConfig)
 }

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -26,6 +26,20 @@ var (
 		"key":   "key 3",
 		"value": "value 3",
 	}
+	ClusterLabelsMap1 = map[string]string{
+		"key":   "label key 1",
+		"value": "label value 1",
+	}
+
+	ClusterLabelsMap2 = map[string]string{
+		"key":   "label key 2",
+		"value": "label value 2",
+	}
+
+	ClusterLabelsMap3 = map[string]string{
+		"key":   "label key 3",
+		"value": "label value 3",
+	}
 )
 
 func CheckDestroyCluster(s *terraform.State) error {

--- a/internal/testutil/acc/tpf_converter.go
+++ b/internal/testutil/acc/tpf_converter.go
@@ -30,6 +30,7 @@ func ConvertAdvancedClusterToTPF(t *testing.T, def string) string {
 		convertAttrs(t, "tags", writeBody, true, getAttrVal)
 		convertAttrs(t, "replication_specs", writeBody, true, getReplicationSpecs)
 		convertAttrs(t, "advanced_configuration", writeBody, false, getAttrVal)
+		convertAttrs(t, "bi_connector_config", writeBody, false, getAttrVal)
 	}
 	content := parse.Bytes()
 	return string(content)

--- a/internal/testutil/acc/tpf_converter.go
+++ b/internal/testutil/acc/tpf_converter.go
@@ -1,7 +1,6 @@
 package acc
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -30,8 +29,6 @@ func ConvertAdvancedClusterToTPF(t *testing.T, def string) string {
 		generateAllReplicationSpecs(t, writeBody)
 	}
 	content := parse.Bytes()
-	// RemoveBlock is not deleting the newline at the end of the block
-	content = bytes.ReplaceAll(content, []byte("\n\n"), []byte("\n"))
 	return string(content)
 }
 
@@ -50,6 +47,7 @@ func generateAllReplicationSpecs(t *testing.T, writeBody *hclwrite.Body) {
 			break
 		}
 		vals = append(vals, getOneReplicationSpecs(t, getBlockBody(t, match)))
+		// TODO: RemoveBlock doesn't remove newline just after the block so an extra line is added
 		writeBody.RemoveBlock(match)
 	}
 	require.NotEmpty(t, vals, "there must be at least one %s block", name)

--- a/internal/testutil/acc/tpf_converter.go
+++ b/internal/testutil/acc/tpf_converter.go
@@ -27,10 +27,10 @@ func ConvertAdvancedClusterToTPF(t *testing.T, def string) string {
 		}
 		writeBody := resource.Body()
 		generateAllAttributeSpecs(t, "labels", writeBody, func(body *hclsyntax.Body) cty.Value {
-			return cty.ObjectVal(getVal(t, body))
+			return getVal(t, body)
 		})
 		generateAllAttributeSpecs(t, "tags", writeBody, func(body *hclsyntax.Body) cty.Value {
-			return cty.ObjectVal(getVal(t, body))
+			return getVal(t, body)
 		})
 		generateAllAttributeSpecs(t, "replication_specs", writeBody, func(body *hclsyntax.Body) cty.Value {
 			return getOneReplicationSpecs(t, body)
@@ -67,7 +67,7 @@ func getOneReplicationSpecs(t *testing.T, body *hclsyntax.Body) cty.Value {
 	var vals []cty.Value
 	for _, block := range body.Blocks {
 		assert.Equal(t, name, block.Type, "unexpected block type: %s", block.Type)
-		oneRegionConfigs := cty.ObjectVal(getVal(t, block.Body))
+		oneRegionConfigs := getVal(t, block.Body)
 		vals = append(vals, oneRegionConfigs)
 	}
 	return cty.ObjectVal(map[string]cty.Value{
@@ -75,7 +75,7 @@ func getOneReplicationSpecs(t *testing.T, body *hclsyntax.Body) cty.Value {
 	})
 }
 
-func getVal(t *testing.T, body *hclsyntax.Body) map[string]cty.Value {
+func getVal(t *testing.T, body *hclsyntax.Body) cty.Value {
 	t.Helper()
 	ret := make(map[string]cty.Value)
 	for name, attr := range body.Attributes {
@@ -84,9 +84,9 @@ func getVal(t *testing.T, body *hclsyntax.Body) map[string]cty.Value {
 		ret[name] = val
 	}
 	for _, block := range body.Blocks {
-		ret[block.Type] = cty.ObjectVal(getVal(t, block.Body))
+		ret[block.Type] = getVal(t, block.Body)
 	}
-	return ret
+	return cty.ObjectVal(ret)
 }
 
 func canonicalHCL(t *testing.T, def string) string {

--- a/internal/testutil/acc/tpf_converter_test.go
+++ b/internal/testutil/acc/tpf_converter_test.go
@@ -58,6 +58,31 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 						region_name   = "EU_WEST_1"
 					}
 				}
+
+ 				tags {
+					key   = "Key Tag 2"
+					value = "Value Tag 2"
+  			}
+
+ 				labels {
+					key   = "Key Label 1"
+					value = "Value Label 1"
+  			}
+
+				tags {
+					key   = "Key Tag 1"
+					value = "Value Tag 1"
+			  }
+
+ 				labels {
+					key   = "Key Label 2"
+					value = "Value Label 2"
+  			}
+
+ 				labels {
+					key   = "Key Label 3"
+					value = "Value Label 3"
+  			}
 			}	
  		`
 		// expected has the attributes sorted alphabetically to match the output of ConvertAdvancedClusterToTPF
@@ -67,7 +92,29 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 				name         = "cluster2"
 				cluster_type = "SHARDED"
 
+
+
+
+
+
 				
+				labels = [{
+					key   = "Key Label 1"
+					value = "Value Label 1"
+  			}, {
+					key   = "Key Label 2"
+					value = "Value Label 2"
+  			}, {
+					key   = "Key Label 3"
+					value = "Value Label 3"
+  			}]
+				tags = [{
+					key   = "Key Tag 2"
+					value = "Value Tag 2"
+  			}, {
+					key   = "Key Tag 1"
+					value = "Value Tag 1"
+  			}]
 				replication_specs = [{
 						region_configs = [{
 							analytics_specs = {

--- a/internal/testutil/acc/tpf_converter_test.go
+++ b/internal/testutil/acc/tpf_converter_test.go
@@ -83,6 +83,18 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 					key   = "Key Label 3"
 					value = "Value Label 3"
   			}
+
+				advanced_configuration  {
+					fail_index_key_too_long              = false
+					javascript_enabled                   = true
+					minimum_enabled_tls_protocol         = "TLS1_1"
+					no_table_scan                        = false
+					oplog_size_mb                        = 1000
+					sample_size_bi_connector			 = 110
+					sample_refresh_interval_bi_connector = 310
+			    transaction_lifetime_limit_seconds   = 300  
+			    change_stream_options_pre_and_post_images_expire_after_seconds = 100
+				}
 			}	
  		`
 		// expected has the attributes sorted alphabetically to match the output of ConvertAdvancedClusterToTPF
@@ -91,6 +103,7 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 				project_id   = "MY-PROJECT-ID"
 				name         = "cluster2"
 				cluster_type = "SHARDED"
+
 
 
 
@@ -156,6 +169,17 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 							region_name   = "EU_WEST_1"
 						}]
 					}]
+				advanced_configuration = {
+			    change_stream_options_pre_and_post_images_expire_after_seconds = 100
+					fail_index_key_too_long              = false
+					javascript_enabled                   = true
+					minimum_enabled_tls_protocol         = "TLS1_1"
+					no_table_scan                        = false
+					oplog_size_mb                        = 1000
+					sample_refresh_interval_bi_connector = 310
+					sample_size_bi_connector			 = 110
+			    transaction_lifetime_limit_seconds   = 300  
+				}
 			}
  		`
 	)

--- a/internal/testutil/acc/tpf_converter_test.go
+++ b/internal/testutil/acc/tpf_converter_test.go
@@ -67,6 +67,7 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 				name         = "cluster2"
 				cluster_type = "SHARDED"
 
+				
 				replication_specs = [{
 						region_configs = [{
 							analytics_specs = {

--- a/internal/testutil/acc/tpf_converter_test.go
+++ b/internal/testutil/acc/tpf_converter_test.go
@@ -95,6 +95,11 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 			    transaction_lifetime_limit_seconds   = 300  
 			    change_stream_options_pre_and_post_images_expire_after_seconds = 100
 				}
+
+				bi_connector_config {
+ 					enabled         = true
+  				read_preference = "secondary"
+				}
 			}	
  		`
 		// expected has the attributes sorted alphabetically to match the output of ConvertAdvancedClusterToTPF
@@ -103,6 +108,7 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 				project_id   = "MY-PROJECT-ID"
 				name         = "cluster2"
 				cluster_type = "SHARDED"
+
 
 
 
@@ -179,6 +185,10 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 					sample_refresh_interval_bi_connector = 310
 					sample_size_bi_connector			 = 110
 			    transaction_lifetime_limit_seconds   = 300  
+				}
+				bi_connector_config = {
+ 					enabled         = true
+  				read_preference = "secondary"
 				}
 			}
  		`


### PR DESCRIPTION
## Description

Includes the rest of blocks in TPF test converter:

- `tags` 
- `labels`
- `advanced_configuration`
- `bi_connector_config`

It's a follow-up PR for: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2822

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): CLOUDP-287280

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
