### PR TITLE
chore: Supports setting `retain_backups_enabled` in adv_cluster TPF

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -15,11 +15,13 @@ import (
 const versionBeforeISSRelease = "1.17.6"
 
 func TestMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
+	acc.SkipIfAdvancedClusterV2Schema(t) // AttributeName("advanced_configuration"): invalid JSON, expected "{", got "["
 	testCase := replicaSetAWSProviderTestCase(t, false)
 	mig.CreateAndRunTest(t, &testCase)
 }
 
 func TestMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
+	acc.SkipIfAdvancedClusterV2Schema(t) // AttributeName("advanced_configuration"): invalid JSON, expected "{", got "["
 	testCase := replicaSetMultiCloudTestCase(t, false)
 	mig.CreateAndRunTest(t, &testCase)
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1101,16 +1101,15 @@ func checkReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountEle
 	additionalChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
 	}
+	diskIopsPath := "replication_specs.0.region_configs.0.electable_specs.0.disk_iops"
 	if config.AdvancedClusterV2Schema() {
-		// Manual test fix to remove electable_specs.0 for TPF
 		additionalChecks = append(additionalChecks,
-			resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.disk_iops", acc.IntGreatThan(0)),
+			resource.TestCheckResourceAttrWith(resourceName, acc.AttrNameToSchemaV2(diskIopsPath), acc.IntGreatThan(0)),
 		)
-	}
-	if !config.AdvancedClusterV2Schema() { // TODO: data sources not implemented for TPF yet
+	} else { // TODO: data sources not implemented for TPF yet
 		additionalChecks = append(additionalChecks,
-			resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
-			resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+			resource.TestCheckResourceAttrWith(resourceName, diskIopsPath, acc.IntGreatThan(0)),
+			resource.TestCheckResourceAttrWith(dataSourceName, diskIopsPath, acc.IntGreatThan(0)),
 		)
 	}
 	if checkDiskSizeGBInnerLevel {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -59,9 +59,6 @@ func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 
 func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	// TODO: Already prepared for TPF but getting this error:
-	// unexpected new value: .retain_backups_enabled: was cty.True, but now null.
-	acc.SkipIfAdvancedClusterV2Schema(t)
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		clusterName = acc.RandomClusterName()
@@ -90,9 +87,6 @@ func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 }
 func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	// TODO: Already prepared for TPF but getting this error:
-	// unexpected new value: .retain_backups_enabled: was cty.False, but now null.
-	acc.SkipIfAdvancedClusterV2Schema(t)
 	var (
 		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName        = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1100,10 +1100,16 @@ func configReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountEl
 func checkReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
-		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+	}
+	if config.AdvancedClusterV2Schema() {
+		// Manual test fix to remove electable_specs.0 for TPF
+		additionalChecks = append(additionalChecks,
+			resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.disk_iops", acc.IntGreatThan(0)),
+		)
 	}
 	if !config.AdvancedClusterV2Schema() { // TODO: data sources not implemented for TPF yet
 		additionalChecks = append(additionalChecks,
+			resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
 			resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
 		)
 	}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -408,7 +408,7 @@ func (r *rs) convertClusterAddAdvConfig(ctx context.Context, legacyAdvConfig *ad
 			return nil
 		}
 	}
-	overrideKnowTPFIssueFields(modelIn, modelOut)
+	overrideAttributesWithPrevStateValue(modelIn, modelOut)
 	return modelOut
 }
 

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -11,7 +11,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
-func overrideKnowTPFIssueFields(modelIn, modelOut *TFModel) {
+func overrideAttributesWithPrevStateValue(modelIn, modelOut *TFModel) {
 	beforeVersion := conversion.NilForUnknown(modelIn.MongoDBMajorVersion, modelIn.MongoDBMajorVersion.ValueStringPointer())
 	if beforeVersion != nil && !modelIn.MongoDBMajorVersion.Equal(modelOut.MongoDBMajorVersion) {
 		modelOut.MongoDBMajorVersion = types.StringPointerValue(beforeVersion)

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -16,6 +16,10 @@ func overrideKnowTPFIssueFields(modelIn, modelOut *TFModel) {
 	if beforeVersion != nil && !modelIn.MongoDBMajorVersion.Equal(modelOut.MongoDBMajorVersion) {
 		modelOut.MongoDBMajorVersion = types.StringPointerValue(beforeVersion)
 	}
+	retainBackups := conversion.NilForUnknown(modelIn.RetainBackupsEnabled, modelIn.RetainBackupsEnabled.ValueBoolPointer())
+	if retainBackups != nil && !modelIn.RetainBackupsEnabled.Equal(modelOut.RetainBackupsEnabled) {
+		modelOut.RetainBackupsEnabled = types.BoolPointerValue(retainBackups)
+	}
 }
 
 func findNumShardsUpdates(ctx context.Context, state, plan *TFModel, diags *diag.Diagnostics) map[string]int64 {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -47,7 +47,7 @@ var tpfSingleNestedAttrs = []string{
 }
 
 func AttrNameToSchemaV2(name string) string {
-     if !config.AdvancedClusterV2Schema() {
+	if !config.AdvancedClusterV2Schema() {
 		return name
 	}
 	for _, singleAttrName := range tpfSingleNestedAttrs {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -47,6 +47,9 @@ var tpfSingleNestedAttrs = []string{
 }
 
 func AttrNameToSchemaV2(name string) string {
+     if !config.AdvancedClusterV2Schema() {
+		return name
+	}
 	for _, singleAttrName := range tpfSingleNestedAttrs {
 		name = strings.ReplaceAll(name, singleAttrName+".0", singleAttrName)
 	}

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -21,7 +21,7 @@ func ConvertToTPFAttrsMap(attrsMap map[string]string) map[string]string {
 	}
 	ret := make(map[string]string, len(attrsMap))
 	for name, value := range attrsMap {
-		ret[attrNameToSchemaV2(name)] = value
+		ret[AttrNameToSchemaV2(name)] = value
 	}
 	return ret
 }
@@ -32,7 +32,7 @@ func ConvertToTPFAttrsSet(attrsSet []string) []string {
 	}
 	ret := make([]string, 0, len(attrsSet))
 	for _, name := range attrsSet {
-		ret = append(ret, attrNameToSchemaV2(name))
+		ret = append(ret, AttrNameToSchemaV2(name))
 	}
 	return ret
 }
@@ -46,7 +46,7 @@ var tpfSingleNestedAttrs = []string{
 	"bi_connector_config",
 }
 
-func attrNameToSchemaV2(name string) string {
+func AttrNameToSchemaV2(name string) string {
 	for _, singleAttrName := range tpfSingleNestedAttrs {
 		name = strings.ReplaceAll(name, singleAttrName+".0", singleAttrName)
 	}


### PR DESCRIPTION
## Description

Supports setting `retain_backups_enabled`

Link to any related issue(s): CLOUDP-287995

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
