### PR TITLE
chore: Uses zero values for computed attributes and avoids `""` in payloads

### DIFF
--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -15,7 +15,6 @@ func SafeValue[T any](v *T) T {
 	return *emptyValue
 }
 
-
 func SafeString(s *string) string {
 	if s != nil {
 		return *s

--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -3,6 +3,8 @@ package conversion
 import (
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func SafeValue[T any](v *T) T {
@@ -91,6 +93,14 @@ type TFPrimitiveType interface {
 
 func NilForUnknown[T any](primitiveAttr TFPrimitiveType, value *T) *T {
 	if primitiveAttr.IsUnknown() {
+		return nil
+	}
+	return value
+}
+
+func NilForUnknownOrEmpty(primitiveAttr types.String) *string {
+	value := NilForUnknown(primitiveAttr, primitiveAttr.ValueStringPointer())
+	if value == nil || *value == "" {
 		return nil
 	}
 	return value

--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -5,6 +5,15 @@ import (
 	"time"
 )
 
+func SafeValue[T any](v *T) T {
+	if v != nil {
+		return *v
+	}
+	emptyValue := new(T)
+	return *emptyValue
+}
+
+
 func SafeString(s *string) string {
 	if s != nil {
 		return *s

--- a/internal/common/conversion/type_conversion.go
+++ b/internal/common/conversion/type_conversion.go
@@ -11,8 +11,8 @@ func SafeValue[T any](v *T) T {
 	if v != nil {
 		return *v
 	}
-	emptyValue := new(T)
-	return *emptyValue
+	var emptyValue T
+	return emptyValue
 }
 
 func SafeString(s *string) string {
@@ -97,7 +97,7 @@ func NilForUnknown[T any](primitiveAttr TFPrimitiveType, value *T) *T {
 	return value
 }
 
-func NilForUnknownOrEmpty(primitiveAttr types.String) *string {
+func NilForUnknownOrEmptyString(primitiveAttr types.String) *string {
 	value := NilForUnknown(primitiveAttr, primitiveAttr.ValueStringPointer())
 	if value == nil || *value == "" {
 		return nil

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -95,3 +95,14 @@ func TestAWSRegionToMongoDBRegion(t *testing.T) {
 		}
 	}
 }
+
+func TestSafeValue(t *testing.T) {
+	var boolPointer *bool
+	assert.False(t, conversion.SafeValue(boolPointer))
+	trueBool := true
+	assert.True(t, conversion.SafeValue(&trueBool))
+	var intPointer *int
+	assert.Equal(t, 0, conversion.SafeValue(intPointer))
+	var stringPointer *string
+	assert.Equal(t, "", conversion.SafeValue(stringPointer))
+}

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -105,4 +106,12 @@ func TestSafeValue(t *testing.T) {
 	assert.Equal(t, 0, conversion.SafeValue(intPointer))
 	var stringPointer *string
 	assert.Equal(t, "", conversion.SafeValue(stringPointer))
+}
+
+func TestNilForUnknownOrEmpty(t *testing.T)	{
+	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(nil)))
+	emptyString := ""
+	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(&emptyString)))
+	testString := "test"
+	assert.Equal(t, "test", *conversion.NilForUnknownOrEmpty(types.StringPointerValue(&testString)))
 }

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -108,7 +108,7 @@ func TestSafeValue(t *testing.T) {
 	assert.Equal(t, "", conversion.SafeValue(stringPointer))
 }
 
-func TestNilForUnknownOrEmpty(t *testing.T)	{
+func TestNilForUnknownOrEmpty(t *testing.T) {
 	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(nil)))
 	emptyString := ""
 	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(&emptyString)))

--- a/internal/common/conversion/type_conversion_test.go
+++ b/internal/common/conversion/type_conversion_test.go
@@ -109,9 +109,9 @@ func TestSafeValue(t *testing.T) {
 }
 
 func TestNilForUnknownOrEmpty(t *testing.T) {
-	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(nil)))
+	assert.Nil(t, conversion.NilForUnknownOrEmptyString(types.StringPointerValue(nil)))
 	emptyString := ""
-	assert.Nil(t, conversion.NilForUnknownOrEmpty(types.StringPointerValue(&emptyString)))
+	assert.Nil(t, conversion.NilForUnknownOrEmptyString(types.StringPointerValue(&emptyString)))
 	testString := "test"
-	assert.Equal(t, "test", *conversion.NilForUnknownOrEmpty(types.StringPointerValue(&testString)))
+	assert.Equal(t, "test", *conversion.NilForUnknownOrEmptyString(types.StringPointerValue(&testString)))
 }

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -38,32 +38,32 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 	}
 	return &TFModel{
 		AcceptDataRisksAndForceReplicaSetReconfig: types.StringPointerValue(conversion.TimePtrToStringPtr(input.AcceptDataRisksAndForceReplicaSetReconfig)),
-		BackupEnabled:                    types.BoolPointerValue(input.BackupEnabled),
+		BackupEnabled:                    types.BoolValue(conversion.SafeValue(input.BackupEnabled)),
 		BiConnectorConfig:                biConnector,
-		ClusterType:                      types.StringPointerValue(input.ClusterType),
-		ConfigServerManagementMode:       types.StringPointerValue(input.ConfigServerManagementMode),
-		ConfigServerType:                 types.StringPointerValue(input.ConfigServerType),
+		ClusterType:                      types.StringValue(conversion.SafeValue(input.ClusterType)),
+		ConfigServerManagementMode:       types.StringValue(conversion.SafeValue(input.ConfigServerManagementMode)),
+		ConfigServerType:                 types.StringValue(conversion.SafeValue(input.ConfigServerType)),
 		ConnectionStrings:                connectionStrings,
-		CreateDate:                       types.StringPointerValue(conversion.TimePtrToStringPtr(input.CreateDate)),
+		CreateDate:                       types.StringValue(conversion.SafeValue(conversion.TimePtrToStringPtr(input.CreateDate))),
 		DiskSizeGB:                       types.Float64PointerValue(findRegionRootDiskSize(input.ReplicationSpecs)),
-		EncryptionAtRestProvider:         types.StringPointerValue(input.EncryptionAtRestProvider),
-		GlobalClusterSelfManagedSharding: types.BoolPointerValue(input.GlobalClusterSelfManagedSharding),
-		ProjectID:                        types.StringPointerValue(input.GroupId),
-		ClusterID:                        types.StringPointerValue(input.Id),
+		EncryptionAtRestProvider:         types.StringValue(conversion.SafeValue(input.EncryptionAtRestProvider)),
+		GlobalClusterSelfManagedSharding: types.BoolValue(conversion.SafeValue(input.GlobalClusterSelfManagedSharding)),
+		ProjectID:                        types.StringValue(conversion.SafeValue(input.GroupId)),
+		ClusterID:                        types.StringValue(conversion.SafeValue(input.Id)),
 		Labels:                           labels,
-		MongoDBMajorVersion:              types.StringPointerValue(input.MongoDBMajorVersion),
-		MongoDBVersion:                   types.StringPointerValue(input.MongoDBVersion),
-		Name:                             types.StringPointerValue(input.Name),
-		Paused:                           types.BoolPointerValue(input.Paused),
-		PitEnabled:                       types.BoolPointerValue(input.PitEnabled),
-		RedactClientLogData:              types.BoolPointerValue(input.RedactClientLogData),
-		ReplicaSetScalingStrategy:        types.StringPointerValue(input.ReplicaSetScalingStrategy),
+		MongoDBMajorVersion:              types.StringValue(conversion.SafeValue(input.MongoDBMajorVersion)),
+		MongoDBVersion:                   types.StringValue(conversion.SafeValue(input.MongoDBVersion)),
+		Name:                             types.StringValue(conversion.SafeValue(input.Name)),
+		Paused:                           types.BoolValue(conversion.SafeValue(input.Paused)),
+		PitEnabled:                       types.BoolValue(conversion.SafeValue(input.PitEnabled)),
+		RedactClientLogData:              types.BoolValue(conversion.SafeValue(input.RedactClientLogData)),
+		ReplicaSetScalingStrategy:        types.StringValue(conversion.SafeValue(input.ReplicaSetScalingStrategy)),
 		ReplicationSpecs:                 replicationSpecs,
-		RootCertType:                     types.StringPointerValue(input.RootCertType),
-		StateName:                        types.StringPointerValue(input.StateName),
+		RootCertType:                     types.StringValue(conversion.SafeValue(input.RootCertType)),
+		StateName:                        types.StringValue(conversion.SafeValue(input.StateName)),
 		Tags:                             tags,
-		TerminationProtectionEnabled:     types.BoolPointerValue(input.TerminationProtectionEnabled),
-		VersionReleaseSystem:             types.StringPointerValue(input.VersionReleaseSystem),
+		TerminationProtectionEnabled:     types.BoolValue(conversion.SafeValue(input.TerminationProtectionEnabled)),
+		VersionReleaseSystem:             types.StringValue(conversion.SafeValue(input.VersionReleaseSystem)),
 		Timeouts:                         timeout,
 	}
 }
@@ -73,8 +73,8 @@ func NewBiConnectorConfigObjType(ctx context.Context, input *admin.BiConnector, 
 		return types.ObjectNull(BiConnectorConfigObjType.AttrTypes)
 	}
 	tfModel := TFBiConnectorModel{
-		Enabled:        types.BoolPointerValue(input.Enabled),
-		ReadPreference: types.StringPointerValue(input.ReadPreference),
+		Enabled:        types.BoolValue(conversion.SafeValue(input.Enabled)),
+		ReadPreference: types.StringValue(conversion.SafeValue(input.ReadPreference)),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, BiConnectorConfigObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)
@@ -87,11 +87,11 @@ func NewConnectionStringsObjType(ctx context.Context, input *admin.ClusterConnec
 	}
 	privateEndpoint := NewPrivateEndpointObjType(ctx, input.PrivateEndpoint, diags)
 	tfModel := TFConnectionStringsModel{
-		Private:         types.StringPointerValue(input.Private),
+		Private:         types.StringValue(conversion.SafeValue(input.Private)),
 		PrivateEndpoint: privateEndpoint,
-		PrivateSrv:      types.StringPointerValue(input.PrivateSrv),
-		Standard:        types.StringPointerValue(input.Standard),
-		StandardSrv:     types.StringPointerValue(input.StandardSrv),
+		PrivateSrv:      types.StringValue(conversion.SafeValue(input.PrivateSrv)),
+		Standard:        types.StringValue(conversion.SafeValue(input.Standard)),
+		StandardSrv:     types.StringValue(conversion.SafeValue(input.StandardSrv)),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, ConnectionStringsObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)
@@ -105,8 +105,8 @@ func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags 
 	tfModels := make([]TFLabelsModel, len(*input))
 	for i, item := range *input {
 		tfModels[i] = TFLabelsModel{
-			Key:   types.StringPointerValue(item.Key),
-			Value: types.StringPointerValue(item.Value),
+			Key:   types.StringValue(conversion.SafeValue(item.Key)),
+			Value: types.StringValue(conversion.SafeValue(item.Value)),
 		}
 	}
 	setType, diagsLocal := types.SetValueFrom(ctx, LabelsObjType, tfModels)
@@ -144,12 +144,12 @@ func convertReplicationSpecs(ctx context.Context, input *[]admin.ReplicationSpec
 		legacyID := apiInfo.ZoneNameReplicationSpecIDs[zoneName]
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            conversion.StringNullIfEmpty(legacyID),
-			ExternalId:    types.StringPointerValue(item.Id),
+			ExternalId:    types.StringValue(conversion.SafeValue(item.Id)),
 			NumShards:     types.Int64Value(1),
 			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &apiInfo.ContainerIDs),
 			RegionConfigs: regionConfigs,
-			ZoneId:        types.StringPointerValue(item.ZoneId),
-			ZoneName:      types.StringPointerValue(item.ZoneName),
+			ZoneId:        types.StringValue(conversion.SafeValue(item.ZoneId)),
+			ZoneName:      types.StringValue(conversion.SafeValue(item.ZoneName)),
 		}
 	}
 	return &tfModels
@@ -188,12 +188,12 @@ func convertReplicationSpecsLegacy(ctx context.Context, input *[]admin.Replicati
 		}
 		tfModels = append(tfModels, TFReplicationSpecsModel{
 			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &apiInfo.ContainerIDs),
-			ExternalId:    types.StringPointerValue(item.Id),
+			ExternalId:    types.StringValue(conversion.SafeValue(item.Id)),
 			Id:            types.StringValue(legacyID),
 			RegionConfigs: regionConfigs,
 			NumShards:     types.Int64Value(numShards),
-			ZoneId:        types.StringPointerValue(item.ZoneId),
-			ZoneName:      types.StringPointerValue(item.ZoneName),
+			ZoneId:        types.StringValue(conversion.SafeValue(item.ZoneId)),
+			ZoneName:      types.StringValue(conversion.SafeValue(item.ZoneName)),
 		})
 	}
 	return &tfModels
@@ -224,11 +224,11 @@ func NewPrivateEndpointObjType(ctx context.Context, input *[]admin.ClusterDescri
 	for i, item := range *input {
 		endpoints := NewEndpointsObjType(ctx, item.Endpoints, diags)
 		tfModels[i] = TFPrivateEndpointModel{
-			ConnectionString:                  types.StringPointerValue(item.ConnectionString),
+			ConnectionString:                  types.StringValue(conversion.SafeValue(item.ConnectionString)),
 			Endpoints:                         endpoints,
-			SrvConnectionString:               types.StringPointerValue(item.SrvConnectionString),
-			SrvShardOptimizedConnectionString: types.StringPointerValue(item.SrvShardOptimizedConnectionString),
-			Type:                              types.StringPointerValue(item.Type),
+			SrvConnectionString:               types.StringValue(conversion.SafeValue(item.SrvConnectionString)),
+			SrvShardOptimizedConnectionString: types.StringValue(conversion.SafeValue(item.SrvShardOptimizedConnectionString)),
+			Type:                              types.StringValue(conversion.SafeValue(item.Type)),
 		}
 	}
 	listType, diagsLocal := types.ListValueFrom(ctx, PrivateEndpointObjType, tfModels)
@@ -254,9 +254,9 @@ func NewRegionConfigsObjType(ctx context.Context, input *[]admin.CloudRegionConf
 			BackingProviderName:  types.StringPointerValue(item.BackingProviderName),
 			ElectableSpecs:       electableSpecs,
 			Priority:             types.Int64PointerValue(conversion.IntPtrToInt64Ptr(item.Priority)),
-			ProviderName:         types.StringPointerValue(item.ProviderName),
+			ProviderName:         types.StringValue(conversion.SafeValue(item.ProviderName)),
 			ReadOnlySpecs:        readOnlySpecs,
-			RegionName:           types.StringPointerValue(item.RegionName),
+			RegionName:           types.StringValue(conversion.SafeValue(item.RegionName)),
 		}
 	}
 	listType, diagsLocal := types.ListValueFrom(ctx, RegionConfigsObjType, tfModels)
@@ -271,9 +271,9 @@ func NewEndpointsObjType(ctx context.Context, input *[]admin.ClusterDescriptionC
 	tfModels := make([]TFEndpointsModel, len(*input))
 	for i, item := range *input {
 		tfModels[i] = TFEndpointsModel{
-			EndpointId:   types.StringPointerValue(item.EndpointId),
-			ProviderName: types.StringPointerValue(item.ProviderName),
-			Region:       types.StringPointerValue(item.Region),
+			EndpointId:   types.StringValue(conversion.SafeValue(item.EndpointId)),
+			ProviderName: types.StringValue(conversion.SafeValue(item.ProviderName)),
+			Region:       types.StringValue(conversion.SafeValue(item.Region)),
 		}
 	}
 	listType, diagsLocal := types.ListValueFrom(ctx, EndpointsObjType, tfModels)
@@ -288,8 +288,8 @@ func NewSpecsObjType(ctx context.Context, input *admin.DedicatedHardwareSpec2024
 	tfModel := TFSpecsModel{
 		DiskIops:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
 		DiskSizeGb:    types.Float64PointerValue(input.DiskSizeGB),
-		EbsVolumeType: types.StringPointerValue(input.EbsVolumeType),
-		InstanceSize:  types.StringPointerValue(input.InstanceSize),
+		EbsVolumeType: types.StringValue(conversion.SafeValue(input.EbsVolumeType)),
+		InstanceSize:  types.StringValue(conversion.SafeValue(input.InstanceSize)),
 		NodeCount:     types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, SpecsObjType.AttrTypes, tfModel)
@@ -304,8 +304,8 @@ func NewSpecsFromHwObjType(ctx context.Context, input *admin.HardwareSpec2024080
 	tfModel := TFSpecsModel{
 		DiskIops:      types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.DiskIOPS)),
 		DiskSizeGb:    types.Float64PointerValue(input.DiskSizeGB),
-		EbsVolumeType: types.StringPointerValue(input.EbsVolumeType),
-		InstanceSize:  types.StringPointerValue(input.InstanceSize),
+		EbsVolumeType: types.StringValue(conversion.SafeValue(input.EbsVolumeType)),
+		InstanceSize:  types.StringValue(conversion.SafeValue(input.InstanceSize)),
 		NodeCount:     types.Int64PointerValue(conversion.IntPtrToInt64Ptr(input.NodeCount)),
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, SpecsObjType.AttrTypes, tfModel)
@@ -320,14 +320,14 @@ func NewAutoScalingObjType(ctx context.Context, input *admin.AdvancedAutoScaling
 	compute := input.Compute
 	tfModel := TFAutoScalingModel{}
 	if compute != nil {
-		tfModel.ComputeMaxInstanceSize = types.StringPointerValue(compute.MaxInstanceSize)
-		tfModel.ComputeMinInstanceSize = types.StringPointerValue(compute.MinInstanceSize)
-		tfModel.ComputeEnabled = types.BoolPointerValue(compute.Enabled)
-		tfModel.ComputeScaleDownEnabled = types.BoolPointerValue(compute.ScaleDownEnabled)
+		tfModel.ComputeMaxInstanceSize = types.StringValue(conversion.SafeValue(compute.MaxInstanceSize))
+		tfModel.ComputeMinInstanceSize = types.StringValue(conversion.SafeValue(compute.MinInstanceSize))
+		tfModel.ComputeEnabled = types.BoolValue(conversion.SafeValue(compute.Enabled))
+		tfModel.ComputeScaleDownEnabled = types.BoolValue(conversion.SafeValue(compute.ScaleDownEnabled))
 	}
 	diskGB := input.DiskGB
 	if diskGB != nil {
-		tfModel.DiskGBEnabled = types.BoolPointerValue(diskGB.Enabled)
+		tfModel.DiskGBEnabled = types.BoolValue(conversion.SafeValue(diskGB.Enabled))
 	}
 	objType, diagsLocal := types.ObjectValueFrom(ctx, AutoScalingObjType.AttrTypes, tfModel)
 	diags.Append(diagsLocal...)

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -202,7 +202,7 @@ func newDedicatedHardwareSpec20240805(ctx context.Context, input types.Object, d
 		DiskIOPS:      conversion.NilForUnknown(item.DiskIops, conversion.Int64PtrToIntPtr(item.DiskIops.ValueInt64Pointer())),
 		DiskSizeGB:    conversion.NilForUnknown(item.DiskSizeGb, item.DiskSizeGb.ValueFloat64Pointer()),
 		EbsVolumeType: conversion.NilForUnknown(item.EbsVolumeType, item.EbsVolumeType.ValueStringPointer()),
-		InstanceSize:  conversion.NilForUnknown(item.InstanceSize, item.InstanceSize.ValueStringPointer()),
+		InstanceSize:  conversion.NilForUnknownOrEmpty(item.InstanceSize),
 		NodeCount:     conversion.NilForUnknown(item.NodeCount, conversion.Int64PtrToIntPtr(item.NodeCount.ValueInt64Pointer())),
 	}
 }
@@ -220,8 +220,8 @@ func newAdvancedComputeAutoScaling(ctx context.Context, input types.Object, diag
 	return &admin.AdvancedComputeAutoScaling{
 		Enabled:          conversion.NilForUnknown(item.ComputeEnabled, item.ComputeEnabled.ValueBoolPointer()),
 		ScaleDownEnabled: conversion.NilForUnknown(item.ComputeScaleDownEnabled, item.ComputeScaleDownEnabled.ValueBoolPointer()),
-		MaxInstanceSize:  conversion.NilForUnknown(item.ComputeMaxInstanceSize, item.ComputeMaxInstanceSize.ValueStringPointer()),
-		MinInstanceSize:  conversion.NilForUnknown(item.ComputeMinInstanceSize, item.ComputeMinInstanceSize.ValueStringPointer()),
+		MaxInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMaxInstanceSize),
+		MinInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMinInstanceSize),
 	}
 }
 func newDiskGBAutoScaling(ctx context.Context, input types.Object, diags *diag.Diagnostics) *admin.DiskGBAutoScaling {

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -183,7 +183,7 @@ func newHardwareSpec20240805(ctx context.Context, input types.Object, diags *dia
 	return &admin.HardwareSpec20240805{
 		DiskIOPS:      conversion.NilForUnknown(item.DiskIops, conversion.Int64PtrToIntPtr(item.DiskIops.ValueInt64Pointer())),
 		DiskSizeGB:    conversion.NilForUnknown(item.DiskSizeGb, item.DiskSizeGb.ValueFloat64Pointer()),
-		EbsVolumeType: conversion.NilForUnknown(item.EbsVolumeType, item.EbsVolumeType.ValueStringPointer()),
+		EbsVolumeType: conversion.NilForUnknownOrEmpty(item.EbsVolumeType),
 		InstanceSize:  conversion.NilForUnknown(item.InstanceSize, item.InstanceSize.ValueStringPointer()),
 		NodeCount:     conversion.NilForUnknown(item.NodeCount, conversion.Int64PtrToIntPtr(item.NodeCount.ValueInt64Pointer())),
 	}

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -183,7 +183,7 @@ func newHardwareSpec20240805(ctx context.Context, input types.Object, diags *dia
 	return &admin.HardwareSpec20240805{
 		DiskIOPS:      conversion.NilForUnknown(item.DiskIops, conversion.Int64PtrToIntPtr(item.DiskIops.ValueInt64Pointer())),
 		DiskSizeGB:    conversion.NilForUnknown(item.DiskSizeGb, item.DiskSizeGb.ValueFloat64Pointer()),
-		EbsVolumeType: conversion.NilForUnknownOrEmpty(item.EbsVolumeType),
+		EbsVolumeType: conversion.NilForUnknownOrEmptyString(item.EbsVolumeType),
 		InstanceSize:  conversion.NilForUnknown(item.InstanceSize, item.InstanceSize.ValueStringPointer()),
 		NodeCount:     conversion.NilForUnknown(item.NodeCount, conversion.Int64PtrToIntPtr(item.NodeCount.ValueInt64Pointer())),
 	}
@@ -202,7 +202,7 @@ func newDedicatedHardwareSpec20240805(ctx context.Context, input types.Object, d
 		DiskIOPS:      conversion.NilForUnknown(item.DiskIops, conversion.Int64PtrToIntPtr(item.DiskIops.ValueInt64Pointer())),
 		DiskSizeGB:    conversion.NilForUnknown(item.DiskSizeGb, item.DiskSizeGb.ValueFloat64Pointer()),
 		EbsVolumeType: conversion.NilForUnknown(item.EbsVolumeType, item.EbsVolumeType.ValueStringPointer()),
-		InstanceSize:  conversion.NilForUnknownOrEmpty(item.InstanceSize),
+		InstanceSize:  conversion.NilForUnknownOrEmptyString(item.InstanceSize),
 		NodeCount:     conversion.NilForUnknown(item.NodeCount, conversion.Int64PtrToIntPtr(item.NodeCount.ValueInt64Pointer())),
 	}
 }
@@ -220,8 +220,8 @@ func newAdvancedComputeAutoScaling(ctx context.Context, input types.Object, diag
 	return &admin.AdvancedComputeAutoScaling{
 		Enabled:          conversion.NilForUnknown(item.ComputeEnabled, item.ComputeEnabled.ValueBoolPointer()),
 		ScaleDownEnabled: conversion.NilForUnknown(item.ComputeScaleDownEnabled, item.ComputeScaleDownEnabled.ValueBoolPointer()),
-		MaxInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMaxInstanceSize),
-		MinInstanceSize:  conversion.NilForUnknownOrEmpty(item.ComputeMinInstanceSize),
+		MaxInstanceSize:  conversion.NilForUnknownOrEmptyString(item.ComputeMaxInstanceSize),
+		MinInstanceSize:  conversion.NilForUnknownOrEmptyString(item.ComputeMinInstanceSize),
 	}
 }
 func newDiskGBAutoScaling(ctx context.Context, input types.Object, diags *diag.Diagnostics) *admin.DiskGBAutoScaling {


### PR DESCRIPTION
## Description

- Uses zero values for computed attributes and avoids `""` in payloads

Link to any related issue(s): CLOUDP-287995

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
