### PR TITLE
chore: Reads schema v2 environment variable only once

### DIFF
--- a/internal/config/advanced_cluster_v2_schema.go
+++ b/internal/config/advanced_cluster_v2_schema.go
@@ -8,7 +8,9 @@ import (
 const AdvancedClusterV2SchemaEnvVar = "MONGODB_ATLAS_ADVANCED_CLUSTER_V2_SCHEMA"
 const allowAdvancedClusterV2Schema = false // Don't allow in master branch yet, not in const block to allow automatic change
 
+// Environment variable is read only once to avoid possible changes during runtime
+var advancedClusterV2Schema, _ = strconv.ParseBool(os.Getenv(AdvancedClusterV2SchemaEnvVar))
+
 func AdvancedClusterV2Schema() bool {
-	env, _ := strconv.ParseBool(os.Getenv(AdvancedClusterV2SchemaEnvVar))
-	return allowAdvancedClusterV2Schema && env
+	return allowAdvancedClusterV2Schema && advancedClusterV2Schema
 }


### PR DESCRIPTION
## Description

Reads schema v2 environment variable only once

Link to any related issue(s): CLOUDP-290309

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
