### PR TITLE
chore: Supports empty instance_size in adv_cluster TPF autoscaling config

### DIFF
--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -3,6 +3,8 @@ package conversion
 import (
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func SafeString(s *string) string {
@@ -82,6 +84,14 @@ type TFPrimitiveType interface {
 
 func NilForUnknown[T any](primitiveAttr TFPrimitiveType, value *T) *T {
 	if primitiveAttr.IsUnknown() {
+		return nil
+	}
+	return value
+}
+
+func NilForUnknownOrEmpty(primitiveAttr types.String) *string {
+	value := NilForUnknown(primitiveAttr, primitiveAttr.ValueStringPointer())
+	if value == nil || *value == "" {
 		return nil
 	}
 	return value

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -97,7 +97,7 @@ func TestAWSRegionToMongoDBRegion(t *testing.T) {
 	}
 }
 
-func TestNilForUnknownOrEmpty(t *testing.T)	{
+func TestNilForUnknownOrEmpty(t *testing.T) {
 	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(nil)))
 	emptyString := ""
 	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(&emptyString)))

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -94,4 +95,12 @@ func TestAWSRegionToMongoDBRegion(t *testing.T) {
 			t.Errorf("AWSRegionToMongoDBRegion(%v) = %v; want %v", test.region, resp, test.expected)
 		}
 	}
+}
+
+func TestNilForUnknownOrEmpty(t *testing.T)	{
+	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(nil)))
+	emptyString := ""
+	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(&emptyString)))
+	testString := "test"
+	assert.Equal(t, "test", *conversion.NilForUnknownOrEmpty(types.StringPointerValue(&testString)))
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -319,9 +319,6 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 }
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.T) {
-	// TODO: Already prepared for TPF but getting this error:
-	// POST: HTTP 400 Bad Request (Error code: "INVALID_ENUM_VALUE") Detail: An invalid enumeration value  was specified. Reason: Bad Request. Params: [],
-	acc.SkipIfAdvancedClusterV2Schema(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -365,9 +362,6 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 }
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t *testing.T) {
-	// TODO: Already prepared for TPF but getting this error:
-	// POST: HTTP 400 Bad Request (Error code: "INVALID_ENUM_VALUE") Detail: An invalid enumeration value  was specified. Reason: Bad Request. Params: [],
-	acc.SkipIfAdvancedClusterV2Schema(t)
 	var (
 		projectID          = acc.ProjectIDExecution(t)
 		clusterName        = acc.RandomClusterName()
@@ -582,9 +576,6 @@ func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing
 
 func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	// TODO: Already prepared for TPF but getting this error:
-	// POST: HTTP 400 Bad Request (Error code: "INVALID_ENUM_VALUE") Detail: An invalid enumeration value  was specified. Reason: Bad Request. Params: [],
-	acc.SkipIfAdvancedClusterV2Schema(t)
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -202,7 +202,7 @@ func newDedicatedHardwareSpec20240805(ctx context.Context, input types.Object, d
 		DiskIOPS:      conversion.NilForUnknown(item.DiskIops, conversion.Int64PtrToIntPtr(item.DiskIops.ValueInt64Pointer())),
 		DiskSizeGB:    conversion.NilForUnknown(item.DiskSizeGb, item.DiskSizeGb.ValueFloat64Pointer()),
 		EbsVolumeType: conversion.NilForUnknown(item.EbsVolumeType, item.EbsVolumeType.ValueStringPointer()),
-		InstanceSize:  conversion.NilForUnknown(item.InstanceSize, item.InstanceSize.ValueStringPointer()),
+		InstanceSize:  conversion.NilForUnknownOrEmpty(item.InstanceSize),
 		NodeCount:     conversion.NilForUnknown(item.NodeCount, conversion.Int64PtrToIntPtr(item.NodeCount.ValueInt64Pointer())),
 	}
 }
@@ -220,8 +220,8 @@ func newAdvancedComputeAutoScaling(ctx context.Context, input types.Object, diag
 	return &admin.AdvancedComputeAutoScaling{
 		Enabled:          conversion.NilForUnknown(item.ComputeEnabled, item.ComputeEnabled.ValueBoolPointer()),
 		ScaleDownEnabled: conversion.NilForUnknown(item.ComputeScaleDownEnabled, item.ComputeScaleDownEnabled.ValueBoolPointer()),
-		MaxInstanceSize:  conversion.NilForUnknown(item.ComputeMaxInstanceSize, item.ComputeMaxInstanceSize.ValueStringPointer()),
-		MinInstanceSize:  conversion.NilForUnknown(item.ComputeMinInstanceSize, item.ComputeMinInstanceSize.ValueStringPointer()),
+		MaxInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMaxInstanceSize),
+		MinInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMinInstanceSize),
 	}
 }
 func newDiskGBAutoScaling(ctx context.Context, input types.Object, diags *diag.Diagnostics) *admin.DiskGBAutoScaling {


### PR DESCRIPTION
## Description

Supports empty instance_size in adv_cluster TPF autoscaling config

Link to any related issue(s): CLOUDP-287995

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
