### PR TITLE
fix: Fixes `mongodbatlas_search_index` create and update when attribute `wait_for_index_build_completion` is used

### DIFF
--- a/.changelog/2887.txt
+++ b/.changelog/2887.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_search_index: Fixes resource create and update when `wait_for_index_build_completion` attribute is used
+```

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -275,7 +275,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.Get("wait_for_index_build_completion").(bool) {
 		timeout := d.Timeout(schema.TimeoutUpdate)
 		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"PENDING", "IN_PROGRESS", "MIGRATING"},
+			Pending:    []string{"PENDING", "BUILDING", "IN_PROGRESS", "MIGRATING"},
 			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,
@@ -449,7 +449,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.Get("wait_for_index_build_completion").(bool) {
 		timeout := d.Timeout(schema.TimeoutCreate)
 		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"PENDING", "IN_PROGRESS", "MIGRATING"},
+			Pending:    []string{"PENDING", "BUILDING", "IN_PROGRESS", "MIGRATING"},
 			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -275,7 +275,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.Get("wait_for_index_build_completion").(bool) {
 		timeout := d.Timeout(schema.TimeoutUpdate)
 		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"IN_PROGRESS", "MIGRATING"},
+			Pending:    []string{"PENDING", "IN_PROGRESS", "MIGRATING"},
 			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,
@@ -449,7 +449,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.Get("wait_for_index_build_completion").(bool) {
 		timeout := d.Timeout(schema.TimeoutCreate)
 		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"IN_PROGRESS", "MIGRATING"},
+			Pending:    []string{"PENDING", "IN_PROGRESS", "MIGRATING"},
 			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -276,7 +276,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		timeout := d.Timeout(schema.TimeoutUpdate)
 		stateConf := &retry.StateChangeConf{
 			Pending:    []string{"IN_PROGRESS", "MIGRATING"},
-			Target:     []string{"STEADY"},
+			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,
 			MinTimeout: 1 * time.Minute,
@@ -450,7 +450,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		timeout := d.Timeout(schema.TimeoutCreate)
 		stateConf := &retry.StateChangeConf{
 			Pending:    []string{"IN_PROGRESS", "MIGRATING"},
-			Target:     []string{"STEADY"},
+			Target:     []string{"READY", "STEADY"},
 			Refresh:    resourceSearchIndexRefreshFunc(ctx, clusterName, projectID, indexID, connV2),
 			Timeout:    timeout,
 			MinTimeout: 1 * time.Minute,

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -16,25 +16,6 @@ func TestAccSearchIndex_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
 }
 
-func TestAccSearchIndex_withWaitForIndexBuildCompletion(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t)
-		indexName              = acc.RandomName()
-		databaseName           = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroySearchIndex,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(projectID, clusterName, indexName, "", databaseName, "", true),
-				Check:  checkBasic(projectID, clusterName, indexName, "", databaseName, ""),
-			},
-		},
-	})
-}
-
 func TestAccSearchIndex_withSearchType(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t)
@@ -47,7 +28,7 @@ func TestAccSearchIndex_withSearchType(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, indexName, "search", databaseName, "", false),
+				Config: configBasic(projectID, clusterName, indexName, "search", databaseName, ""),
 				Check:  checkBasic(projectID, clusterName, indexName, "search", databaseName, ""),
 			},
 		},
@@ -182,11 +163,11 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, indexName, "", databaseName, "", false),
+				Config: configBasic(projectID, clusterName, indexName, "", databaseName, ""),
 				Check:  checkBasic(projectID, clusterName, indexName, "", databaseName, ""),
 			},
 			{
-				Config:            configBasic(projectID, clusterName, indexName, "", databaseName, "", false),
+				Config:            configBasic(projectID, clusterName, indexName, "", databaseName, ""),
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
@@ -233,7 +214,7 @@ func storedSourceTestCase(tb testing.TB, storedSource string) *resource.TestCase
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, indexName, "search", databaseName, storedSource, false),
+				Config: configBasic(projectID, clusterName, indexName, "search", databaseName, storedSource),
 				Check:  checkBasic(projectID, clusterName, indexName, "search", databaseName, storedSource),
 			},
 		},
@@ -253,11 +234,11 @@ func storedSourceTestCaseUpdate(tb testing.TB, searchType string) *resource.Test
 		CheckDestroy:             acc.CheckDestroySearchIndex,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(projectID, clusterName, indexName, searchType, databaseName, "false", false),
+				Config: configBasic(projectID, clusterName, indexName, searchType, databaseName, "false"),
 				Check:  checkBasic(projectID, clusterName, indexName, searchType, databaseName, "false"),
 			},
 			{
-				Config: configBasic(projectID, clusterName, indexName, searchType, databaseName, "true", false),
+				Config: configBasic(projectID, clusterName, indexName, searchType, databaseName, "true"),
 				Check:  checkBasic(projectID, clusterName, indexName, searchType, databaseName, "true"),
 			},
 		},
@@ -325,7 +306,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 	}
 }
 
-func configBasic(projectID, clusterName, indexName, indexType, databaseName, storedSource string, waitForIndexBuildCompletion bool) string {
+func configBasic(projectID, clusterName, indexName, indexType, databaseName, storedSource string) string {
 	var extra string
 	if indexType != "" {
 		extra += fmt.Sprintf("type=%q\n", indexType)
@@ -336,9 +317,6 @@ func configBasic(projectID, clusterName, indexName, indexType, databaseName, sto
 		} else {
 			extra += fmt.Sprintf("stored_source= <<-EOF\n%s\nEOF\n", storedSource)
 		}
-	}
-	if waitForIndexBuildCompletion {
-		extra += "wait_for_index_build_completion=true\n"
 	}
 
 	return fmt.Sprintf(`


### PR DESCRIPTION
## Description

Fixes `mongodbatlas_search_index` create and update when attribute `wait_for_index_build_completion` is used.

This fixes: HELP-68613

Link to any related issue(s): CLOUDP-289942

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
