### PR TITLE
chore: Converts resource blocks to resource attributes in data source schema auto-generation

### DIFF
--- a/internal/common/conversion/schema_generation.go
+++ b/internal/common/conversion/schema_generation.go
@@ -91,9 +91,6 @@ var convertNestedMappings = map[string]reflect.Type{
 
 func convertAttrs(rsAttrs map[string]schema.Attribute, requiredFields []string) map[string]dsschema.Attribute {
 	const ignoreField = "timeouts"
-	if rsAttrs == nil {
-		return nil
-	}
 	dsAttrs := make(map[string]dsschema.Attribute, len(rsAttrs))
 	for name, attr := range rsAttrs {
 		if name == ignoreField {
@@ -105,9 +102,6 @@ func convertAttrs(rsAttrs map[string]schema.Attribute, requiredFields []string) 
 }
 
 func convertBlocksToAttrs(rsBlocks map[string]schema.Block, requiredFields []string) map[string]dsschema.Attribute {
-	if rsBlocks == nil {
-		return nil
-	}
 	dsAttrs := make(map[string]dsschema.Attribute, len(rsBlocks))
 	for name, block := range rsBlocks {
 		dsAttrs[name] = convertElement(name, block, requiredFields).(dsschema.Attribute)

--- a/internal/common/conversion/schema_generation.go
+++ b/internal/common/conversion/schema_generation.go
@@ -1,6 +1,7 @@
 package conversion
 
 import (
+	"maps"
 	"reflect"
 	"slices"
 
@@ -22,20 +23,17 @@ type PluralDataSourceSchemaRequest struct {
 }
 
 func DataSourceSchemaFromResource(rs schema.Schema, req *DataSourceSchemaRequest) dsschema.Schema {
-	blocks := convertBlocks(rs.Blocks, req.RequiredFields)
 	attrs := convertAttrs(rs.Attributes, req.RequiredFields)
+	maps.Copy(attrs, convertBlocksToAttrs(rs.Blocks, req.RequiredFields))
 	overrideFields(attrs, req.OverridenFields)
-	ds := dsschema.Schema{Attributes: attrs, Blocks: blocks}
+	ds := dsschema.Schema{Attributes: attrs}
 	UpdateSchemaDescription(&ds)
 	return ds
 }
 
 func PluralDataSourceSchemaFromResource(rs schema.Schema, req *PluralDataSourceSchemaRequest) dsschema.Schema {
-	blocks := convertBlocks(rs.Blocks, nil)
-	if len(blocks) > 0 {
-		panic("blocks not supported yet in auto-generated plural data source schema as they can't go in ListNestedAttribute")
-	}
 	attrs := convertAttrs(rs.Attributes, nil)
+	maps.Copy(attrs, convertBlocksToAttrs(rs.Blocks, nil))
 	overrideFields(attrs, req.OverridenFields)
 	rootAttrs := convertAttrs(rs.Attributes, req.RequiredFields)
 	for name := range rootAttrs {
@@ -76,12 +74,14 @@ var convertMappings = map[string]reflect.Type{
 	"Int64Attribute":        reflect.TypeOf(dsschema.Int64Attribute{}),
 	"Float64Attribute":      reflect.TypeOf(dsschema.Float64Attribute{}),
 	"MapAttribute":          reflect.TypeOf(dsschema.MapAttribute{}),
+	"ListAttribute":         reflect.TypeOf(dsschema.ListAttribute{}),
+	"SetAttribute":          reflect.TypeOf(dsschema.SetAttribute{}),
 	"SingleNestedAttribute": reflect.TypeOf(dsschema.SingleNestedAttribute{}),
 	"ListNestedAttribute":   reflect.TypeOf(dsschema.ListNestedAttribute{}),
 	"SetNestedAttribute":    reflect.TypeOf(dsschema.SetNestedAttribute{}),
-	"ListAttribute":         reflect.TypeOf(dsschema.ListAttribute{}),
-	"SetNestedBlock":        reflect.TypeOf(dsschema.SetNestedBlock{}),
-	"SetAttribute":          reflect.TypeOf(dsschema.SetAttribute{}),
+	"SingleNestedBlock":     reflect.TypeOf(dsschema.SingleNestedAttribute{}),
+	"ListNestedBlock":       reflect.TypeOf(dsschema.ListNestedAttribute{}),
+	"SetNestedBlock":        reflect.TypeOf(dsschema.SetNestedAttribute{}),
 }
 
 var convertNestedMappings = map[string]reflect.Type{
@@ -104,15 +104,15 @@ func convertAttrs(rsAttrs map[string]schema.Attribute, requiredFields []string) 
 	return dsAttrs
 }
 
-func convertBlocks(rsBlocks map[string]schema.Block, requiredFields []string) map[string]dsschema.Block {
+func convertBlocksToAttrs(rsBlocks map[string]schema.Block, requiredFields []string) map[string]dsschema.Attribute {
 	if rsBlocks == nil {
 		return nil
 	}
-	dsBlocks := make(map[string]dsschema.Block, len(rsBlocks))
+	dsAttrs := make(map[string]dsschema.Attribute, len(rsBlocks))
 	for name, block := range rsBlocks {
-		dsBlocks[name] = convertElement(name, block, requiredFields).(dsschema.Block)
+		dsAttrs[name] = convertElement(name, block, requiredFields).(dsschema.Attribute)
 	}
-	return dsBlocks
+	return dsAttrs
 }
 
 func convertElement(name string, element any, requiredFields []string) any {
@@ -131,8 +131,8 @@ func convertElement(name string, element any, requiredFields []string) any {
 	vDest := reflect.New(tDest).Elem()
 	vDest.FieldByName("MarkdownDescription").Set(vSrc.FieldByName("MarkdownDescription"))
 	vDest.FieldByName("DeprecationMessage").Set(vSrc.FieldByName("DeprecationMessage"))
-	if fSensitive := vDest.FieldByName("Sensitive"); fSensitive.CanSet() {
-		fSensitive.Set(vSrc.FieldByName("Sensitive"))
+	if fSensitive, sSensitive := vDest.FieldByName("Sensitive"), vSrc.FieldByName("Sensitive"); fSensitive.CanSet() && sSensitive.IsValid() {
+		fSensitive.Set(sSensitive)
 	}
 	if fComputed := vDest.FieldByName("Computed"); fComputed.CanSet() {
 		fComputed.SetBool(computed)
@@ -145,16 +145,29 @@ func convertElement(name string, element any, requiredFields []string) any {
 	}
 	if fAttributes := vDest.FieldByName("Attributes"); fAttributes.CanSet() {
 		attrsSrc := vSrc.FieldByName("Attributes").Interface().(map[string]schema.Attribute)
-		fAttributes.Set(reflect.ValueOf(convertAttrs(attrsSrc, nil)))
+		attrSrcDS := convertAttrs(attrsSrc, nil)
+		if fBlocks := vSrc.FieldByName("Blocks"); fBlocks.IsValid() {
+			blocksSrc := vSrc.FieldByName("Blocks").Interface().(map[string]schema.Block)
+			blockSrcDS := convertBlocksToAttrs(blocksSrc, requiredFields)
+			maps.Copy(attrSrcDS, blockSrcDS)
+		}
+		fAttributes.Set(reflect.ValueOf(attrSrcDS))
 	}
+
 	if fNested := vDest.FieldByName("NestedObject"); fNested.CanSet() {
 		tNested := convertNestedMappings[fNested.Type().Name()]
 		if tNested == nil {
 			panic("nested type not support yet, add it to convertNestedMappings: " + fNested.Type().Name())
 		}
 		attrsSrc := vSrc.FieldByName("NestedObject").FieldByName("Attributes").Interface().(map[string]schema.Attribute)
+		attrSrcDS := convertAttrs(attrsSrc, nil)
+		if fBlocks := vSrc.FieldByName("NestedObject").FieldByName("Blocks"); fBlocks.IsValid() {
+			blocksSrc := vSrc.FieldByName("NestedObject").FieldByName("Blocks").Interface().(map[string]schema.Block)
+			blockSrcDS := convertBlocksToAttrs(blocksSrc, requiredFields)
+			maps.Copy(attrSrcDS, blockSrcDS)
+		}
 		vNested := reflect.New(tNested).Elem()
-		vNested.FieldByName("Attributes").Set(reflect.ValueOf(convertAttrs(attrsSrc, nil)))
+		vNested.FieldByName("Attributes").Set(reflect.ValueOf(attrSrcDS))
 		fNested.Set(vNested)
 	}
 	return vDest.Interface()

--- a/internal/common/conversion/schema_generation_test.go
+++ b/internal/common/conversion/schema_generation_test.go
@@ -263,12 +263,12 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"block block 1": schema.SingleNestedBlock{
-							MarkdownDescription: "desc block block 1",
+						"bb 1": schema.SingleNestedBlock{
+							MarkdownDescription: "desc bb 1",
 							Attributes: map[string]schema.Attribute{
-								"block block attr 1": schema.StringAttribute{
+								"bb attr 1": schema.StringAttribute{
 									Computed:            true,
-									MarkdownDescription: "desc block block attr 1",
+									MarkdownDescription: "desc bb attr 1",
 								},
 							},
 						},
@@ -285,13 +285,13 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"block block 2": schema.ListNestedBlock{
-							MarkdownDescription: "desc block block 2",
+						"bb 2": schema.ListNestedBlock{
+							MarkdownDescription: "desc bb 2",
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
-									"block block attr 2": schema.StringAttribute{
+									"bb attr 2": schema.StringAttribute{
 										Computed:            true,
-										MarkdownDescription: "desc block block attr 2",
+										MarkdownDescription: "desc bb attr 2",
 									},
 								},
 							},
@@ -308,13 +308,13 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 					},
 				},
 				Blocks: map[string]schema.Block{
-					"block block 3": schema.ListNestedBlock{
-						MarkdownDescription: "desc block block 3",
+					"bb 3": schema.ListNestedBlock{
+						MarkdownDescription: "desc bb 3",
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"block block attr 3": schema.StringAttribute{
+								"bb attr 3": schema.StringAttribute{
 									Computed:            true,
-									MarkdownDescription: "desc block block attr 3",
+									MarkdownDescription: "desc bb attr 3",
 								},
 							},
 						},
@@ -347,15 +347,15 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 							Description:         "desc setNestedBlockAttr",
 							MarkdownDescription: "desc setNestedBlockAttr",
 						},
-						"block block 1": dsschema.SingleNestedAttribute{
+						"bb 1": dsschema.SingleNestedAttribute{
 							Computed:            true,
-							Description:         "desc block block 1",
-							MarkdownDescription: "desc block block 1",
+							Description:         "desc bb 1",
+							MarkdownDescription: "desc bb 1",
 							Attributes: map[string]dsschema.Attribute{
-								"block block attr 1": dsschema.StringAttribute{
+								"bb attr 1": dsschema.StringAttribute{
 									Computed:            true,
-									Description:         "desc block block attr 1",
-									MarkdownDescription: "desc block block attr 1",
+									Description:         "desc bb attr 1",
+									MarkdownDescription: "desc bb attr 1",
 								},
 							},
 						},
@@ -373,16 +373,16 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 							Description:         "desc listNestedBlockAttr",
 							MarkdownDescription: "desc listNestedBlockAttr",
 						},
-						"block block 2": dsschema.ListNestedAttribute{
+						"bb 2": dsschema.ListNestedAttribute{
 							Computed:            true,
-							Description:         "desc block block 2",
-							MarkdownDescription: "desc block block 2",
+							Description:         "desc bb 2",
+							MarkdownDescription: "desc bb 2",
 							NestedObject: dsschema.NestedAttributeObject{
 								Attributes: map[string]dsschema.Attribute{
-									"block block attr 2": dsschema.StringAttribute{
+									"bb attr 2": dsschema.StringAttribute{
 										Computed:            true,
-										Description:         "desc block block attr 2",
-										MarkdownDescription: "desc block block attr 2",
+										Description:         "desc bb attr 2",
+										MarkdownDescription: "desc bb attr 2",
 									},
 								},
 							},
@@ -400,16 +400,16 @@ func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
 						Description:         "desc nestattr",
 						MarkdownDescription: "desc nestattr",
 					},
-					"block block 3": dsschema.ListNestedAttribute{
+					"bb 3": dsschema.ListNestedAttribute{
 						Computed:            true,
-						Description:         "desc block block 3",
-						MarkdownDescription: "desc block block 3",
+						Description:         "desc bb 3",
+						MarkdownDescription: "desc bb 3",
 						NestedObject: dsschema.NestedAttributeObject{
 							Attributes: map[string]dsschema.Attribute{
-								"block block attr 3": dsschema.StringAttribute{
+								"bb attr 3": dsschema.StringAttribute{
 									Computed:            true,
-									Description:         "desc block block attr 3",
-									MarkdownDescription: "desc block block attr 3",
+									Description:         "desc bb attr 3",
+									MarkdownDescription: "desc bb attr 3",
 								},
 							},
 						},

--- a/internal/common/conversion/schema_generation_test.go
+++ b/internal/common/conversion/schema_generation_test.go
@@ -66,19 +66,19 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 				ElementType:         types.StringType,
 				MarkdownDescription: "desc setAttr",
 			},
-			"nestSingle": schema.SingleNestedAttribute{
+			"singleNestedAttribute": schema.SingleNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestSingle",
+				MarkdownDescription: "desc singleNestedAttribute",
 				Attributes: map[string]schema.Attribute{
-					"nestedSingleAttr": schema.StringAttribute{
+					"singleNestedAttributeAttr": schema.StringAttribute{
 						Computed:            true,
-						MarkdownDescription: "desc nestedSingleAttr",
+						MarkdownDescription: "desc singleNestedAttributeAttr",
 					},
 				},
 			},
-			"nestList": schema.ListNestedAttribute{
+			"listNestedAttribute": schema.ListNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestList",
+				MarkdownDescription: "desc listNestedAttribute",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"nestedAttr": schema.StringAttribute{
@@ -92,9 +92,9 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 					},
 				},
 			},
-			"nestSet": schema.SetNestedAttribute{
+			"setNestedAttribute": schema.SetNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestSet",
+				MarkdownDescription: "desc setNestedAttribute",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"nestedAttr": schema.StringAttribute{
@@ -109,18 +109,6 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 				Update: true,
 				Delete: true,
 			}),
-		},
-		Blocks: map[string]schema.Block{
-			"nestBlock": schema.SetNestedBlock{
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"nestBlockAttr": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "desc nestBlockAttr",
-						},
-					},
-				},
-			},
 		},
 	}
 
@@ -180,22 +168,22 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 				MarkdownDescription: "desc setAttr",
 				Description:         "desc setAttr",
 			},
-			"nestSingle": dsschema.SingleNestedAttribute{
+			"singleNestedAttribute": dsschema.SingleNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestSingle",
-				Description:         "desc nestSingle",
+				MarkdownDescription: "desc singleNestedAttribute",
+				Description:         "desc singleNestedAttribute",
 				Attributes: map[string]dsschema.Attribute{
-					"nestedSingleAttr": dsschema.StringAttribute{
+					"singleNestedAttributeAttr": dsschema.StringAttribute{
 						Computed:            true,
-						MarkdownDescription: "desc nestedSingleAttr",
-						Description:         "desc nestedSingleAttr",
+						MarkdownDescription: "desc singleNestedAttributeAttr",
+						Description:         "desc singleNestedAttributeAttr",
 					},
 				},
 			},
-			"nestList": dsschema.ListNestedAttribute{
+			"listNestedAttribute": dsschema.ListNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestList",
-				Description:         "desc nestList",
+				MarkdownDescription: "desc listNestedAttribute",
+				Description:         "desc listNestedAttribute",
 				NestedObject: dsschema.NestedAttributeObject{
 					Attributes: map[string]dsschema.Attribute{
 						"nestedAttr": dsschema.StringAttribute{
@@ -211,10 +199,10 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 					},
 				},
 			},
-			"nestSet": dsschema.SetNestedAttribute{
+			"setNestedAttribute": dsschema.SetNestedAttribute{
 				Computed:            true,
-				MarkdownDescription: "desc nestSet",
-				Description:         "desc nestSet",
+				MarkdownDescription: "desc setNestedAttribute",
+				Description:         "desc setNestedAttribute",
 				NestedObject: dsschema.NestedAttributeObject{
 					Attributes: map[string]dsschema.Attribute{
 						"nestedAttr": dsschema.StringAttribute{
@@ -234,19 +222,6 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 				},
 			},
 		},
-		Blocks: map[string]dsschema.Block{
-			"nestBlock": dsschema.SetNestedBlock{
-				NestedObject: dsschema.NestedBlockObject{
-					Attributes: map[string]dsschema.Attribute{
-						"nestBlockAttr": dsschema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "desc nestBlockAttr",
-							Description:         "desc nestBlockAttr",
-						},
-					},
-				},
-			},
-		},
 	}
 
 	ds := conversion.DataSourceSchemaFromResource(s, &conversion.DataSourceSchemaRequest{
@@ -261,6 +236,191 @@ func TestDataSourceSchemaFromResource(t *testing.T) {
 			},
 			"attrDelete": nil,
 		},
+	})
+	assert.Equal(t, expected, ds)
+}
+
+func TestDataSourceSchemaFromResource_blocksToAttrs(t *testing.T) {
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"requiredAttrString": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "desc requiredAttrString",
+			},
+			"attrString": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "desc attrString",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"setNestedBlock": schema.SetNestedBlock{
+				MarkdownDescription: "desc setNestedBlock",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"setNestedBlockAttr": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "desc setNestedBlockAttr",
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"block block 1": schema.SingleNestedBlock{
+							MarkdownDescription: "desc block block 1",
+							Attributes: map[string]schema.Attribute{
+								"block block attr 1": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "desc block block attr 1",
+								},
+							},
+						},
+					},
+				},
+			},
+			"listNestedBlock": schema.ListNestedBlock{
+				MarkdownDescription: "desc listNestedBlock",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"listNestedBlockAttr": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "desc listNestedBlockAttr",
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"block block 2": schema.ListNestedBlock{
+							MarkdownDescription: "desc block block 2",
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"block block attr 2": schema.StringAttribute{
+										Computed:            true,
+										MarkdownDescription: "desc block block attr 2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"singleNestedBlock": schema.SingleNestedBlock{
+				MarkdownDescription: "desc singleNestedBlock",
+				Attributes: map[string]schema.Attribute{
+					"nestattr": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "desc nestattr",
+					},
+				},
+				Blocks: map[string]schema.Block{
+					"block block 3": schema.ListNestedBlock{
+						MarkdownDescription: "desc block block 3",
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"block block attr 3": schema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "desc block block attr 3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := dsschema.Schema{
+		Attributes: map[string]dsschema.Attribute{
+			"requiredAttrString": dsschema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "desc requiredAttrString",
+				Description:         "desc requiredAttrString",
+			},
+			"attrString": dsschema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "desc attrString",
+				Description:         "desc attrString",
+			},
+			"setNestedBlock": dsschema.SetNestedAttribute{
+				Computed:            true,
+				Description:         "desc setNestedBlock",
+				MarkdownDescription: "desc setNestedBlock",
+				NestedObject: dsschema.NestedAttributeObject{
+					Attributes: map[string]dsschema.Attribute{
+						"setNestedBlockAttr": dsschema.StringAttribute{
+							Computed:            true,
+							Description:         "desc setNestedBlockAttr",
+							MarkdownDescription: "desc setNestedBlockAttr",
+						},
+						"block block 1": dsschema.SingleNestedAttribute{
+							Computed:            true,
+							Description:         "desc block block 1",
+							MarkdownDescription: "desc block block 1",
+							Attributes: map[string]dsschema.Attribute{
+								"block block attr 1": dsschema.StringAttribute{
+									Computed:            true,
+									Description:         "desc block block attr 1",
+									MarkdownDescription: "desc block block attr 1",
+								},
+							},
+						},
+					},
+				},
+			},
+			"listNestedBlock": dsschema.ListNestedAttribute{
+				Computed:            true,
+				Description:         "desc listNestedBlock",
+				MarkdownDescription: "desc listNestedBlock",
+				NestedObject: dsschema.NestedAttributeObject{
+					Attributes: map[string]dsschema.Attribute{
+						"listNestedBlockAttr": dsschema.StringAttribute{
+							Computed:            true,
+							Description:         "desc listNestedBlockAttr",
+							MarkdownDescription: "desc listNestedBlockAttr",
+						},
+						"block block 2": dsschema.ListNestedAttribute{
+							Computed:            true,
+							Description:         "desc block block 2",
+							MarkdownDescription: "desc block block 2",
+							NestedObject: dsschema.NestedAttributeObject{
+								Attributes: map[string]dsschema.Attribute{
+									"block block attr 2": dsschema.StringAttribute{
+										Computed:            true,
+										Description:         "desc block block attr 2",
+										MarkdownDescription: "desc block block attr 2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"singleNestedBlock": dsschema.SingleNestedAttribute{
+				Computed:            true,
+				Description:         "desc singleNestedBlock",
+				MarkdownDescription: "desc singleNestedBlock",
+				Attributes: map[string]dsschema.Attribute{
+					"nestattr": dsschema.StringAttribute{
+						Computed:            true,
+						Description:         "desc nestattr",
+						MarkdownDescription: "desc nestattr",
+					},
+					"block block 3": dsschema.ListNestedAttribute{
+						Computed:            true,
+						Description:         "desc block block 3",
+						MarkdownDescription: "desc block block 3",
+						NestedObject: dsschema.NestedAttributeObject{
+							Attributes: map[string]dsschema.Attribute{
+								"block block attr 3": dsschema.StringAttribute{
+									Computed:            true,
+									Description:         "desc block block attr 3",
+									MarkdownDescription: "desc block block attr 3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ds := conversion.DataSourceSchemaFromResource(s, &conversion.DataSourceSchemaRequest{
+		RequiredFields: []string{"requiredAttrString"},
 	})
 	assert.Equal(t, expected, ds)
 }

--- a/internal/common/conversion/schema_generation_test.go
+++ b/internal/common/conversion/schema_generation_test.go
@@ -446,6 +446,18 @@ func TestPluralDataSourceSchemaFromResource(t *testing.T) {
 				MarkdownDescription: "desc overridenString",
 			},
 		},
+		Blocks: map[string]schema.Block{
+			"nested": schema.ListNestedBlock{
+				MarkdownDescription: "desc nested",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"nested attr": schema.StringAttribute{
+							MarkdownDescription: "desc nested attr",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	expected := dsschema.Schema{
@@ -485,6 +497,20 @@ func TestPluralDataSourceSchemaFromResource(t *testing.T) {
 							MarkdownDescription: "desc overridenString",
 							Validators: []validator.String{
 								stringvalidator.ConflictsWith(path.MatchRoot("otherAttr")),
+							},
+						},
+						"nested": dsschema.ListNestedAttribute{
+							Computed:            true,
+							Description:         "desc nested",
+							MarkdownDescription: "desc nested",
+							NestedObject: dsschema.NestedAttributeObject{
+								Attributes: map[string]dsschema.Attribute{
+									"nested attr": dsschema.StringAttribute{
+										Computed:            true,
+										Description:         "desc nested attr",
+										MarkdownDescription: "desc nested attr",
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
## Description

Converts resource blocks to resource attributes in data source schema auto-generation. In this way singular data source can be nested in `Results` attribute in plural data source.

Link to any related issue(s): CLOUDP-290561

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
