### PR TITLE
chore: Fixes converting to TPF by including all attributes in replication_specs

### DIFF
--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -174,7 +174,9 @@ func getReplicationSpecs(t *testing.T, body *hclsyntax.Body) cty.Value {
 		assert.Equal(t, name, block.Type, "unexpected block type: %s", block.Type)
 		vals = append(vals, hcl.GetAttrVal(t, block.Body))
 	}
-	return cty.ObjectVal(map[string]cty.Value{
+	attributeValues := map[string]cty.Value{
 		name: cty.TupleVal(vals),
-	})
+	}
+	hcl.AddAttributes(t, body, attributeValues)
+	return cty.ObjectVal(attributeValues)
 }

--- a/internal/testutil/acc/advanced_cluster_schema_v2_test.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2_test.go
@@ -56,6 +56,7 @@ func TestConvertAdvancedClusterToSchemaV2(t *testing.T) {
 				cluster_type = "SHARDED"
 
 				replication_specs {
+					zone_name = "zone1"
 					region_configs {
 						electable_specs {
 							disk_size_gb  = 10
@@ -198,7 +199,8 @@ func TestConvertAdvancedClusterToSchemaV2(t *testing.T) {
 							priority      = 6
 							provider_name = "AZURE"
 							region_name   = "US_EAST_2"
-						}] 
+						}]
+						zone_name = "zone1" 
 						}, {
 						region_configs = [{
 							analytics_specs = {


### PR DESCRIPTION
## Description

Fixes converting to TPF by including all attributes in replication_specs

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
