### PR TITLE
Fix error message typo

### DIFF
--- a/internal/service/apikey/resource_api_key.go
+++ b/internal/service/apikey/resource_api_key.go
@@ -76,7 +76,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if err := d.Set("private_key", apiKey.GetPrivateKey()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `public_key`: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting `private_key`: %s", err))
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{


### PR DESCRIPTION
## Description

When there's an error setting the `private_key`, it should output an error message mentioning `private_key` instead of `public_key`

Link to any related issue(s):

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
