### PR TITLE
chore: Adds validation for descending priority order in region_configs for adv_cluster TPF

### DIFF
--- a/internal/service/advancedclustertpf/resource_schema.go
+++ b/internal/service/advancedclustertpf/resource_schema.go
@@ -239,6 +239,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"region_configs": schema.ListNestedAttribute{
 							Required:            true,
 							MarkdownDescription: "Hardware specifications for nodes set for a given region. Each **regionConfigs** object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each **regionConfigs** object must have either an **analyticsSpecs** object, **electableSpecs** object, or **readOnlySpecs** object. Tenant clusters only require **electableSpecs. Dedicated** clusters can specify any of these specifications, but must have at least one **electableSpecs** object within a **replicationSpec**.\n\n**Example:**\n\nIf you set `\"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize\" : \"M30\"`, set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : `\"M30\"` if you have electable nodes and `\"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize\" : `\"M30\"` if you have read-only nodes.",
+							Validators: []validator.List{
+								RegionSpecPriorityOrderDecreasingValidator{},
+							},
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"analytics_auto_scaling": AutoScalingSchema(),

--- a/internal/service/advancedclustertpf/resource_schema_test.go
+++ b/internal/service/advancedclustertpf/resource_schema_test.go
@@ -18,6 +18,10 @@ func TestAdvancedCluster_ValidationErrors(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
+				Config:      acc.ConvertAdvancedClusterToTPF(t, invalidRegionConfigsPriorities),
+				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
+			},
+			{
 				Config:      configBasic(projectID, clusterName, "mongo_db_major_version = \"8a\""),
 				ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
 			},
@@ -115,3 +119,33 @@ func configBasic(projectID, clusterName, extra string) string {
 		}
 	`, projectID, clusterName, extra)
 }
+
+var invalidRegionConfigsPriorities = `
+resource "mongodbatlas_advanced_cluster" "test" {
+	project_id     = "111111111111111111111111"
+	name           = "test-acc-tf-c-2670522663699021050"
+	cluster_type   = "REPLICASET"
+	backup_enabled = false
+
+	replication_specs {
+		region_configs {
+			provider_name = "AWS"
+			priority      = 6
+			region_name   = "US_WEST_2"
+			electable_specs {
+				node_count    = 1
+				instance_size = "M10"
+			}
+		}
+		region_configs {
+			provider_name = "AWS"
+			priority      = 7
+			region_name   = "US_EAST_1"
+			electable_specs {
+				node_count    = 2
+				instance_size = "M10"
+			}
+		}
+	}
+}
+`

--- a/internal/service/advancedclustertpf/validate_schema.go
+++ b/internal/service/advancedclustertpf/validate_schema.go
@@ -99,7 +99,7 @@ func (v RegionSpecPriorityOrderDecreasingValidator) ValidateList(ctx context.Con
 		return
 	}
 	configs := *regionConfigs
-	for i := range configs[:len(configs)-1] {
+	for i := range len(configs)-1
 		if configs[i].GetPriority() < configs[i+1].GetPriority() {
 			diags.AddError("priority values in region_configs must be in descending order", fmt.Sprintf("priority value at index %d is %d and priority value at index %d is %d", i, configs[i].GetPriority(), i+1, configs[i+1].GetPriority()))
 		}

--- a/internal/service/advancedclustertpf/validate_schema.go
+++ b/internal/service/advancedclustertpf/validate_schema.go
@@ -99,7 +99,7 @@ func (v RegionSpecPriorityOrderDecreasingValidator) ValidateList(ctx context.Con
 		return
 	}
 	configs := *regionConfigs
-	for i := range len(configs)-1
+	for i := range len(configs) - 1 {
 		if configs[i].GetPriority() < configs[i+1].GetPriority() {
 			diags.AddError("priority values in region_configs must be in descending order", fmt.Sprintf("priority value at index %d is %d and priority value at index %d is %d", i, configs[i].GetPriority(), i+1, configs[i+1].GetPriority()))
 		}


### PR DESCRIPTION
## Description

Adds validation for descending priority order in region_configs for adv_cluster TPF

Link to any related issue(s): CLOUDP-287995

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
