### PR TITLE
chore: Wait in each cluster creation in tests

### DIFF
--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -85,7 +85,7 @@ func ClusterNameExecution(tb testing.TB) (projectID, clusterName string) {
 	return sharedInfo.projectID, sharedInfo.clusterName
 }
 
-// SerialSleep waits a few seconds the first time so the first cluster in a project is not created concurrently, see HELP-65223.
+// SerialSleep waits a few seconds so clusters in a project are not created concurrently, see HELP-65223.
 // This must be called once the test is marked as parallel, e.g. in PreCheck inside Terraform tests.
 func SerialSleep(tb testing.TB) {
 	tb.Helper()
@@ -95,11 +95,7 @@ func SerialSleep(tb testing.TB) {
 	sharedInfo.muSleep.Lock()
 	defer sharedInfo.muSleep.Unlock()
 
-	sharedInfo.testCount++
-	// SerialSleep is called in tests before they create the cluster, so wait in the second test after the first cluster is being created before creating the second cluster
-	if sharedInfo.testCount == 2 {
-		time.Sleep(5 * time.Second)
-	}
+	time.Sleep(5 * time.Second)
 }
 
 var sharedInfo = struct {
@@ -108,6 +104,5 @@ var sharedInfo = struct {
 	clusterName string
 	mu          sync.Mutex
 	muSleep     sync.Mutex
-	testCount   int
 	init        bool
 }{}


### PR DESCRIPTION
## Description

Wait in each cluster creation in tests, more info in: HELP-65223


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
