### PR TITLE
chore: Generate `mongodbatlas_stream_privatelink_endpoint` file structure and resource schema

### DIFF
--- a/internal/service/streamprivatelinkendpoint/main_test.go
+++ b/internal/service/streamprivatelinkendpoint/main_test.go
@@ -1,0 +1,15 @@
+package streamprivatelinkendpoint_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -1,0 +1,28 @@
+package streamprivatelinkendpoint
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"go.mongodb.org/atlas-sdk/v20241113002/admin"
+)
+
+// TODO: `ctx` parameter and `diags` return value can be removed if tf schema has no complex data types (e.g., schema.ListAttribute, schema.SetAttribute)
+func NewTFModel(ctx context.Context, apiResp *admin.StreamsPrivateLinkConnection) (*TFModel, diag.Diagnostics) {
+	// complexAttr, diagnostics := types.ListValueFrom(ctx, InnerObjectType, newTFComplexAttrModel(apiResp.ComplexAttr))
+	// if diagnostics.HasError() {
+	// 	return nil, diagnostics
+	// }
+	return &TFModel{}, nil
+}
+
+// TODO: If SDK defined different models for create and update separate functions will need to be defined.
+// TODO: `ctx` parameter and `diags` in return value can be removed if tf schema has no complex data types (e.g., schema.ListAttribute, schema.SetAttribute)
+func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkConnection, diag.Diagnostics) {
+	// var tfList []complexArgumentData
+	// resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+	// if resp.Diagnostics.HasError() {
+	// 	return nil, diagnostics
+	// }
+	return &admin.StreamsPrivateLinkConnection{}, nil
+}

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -1,3 +1,4 @@
+//nolint:gocritic
 package streamprivatelinkendpoint
 
 import (

--- a/internal/service/streamprivatelinkendpoint/model_test.go
+++ b/internal/service/streamprivatelinkendpoint/model_test.go
@@ -1,0 +1,58 @@
+package streamprivatelinkendpoint_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprivatelinkendpoint"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20241113002/admin"
+)
+
+type sdkToTFModelTestCase struct {
+	SDKResp         *admin.StreamsPrivateLinkConnection
+	expectedTFModel *streamprivatelinkendpoint.TFModel
+}
+
+func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
+	testCases := map[string]sdkToTFModelTestCase{ // TODO: consider adding test cases to contemplate all possible API responses
+		"Complete SDK response": {
+			SDKResp:         &admin.StreamsPrivateLinkConnection{},
+			expectedTFModel: &streamprivatelinkendpoint.TFModel{},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resultModel, diags := streamprivatelinkendpoint.NewTFModel(context.Background(), tc.SDKResp)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}
+
+type tfToSDKModelTestCase struct {
+	tfModel        *streamprivatelinkendpoint.TFModel
+	expectedSDKReq *admin.StreamsPrivateLinkConnection
+}
+
+func TestStreamPrivatelinkEndpointTFModelToSDK(t *testing.T) {
+	testCases := map[string]tfToSDKModelTestCase{
+		"Complete TF state": {
+			tfModel:        &streamprivatelinkendpoint.TFModel{},
+			expectedSDKReq: &admin.StreamsPrivateLinkConnection{},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			apiReqResult, diags := streamprivatelinkendpoint.NewAtlasReq(context.Background(), tc.tfModel)
+			if diags.HasError() {
+				t.Errorf("unexpected errors found: %s", diags.Errors()[0].Summary())
+			}
+			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
+		})
+	}
+}

--- a/internal/service/streamprivatelinkendpoint/resource.go
+++ b/internal/service/streamprivatelinkendpoint/resource.go
@@ -1,3 +1,4 @@
+//nolint:gocritic
 package streamprivatelinkendpoint
 
 import (

--- a/internal/service/streamprivatelinkendpoint/resource.go
+++ b/internal/service/streamprivatelinkendpoint/resource.go
@@ -1,0 +1,150 @@
+package streamprivatelinkendpoint
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+const resourceName = "stream_privatelink_endpoint"
+
+var _ resource.ResourceWithConfigure = &rs{}
+var _ resource.ResourceWithImportState = &rs{}
+
+func Resource() resource.Resource {
+	return &rs{
+		RSCommon: config.RSCommon{
+			ResourceName: resourceName,
+		},
+	}
+}
+
+type rs struct {
+	config.RSCommon
+}
+
+func (r *rs) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	// TODO: Schema and model must be defined in resource_schema.go. Details on scaffolding this file found in contributing/development-best-practices.md under "Scaffolding Schema and Model Definitions"
+	resp.Schema = ResourceSchema(ctx)
+	conversion.UpdateSchemaDescription(&resp.Schema)
+}
+
+func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var tfModel TFModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// streamPrivatelinkEndpointReq, diags := NewAtlasReq(ctx, &tfModel)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+
+	// TODO: make POST request to Atlas API and handle error in response
+
+	// connV2 := r.Client.AtlasV2
+	// if err != nil {
+	//	resp.Diagnostics.AddError("error creating resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	// newStreamPrivatelinkEndpointModel, diags := NewTFModel(ctx, apiResp)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+	// resp.Diagnostics.Append(resp.State.Set(ctx, newStreamPrivatelinkEndpointModel)...)
+}
+
+func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var streamPrivatelinkEndpointState TFModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &streamPrivatelinkEndpointState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make get request to resource
+
+	// connV2 := r.Client.AtlasV2
+	// if err != nil {
+	//	if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+	//		resp.State.RemoveResource(ctx)
+	//		return
+	//	}
+	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+	// newStreamPrivatelinkEndpointModel, diags := NewTFModel(ctx, apiResp)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+	// resp.Diagnostics.Append(resp.State.Set(ctx, newStreamPrivatelinkEndpointModel)...)
+}
+
+func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var tfModel TFModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &tfModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// streamPrivatelinkEndpointReq, diags := NewAtlasReq(ctx, &tfModel)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+
+	// TODO: make PATCH request to Atlas API and handle error in response
+	// connV2 := r.Client.AtlasV2
+	// if err != nil {
+	//	resp.Diagnostics.AddError("error updating resource", err.Error())
+	//	return
+	//}
+
+	// TODO: process response into new terraform state
+
+	// newStreamPrivatelinkEndpointModel, diags := NewTFModel(ctx, apiResp)
+	// if diags.HasError() {
+	// 	resp.Diagnostics.Append(diags...)
+	// 	return
+	// }
+	// resp.Diagnostics.Append(resp.State.Set(ctx, newStreamPrivatelinkEndpointModel)...)
+}
+
+func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var streamPrivatelinkEndpointState *TFModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &streamPrivatelinkEndpointState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO: make Delete request to Atlas API
+
+	// connV2 := r.Client.AtlasV2
+	// if _, _, err := connV2.Api.Delete().Execute(); err != nil {
+	// 	 resp.Diagnostics.AddError("error deleting resource", err.Error())
+	// 	 return
+	// }
+}
+
+func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// TODO: parse req.ID string taking into account documented format. Example:
+
+	// projectID, other, err := splitStreamPrivatelinkEndpointImportID(req.ID)
+	// if err != nil {
+	//	resp.Diagnostics.AddError("error splitting import ID", err.Error())
+	//	return
+	//}
+
+	// TODO: define attributes that are required for read operation to work correctly. Example:
+
+	// resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
+}

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -1,0 +1,69 @@
+package streamprivatelinkendpoint
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ResourceSchema(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The ID of the Private Link connection.",
+			},
+			"dns_domain": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Domain name of Privatelink connected cluster.",
+			},
+			"dns_sub_domain": schema.ListAttribute{
+				Optional:            true,
+				MarkdownDescription: "Sub-Domain name of Confluent cluster. These are typically your availability zones.",
+				ElementType:         types.StringType,
+			},
+			"project_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+			},
+			"interface_endpoint_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Interface endpoint ID that is created from the service endpoint ID provided.",
+			},
+			"provider": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Provider where the Kafka cluster is deployed.",
+			},
+			"region": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Domain name of Confluent cluster.",
+			},
+			"service_endpoint_id": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Service Endpoint ID.",
+			},
+			"state": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "State the connection is in.",
+			},
+			"vendor": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Vendor who manages the Kafka cluster.",
+			},
+		},
+	}
+}
+
+type TFModel struct {
+	Id                  types.String `tfsdk:"id"`
+	DnsDomain           types.String `tfsdk:"dns_domain"`
+	DnsSubDomain        types.List   `tfsdk:"dns_sub_domain"`
+	ProjectId           types.String `tfsdk:"project_id"`
+	InterfaceEndpointId types.String `tfsdk:"interface_endpoint_id"`
+	Provider            types.String `tfsdk:"provider"`
+	Region              types.String `tfsdk:"region"`
+	ServiceEndpointId   types.String `tfsdk:"service_endpoint_id"`
+	State               types.String `tfsdk:"state"`
+	Vendor              types.String `tfsdk:"vendor"`
+}

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -15,7 +15,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The ID of the Private Link connection.",
 			},
 			"dns_domain": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Domain name of Privatelink connected cluster.",
 			},
 			"dns_sub_domain": schema.ListAttribute{
@@ -32,15 +32,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Interface endpoint ID that is created from the service endpoint ID provided.",
 			},
 			"provider": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Provider where the Kafka cluster is deployed.",
 			},
 			"region": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Domain name of Confluent cluster.",
 			},
 			"service_endpoint_id": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Service Endpoint ID.",
 			},
 			"state": schema.StringAttribute{
@@ -48,7 +48,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "State the connection is in.",
 			},
 			"vendor": schema.StringAttribute{
-				Optional:            true,
+				Required:            true,
 				MarkdownDescription: "Vendor who manages the Kafka cluster.",
 			},
 		},

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -1,0 +1,35 @@
+package streamprivatelinkendpoint_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+// TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
+// In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
+func TestAccStreamPrivatelinkEndpointRS_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		//		CheckDestroy:             checkDestroyStreamPrivatelinkEndpoint,
+		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
+			//			{
+			//				Config: streamPrivatelinkEndpointConfig(),
+			//				Check:  streamPrivatelinkEndpointAttributeChecks(),
+			//			},
+			//          {
+			//				Config: streamPrivatelinkEndpointConfig(),
+			//				Check:  streamPrivatelinkEndpointAttributeChecks(),
+			//			},
+			//			{
+			//				Config:            streamPrivatelinkEndpointConfig(),
+			//				ResourceName:      resourceName,
+			//				ImportStateIdFunc: checkStreamPrivatelinkEndpointImportStateIDFunc,
+			//				ImportState:       true,
+			//				ImportStateVerify: true,
+		},
+	},
+	)
+}

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -2,34 +2,33 @@ package streamprivatelinkendpoint_test
 
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	// "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	// "github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
 // TODO: if acceptance test will be run in an existing CI group of resources, the name should include the group in the prefix followed by the name of the resource e.i. TestAccStreamRSStreamInstance_basic
 // In addition, if acceptance test contains testing of both resource and data sources, the RS/DS can be omitted.
 func TestAccStreamPrivatelinkEndpointRS_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		//		CheckDestroy:             checkDestroyStreamPrivatelinkEndpoint,
-		Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
-			//			{
-			//				Config: streamPrivatelinkEndpointConfig(),
-			//				Check:  streamPrivatelinkEndpointAttributeChecks(),
-			//			},
-			//          {
-			//				Config: streamPrivatelinkEndpointConfig(),
-			//				Check:  streamPrivatelinkEndpointAttributeChecks(),
-			//			},
-			//			{
-			//				Config:            streamPrivatelinkEndpointConfig(),
-			//				ResourceName:      resourceName,
-			//				ImportStateIdFunc: checkStreamPrivatelinkEndpointImportStateIDFunc,
-			//				ImportState:       true,
-			//				ImportStateVerify: true,
-		},
-	},
-	)
+	// resource.ParallelTest(t, resource.TestCase{
+	// 	PreCheck:                 func() { acc.PreCheckBasic(t) },
+	// 	ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+	// 	//		CheckDestroy:             checkDestroyStreamPrivatelinkEndpoint,
+	// 	Steps: []resource.TestStep{ // TODO: verify updates and import in case of resources
+	// 		//			{
+	// 		//				Config: streamPrivatelinkEndpointConfig(),
+	// 		//				Check:  streamPrivatelinkEndpointAttributeChecks(),
+	// 		//			},
+	// 		//          {
+	// 		//				Config: streamPrivatelinkEndpointConfig(),
+	// 		//				Check:  streamPrivatelinkEndpointAttributeChecks(),
+	// 		//			},
+	// 		//			{
+	// 		//				Config:            streamPrivatelinkEndpointConfig(),
+	// 		//				ResourceName:      resourceName,
+	// 		//				ImportStateIdFunc: checkStreamPrivatelinkEndpointImportStateIDFunc,
+	// 		//				ImportState:       true,
+	// 		//				ImportStateVerify: true,
+	// 	},
+	// },
+	// )
 }

--- a/internal/service/streamprivatelinkendpoint/tfplugingen/generator_config.yml
+++ b/internal/service/streamprivatelinkendpoint/tfplugingen/generator_config.yml
@@ -1,0 +1,23 @@
+provider:
+  name: mongodbatlas
+
+# TODO: Endpoints from Atlas Admin API must be specified for schema and model generation. Singular or plural data sources can be removed if not used.
+
+resources:
+  stream_privatelink_endpoint:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections/{connectionId}
+      method: GET
+    create:
+      path: /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections
+      method: POST
+
+# data_sources:
+#   stream_privatelink_endpoint:
+#     read:
+#       path: /api/atlas/v2/*
+#       method: GET
+#   stream_privatelink_endpoints:
+#     read:
+#       path: /api/atlas/v2/*
+#       method: GET

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -65,3 +65,16 @@ resources:
     schema:
       aliases:
         group_id: project_id
+
+  stream_privatelink_endpoint:
+    read:
+      path: /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections/{connectionId}
+      method: GET
+    create:
+      path: /api/atlas/v2/groups/{groupId}/streams/privateLinkConnections
+      method: POST
+    schema:
+      aliases:
+        group_id: project_id
+        _id: id
+      ignores: ["links"]


### PR DESCRIPTION
## Description

Generate `mongodbatlas_stream_privatelink_endpoint` file structure and resource schema

Link to any related issue(s): CLOUDP-289116

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
