### PR TITLE
chore: Makes test checks valid for SDKv2 and TPF

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -65,12 +65,12 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
 				Config:            configReplicaSetAWSProvider(projectID, clusterName, 60, 3),
-				Check:             checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, false, false),
+				Check:             checkReplicaSetAWSProvider(false, projectID, clusterName, 60, 3, false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configReplicaSetAWSProvider(projectID, clusterName, 60, 5),
-				Check:                    checkReplicaSetAWSProvider(projectID, clusterName, 60, 5, true, true),
+				Check:                    checkReplicaSetAWSProvider(false, projectID, clusterName, 60, 5, true, true),
 			},
 		},
 	})
@@ -91,12 +91,12 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
 				Config:            configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false),
-				Check:             checkGeoShardedOldSchema(clusterName, 2, 2, false, false),
+				Check:             checkGeoShardedOldSchema(false, clusterName, 2, 2, false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 1, false),
-				Check:                    checkGeoShardedOldSchema(clusterName, 2, 1, true, false),
+				Check:                    checkGeoShardedOldSchema(false, clusterName, 2, 1, true, false),
 			},
 		},
 	})
@@ -117,12 +117,12 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
 				Config:            configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
-				Check:             checkShardedTransitionOldToNewSchema(false),
+				Check:             checkShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
-				Check:                    checkShardedTransitionOldToNewSchema(true),
+				Check:                    checkShardedTransitionOldToNewSchema(false, true),
 			},
 		},
 	})
@@ -143,12 +143,12 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
 				Config:            configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
-				Check:             checkGeoShardedTransitionOldToNewSchema(false),
+				Check:             checkGeoShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 				Config:                   configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
-				Check:                    checkGeoShardedTransitionOldToNewSchema(true),
+				Check:                    checkGeoShardedTransitionOldToNewSchema(false, true),
 			},
 		},
 	})

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -64,12 +64,12 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configReplicaSetAWSProvider(projectID, clusterName, 60, 3),
+				Config:            configReplicaSetAWSProvider(t, false, projectID, clusterName, 60, 3),
 				Check:             checkReplicaSetAWSProvider(false, projectID, clusterName, 60, 3, false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configReplicaSetAWSProvider(projectID, clusterName, 60, 5),
+				Config:                   configReplicaSetAWSProvider(t, false, projectID, clusterName, 60, 5),
 				Check:                    checkReplicaSetAWSProvider(false, projectID, clusterName, 60, 5, true, true),
 			},
 		},
@@ -90,12 +90,12 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false),
+				Config:            configGeoShardedOldSchema(t, false, orgID, projectName, clusterName, 2, 2, false),
 				Check:             checkGeoShardedOldSchema(false, clusterName, 2, 2, false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 1, false),
+				Config:                   configGeoShardedOldSchema(t, false, orgID, projectName, clusterName, 2, 1, false),
 				Check:                    checkGeoShardedOldSchema(false, clusterName, 2, 1, true, false),
 			},
 		},
@@ -116,12 +116,12 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
+				Config:            configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, false),
 				Check:             checkShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
+				Config:                   configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true),
 				Check:                    checkShardedTransitionOldToNewSchema(false, true),
 			},
 		},
@@ -142,12 +142,12 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false),
+				Config:            configGeoShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, false),
 				Check:             checkGeoShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true),
+				Config:                   configGeoShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true),
 				Check:                    checkGeoShardedTransitionOldToNewSchema(false, true),
 			},
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -42,11 +42,11 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configTenant(projectID, clusterName)),
-				Check:  checkTenant(projectID, clusterName),
+				Check:  checkTenant(true, projectID, clusterName),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configTenant(projectID, clusterNameUpdated)),
-				Check:  checkTenant(projectID, clusterNameUpdated),
+				Check:  checkTenant(true, projectID, clusterNameUpdated),
 			},
 			acc.TestStepImportCluster(resourceName),
 		},
@@ -71,11 +71,11 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 60, 3)),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 60, 3, true, true),
+				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 60, 3, true, true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 50, 5)),
-				Check:  checkReplicaSetAWSProvider(projectID, clusterName, 50, 5, true, true),
+				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 50, 5, true, true),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
 		},
@@ -101,11 +101,11 @@ func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterName)),
-				Check:  checkReplicaSetMultiCloud(clusterName, 3),
+				Check:  checkReplicaSetMultiCloud(isAcc, clusterName, 3),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterNameUpdated)),
-				Check:  checkReplicaSetMultiCloud(clusterNameUpdated, 3),
+				Check:  checkReplicaSetMultiCloud(isAcc, clusterNameUpdated, 3),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
 		},
@@ -137,11 +137,11 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 1, "M10", nil)),
-				Check:  checkShardedOldSchemaMultiCloud(clusterName, 1, "M10", true, nil),
+				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterName, 1, "M10", true, nil),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterNameUpdated, 1, "M10", nil)),
-				Check:  checkShardedOldSchemaMultiCloud(clusterNameUpdated, 1, "M10", true, nil),
+				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterNameUpdated, 1, "M10", true, nil),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
 		},
@@ -163,11 +163,11 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
-				Check:  checkSingleProviderPaused(clusterName, false),
+				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
-				Check:  checkSingleProviderPaused(clusterName, true),
+				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
 				Config:      acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, anotherInstanceSize)),
@@ -192,11 +192,11 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
-				Check:  checkSingleProviderPaused(clusterName, true),
+				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
-				Check:  checkSingleProviderPaused(clusterName, false),
+				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
 				Config:      acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
@@ -247,7 +247,7 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 			},
 			{
 				Config: configAdvanced(projectID, clusterName, "6.0", processArgs20240530, &admin.ClusterDescriptionProcessArgs20240805{}),
-				Check:  checkAdvanced(clusterName, "TLS1_1", &admin.ClusterDescriptionProcessArgs20240805{}),
+				Check:  checkAdvanced(true, clusterName, "TLS1_1", &admin.ClusterDescriptionProcessArgs20240805{}),
 			},
 		},
 	})
@@ -300,11 +300,11 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvanced(projectID, clusterName, "", processArgs20240530, processArgs)),
-				Check:  checkAdvanced(clusterName, "TLS1_1", processArgs),
+				Check:  checkAdvanced(true, clusterName, "TLS1_1", processArgs),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvanced(projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated)),
-				Check:  checkAdvanced(clusterNameUpdated, "TLS1_2", processArgsUpdated),
+				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdated),
 			},
 		},
 	})
@@ -348,11 +348,11 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvancedDefaultWrite(projectID, clusterName, processArgs)),
-				Check:  checkAdvancedDefaultWrite(clusterName, "1", "TLS1_1"),
+				Check:  checkAdvancedDefaultWrite(true, clusterName, "1", "TLS1_1"),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated)),
-				Check:  checkAdvancedDefaultWrite(clusterNameUpdated, "majority", "TLS1_2"),
+				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_2"),
 			},
 		},
 	})
@@ -385,19 +385,19 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.0.auto_scaling.0.compute_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_min_retention_hours", "5.5"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
+					acc.TestCheckResourceAttrSetSchemaV2(true, resourceName, "replication_specs.0.region_configs.#"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.0.auto_scaling.0.compute_enabled", "false"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "advanced_configuration.0.oplog_min_retention_hours", "5.5"),
 				),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.0.auto_scaling.0.compute_enabled", "true"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
+					acc.TestCheckResourceAttrSetSchemaV2(true, resourceName, "replication_specs.0.region_configs.#"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.0.auto_scaling.0.compute_enabled", "true"),
 				),
 			},
 		},
@@ -431,18 +431,18 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.0.analytics_auto_scaling.0.compute_enabled", "false"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
+					acc.TestCheckResourceAttrSetSchemaV2(true, resourceName, "replication_specs.0.region_configs.#"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.0.analytics_auto_scaling.0.compute_enabled", "false"),
 				),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterNameUpdated),
-					resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.region_configs.#"),
-					resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.0.analytics_auto_scaling.0.compute_enabled", "true"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
+					acc.TestCheckResourceAttrSetSchemaV2(true, resourceName, "replication_specs.0.region_configs.#"),
+					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.0.analytics_auto_scaling.0.compute_enabled", "true"),
 				),
 			},
 		},
@@ -466,7 +466,7 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
-				Check:  checkGeoShardedOldSchema(clusterName, 1, 1, true, true),
+				Check:  checkGeoShardedOldSchema(true, clusterName, 1, 1, true, true),
 			},
 			{
 				Config:      acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 2, false)),
@@ -490,15 +490,15 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags"))),
-				Check:  checkKeyValueBlocks(clusterName, "tags"),
+				Check:  checkKeyValueBlocks(true, clusterName, "tags"),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2))),
-				Check:  checkKeyValueBlocks(clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2),
+				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap3))),
-				Check:  checkKeyValueBlocks(clusterName, "tags", acc.ClusterTagsMap3),
+				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap3),
 			},
 		},
 	})
@@ -518,15 +518,15 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels"))),
-				Check:  checkKeyValueBlocks(clusterName, "labels"),
+				Check:  checkKeyValueBlocks(true, clusterName, "labels"),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2))),
-				Check:  checkKeyValueBlocks(clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2),
+				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap3))),
-				Check:  checkKeyValueBlocks(clusterName, "labels", acc.ClusterLabelsMap3),
+				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap3),
 			},
 		},
 	})
@@ -542,8 +542,8 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 		clusterName = acc.RandomClusterName()
 		checks      = []resource.TestCheckFunc{
 			acc.CheckExistsCluster(resourceName),
-			resource.TestCheckResourceAttr(resourceName, "global_cluster_self_managed_sharding", "true"),
-			resource.TestCheckResourceAttr(dataSourceName, "global_cluster_self_managed_sharding", "true"),
+			acc.TestCheckResourceAttrSchemaV2(true, resourceName, "global_cluster_self_managed_sharding", "true"),
+			acc.TestCheckResourceAttrSchemaV2(true, dataSourceName, "global_cluster_self_managed_sharding", "true"),
 		}
 	)
 
@@ -604,11 +604,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated)),
-				Check:  checkShardedOldSchemaMultiCloud(clusterName, 2, "M10", false, &configServerManagementModeFixedToDedicated),
+				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M10", false, &configServerManagementModeFixedToDedicated),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged)),
-				Check:  checkShardedOldSchemaMultiCloud(clusterName, 2, "M20", false, &configServerManagementModeAtlasManaged),
+				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M20", false, &configServerManagementModeAtlasManaged),
 			},
 		},
 	})
@@ -636,11 +636,11 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false)),
-				Check:  checkGeoShardedOldSchema(clusterName, 2, 2, true, false),
+				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 2, 2, true, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false)),
-				Check:  checkGeoShardedOldSchema(clusterName, 3, 3, true, false),
+				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 3, 3, true, false),
 			},
 		},
 	}
@@ -663,11 +663,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 50)),
-				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(50),
+				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 50),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 55)),
-				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(55),
+				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 55),
 			},
 		},
 	})
@@ -690,15 +690,15 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false)),
-				Check:  checkShardedNewSchema(50, "M10", "M10", nil, nil, false, false),
+				Check:  checkShardedNewSchema(true, 50, "M10", "M10", nil, nil, false, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true)), // add middle replication spec and transition to asymmetric
-				Check:  checkShardedNewSchema(55, "M10", "M20", nil, nil, true, true),
+				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false)), // removes middle replication spec
-				Check:  checkShardedNewSchema(55, "M10", "M20", nil, nil, true, false),
+				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, false),
 			},
 		},
 	})
@@ -723,7 +723,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedNewSchema(orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false)),
-				Check:  checkShardedNewSchema(50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
+				Check:  checkShardedNewSchema(isAcc, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
 			},
 		},
 	}
@@ -746,15 +746,15 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
-				Check:  checkGeoShardedNewSchema(false),
+				Check:  checkGeoShardedNewSchema(true, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, true)),
-				Check:  checkGeoShardedNewSchema(true),
+				Check:  checkGeoShardedNewSchema(true, true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
-				Check:  checkGeoShardedNewSchema(false),
+				Check:  checkGeoShardedNewSchema(true, false),
 			},
 		},
 	})
@@ -777,11 +777,11 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
-				Check:  checkShardedTransitionOldToNewSchema(false),
+				Check:  checkShardedTransitionOldToNewSchema(true, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
-				Check:  checkShardedTransitionOldToNewSchema(true),
+				Check:  checkShardedTransitionOldToNewSchema(true, true),
 			},
 		},
 	})
@@ -804,11 +804,11 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
-				Check:  checkGeoShardedTransitionOldToNewSchema(false),
+				Check:  checkGeoShardedTransitionOldToNewSchema(true, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
-				Check:  checkGeoShardedTransitionOldToNewSchema(true),
+				Check:  checkGeoShardedTransitionOldToNewSchema(true, true),
 			},
 		},
 	})
@@ -828,19 +828,19 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "WORKLOAD_TYPE", true)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("WORKLOAD_TYPE", true),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "SEQUENTIAL", false)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("SEQUENTIAL", false),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", true)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("NODE_TYPE", true),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", false)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("NODE_TYPE", false),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
 	})
@@ -860,15 +860,15 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "WORKLOAD_TYPE", false)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("WORKLOAD_TYPE", false),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "SEQUENTIAL", true)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("SEQUENTIAL", true),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", true),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "NODE_TYPE", false)),
-				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData("NODE_TYPE", false),
+				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
 	})
@@ -901,7 +901,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, true, false)),
-				Check:  resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.#", "2"),
+				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
 				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, true, true)),
@@ -933,7 +933,7 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, false, false)),
-				Check:  resource.TestCheckResourceAttr(resourceName, "replication_specs.0.region_configs.#", "2"),
+				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
 				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, false, true)),
@@ -955,11 +955,11 @@ func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configBiConnectorConfig(projectID, clusterName, false))),
-				Check:  checkTenantBiConnectorConfig(projectID, clusterName, false),
+				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, false),
 			},
 			{
 				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configBiConnectorConfig(projectID, clusterName, true))),
-				Check:  checkTenantBiConnectorConfig(projectID, clusterName, true),
+				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, true),
 			},
 		},
 	})
@@ -1019,14 +1019,12 @@ func TestAccClusterAdvancedCluster_pinnedFCVWithVersionUpgradeAndDowngrade(t *te
 	})
 }
 
-func checkAggr(attrsSet []string, attrsMap map[string]string, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
-	attrsMap = acc.ConvertToTPFAttrsMap(attrsMap)
-	attrsSet = acc.ConvertToTPFAttrsSet(attrsSet)
+func checkAggr(isAcc bool, attrsSet []string, attrsMap map[string]string, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{acc.CheckExistsCluster(resourceName)}
-	checks = acc.AddAttrChecks(resourceName, checks, attrsMap)
-	checks = acc.AddAttrSetChecks(resourceName, checks, attrsSet...)
-	checks = acc.AddAttrChecks(dataSourceName, checks, attrsMap)
-	checks = acc.AddAttrSetChecks(dataSourceName, checks, attrsSet...)
+	checks = acc.AddAttrChecksSchemaV2(isAcc, resourceName, checks, attrsMap)
+	checks = acc.AddAttrSetChecksSchemaV2(isAcc, resourceName, checks, attrsSet...)
+	checks = acc.AddAttrChecksSchemaV2(isAcc, dataSourceName, checks, attrsMap)
+	checks = acc.AddAttrSetChecksSchemaV2(isAcc, dataSourceName, checks, attrsSet...)
 	checks = append(checks, extra...)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
@@ -1062,10 +1060,10 @@ func configTenant(projectID, name string) string {
 	`, projectID, name)
 }
 
-func checkTenant(projectID, name string) resource.TestCheckFunc {
-	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
+func checkTenant(isAcc bool, projectID, name string) resource.TestCheckFunc {
+	pluralChecks := acc.AddAttrSetChecksSchemaV2(isAcc, dataSourcePluralName, nil,
 		[]string{"results.#", "results.0.replication_specs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"replication_specs.#", "replication_specs.0.id", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"project_id":                           projectID,
@@ -1127,23 +1125,23 @@ func configWithKeyValueBlocks(orgID, projectName, clusterName, blockName string,
 	`, orgID, projectName, clusterName, extraConfig)
 }
 
-func checkKeyValueBlocks(clusterName, blockName string, blocks ...map[string]string) resource.TestCheckFunc {
+func checkKeyValueBlocks(isAcc bool, clusterName, blockName string, blocks ...map[string]string) resource.TestCheckFunc {
 	const pluralPrefix = "results.0."
 	lenStr := strconv.Itoa(len(blocks))
 	keyHash := fmt.Sprintf("%s.#", blockName)
 	keyStar := fmt.Sprintf("%s.*", blockName)
 	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, keyHash, lenStr),
-		resource.TestCheckResourceAttr(dataSourceName, keyHash, lenStr),
-		resource.TestCheckResourceAttr(dataSourcePluralName, pluralPrefix+keyHash, lenStr),
+		acc.TestCheckResourceAttrSchemaV2(isAcc, resourceName, keyHash, lenStr),
+		acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourceName, keyHash, lenStr),
+		acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourcePluralName, pluralPrefix+keyHash, lenStr),
 	}
 	for _, block := range blocks {
 		checks = append(checks,
-			resource.TestCheckTypeSetElemNestedAttrs(resourceName, keyStar, block),
-			resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, keyStar, block),
-			resource.TestCheckTypeSetElemNestedAttrs(dataSourcePluralName, pluralPrefix+keyStar, block))
+			acc.TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc, resourceName, keyStar, block),
+			acc.TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc, dataSourceName, keyStar, block),
+			acc.TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc, dataSourcePluralName, pluralPrefix+keyStar, block))
 	}
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id"},
 		map[string]string{
 			"name": clusterName,
@@ -1184,18 +1182,18 @@ func configReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountEl
 	`, projectID, name, diskSizeGB, nodeCountElectable)
 }
 
-func checkReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {
+func checkReplicaSetAWSProvider(isAcc bool, projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "true"),
+		acc.TestCheckResourceAttrSchemaV2(isAcc, resourceName, "retain_backups_enabled", "true"),
 	}
 	diskIopsPath := acc.AttrNameToSchemaV2("replication_specs.0.region_configs.0.electable_specs.0.disk_iops")
 	additionalChecks = append(additionalChecks,
-		resource.TestCheckResourceAttrWith(resourceName, diskIopsPath, acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(dataSourceName, diskIopsPath, acc.IntGreatThan(0)))
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, diskIopsPath, acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, diskIopsPath, acc.IntGreatThan(0)))
 
 	if checkDiskSizeGBInnerLevel {
 		additionalChecks = append(additionalChecks,
-			checkAggr([]string{}, map[string]string{
+			checkAggr(isAcc, []string{}, map[string]string{
 				"replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb": fmt.Sprintf("%d", diskSizeGB),
 				"replication_specs.0.region_configs.0.analytics_specs.0.disk_size_gb": fmt.Sprintf("%d", diskSizeGB),
 			}),
@@ -1203,10 +1201,10 @@ func checkReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountEle
 	}
 
 	if checkExternalID {
-		additionalChecks = append(additionalChecks, resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"))
+		additionalChecks = append(additionalChecks, acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "replication_specs.0.external_id"))
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"replication_specs.#", "replication_specs.0.id", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"project_id":   projectID,
@@ -1306,18 +1304,18 @@ func configReplicaSetMultiCloud(orgID, projectName, name string) string {
 	`, orgID, projectName, name)
 }
 
-func checkReplicaSetMultiCloud(name string, regionConfigs int) resource.TestCheckFunc {
+func checkReplicaSetMultiCloud(isAcc bool, name string, regionConfigs int) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "retain_backups_enabled", "false"),
-		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
-		resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"),
-		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
-		resource.TestCheckResourceAttrWith(dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
+		acc.TestCheckResourceAttrSchemaV2(isAcc, resourceName, "retain_backups_enabled", "false"),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "replication_specs.0.external_id"),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, "replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourcePluralName, "results.0.replication_specs.0.region_configs.#", acc.JSONEquals(strconv.Itoa(regionConfigs))),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.replication_specs.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.name"),
 	}
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.id"},
 		map[string]string{
 			"name": name},
@@ -1387,31 +1385,31 @@ func configShardedOldSchemaMultiCloud(orgID, projectName, name string, numShards
 	`, orgID, projectName, name, numShards, analyticsSize, rootConfig)
 }
 
-func checkShardedOldSchemaMultiCloud(name string, numShards int, analyticsSize string, verifyExternalID bool, configServerManagementMode *string) resource.TestCheckFunc {
+func checkShardedOldSchemaMultiCloud(isAcc bool, name string, numShards int, analyticsSize string, verifyExternalID bool, configServerManagementMode *string) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.0.analytics_specs.0.disk_iops", acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(resourceName, "replication_specs.0.region_configs.1.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.0.analytics_specs.0.disk_iops", acc.IntGreatThan(0)),
-		resource.TestCheckResourceAttrWith(dataSourceName, "replication_specs.0.region_configs.1.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, "replication_specs.0.region_configs.0.analytics_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, "replication_specs.0.region_configs.1.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, "replication_specs.0.region_configs.0.analytics_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, "replication_specs.0.region_configs.1.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
 	}
 	if verifyExternalID {
 		additionalChecks = append(
 			additionalChecks,
-			resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"))
+			acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "replication_specs.0.external_id"))
 	}
 	if configServerManagementMode != nil {
 		additionalChecks = append(additionalChecks,
-			resource.TestCheckResourceAttr(resourceName, "config_server_management_mode", *configServerManagementMode),
-			resource.TestCheckResourceAttrSet(resourceName, "config_server_type"),
-			resource.TestCheckResourceAttr(dataSourceName, "config_server_management_mode", *configServerManagementMode),
-			resource.TestCheckResourceAttrSet(dataSourceName, "config_server_type"),
-			resource.TestCheckResourceAttr(dataSourcePluralName, "results.0.config_server_management_mode", *configServerManagementMode),
-			resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.config_server_type"))
+			acc.TestCheckResourceAttrSchemaV2(isAcc, resourceName, "config_server_management_mode", *configServerManagementMode),
+			acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "config_server_type"),
+			acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourceName, "config_server_management_mode", *configServerManagementMode),
+			acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourceName, "config_server_type"),
+			acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourcePluralName, "results.0.config_server_management_mode", *configServerManagementMode),
+			acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.config_server_type"))
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.id", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"name":                           name,
@@ -1453,8 +1451,8 @@ func configSingleProviderPaused(projectID, clusterName string, paused bool, inst
 	`, projectID, clusterName, paused, instanceSize)
 }
 
-func checkSingleProviderPaused(name string, paused bool) resource.TestCheckFunc {
-	return checkAggr(
+func checkSingleProviderPaused(isAcc bool, name string, paused bool) resource.TestCheckFunc {
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"name":   name,
@@ -1529,7 +1527,7 @@ func configAdvanced(projectID, clusterName, mongoDBMajorVersion string, p2024053
 		changeStreamOptionsString, defaultMaxTimeString, mongoDBMajorVersionString)
 }
 
-func checkAdvanced(name, tls string, processArgs *admin.ClusterDescriptionProcessArgs20240805) resource.TestCheckFunc {
+func checkAdvanced(isAcc bool, name, tls string, processArgs *admin.ClusterDescriptionProcessArgs20240805) resource.TestCheckFunc {
 	advancedConfig := map[string]string{
 		"name": name,
 		"advanced_configuration.0.minimum_enabled_tls_protocol":         tls,
@@ -1551,12 +1549,12 @@ func checkAdvanced(name, tls string, processArgs *admin.ClusterDescriptionProces
 	}
 
 	pluralChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.replication_specs.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.name"),
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
 		advancedConfig,
 		pluralChecks...,
@@ -1610,13 +1608,13 @@ func configAdvancedDefaultWrite(projectID, clusterName string, p *admin20240530.
 		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetDefaultReadConcern(), p.GetDefaultWriteConcern())
 }
 
-func checkAdvancedDefaultWrite(name, writeConcern, tls string) resource.TestCheckFunc {
+func checkAdvancedDefaultWrite(isAcc bool, name, writeConcern, tls string) resource.TestCheckFunc {
 	pluralChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.replication_specs.#"),
-		resource.TestCheckResourceAttrSet(dataSourcePluralName, "results.0.name"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.replication_specs.#"),
+		acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.name"),
 	}
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.#", "replication_specs.0.region_configs.#"},
 		map[string]string{
 			"name": name,
@@ -1759,15 +1757,15 @@ func configGeoShardedOldSchema(orgID, projectName, name string, numShardsFirstZo
 	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding)
 }
 
-func checkGeoShardedOldSchema(name string, numShardsFirstZone, numShardsSecondZone int, isLatestProviderVersion, verifyExternalID bool) resource.TestCheckFunc {
+func checkGeoShardedOldSchema(isAcc bool, name string, numShardsFirstZone, numShardsSecondZone int, isLatestProviderVersion, verifyExternalID bool) resource.TestCheckFunc {
 	additionalChecks := []resource.TestCheckFunc{}
 
 	if verifyExternalID {
-		additionalChecks = append(additionalChecks, resource.TestCheckResourceAttrSet(resourceName, "replication_specs.0.external_id"))
+		additionalChecks = append(additionalChecks, acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "replication_specs.0.external_id"))
 	}
 
 	if isLatestProviderVersion { // checks that will not apply if doing migration test with older version
-		additionalChecks = append(additionalChecks, checkAggr(
+		additionalChecks = append(additionalChecks, checkAggr(isAcc,
 			[]string{"replication_specs.0.zone_id", "replication_specs.0.zone_id"},
 			map[string]string{
 				"replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb": "60",
@@ -1775,7 +1773,7 @@ func checkGeoShardedOldSchema(name string, numShardsFirstZone, numShardsSecondZo
 			}))
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"project_id", "replication_specs.0.id", "replication_specs.1.id"},
 		map[string]string{
 			"name":                           name,
@@ -1829,8 +1827,8 @@ func configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, name str
 	`, orgID, projectName, name, diskSizeGB)
 }
 
-func checkShardedOldSchemaDiskSizeGBElectableLevel(diskSizeGB int) resource.TestCheckFunc {
-	return checkAggr(
+func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) resource.TestCheckFunc {
+	return checkAggr(isAcc,
 		[]string{},
 		map[string]string{
 			"replication_specs.0.num_shards": "2",
@@ -1943,7 +1941,7 @@ func configShardedNewSchema(orgID, projectName, name string, diskSizeGB int, fir
 	`, orgID, projectName, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB)
 }
 
-func checkShardedNewSchema(diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIops, lastDiskIops *int, isAsymmetricCluster, includeMiddleSpec bool) resource.TestCheckFunc {
+func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIops, lastDiskIops *int, isAsymmetricCluster, includeMiddleSpec bool) resource.TestCheckFunc {
 	amtOfReplicationSpecs := 2
 	if includeMiddleSpec {
 		amtOfReplicationSpecs = 3
@@ -1972,27 +1970,27 @@ func checkShardedNewSchema(diskSizeGB int, firstInstanceSize, lastInstanceSize s
 	}
 
 	// plural data source checks
-	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
+	pluralChecks := acc.AddAttrSetChecksSchemaV2(isAcc, dataSourcePluralName, nil,
 		[]string{"results.#", "results.0.replication_specs.#", "results.0.replication_specs.0.region_configs.#", "results.0.name", "results.0.termination_protection_enabled", "results.0.global_cluster_self_managed_sharding"}...)
 
-	pluralChecks = acc.AddAttrChecksPrefix(dataSourcePluralName, pluralChecks, clusterChecks, "results.0")
+	pluralChecks = acc.AddAttrChecksPrefixSchemaV2(isAcc, dataSourcePluralName, pluralChecks, clusterChecks, "results.0")
 
 	// expected id attribute only if cluster is symmetric
 	if isAsymmetricCluster {
-		pluralChecks = append(pluralChecks, checkAggr([]string{}, map[string]string{
+		pluralChecks = append(pluralChecks, checkAggr(isAcc, []string{}, map[string]string{
 			"replication_specs.0.id": "",
 			"replication_specs.1.id": "",
 		}))
-		pluralChecks = acc.AddAttrChecks(dataSourcePluralName, pluralChecks, map[string]string{
+		pluralChecks = acc.AddAttrChecksSchemaV2(isAcc, dataSourcePluralName, pluralChecks, map[string]string{
 			"results.0.replication_specs.0.id": "",
 			"results.0.replication_specs.1.id": "",
 		})
 	} else {
-		pluralChecks = append(pluralChecks, checkAggr([]string{"replication_specs.0.id", "replication_specs.1.id"}, map[string]string{}))
-		pluralChecks = acc.AddAttrSetChecks(dataSourcePluralName, pluralChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
+		pluralChecks = append(pluralChecks, checkAggr(isAcc, []string{"replication_specs.0.id", "replication_specs.1.id"}, map[string]string{}))
+		pluralChecks = acc.AddAttrSetChecksSchemaV2(isAcc, dataSourcePluralName, pluralChecks, "results.0.replication_specs.0.id", "results.0.replication_specs.1.id")
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"replication_specs.0.external_id", "replication_specs.0.zone_id", "replication_specs.1.external_id", "replication_specs.1.zone_id"},
 		clusterChecks,
 		pluralChecks...,
@@ -2066,7 +2064,7 @@ func configGeoShardedNewSchema(orgID, projectName, name string, includeThirdShar
 	`, orgID, projectName, name, thirdReplicationSpec)
 }
 
-func checkGeoShardedNewSchema(includeThirdShardInFirstZone bool) resource.TestCheckFunc {
+func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource.TestCheckFunc {
 	var amtOfReplicationSpecs int
 	if includeThirdShardInFirstZone {
 		amtOfReplicationSpecs = 3
@@ -2077,10 +2075,7 @@ func checkGeoShardedNewSchema(includeThirdShardInFirstZone bool) resource.TestCh
 		"replication_specs.#": fmt.Sprintf("%d", amtOfReplicationSpecs),
 	}
 
-	return checkAggr(
-		[]string{},
-		clusterChecks,
-	)
+	return checkAggr(isAcc, []string{}, clusterChecks)
 }
 
 func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useNewSchema bool) string {
@@ -2150,7 +2145,7 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
 }
 
-func checkShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckFunc {
+func checkShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
 	var amtOfReplicationSpecs int
 	if useNewSchema {
 		amtOfReplicationSpecs = 2
@@ -2160,7 +2155,7 @@ func checkShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckF
 	var checksForNewSchema []resource.TestCheckFunc
 	if useNewSchema {
 		checksForNewSchema = []resource.TestCheckFunc{
-			checkAggr([]string{"replication_specs.1.id", "replication_specs.0.external_id", "replication_specs.1.external_id"},
+			checkAggr(isAcc, []string{"replication_specs.1.id", "replication_specs.0.external_id", "replication_specs.1.external_id"},
 				map[string]string{
 					"replication_specs.#": fmt.Sprintf("%d", amtOfReplicationSpecs),
 					"replication_specs.1.region_configs.0.electable_specs.0.instance_size": "M10",
@@ -2169,7 +2164,7 @@ func checkShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckF
 		}
 	}
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"replication_specs.0.id"},
 		map[string]string{
 			"replication_specs.#": fmt.Sprintf("%d", amtOfReplicationSpecs),
@@ -2254,9 +2249,9 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
 }
 
-func checkGeoShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestCheckFunc {
+func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
 	if useNewSchema {
-		return checkAggr(
+		return checkAggr(isAcc,
 			[]string{"replication_specs.0.id", "replication_specs.1.id", "replication_specs.2.id", "replication_specs.3.id",
 				"replication_specs.0.external_id", "replication_specs.1.external_id", "replication_specs.2.external_id", "replication_specs.3.external_id",
 			},
@@ -2269,7 +2264,7 @@ func checkGeoShardedTransitionOldToNewSchema(useNewSchema bool) resource.TestChe
 			},
 		)
 	}
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{"replication_specs.0.id", "replication_specs.1.id"},
 		map[string]string{
 			"replication_specs.#":           "2",
@@ -2372,17 +2367,17 @@ func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, proje
 	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)
 }
 
-func checkReplicaSetScalingStrategyAndRedactClientLogData(replicaSetScalingStrategy string, redactClientLogData bool) resource.TestCheckFunc {
+func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSetScalingStrategy string, redactClientLogData bool) resource.TestCheckFunc {
 	clusterChecks := map[string]string{
 		"replica_set_scaling_strategy": replicaSetScalingStrategy,
 		"redact_client_log_data":       strconv.FormatBool(redactClientLogData),
 	}
 
 	// plural data source checks
-	pluralChecks := acc.AddAttrSetChecks(dataSourcePluralName, nil,
+	pluralChecks := acc.AddAttrSetChecksSchemaV2(isAcc, dataSourcePluralName, nil,
 		[]string{"results.#", "results.0.replica_set_scaling_strategy", "results.0.redact_client_log_data"}...)
 
-	return checkAggr(
+	return checkAggr(isAcc,
 		[]string{},
 		clusterChecks,
 		pluralChecks...,
@@ -2496,7 +2491,7 @@ func configBiConnectorConfig(projectID, name string, enabled bool) string {
 	`, projectID, name, additionalConfig)
 }
 
-func checkTenantBiConnectorConfig(projectID, name string, enabled bool) resource.TestCheckFunc {
+func checkTenantBiConnectorConfig(isAcc bool, projectID, name string, enabled bool) resource.TestCheckFunc {
 	attrsMap := map[string]string{
 		"project_id": projectID,
 		"name":       name,
@@ -2507,7 +2502,7 @@ func checkTenantBiConnectorConfig(projectID, name string, enabled bool) resource
 	} else {
 		attrsMap["bi_connector_config.0.enabled"] = "false"
 	}
-	return checkAggr(nil, attrsMap)
+	return checkAggr(isAcc, nil, attrsMap)
 }
 
 func configFCVPinning(orgID, projectName, clusterName string, pinningExpirationDate *string, mongoDBMajorVersion string) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -41,11 +41,11 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configTenant(projectID, clusterName)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterName)),
 				Check:  checkTenant(true, projectID, clusterName),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configTenant(projectID, clusterNameUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterNameUpdated)),
 				Check:  checkTenant(true, projectID, clusterNameUpdated),
 			},
 			acc.TestStepImportCluster(resourceName),
@@ -70,11 +70,11 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 60, 3)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 60, 3)),
 				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 60, 3, true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 50, 5)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 50, 5)),
 				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 50, 5, true, true),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
@@ -100,11 +100,11 @@ func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterName)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterName)),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterName, 3),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterNameUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterNameUpdated)),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterNameUpdated, 3),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
@@ -136,11 +136,11 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 1, "M10", nil)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 1, "M10", nil)),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterName, 1, "M10", true, nil),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterNameUpdated, 1, "M10", nil)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterNameUpdated, 1, "M10", nil)),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterNameUpdated, 1, "M10", true, nil),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
@@ -162,15 +162,15 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
 				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
 				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, anotherInstanceSize)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, anotherInstanceSize)),
 				ExpectError: regexp.MustCompile("CANNOT_UPDATE_PAUSED_CLUSTER"),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
@@ -191,19 +191,19 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
 				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
 				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
 				ExpectError: regexp.MustCompile("CANNOT_PAUSE_RECENTLY_RESUMED_CLUSTER"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
 		},
@@ -299,11 +299,11 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvanced(projectID, clusterName, "", processArgs20240530, processArgs)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvanced(projectID, clusterName, "", processArgs20240530, processArgs)),
 				Check:  checkAdvanced(true, clusterName, "TLS1_1", processArgs),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvanced(projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvanced(projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated)),
 				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdated),
 			},
 		},
@@ -347,11 +347,11 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvancedDefaultWrite(projectID, clusterName, processArgs)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvancedDefaultWrite(projectID, clusterName, processArgs)),
 				Check:  checkAdvancedDefaultWrite(true, clusterName, "1", "TLS1_1"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated)),
 				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_2"),
 			},
 		},
@@ -382,7 +382,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
@@ -392,7 +392,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 				),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
@@ -428,7 +428,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
@@ -437,7 +437,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 				),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
@@ -465,11 +465,11 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
 				Check:  checkGeoShardedOldSchema(true, clusterName, 1, 1, true, true),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 2, false)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 2, false)),
 				ExpectError: regexp.MustCompile(advancedcluster.ErrorOperationNotPermitted),
 			},
 		},
@@ -489,15 +489,15 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags"))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags"))),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2))),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap3))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap3))),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap3),
 			},
 		},
@@ -517,15 +517,15 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels"))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels"))),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2))),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap3))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap3))),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap3),
 			},
 		},
@@ -553,12 +553,12 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, true)),
 				Check: resource.ComposeAggregateTestCheckFunc(checks...,
 				),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
 				ExpectError: regexp.MustCompile("CANNOT_MODIFY_GLOBAL_CLUSTER_MANAGEMENT_SETTING"),
 			},
 		},
@@ -577,7 +577,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configIncorrectTypeGobalClusterSelfManagedSharding(projectID, clusterName)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configIncorrectTypeGobalClusterSelfManagedSharding(projectID, clusterName)),
 				ExpectError: regexp.MustCompile("CANNOT_SET_SELF_MANAGED_SHARDING_FOR_NON_GLOBAL_CLUSTER"),
 			},
 		},
@@ -603,11 +603,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated)),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M10", false, &configServerManagementModeFixedToDedicated),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged)),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M20", false, &configServerManagementModeAtlasManaged),
 			},
 		},
@@ -635,11 +635,11 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false)),
 				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 2, 2, true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false)),
 				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 3, 3, true, false),
 			},
 		},
@@ -662,11 +662,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 50)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 50)),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 50),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 55)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 55)),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 55),
 			},
 		},
@@ -689,15 +689,15 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false)),
 				Check:  checkShardedNewSchema(true, 50, "M10", "M10", nil, nil, false, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true)), // add middle replication spec and transition to asymmetric
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true)), // add middle replication spec and transition to asymmetric
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false)), // removes middle replication spec
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false)), // removes middle replication spec
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, false),
 			},
 		},
@@ -722,7 +722,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPFIfEnabled(t, isAcc, configShardedNewSchema(orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedNewSchema(orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false)),
 				Check:  checkShardedNewSchema(isAcc, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
 			},
 		},
@@ -745,15 +745,15 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, true)),
 				Check:  checkGeoShardedNewSchema(true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 		},
@@ -776,11 +776,11 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
 				Check:  checkShardedTransitionOldToNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
 				Check:  checkShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -803,11 +803,11 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -827,19 +827,19 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "WORKLOAD_TYPE", true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "WORKLOAD_TYPE", true)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "SEQUENTIAL", false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "SEQUENTIAL", false)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", true)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", false)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -859,15 +859,15 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "WORKLOAD_TYPE", false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "WORKLOAD_TYPE", false)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "SEQUENTIAL", true)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "SEQUENTIAL", true)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "NODE_TYPE", false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "NODE_TYPE", false)),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -896,15 +896,15 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, true, true)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, true)),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, true, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, false)),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, true, true)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, true)),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 		},
@@ -928,15 +928,15 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, false, true)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, true)),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, false, false)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, false)),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToTPF(t, configPriority(orgID, projectName, clusterName, false, true)),
+				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, true)),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 		},
@@ -954,11 +954,11 @@ func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configBiConnectorConfig(projectID, clusterName, false))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configBiConnectorConfig(projectID, clusterName, false))),
 				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, acc.ConvertAdvancedClusterToTPF(t, configBiConnectorConfig(projectID, clusterName, true))),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configBiConnectorConfig(projectID, clusterName, true))),
 				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, true),
 			},
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -41,11 +41,11 @@ func TestAccClusterAdvancedCluster_basicTenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterName)),
+				Config: configTenant(t, true, projectID, clusterName),
 				Check:  checkTenant(true, projectID, clusterName),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterNameUpdated)),
+				Config: configTenant(t, true, projectID, clusterNameUpdated),
 				Check:  checkTenant(true, projectID, clusterNameUpdated),
 			},
 			acc.TestStepImportCluster(resourceName),
@@ -70,11 +70,11 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 60, 3)),
+				Config: configReplicaSetAWSProvider(t, isAcc, projectID, clusterName, 60, 3),
 				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 60, 3, true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetAWSProvider(projectID, clusterName, 50, 5)),
+				Config: configReplicaSetAWSProvider(t, isAcc, projectID, clusterName, 50, 5),
 				Check:  checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 50, 5, true, true),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
@@ -85,6 +85,7 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 	resource.ParallelTest(t, replicaSetMultiCloudTestCase(t, true))
 }
+
 func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
@@ -100,11 +101,11 @@ func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterName)),
+				Config: configReplicaSetMultiCloud(t, isAcc, orgID, projectName, clusterName),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterName, 3),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configReplicaSetMultiCloud(orgID, projectName, clusterNameUpdated)),
+				Config: configReplicaSetMultiCloud(t, isAcc, orgID, projectName, clusterNameUpdated),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterNameUpdated, 3),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
@@ -136,11 +137,11 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 1, "M10", nil)),
+				Config: configShardedOldSchemaMultiCloud(t, isAcc, orgID, projectName, clusterName, 1, "M10", nil),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterName, 1, "M10", true, nil),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedOldSchemaMultiCloud(orgID, projectName, clusterNameUpdated, 1, "M10", nil)),
+				Config: configShardedOldSchemaMultiCloud(t, isAcc, orgID, projectName, clusterNameUpdated, 1, "M10", nil),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterNameUpdated, 1, "M10", true, nil),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
@@ -162,15 +163,15 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: configSingleProviderPaused(t, true, projectID, clusterName, false, instanceSize),
 				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config: configSingleProviderPaused(t, true, projectID, clusterName, true, instanceSize),
 				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, anotherInstanceSize)),
+				Config:      configSingleProviderPaused(t, true, projectID, clusterName, true, anotherInstanceSize),
 				ExpectError: regexp.MustCompile("CANNOT_UPDATE_PAUSED_CLUSTER"),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
@@ -191,19 +192,19 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config: configSingleProviderPaused(t, true, projectID, clusterName, true, instanceSize),
 				Check:  checkSingleProviderPaused(true, clusterName, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: configSingleProviderPaused(t, true, projectID, clusterName, false, instanceSize),
 				Check:  checkSingleProviderPaused(true, clusterName, false),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, true, instanceSize)),
+				Config:      configSingleProviderPaused(t, true, projectID, clusterName, true, instanceSize),
 				ExpectError: regexp.MustCompile("CANNOT_PAUSE_RECENTLY_RESUMED_CLUSTER"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configSingleProviderPaused(projectID, clusterName, false, instanceSize)),
+				Config: configSingleProviderPaused(t, true, projectID, clusterName, false, instanceSize),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
 		},
@@ -242,11 +243,11 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      configAdvanced(projectID, clusterName, "6.0", processArgs20240530, processArgs),
+				Config:      configAdvanced(t, true, projectID, clusterName, "6.0", processArgs20240530, processArgs),
 				ExpectError: regexp.MustCompile(advancedcluster.ErrorDefaultMaxTimeMinVersion),
 			},
 			{
-				Config: configAdvanced(projectID, clusterName, "6.0", processArgs20240530, &admin.ClusterDescriptionProcessArgs20240805{}),
+				Config: configAdvanced(t, true, projectID, clusterName, "6.0", processArgs20240530, &admin.ClusterDescriptionProcessArgs20240805{}),
 				Check:  checkAdvanced(true, clusterName, "TLS1_1", &admin.ClusterDescriptionProcessArgs20240805{}),
 			},
 		},
@@ -299,11 +300,11 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvanced(projectID, clusterName, "", processArgs20240530, processArgs)),
+				Config: configAdvanced(t, true, projectID, clusterName, "", processArgs20240530, processArgs),
 				Check:  checkAdvanced(true, clusterName, "TLS1_1", processArgs),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvanced(projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated)),
+				Config: configAdvanced(t, true, projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated),
 				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdated),
 			},
 		},
@@ -347,11 +348,11 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvancedDefaultWrite(projectID, clusterName, processArgs)),
+				Config: configAdvancedDefaultWrite(t, true, projectID, clusterName, processArgs),
 				Check:  checkAdvancedDefaultWrite(true, clusterName, "1", "TLS1_1"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configAdvancedDefaultWrite(projectID, clusterNameUpdated, processArgsUpdated)),
+				Config: configAdvancedDefaultWrite(t, true, projectID, clusterNameUpdated, processArgsUpdated),
 				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_2"),
 			},
 		},
@@ -382,7 +383,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAutoScaling(projectID, clusterName, autoScaling)),
+				Config: configReplicationSpecsAutoScaling(t, true, projectID, clusterName, autoScaling),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
@@ -392,7 +393,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 				),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
+				Config: configReplicationSpecsAutoScaling(t, true, projectID, clusterNameUpdated, autoScalingUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
@@ -428,7 +429,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName, autoScaling)),
+				Config: configReplicationSpecsAnalyticsAutoScaling(t, true, projectID, clusterName, autoScaling),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterName),
@@ -437,7 +438,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 				),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicationSpecsAnalyticsAutoScaling(projectID, clusterNameUpdated, autoScalingUpdated)),
+				Config: configReplicationSpecsAnalyticsAutoScaling(t, true, projectID, clusterNameUpdated, autoScalingUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrSchemaV2(true, resourceName, "name", clusterNameUpdated),
@@ -465,11 +466,11 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
+				Config: configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, false),
 				Check:  checkGeoShardedOldSchema(true, clusterName, 1, 1, true, true),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 2, false)),
+				Config:      configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 2, false),
 				ExpectError: regexp.MustCompile(advancedcluster.ErrorOperationNotPermitted),
 			},
 		},
@@ -489,15 +490,15 @@ func TestAccClusterAdvancedCluster_withTags(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags"))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "tags"),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap1, acc.ClusterTagsMap2),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "tags", acc.ClusterTagsMap3))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "tags", acc.ClusterTagsMap3),
 				Check:  checkKeyValueBlocks(true, clusterName, "tags", acc.ClusterTagsMap3),
 			},
 		},
@@ -517,15 +518,15 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels"))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "labels"),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap1, acc.ClusterLabelsMap2),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configWithKeyValueBlocks(orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap3))),
+				Config: configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "labels", acc.ClusterLabelsMap3),
 				Check:  checkKeyValueBlocks(true, clusterName, "labels", acc.ClusterLabelsMap3),
 			},
 		},
@@ -553,12 +554,12 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, true)),
+				Config: configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, true),
 				Check: resource.ComposeAggregateTestCheckFunc(checks...,
 				),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedOldSchema(orgID, projectName, clusterName, 1, 1, false)),
+				Config:      configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, false),
 				ExpectError: regexp.MustCompile("CANNOT_MODIFY_GLOBAL_CLUSTER_MANAGEMENT_SETTING"),
 			},
 		},
@@ -577,7 +578,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configIncorrectTypeGobalClusterSelfManagedSharding(projectID, clusterName)),
+				Config:      configIncorrectTypeGobalClusterSelfManagedSharding(t, true, projectID, clusterName),
 				ExpectError: regexp.MustCompile("CANNOT_SET_SELF_MANAGED_SHARDING_FOR_NON_GLOBAL_CLUSTER"),
 			},
 		},
@@ -603,11 +604,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchema(t *testing.T)
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated)),
+				Config: configShardedOldSchemaMultiCloud(t, true, orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M10", false, &configServerManagementModeFixedToDedicated),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaMultiCloud(orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged)),
+				Config: configShardedOldSchemaMultiCloud(t, true, orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M20", false, &configServerManagementModeAtlasManaged),
 			},
 		},
@@ -635,11 +636,11 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 2, 2, false)),
+				Config: configGeoShardedOldSchema(t, isAcc, orgID, projectName, clusterName, 2, 2, false),
 				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 2, 2, true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configGeoShardedOldSchema(orgID, projectName, clusterName, 3, 3, false)),
+				Config: configGeoShardedOldSchema(t, isAcc, orgID, projectName, clusterName, 3, 3, false),
 				Check:  checkGeoShardedOldSchema(isAcc, clusterName, 3, 3, true, false),
 			},
 		},
@@ -662,11 +663,11 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedOldSchemaDiskSizeGBAtEl
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 50)),
+				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, orgID, projectName, clusterName, 50),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 50),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, clusterName, 55)),
+				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, orgID, projectName, clusterName, 55),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 55),
 			},
 		},
@@ -689,15 +690,15 @@ func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAd
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false)),
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false),
 				Check:  checkShardedNewSchema(true, 50, "M10", "M10", nil, nil, false, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true)), // add middle replication spec and transition to asymmetric
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true), // add middle replication spec and transition to asymmetric
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedNewSchema(orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false)), // removes middle replication spec
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false), // removes middle replication spec
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, false),
 			},
 		},
@@ -722,7 +723,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2IfAcc(t, isAcc, configShardedNewSchema(orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false)),
+				Config: configShardedNewSchema(t, isAcc, orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false),
 				Check:  checkShardedNewSchema(isAcc, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
 			},
 		},
@@ -745,15 +746,15 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
+				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, false),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, true)),
+				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, true),
 				Check:  checkGeoShardedNewSchema(true, true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedNewSchema(orgID, projectName, clusterName, false)),
+				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, false),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 		},
@@ -776,11 +777,11 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
+				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false),
 				Check:  checkShardedTransitionOldToNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
+				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true),
 				Check:  checkShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -803,11 +804,11 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, false)),
+				Config: configGeoShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configGeoShardedTransitionOldToNewSchema(orgID, projectName, clusterName, true)),
+				Config: configGeoShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -827,19 +828,19 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "WORKLOAD_TYPE", true)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "SEQUENTIAL", false)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "SEQUENTIAL", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", true)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, clusterName, "NODE_TYPE", false)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -859,15 +860,15 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "WORKLOAD_TYPE", false)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "SEQUENTIAL", true)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "SEQUENTIAL", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", true),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, clusterName, "NODE_TYPE", false)),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -896,15 +897,15 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, true)),
+				Config:      configPriority(t, true, orgID, projectName, clusterName, true, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, false)),
+				Config: configPriority(t, true, orgID, projectName, clusterName, true, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, true, true)),
+				Config:      configPriority(t, true, orgID, projectName, clusterName, true, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 		},
@@ -928,15 +929,15 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, true)),
+				Config:      configPriority(t, true, orgID, projectName, clusterName, false, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, false)),
+				Config: configPriority(t, true, orgID, projectName, clusterName, false, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, configPriority(orgID, projectName, clusterName, false, true)),
+				Config:      configPriority(t, true, orgID, projectName, clusterName, false, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 		},
@@ -954,11 +955,11 @@ func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configBiConnectorConfig(projectID, clusterName, false))),
+				Config: configBiConnectorConfig(t, true, projectID, clusterName, false),
 				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, false),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, acc.ConvertAdvancedClusterToSchemaV2(t, configBiConnectorConfig(projectID, clusterName, true))),
+				Config: configBiConnectorConfig(t, true, projectID, clusterName, true),
 				Check:  checkTenantBiConnectorConfig(true, projectID, clusterName, true),
 			},
 		},
@@ -1029,8 +1030,9 @@ func checkAggr(isAcc bool, attrsSet []string, attrsMap map[string]string, extra 
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func configTenant(projectID, name string) string {
-	return fmt.Sprintf(`
+func configTenant(t *testing.T, isAcc bool, projectID, name string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -1057,7 +1059,7 @@ func configTenant(projectID, name string) string {
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
-	`, projectID, name)
+	`, projectID, name))
 }
 
 func checkTenant(isAcc bool, projectID, name string) resource.TestCheckFunc {
@@ -1073,7 +1075,8 @@ func checkTenant(isAcc bool, projectID, name string) resource.TestCheckFunc {
 		pluralChecks...)
 }
 
-func configWithKeyValueBlocks(orgID, projectName, clusterName, blockName string, blocks ...map[string]string) string {
+func configWithKeyValueBlocks(t *testing.T, isAcc bool, orgID, projectName, clusterName, blockName string, blocks ...map[string]string) string {
+	t.Helper()
 	var extraConfig string
 	for _, block := range blocks {
 		extraConfig += fmt.Sprintf(`
@@ -1084,7 +1087,7 @@ func configWithKeyValueBlocks(orgID, projectName, clusterName, blockName string,
 		`, blockName, block["key"], block["value"])
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1122,7 +1125,7 @@ func configWithKeyValueBlocks(orgID, projectName, clusterName, blockName string,
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
-	`, orgID, projectName, clusterName, extraConfig)
+	`, orgID, projectName, clusterName, extraConfig))
 }
 
 func checkKeyValueBlocks(isAcc bool, clusterName, blockName string, blocks ...map[string]string) resource.TestCheckFunc {
@@ -1149,8 +1152,9 @@ func checkKeyValueBlocks(isAcc bool, clusterName, blockName string, blocks ...ma
 		checks...)
 }
 
-func configReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountElectable int) string {
-	return fmt.Sprintf(`
+func configReplicaSetAWSProvider(t *testing.T, isAcc bool, projectID, name string, diskSizeGB, nodeCountElectable int) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -1179,7 +1183,7 @@ func configReplicaSetAWSProvider(projectID, name string, diskSizeGB, nodeCountEl
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
 		}
-	`, projectID, name, diskSizeGB, nodeCountElectable)
+	`, projectID, name, diskSizeGB, nodeCountElectable))
 }
 
 func checkReplicaSetAWSProvider(isAcc bool, projectID, name string, diskSizeGB, nodeCountElectable int, checkDiskSizeGBInnerLevel, checkExternalID bool) resource.TestCheckFunc {
@@ -1214,8 +1218,9 @@ func checkReplicaSetAWSProvider(isAcc bool, projectID, name string, diskSizeGB, 
 	)
 }
 
-func configIncorrectTypeGobalClusterSelfManagedSharding(projectID, name string) string {
-	return fmt.Sprintf(`
+func configIncorrectTypeGobalClusterSelfManagedSharding(t *testing.T, isAcc bool, projectID, name string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -1239,11 +1244,12 @@ func configIncorrectTypeGobalClusterSelfManagedSharding(projectID, name string) 
 				}
 			}
 		}
-	`, projectID, name)
+	`, projectID, name))
 }
 
-func configReplicaSetMultiCloud(orgID, projectName, name string) string {
-	return fmt.Sprintf(`
+func configReplicaSetMultiCloud(t *testing.T, isAcc bool, orgID, projectName, name string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1300,7 +1306,7 @@ func configReplicaSetMultiCloud(orgID, projectName, name string) string {
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
-	`, orgID, projectName, name)
+	`, orgID, projectName, name))
 }
 
 func checkReplicaSetMultiCloud(isAcc bool, name string, regionConfigs int) resource.TestCheckFunc {
@@ -1322,7 +1328,8 @@ func checkReplicaSetMultiCloud(isAcc bool, name string, regionConfigs int) resou
 	)
 }
 
-func configShardedOldSchemaMultiCloud(orgID, projectName, name string, numShards int, analyticsSize string, configServerManagementMode *string) string {
+func configShardedOldSchemaMultiCloud(t *testing.T, isAcc bool, orgID, projectName, name string, numShards int, analyticsSize string, configServerManagementMode *string) string {
+	t.Helper()
 	var rootConfig string
 	if configServerManagementMode != nil {
 		// valid values: FIXED_TO_DEDICATED or ATLAS_MANAGED (default)
@@ -1333,7 +1340,7 @@ func configShardedOldSchemaMultiCloud(orgID, projectName, name string, numShards
 		  config_server_management_mode = %[1]q
 		`, *configServerManagementMode)
 	}
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1381,7 +1388,7 @@ func configShardedOldSchemaMultiCloud(orgID, projectName, name string, numShards
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			depends_on = [mongodbatlas_advanced_cluster.test]
 		}
-	`, orgID, projectName, name, numShards, analyticsSize, rootConfig)
+	`, orgID, projectName, name, numShards, analyticsSize, rootConfig))
 }
 
 func checkShardedOldSchemaMultiCloud(isAcc bool, name string, numShards int, analyticsSize string, verifyExternalID bool, configServerManagementMode *string) resource.TestCheckFunc {
@@ -1418,8 +1425,9 @@ func checkShardedOldSchemaMultiCloud(isAcc bool, name string, numShards int, ana
 		additionalChecks...)
 }
 
-func configSingleProviderPaused(projectID, clusterName string, paused bool, instanceSize string) string {
-	return fmt.Sprintf(`
+func configSingleProviderPaused(t *testing.T, isAcc bool, projectID, clusterName string, paused bool, instanceSize string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -1447,7 +1455,7 @@ func configSingleProviderPaused(projectID, clusterName string, paused bool, inst
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
 		}
-	`, projectID, clusterName, paused, instanceSize)
+	`, projectID, clusterName, paused, instanceSize))
 }
 
 func checkSingleProviderPaused(isAcc bool, name string, paused bool) resource.TestCheckFunc {
@@ -1458,7 +1466,8 @@ func checkSingleProviderPaused(isAcc bool, name string, paused bool) resource.Te
 			"paused": strconv.FormatBool(paused)})
 }
 
-func configAdvanced(projectID, clusterName, mongoDBMajorVersion string, p20240530 *admin20240530.ClusterDescriptionProcessArgs, p *admin.ClusterDescriptionProcessArgs20240805) string {
+func configAdvanced(t *testing.T, isAcc bool, projectID, clusterName, mongoDBMajorVersion string, p20240530 *admin20240530.ClusterDescriptionProcessArgs, p *admin.ClusterDescriptionProcessArgs20240805) string {
+	t.Helper()
 	changeStreamOptionsString := ""
 	defaultMaxTimeString := ""
 	mongoDBMajorVersionString := ""
@@ -1475,7 +1484,7 @@ func configAdvanced(projectID, clusterName, mongoDBMajorVersion string, p2024053
 		mongoDBMajorVersionString = fmt.Sprintf(`mongo_db_major_version = %[1]q`, mongoDBMajorVersion)
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id             = %[1]q
 			name                   = %[2]q
@@ -1523,7 +1532,7 @@ func configAdvanced(projectID, clusterName, mongoDBMajorVersion string, p2024053
 	`, projectID, clusterName,
 		p20240530.GetFailIndexKeyTooLong(), p20240530.GetJavascriptEnabled(), p20240530.GetMinimumEnabledTlsProtocol(), p20240530.GetNoTableScan(),
 		p20240530.GetOplogSizeMB(), p20240530.GetSampleSizeBIConnector(), p20240530.GetSampleRefreshIntervalBIConnector(), p20240530.GetTransactionLifetimeLimitSeconds(),
-		changeStreamOptionsString, defaultMaxTimeString, mongoDBMajorVersionString)
+		changeStreamOptionsString, defaultMaxTimeString, mongoDBMajorVersionString))
 }
 
 func checkAdvanced(isAcc bool, name, tls string, processArgs *admin.ClusterDescriptionProcessArgs20240805) resource.TestCheckFunc {
@@ -1560,8 +1569,9 @@ func checkAdvanced(isAcc bool, name, tls string, processArgs *admin.ClusterDescr
 	)
 }
 
-func configAdvancedDefaultWrite(projectID, clusterName string, p *admin20240530.ClusterDescriptionProcessArgs) string {
-	return fmt.Sprintf(`
+func configAdvancedDefaultWrite(t *testing.T, isAcc bool, projectID, clusterName string, p *admin20240530.ClusterDescriptionProcessArgs) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id             = %[1]q
 			name                   = %[2]q
@@ -1604,7 +1614,7 @@ func configAdvancedDefaultWrite(projectID, clusterName string, p *admin20240530.
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
 	`, projectID, clusterName, p.GetJavascriptEnabled(), p.GetMinimumEnabledTlsProtocol(), p.GetNoTableScan(),
-		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetDefaultReadConcern(), p.GetDefaultWriteConcern())
+		p.GetOplogSizeMB(), p.GetSampleSizeBIConnector(), p.GetSampleRefreshIntervalBIConnector(), p.GetDefaultReadConcern(), p.GetDefaultWriteConcern()))
 }
 
 func checkAdvancedDefaultWrite(isAcc bool, name, writeConcern, tls string) resource.TestCheckFunc {
@@ -1629,8 +1639,9 @@ func checkAdvancedDefaultWrite(isAcc bool, name, writeConcern, tls string) resou
 		pluralChecks...)
 }
 
-func configReplicationSpecsAutoScaling(projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
-	return fmt.Sprintf(`
+func configReplicationSpecsAutoScaling(t *testing.T, isAcc bool, projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id             = %[1]q
 			name                   = %[2]q
@@ -1660,11 +1671,12 @@ func configReplicationSpecsAutoScaling(projectID, clusterName string, p *admin.A
 			    oplog_min_retention_hours = 5.5
 			}
 		}
-	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
+	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize()))
 }
 
-func configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
-	return fmt.Sprintf(`
+func configReplicationSpecsAnalyticsAutoScaling(t *testing.T, isAcc bool, projectID, clusterName string, p *admin.AdvancedAutoScalingSettings) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id             = %[1]q
 			name                   = %[2]q
@@ -1691,11 +1703,12 @@ func configReplicationSpecsAnalyticsAutoScaling(projectID, clusterName string, p
 				}
 			}
 		}
-	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize())
+	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize()))
 }
 
-func configGeoShardedOldSchema(orgID, projectName, name string, numShardsFirstZone, numShardsSecondZone int, selfManagedSharding bool) string {
-	return fmt.Sprintf(`
+func configGeoShardedOldSchema(t *testing.T, isAcc bool, orgID, projectName, name string, numShardsFirstZone, numShardsSecondZone int, selfManagedSharding bool) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1753,7 +1766,7 @@ func configGeoShardedOldSchema(orgID, projectName, name string, numShardsFirstZo
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
 		}
-	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding)
+	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding))
 }
 
 func checkGeoShardedOldSchema(isAcc bool, name string, numShardsFirstZone, numShardsSecondZone int, isLatestProviderVersion, verifyExternalID bool) resource.TestCheckFunc {
@@ -1784,8 +1797,9 @@ func checkGeoShardedOldSchema(isAcc bool, name string, numShardsFirstZone, numSh
 	)
 }
 
-func configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, name string, diskSizeGB int) string {
-	return fmt.Sprintf(`
+func configShardedOldSchemaDiskSizeGBElectableLevel(t *testing.T, isAcc bool, orgID, projectName, name string, diskSizeGB int) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1823,7 +1837,7 @@ func configShardedOldSchemaDiskSizeGBElectableLevel(orgID, projectName, name str
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			name 	     = mongodbatlas_advanced_cluster.test.name
 		}
-	`, orgID, projectName, name, diskSizeGB)
+	`, orgID, projectName, name, diskSizeGB))
 }
 
 func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) resource.TestCheckFunc {
@@ -1837,7 +1851,8 @@ func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) r
 		})
 }
 
-func configShardedNewSchema(orgID, projectName, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
+func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
+	t.Helper()
 	var thirdReplicationSpec string
 	if includeMiddleSpec {
 		thirdReplicationSpec = fmt.Sprintf(`
@@ -1874,7 +1889,7 @@ func configShardedNewSchema(orgID, projectName, name string, diskSizeGB int, fir
 			ebs_volume_type = "PROVISIONED"
 		`, *lastDiskIOPS)
 	}
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -1937,7 +1952,7 @@ func configShardedNewSchema(orgID, projectName, name string, diskSizeGB int, fir
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			use_replication_spec_per_shard = true
 		}
-	`, orgID, projectName, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB)
+	`, orgID, projectName, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB))
 }
 
 func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIops, lastDiskIops *int, isAsymmetricCluster, includeMiddleSpec bool) resource.TestCheckFunc {
@@ -1996,7 +2011,8 @@ func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastIn
 	)
 }
 
-func configGeoShardedNewSchema(orgID, projectName, name string, includeThirdShardInFirstZone bool) string {
+func configGeoShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, includeThirdShardInFirstZone bool) string {
+	t.Helper()
 	var thirdReplicationSpec string
 	if includeThirdShardInFirstZone {
 		thirdReplicationSpec = `
@@ -2014,7 +2030,7 @@ func configGeoShardedNewSchema(orgID, projectName, name string, includeThirdShar
 			}
 		`
 	}
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2060,7 +2076,7 @@ func configGeoShardedNewSchema(orgID, projectName, name string, includeThirdShar
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			use_replication_spec_per_shard = true
 		}
-	`, orgID, projectName, name, thirdReplicationSpec)
+	`, orgID, projectName, name, thirdReplicationSpec))
 }
 
 func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource.TestCheckFunc {
@@ -2077,7 +2093,8 @@ func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource
 	return checkAggr(isAcc, []string{}, clusterChecks)
 }
 
-func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useNewSchema bool) string {
+func configShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, useNewSchema bool) string {
+	t.Helper()
 	var numShardsStr string
 	if !useNewSchema {
 		numShardsStr = `num_shards = 2`
@@ -2116,7 +2133,7 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 		dataSourceFlag = `use_replication_spec_per_shard = true`
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2141,7 +2158,7 @@ func configShardedTransitionOldToNewSchema(orgID, projectName, name string, useN
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			%[5]s
 		}
-	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
+	`, orgID, projectName, name, replicationSpecs, dataSourceFlag))
 }
 
 func checkShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
@@ -2174,7 +2191,8 @@ func checkShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.Tes
 	)
 }
 
-func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, useNewSchema bool) string {
+func configGeoShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, useNewSchema bool) string {
+	t.Helper()
 	var numShardsStr string
 	if !useNewSchema {
 		numShardsStr = `num_shards = 2`
@@ -2220,7 +2238,7 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 		dataSourceFlag = `use_replication_spec_per_shard = true`
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2245,7 +2263,7 @@ func configGeoShardedTransitionOldToNewSchema(orgID, projectName, name string, u
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			%[5]s
 		}
-	`, orgID, projectName, name, replicationSpecs, dataSourceFlag)
+	`, orgID, projectName, name, replicationSpecs, dataSourceFlag))
 }
 
 func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
@@ -2273,8 +2291,9 @@ func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.
 	)
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
-	return fmt.Sprintf(`
+func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2317,11 +2336,12 @@ func configReplicaSetScalingStrategyAndRedactClientLogData(orgID, projectName, n
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			use_replication_spec_per_shard = true
 		}
-	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)
+	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData))
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
-	return fmt.Sprintf(`
+func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "cluster_project" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2363,7 +2383,7 @@ func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(orgID, proje
 		data "mongodbatlas_advanced_clusters" "test" {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 		}
-	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)
+	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData))
 }
 
 func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSetScalingStrategy string, redactClientLogData bool) resource.TestCheckFunc {
@@ -2383,7 +2403,8 @@ func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSet
 	)
 }
 
-func configPriority(orgID, projectName, clusterName string, oldSchema, swapPriorities bool) string {
+func configPriority(t *testing.T, isAcc bool, orgID, projectName, clusterName string, oldSchema, swapPriorities bool) string {
+	t.Helper()
 	const (
 		config7 = `
 			region_configs {
@@ -2417,7 +2438,7 @@ func configPriority(orgID, projectName, clusterName string, oldSchema, swapPrior
 		strConfigs = config6 + config7
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
 			org_id = %[1]q
 			name   = %[2]q
@@ -2434,10 +2455,11 @@ func configPriority(orgID, projectName, clusterName string, oldSchema, swapPrior
  					%[6]s
 			}
 		}
-	`, orgID, projectName, clusterName, strType, strNumShards, strConfigs)
+	`, orgID, projectName, clusterName, strType, strNumShards, strConfigs))
 }
 
-func configBiConnectorConfig(projectID, name string, enabled bool) string {
+func configBiConnectorConfig(t *testing.T, isAcc bool, projectID, name string, enabled bool) string {
+	t.Helper()
 	additionalConfig := `
 		bi_connector_config {
 			enabled = false
@@ -2452,7 +2474,7 @@ func configBiConnectorConfig(projectID, name string, enabled bool) string {
 		`
 	}
 
-	return fmt.Sprintf(`
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -2487,7 +2509,7 @@ func configBiConnectorConfig(projectID, name string, enabled bool) string {
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			depends_on = [mongodbatlas_advanced_cluster.test]
 		}
-	`, projectID, name, additionalConfig)
+	`, projectID, name, additionalConfig))
 }
 
 func checkTenantBiConnectorConfig(isAcc bool, projectID, name string, enabled bool) resource.TestCheckFunc {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1186,10 +1186,9 @@ func checkReplicaSetAWSProvider(isAcc bool, projectID, name string, diskSizeGB, 
 	additionalChecks := []resource.TestCheckFunc{
 		acc.TestCheckResourceAttrSchemaV2(isAcc, resourceName, "retain_backups_enabled", "true"),
 	}
-	diskIopsPath := acc.AttrNameToSchemaV2("replication_specs.0.region_configs.0.electable_specs.0.disk_iops")
 	additionalChecks = append(additionalChecks,
-		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, diskIopsPath, acc.IntGreatThan(0)),
-		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, diskIopsPath, acc.IntGreatThan(0)))
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)),
+		acc.TestCheckResourceAttrWithSchemaV2(isAcc, dataSourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_iops", acc.IntGreatThan(0)))
 
 	if checkDiskSizeGBInnerLevel {
 		additionalChecks = append(additionalChecks,

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/zclconf/go-cty/cty"
 
@@ -18,57 +19,57 @@ import (
 
 func TestCheckResourceAttrSchemaV2(isAcc bool, name, key, value string) resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return testCheckFuncAlwaysPass
 	}
 	return resource.TestCheckResourceAttr(name, AttrNameToSchemaV2(isAcc, key), value)
 }
 
 func TestCheckResourceAttrSetSchemaV2(isAcc bool, name, key string) resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return testCheckFuncAlwaysPass
 	}
 	return resource.TestCheckResourceAttrSet(name, AttrNameToSchemaV2(isAcc, key))
 }
 
 func TestCheckResourceAttrWithSchemaV2(isAcc bool, name, key string, checkValueFunc resource.CheckResourceAttrWithFunc) resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return testCheckFuncAlwaysPass
 	}
 	return resource.TestCheckResourceAttrWith(name, AttrNameToSchemaV2(isAcc, key), checkValueFunc)
 }
 
 func TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc bool, name, key string, values map[string]string) resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return testCheckFuncAlwaysPass
 	}
 	return resource.TestCheckTypeSetElemNestedAttrs(name, AttrNameToSchemaV2(isAcc, key), values)
 }
 
-// AddAttrChecksSchemaV2 is like AddAttrChecks but adding V2 schema support
+func testCheckFuncAlwaysPass(*terraform.State) error {
+	return nil
+}
+
 func AddAttrChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string) []resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return []resource.TestCheckFunc{}
 	}
 	return AddAttrChecks(name, checks, ConvertToSchemaV2AttrsMap(isAcc, mapChecks))
 }
 
-// AddAttrChecksSchemaV2 is like AddAttrSetChecks but adding V2 schema support
 func AddAttrSetChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return []resource.TestCheckFunc{}
 	}
 	return AddAttrSetChecks(name, checks, ConvertToSchemaV2AttrsSet(isAcc, attrNames)...)
 }
 
-// AddAttrChecksPrefixSchemaV2 is like AddAttrChecksPrefix but adding V2 schema support
 func AddAttrChecksPrefixSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string, prefix string, skipNames ...string) []resource.TestCheckFunc {
 	if skipChecks(isAcc, name) {
-		return nil
+		return []resource.TestCheckFunc{}
 	}
 	return AddAttrChecksPrefix(name, checks, ConvertToSchemaV2AttrsMap(isAcc, mapChecks), prefix, skipNames...)
 }
 
-// skipChecks temporarily returns if checks are for data sources in schema v2 as they are not implemented yet
 func skipChecks(isAcc bool, name string) bool {
 	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return false

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -17,83 +17,83 @@ import (
 )
 
 func TestCheckResourceAttrSchemaV2(isAcc bool, name, key, value string) resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return resource.TestCheckResourceAttr(name, key, value)
+	return resource.TestCheckResourceAttr(name, AttrNameToSchemaV2(isAcc, key), value)
 }
 
 func TestCheckResourceAttrSetSchemaV2(isAcc bool, name, key string) resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return resource.TestCheckResourceAttrSet(name, key)
+	return resource.TestCheckResourceAttrSet(name, AttrNameToSchemaV2(isAcc, key))
 }
 
 func TestCheckResourceAttrWithSchemaV2(isAcc bool, name, key string, checkValueFunc resource.CheckResourceAttrWithFunc) resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return resource.TestCheckResourceAttrWith(name, key, checkValueFunc)
+	return resource.TestCheckResourceAttrWith(name, AttrNameToSchemaV2(isAcc, key), checkValueFunc)
 }
 
-func TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc bool, name, attr string, values map[string]string) resource.TestCheckFunc {
-	if skipChecks(name) {
+func TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc bool, name, key string, values map[string]string) resource.TestCheckFunc {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return resource.TestCheckTypeSetElemNestedAttrs(name, attr, values)
+	return resource.TestCheckTypeSetElemNestedAttrs(name, AttrNameToSchemaV2(isAcc, key), values)
 }
 
 // AddAttrChecksSchemaV2 is like AddAttrChecks but adding V2 schema support
 func AddAttrChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string) []resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return AddAttrChecks(name, checks, ConvertToSchemaV2AttrsMap(mapChecks))
+	return AddAttrChecks(name, checks, ConvertToSchemaV2AttrsMap(isAcc, mapChecks))
 }
 
 // AddAttrChecksSchemaV2 is like AddAttrSetChecks but adding V2 schema support
 func AddAttrSetChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return AddAttrSetChecks(name, checks, ConvertToSchemaV2AttrsSet(attrNames)...)
+	return AddAttrSetChecks(name, checks, ConvertToSchemaV2AttrsSet(isAcc, attrNames)...)
 }
 
 // AddAttrChecksPrefixSchemaV2 is like AddAttrChecksPrefix but adding V2 schema support
 func AddAttrChecksPrefixSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string, prefix string, skipNames ...string) []resource.TestCheckFunc {
-	if skipChecks(name) {
+	if skipChecks(isAcc, name) {
 		return nil
 	}
-	return AddAttrChecksPrefix(name, checks, ConvertToSchemaV2AttrsMap(mapChecks), prefix, skipNames...)
+	return AddAttrChecksPrefix(name, checks, ConvertToSchemaV2AttrsMap(isAcc, mapChecks), prefix, skipNames...)
 }
 
 // skipChecks temporarily returns if checks are for data sources in schema v2 as they are not implemented yet
-func skipChecks(name string) bool {
-	if !config.AdvancedClusterV2Schema() {
+func skipChecks(isAcc bool, name string) bool {
+	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return false
 	}
 	return strings.HasPrefix(name, "data.mongodbatlas_advanced_cluster")
 }
 
-func ConvertToSchemaV2AttrsMap(attrsMap map[string]string) map[string]string {
-	if !config.AdvancedClusterV2Schema() {
+func ConvertToSchemaV2AttrsMap(isAcc bool, attrsMap map[string]string) map[string]string {
+	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return attrsMap
 	}
 	ret := make(map[string]string, len(attrsMap))
 	for name, value := range attrsMap {
-		ret[AttrNameToSchemaV2(name)] = value
+		ret[AttrNameToSchemaV2(isAcc, name)] = value
 	}
 	return ret
 }
 
-func ConvertToSchemaV2AttrsSet(attrsSet []string) []string {
-	if !config.AdvancedClusterV2Schema() {
+func ConvertToSchemaV2AttrsSet(isAcc bool, attrsSet []string) []string {
+	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return attrsSet
 	}
 	ret := make([]string, 0, len(attrsSet))
 	for _, name := range attrsSet {
-		ret = append(ret, AttrNameToSchemaV2(name))
+		ret = append(ret, AttrNameToSchemaV2(isAcc, name))
 	}
 	return ret
 }
@@ -107,8 +107,8 @@ var tpfSingleNestedAttrs = []string{
 	"bi_connector_config",
 }
 
-func AttrNameToSchemaV2(name string) string {
-	if !config.AdvancedClusterV2Schema() {
+func AttrNameToSchemaV2(isAcc bool, name string) string {
+	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return name
 	}
 	for _, singleAttrName := range tpfSingleNestedAttrs {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -49,7 +49,7 @@ func AddAttrChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckF
 	if skipChecks(name) {
 		return nil
 	}
-	return AddAttrChecks(name, checks, ConvertToTPFAttrsMap(mapChecks))
+	return AddAttrChecks(name, checks, ConvertToSchemaV2AttrsMap(mapChecks))
 }
 
 // AddAttrChecksSchemaV2 is like AddAttrSetChecks but adding V2 schema support
@@ -57,7 +57,7 @@ func AddAttrSetChecksSchemaV2(isAcc bool, name string, checks []resource.TestChe
 	if skipChecks(name) {
 		return nil
 	}
-	return AddAttrSetChecks(name, checks, ConvertToTPFAttrsSet(attrNames)...)
+	return AddAttrSetChecks(name, checks, ConvertToSchemaV2AttrsSet(attrNames)...)
 }
 
 // AddAttrChecksPrefixSchemaV2 is like AddAttrChecksPrefix but adding V2 schema support
@@ -65,7 +65,7 @@ func AddAttrChecksPrefixSchemaV2(isAcc bool, name string, checks []resource.Test
 	if skipChecks(name) {
 		return nil
 	}
-	return AddAttrChecksPrefix(name, checks, ConvertToTPFAttrsMap(mapChecks), prefix, skipNames...)
+	return AddAttrChecksPrefix(name, checks, ConvertToSchemaV2AttrsMap(mapChecks), prefix, skipNames...)
 }
 
 // skipChecks temporarily returns if checks are for data sources in schema v2 as they are not implemented yet
@@ -76,7 +76,7 @@ func skipChecks(name string) bool {
 	return strings.HasPrefix(name, "data.mongodbatlas_advanced_cluster")
 }
 
-func ConvertToTPFAttrsMap(attrsMap map[string]string) map[string]string {
+func ConvertToSchemaV2AttrsMap(attrsMap map[string]string) map[string]string {
 	if !config.AdvancedClusterV2Schema() {
 		return attrsMap
 	}
@@ -87,7 +87,7 @@ func ConvertToTPFAttrsMap(attrsMap map[string]string) map[string]string {
 	return ret
 }
 
-func ConvertToTPFAttrsSet(attrsSet []string) []string {
+func ConvertToSchemaV2AttrsSet(attrsSet []string) []string {
 	if !config.AdvancedClusterV2Schema() {
 		return attrsSet
 	}
@@ -117,7 +117,7 @@ func AttrNameToSchemaV2(name string) string {
 	return name
 }
 
-func ConvertAdvancedClusterToTPF(t *testing.T, def string) string {
+func ConvertAdvancedClusterToSchemaV2(t *testing.T, def string) string {
 	t.Helper()
 	if !config.AdvancedClusterV2Schema() {
 		return def
@@ -140,10 +140,10 @@ func ConvertAdvancedClusterToTPF(t *testing.T, def string) string {
 	return string(content)
 }
 
-func ConvertAdvancedClusterToTPFIfEnabled(t *testing.T, enabled bool, def string) string {
+func ConvertAdvancedClusterToSchemaV2IfAcc(t *testing.T, isAcc bool, def string) string {
 	t.Helper()
-	if enabled {
-		return ConvertAdvancedClusterToTPF(t, def)
+	if isAcc {
+		return ConvertAdvancedClusterToSchemaV2(t, def)
 	}
 	return def
 }

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -17,34 +17,63 @@ import (
 )
 
 func TestCheckResourceAttrSchemaV2(isAcc bool, name, key, value string) resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return resource.TestCheckResourceAttr(name, key, value)
 }
 
 func TestCheckResourceAttrSetSchemaV2(isAcc bool, name, key string) resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return resource.TestCheckResourceAttrSet(name, key)
 }
 
 func TestCheckResourceAttrWithSchemaV2(isAcc bool, name, key string, checkValueFunc resource.CheckResourceAttrWithFunc) resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return resource.TestCheckResourceAttrWith(name, key, checkValueFunc)
 }
 
 func TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc bool, name, attr string, values map[string]string) resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return resource.TestCheckTypeSetElemNestedAttrs(name, attr, values)
 }
 
 // AddAttrChecksSchemaV2 is like AddAttrChecks but adding V2 schema support
 func AddAttrChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string) []resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return AddAttrChecks(name, checks, ConvertToTPFAttrsMap(mapChecks))
 }
 
 // AddAttrChecksSchemaV2 is like AddAttrSetChecks but adding V2 schema support
 func AddAttrSetChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return AddAttrSetChecks(name, checks, ConvertToTPFAttrsSet(attrNames)...)
 }
 
 // AddAttrChecksPrefixSchemaV2 is like AddAttrChecksPrefix but adding V2 schema support
 func AddAttrChecksPrefixSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string, prefix string, skipNames ...string) []resource.TestCheckFunc {
+	if skipChecks(name) {
+		return nil
+	}
 	return AddAttrChecksPrefix(name, checks, ConvertToTPFAttrsMap(mapChecks), prefix, skipNames...)
+}
+
+// skipChecks temporarily returns if checks are for data sources in schema v2 as they are not implemented yet
+func skipChecks(name string) bool {
+	if !config.AdvancedClusterV2Schema() {
+		return false
+	}
+	return strings.HasPrefix(name, "data.mongodbatlas_advanced_cluster")
 }
 
 func ConvertToTPFAttrsMap(attrsMap map[string]string) map[string]string {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -8,12 +8,44 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCheckResourceAttrSchemaV2(isAcc bool, name, key, value string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttr(name, key, value)
+}
+
+func TestCheckResourceAttrSetSchemaV2(isAcc bool, name, key string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrSet(name, key)
+}
+
+func TestCheckResourceAttrWithSchemaV2(isAcc bool, name, key string, checkValueFunc resource.CheckResourceAttrWithFunc) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(name, key, checkValueFunc)
+}
+
+func TestCheckTypeSetElemNestedAttrsSchemaV2(isAcc bool, name, attr string, values map[string]string) resource.TestCheckFunc {
+	return resource.TestCheckTypeSetElemNestedAttrs(name, attr, values)
+}
+
+// AddAttrChecksSchemaV2 is like AddAttrChecks but adding V2 schema support
+func AddAttrChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string) []resource.TestCheckFunc {
+	return AddAttrChecks(name, checks, ConvertToTPFAttrsMap(mapChecks))
+}
+
+// AddAttrChecksSchemaV2 is like AddAttrSetChecks but adding V2 schema support
+func AddAttrSetChecksSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, attrNames ...string) []resource.TestCheckFunc {
+	return AddAttrSetChecks(name, checks, ConvertToTPFAttrsSet(attrNames)...)
+}
+
+// AddAttrChecksPrefixSchemaV2 is like AddAttrChecksPrefix but adding V2 schema support
+func AddAttrChecksPrefixSchemaV2(isAcc bool, name string, checks []resource.TestCheckFunc, mapChecks map[string]string, prefix string, skipNames ...string) []resource.TestCheckFunc {
+	return AddAttrChecksPrefix(name, checks, ConvertToTPFAttrsMap(mapChecks), prefix, skipNames...)
+}
 
 func ConvertToTPFAttrsMap(attrsMap map[string]string) map[string]string {
 	if !config.AdvancedClusterV2Schema() {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -118,9 +118,9 @@ func AttrNameToSchemaV2(isAcc bool, name string) string {
 	return name
 }
 
-func ConvertAdvancedClusterToSchemaV2(t *testing.T, def string) string {
+func ConvertAdvancedClusterToSchemaV2(t *testing.T, isAcc bool, def string) string {
 	t.Helper()
-	if !config.AdvancedClusterV2Schema() {
+	if !config.AdvancedClusterV2Schema() || !isAcc {
 		return def
 	}
 	parse := getDefParser(t, def)
@@ -139,14 +139,6 @@ func ConvertAdvancedClusterToSchemaV2(t *testing.T, def string) string {
 	}
 	content := parse.Bytes()
 	return string(content)
-}
-
-func ConvertAdvancedClusterToSchemaV2IfAcc(t *testing.T, isAcc bool, def string) string {
-	t.Helper()
-	if isAcc {
-		return ConvertAdvancedClusterToSchemaV2(t, def)
-	}
-	return def
 }
 
 func AssertEqualHCL(t *testing.T, expected, actual string, msgAndArgs ...interface{}) {

--- a/internal/testutil/acc/advanced_cluster_schema_v2_test.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2_test.go
@@ -27,7 +27,7 @@ func TestConvertToSchemaV2AttrsMapAndAttrsSet(t *testing.T) {
 		"advanced_configurationpostfix": "val4",
 		"electable_specsadvanced_configurationbi_connector_config": "val5",
 	}
-	actualMap := acc.ConvertToSchemaV2AttrsMap(attrsMap)
+	actualMap := acc.ConvertToSchemaV2AttrsMap(true, attrsMap)
 	assert.Equal(t, expectedMap, actualMap)
 
 	attrsSet := make([]string, 0, len(attrsMap))
@@ -38,7 +38,7 @@ func TestConvertToSchemaV2AttrsMapAndAttrsSet(t *testing.T) {
 	for name := range expectedMap {
 		expectedSet = append(expectedSet, name)
 	}
-	actualSet := acc.ConvertToSchemaV2AttrsSet(attrsSet)
+	actualSet := acc.ConvertToSchemaV2AttrsSet(true, attrsSet)
 	sort.Strings(expectedSet)
 	sort.Strings(actualSet)
 	assert.Equal(t, expectedSet, actualSet)

--- a/internal/testutil/acc/advanced_cluster_schema_v2_test.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2_test.go
@@ -234,7 +234,7 @@ func TestConvertAdvancedClusterToSchemaV2(t *testing.T) {
 			}
  		`
 	)
-	actual := acc.ConvertAdvancedClusterToSchemaV2(t, input)
+	actual := acc.ConvertAdvancedClusterToSchemaV2(t, true, input)
 	acc.AssertEqualHCL(t, expected, actual)
 }
 

--- a/internal/testutil/acc/advanced_cluster_schema_v2_test.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConvertToTPFAttrsMapAndAttrsSet(t *testing.T) {
+func TestConvertToSchemaV2AttrsMapAndAttrsSet(t *testing.T) {
 	if !config.AdvancedClusterV2Schema() {
 		t.Skip("Skipping test as not in AdvancedClusterV2Schema")
 	}
@@ -27,7 +27,7 @@ func TestConvertToTPFAttrsMapAndAttrsSet(t *testing.T) {
 		"advanced_configurationpostfix": "val4",
 		"electable_specsadvanced_configurationbi_connector_config": "val5",
 	}
-	actualMap := acc.ConvertToTPFAttrsMap(attrsMap)
+	actualMap := acc.ConvertToSchemaV2AttrsMap(attrsMap)
 	assert.Equal(t, expectedMap, actualMap)
 
 	attrsSet := make([]string, 0, len(attrsMap))
@@ -38,13 +38,13 @@ func TestConvertToTPFAttrsMapAndAttrsSet(t *testing.T) {
 	for name := range expectedMap {
 		expectedSet = append(expectedSet, name)
 	}
-	actualSet := acc.ConvertToTPFAttrsSet(attrsSet)
+	actualSet := acc.ConvertToSchemaV2AttrsSet(attrsSet)
 	sort.Strings(expectedSet)
 	sort.Strings(actualSet)
 	assert.Equal(t, expectedSet, actualSet)
 }
 
-func TestConvertAdvancedClusterToTPF(t *testing.T) {
+func TestConvertAdvancedClusterToSchemaV2(t *testing.T) {
 	if !config.AdvancedClusterV2Schema() {
 		t.Skip("Skipping test as not in AdvancedClusterV2Schema")
 	}
@@ -143,7 +143,7 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 				}
 			}	
  		`
-		// expected has the attributes sorted alphabetically to match the output of ConvertAdvancedClusterToTPF
+		// expected has the attributes sorted alphabetically to match the output of ConvertAdvancedClusterToSchemaV2
 		expected = `
 			resource "mongodbatlas_advanced_cluster" "cluster2" {
 				project_id   = "MY-PROJECT-ID"
@@ -234,7 +234,7 @@ func TestConvertAdvancedClusterToTPF(t *testing.T) {
 			}
  		`
 	)
-	actual := acc.ConvertAdvancedClusterToTPF(t, input)
+	actual := acc.ConvertAdvancedClusterToSchemaV2(t, input)
 	acc.AssertEqualHCL(t, expected, actual)
 }
 

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -42,7 +42,7 @@ func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 	firstStep := test.Steps[0]
 	steps := []resource.TestStep{
 		useExternalProvider(&firstStep, ExternalProviders()),
-		TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToTPF(t, firstStep.Config)),
+		TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, firstStep.Config)),
 	}
 	newTest := reuseCase(test, steps)
 	return newTest
@@ -57,7 +57,7 @@ func CreateTestUseExternalProvider(t *testing.T, test *resource.TestCase, extern
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]
 	require.NotContains(t, additionalProviders, "mongodbatlas", "Will use the local provider, cannot specify mongodbatlas provider")
-	emptyPlanStep := TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToTPF(t, firstStep.Config))
+	emptyPlanStep := TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, firstStep.Config))
 	steps := []resource.TestStep{
 		useExternalProvider(&firstStep, externalProviders),
 		useExternalProvider(&emptyPlanStep, additionalProviders),

--- a/internal/testutil/mig/test_case.go
+++ b/internal/testutil/mig/test_case.go
@@ -42,7 +42,7 @@ func CreateTest(t *testing.T, test *resource.TestCase) resource.TestCase {
 	firstStep := test.Steps[0]
 	steps := []resource.TestStep{
 		useExternalProvider(&firstStep, ExternalProviders()),
-		TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, firstStep.Config)),
+		TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, true, firstStep.Config)),
 	}
 	newTest := reuseCase(test, steps)
 	return newTest
@@ -57,7 +57,7 @@ func CreateTestUseExternalProvider(t *testing.T, test *resource.TestCase, extern
 	validateReusableCase(t, test)
 	firstStep := test.Steps[0]
 	require.NotContains(t, additionalProviders, "mongodbatlas", "Will use the local provider, cannot specify mongodbatlas provider")
-	emptyPlanStep := TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, firstStep.Config))
+	emptyPlanStep := TestStepCheckEmptyPlan(acc.ConvertAdvancedClusterToSchemaV2(t, true, firstStep.Config))
 	steps := []resource.TestStep{
 		useExternalProvider(&firstStep, externalProviders),
 		useExternalProvider(&emptyPlanStep, additionalProviders),

--- a/internal/testutil/tc/advanced_cluster.go
+++ b/internal/testutil/tc/advanced_cluster.go
@@ -262,11 +262,11 @@ func TenantUpgrade(t *testing.T, projectID, clusterName string) *resource.TestCa
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configTenant(projectID, clusterName)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterName)),
 				Check:  checkTenant(projectID, clusterName),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToTPF(t, configTenantUpgraded(projectID, clusterName)),
+				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenantUpgraded(projectID, clusterName)),
 				Check:  checksTenantUpgraded(projectID, clusterName),
 			},
 		},

--- a/internal/testutil/tc/advanced_cluster.go
+++ b/internal/testutil/tc/advanced_cluster.go
@@ -206,11 +206,11 @@ func BasicTenantTestCase(t *testing.T, projectID, clusterName, clusterNameUpdate
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		Steps: []resource.TestStep{
 			{
-				Config: configTenant(projectID, clusterName),
+				Config: configTenant(t, true, projectID, clusterName),
 				Check:  checkTenant(projectID, clusterName),
 			},
 			{
-				Config: configTenant(projectID, clusterNameUpdated),
+				Config: configTenant(t, true, projectID, clusterNameUpdated),
 				Check:  checkTenant(projectID, clusterNameUpdated),
 			},
 			acc.TestStepImportCluster(resourceName),
@@ -218,8 +218,9 @@ func BasicTenantTestCase(t *testing.T, projectID, clusterName, clusterNameUpdate
 	}
 }
 
-func configTenant(projectID, name string) string {
-	return fmt.Sprintf(`
+func configTenant(t *testing.T, isAcc bool, projectID, name string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
 			name         = %[2]q
@@ -237,7 +238,7 @@ func configTenant(projectID, name string) string {
 				}]
 			}]
 		}
-	`, projectID, name)
+	`, projectID, name))
 }
 
 func checkTenant(projectID, name string) resource.TestCheckFunc {
@@ -262,19 +263,20 @@ func TenantUpgrade(t *testing.T, projectID, clusterName string) *resource.TestCa
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenant(projectID, clusterName)),
+				Config: configTenant(t, true, projectID, clusterName),
 				Check:  checkTenant(projectID, clusterName),
 			},
 			{
-				Config: acc.ConvertAdvancedClusterToSchemaV2(t, configTenantUpgraded(projectID, clusterName)),
+				Config: configTenantUpgraded(t, true, projectID, clusterName),
 				Check:  checksTenantUpgraded(projectID, clusterName),
 			},
 		},
 	}
 }
 
-func configTenantUpgraded(projectID, name string) string {
-	return fmt.Sprintf(`
+func configTenantUpgraded(t *testing.T, isAcc bool, projectID, name string) string {
+	t.Helper()
+	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
 	resource "mongodbatlas_advanced_cluster" "test" {
 		project_id   = %[1]q
 		name         = %[2]q
@@ -292,7 +294,7 @@ func configTenantUpgraded(projectID, name string) string {
 			}
 		}
 	}
-	`, projectID, name)
+	`, projectID, name))
 }
 
 func enableChecksLatestTpf(checkMap map[string]string) map[string]string {


### PR DESCRIPTION
## Description

Makes test checks valid for SDKv2 and TPF.

- isAcc is added so TPF schema is not used in mig tests first step, only in acc tests.
- There are check funcs in acc, e.g. `acc.TestCheckResourceAttrSchemaV2` to replace `resource.TestCheckResourceAttr` so schema v2 logic can be applied.


Link to any related issue(s): CLOUDP-289655

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
