### PR TITLE
feat: Implements `mongodbatlas_stream_privatelink_endpoint` data sources

### DIFF
--- a/.changelog/2897.txt
+++ b/.changelog/2897.txt
@@ -1,0 +1,7 @@
+```release-note:new-datasource
+mongodbatlas_stream_privatelink_endpoint
+```
+
+```release-note:new-datasource
+mongodbatlas_stream_privatelink_endpoints
+```

--- a/internal/common/retrystrategy/retry_state.go
+++ b/internal/common/retrystrategy/retry_state.go
@@ -18,4 +18,5 @@ const (
 	RetryStrategyRepeatingState         = "REPEATING"
 	RetryStrategyUpdatingState          = "UPDATING"
 	RetryStrategyDeleteRequestedState   = "DELETE_REQUESTED"
+	RetryStrategyDoneState              = "DONE"
 )

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -448,6 +448,8 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 		encryptionatrestprivateendpoint.DataSource,
 		encryptionatrestprivateendpoint.PluralDataSource,
 		mongodbemployeeaccessgrant.DataSource,
+		streamprivatelinkendpoint.DataSource,
+		streamprivatelinkendpoint.PluralDataSource,
 	}
 	if config.AdvancedClusterV2Schema() {
 		dataSources = append(dataSources, advancedclustertpf.DataSource, advancedclustertpf.PluralDataSource)

--- a/internal/service/streamprivatelinkendpoint/data_source.go
+++ b/internal/service/streamprivatelinkendpoint/data_source.go
@@ -38,9 +38,9 @@ func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasou
 
 	projectID := tfModel.ProjectId.ValueString()
 	connectionID := tfModel.Id.ValueString()
+
 	connV2 := d.Client.AtlasV2
 	streamsPrivateLinkConnection, _, err := connV2.StreamsApi.GetPrivateLinkConnection(ctx, projectID, connectionID).Execute()
-
 	if err != nil {
 		resp.Diagnostics.AddError("error fetching resource", err.Error())
 		return

--- a/internal/service/streamprivatelinkendpoint/data_source.go
+++ b/internal/service/streamprivatelinkendpoint/data_source.go
@@ -1,4 +1,3 @@
-//nolint:gocritic
 package streamprivatelinkendpoint
 
 import (
@@ -37,19 +36,20 @@ func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasou
 		return
 	}
 
-	// TODO: make get request to resource
+	projectID := tfModel.ProjectId.ValueString()
+	connectionID := tfModel.Id.ValueString()
+	connV2 := d.Client.AtlasV2
+	streamsPrivateLinkConnection, _, err := connV2.StreamsApi.GetPrivateLinkConnection(ctx, projectID, connectionID).Execute()
 
-	// connV2 := d.Client.AtlasV2
-	//if err != nil {
-	//	resp.Diagnostics.AddError("error fetching resource", err.Error())
-	//	return
-	//}
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
 
-	// TODO: process response into new terraform state
-	// newStreamPrivatelinkEndpointModel, diags := NewTFModel(ctx, apiResp)
-	// if diags.HasError() {
-	// 	resp.Diagnostics.Append(diags...)
-	// 	return
-	// }
-	// resp.Diagnostics.Append(resp.State.Set(ctx, newStreamPrivatelinkEndpointModel)...)
+	newStreamPrivatelinkEndpointModel, diags := NewTFModel(ctx, projectID, streamsPrivateLinkConnection)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, newStreamPrivatelinkEndpointModel)...)
 }

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -22,9 +22,9 @@ func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPri
 		Vendor:              types.StringPointerValue(apiResp.Vendor),
 	}
 	if apiResp.DnsSubDomain != nil {
-		subdomain, diagn := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
-		if diagn.HasError() {
-			return nil, diagn
+		subdomain, diags := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
+		if diags.HasError() {
+			return nil, diags
 		}
 		result.DnsSubDomain = subdomain
 	}

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -1,4 +1,3 @@
-//nolint:gocritic
 package streamprivatelinkendpoint
 
 import (
@@ -23,9 +22,9 @@ func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPri
 		Vendor:              types.StringPointerValue(apiResp.Vendor),
 	}
 	if apiResp.DnsSubDomain != nil {
-		subdomain, diag := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
-		if diag.HasError() {
-			return nil, diag
+		subdomain, diagn := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
+		if diagn.HasError() {
+			return nil, diagn
 		}
 		result.DnsSubDomain = subdomain
 	}
@@ -55,23 +54,21 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 	return result, nil
 }
 
-func NewTFModelPluralDS(ctx context.Context, projectID string, input []admin.StreamsPrivateLinkConnection) (*TFModelDSP, diag.Diagnostics) {
-	// diags := &diag.Diagnostics{}
-	// tfModels := make([]TFModel, len(input))
-	// for i := range input {
-	// 	item := &input[i]
-	// 	tfModel, diagsLocal := NewTFModel(ctx, item)
-	// 	diags.Append(diagsLocal...)
-	// 	if tfModel != nil {
-	// 		tfModels[i] = *tfModel
-	// 	}
-	// }
-	// if diags.HasError() {
-	// 	return nil, *diags
-	// }
-	// return &TFModelDSP{
-	// 	ProjectId: types.StringValue(projectID),
-	// 	Results:   tfModels,
-	// }, *diags
-	return nil, nil
+func NewTFModelPluralDS(ctx context.Context, projectID string, sdkResults []admin.StreamsPrivateLinkConnection) (*TFModelDSP, diag.Diagnostics) {
+	diags := &diag.Diagnostics{}
+	tfModels := make([]TFModel, len(sdkResults))
+	for i := range sdkResults {
+		tfModel, diagsLocal := NewTFModel(ctx, projectID, &sdkResults[i])
+		diags.Append(diagsLocal...)
+		if tfModel != nil {
+			tfModels[i] = *tfModel
+		}
+	}
+	if diags.HasError() {
+		return nil, *diags
+	}
+	return &TFModelDSP{
+		ProjectId: types.StringValue(projectID),
+		Results:   tfModels,
+	}, *diags
 }

--- a/internal/service/streamprivatelinkendpoint/plural_data_source.go
+++ b/internal/service/streamprivatelinkendpoint/plural_data_source.go
@@ -42,9 +42,7 @@ func (d *pluralDS) Read(ctx context.Context, req datasource.ReadRequest, resp *d
 	}
 
 	projectID := tfModel.ProjectId.ValueString()
-
 	connV2 := d.Client.AtlasV2
-
 	params := admin.ListPrivateLinkConnectionsApiParams{
 		GroupId: projectID,
 	}

--- a/internal/service/streamprivatelinkendpoint/state_transition.go
+++ b/internal/service/streamprivatelinkendpoint/state_transition.go
@@ -23,8 +23,8 @@ func waitStateTransition(ctx context.Context, projectID, endpointID string, clie
 func WaitStateTransitionWithMinTimeout(ctx context.Context, minTimeout time.Duration, projectID, endpointID string, client admin.StreamsApi) (*admin.StreamsPrivateLinkConnection, error) {
 	return waitStateTransitionForStates(
 		ctx,
-		[]string{retrystrategy.RetryStrategyInitiatingState},
-		[]string{retrystrategy.RetryStrategyIdleState, retrystrategy.RetryStrategyFailedState},
+		[]string{retrystrategy.RetryStrategyIdleState},
+		[]string{retrystrategy.RetryStrategyDoneState, retrystrategy.RetryStrategyFailedState},
 		minTimeout, projectID, endpointID, client)
 }
 

--- a/templates/data-source.md.tmpl
+++ b/templates/data-source.md.tmpl
@@ -55,6 +55,7 @@
     {{ else if eq .Name "mongodbatlas_third_party_integration" }}
     {{ else if eq .Name "mongodbatlas_x509_authentication_database_user" }}
     {{ else if eq .Name "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" }}
+    {{ else if eq .Name "mongodbatlas_stream_privatelink_endpoint" }}
     {{ else }}
         {{ tffile (printf "examples/%s/main.tf" .Name )}}
     {{ end }}


### PR DESCRIPTION
## Description

Implements `mongodbatlas_stream_privatelink_endpoint` data sources

Example usage: 
```
data "mongodbatlas_stream_privatelink_endpoint" "singular-datasource-test" {
  project_id = var.project_id
  id         = <id>
}

data "mongodbatlas_stream_privatelink_endpoints" "plural-datasource-test" {
  project_id = var.project_id
}
```


Link to any related issue(s): CLOUDP-289663

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
