### PR TITLE
chore: Refactors CopyModel to return only the new model

### DIFF
--- a/internal/common/conversion/model_generation.go
+++ b/internal/common/conversion/model_generation.go
@@ -6,17 +6,18 @@ import (
 )
 
 // CopyModel creates a new struct with the same values as the source struct. Fields in destination struct that are not in source are left with zero value.
-func CopyModel[T any](src any) (*T, error) {
+// It panics if there are some structural problems so it should only happen during development.
+func CopyModel[T any](src any) *T {
 	dest := new(T)
 	valSrc := reflect.ValueOf(src)
 	valDest := reflect.ValueOf(dest)
 	if valSrc.Kind() != reflect.Ptr || valDest.Kind() != reflect.Ptr {
-		return nil, fmt.Errorf("params must be pointers")
+		panic("params must be pointers")
 	}
 	valSrc = valSrc.Elem()
 	valDest = valDest.Elem()
 	if valSrc.Kind() != reflect.Struct || valDest.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("params must be pointers to structs")
+		panic("params must be pointers to structs")
 	}
 	typeSrc := valSrc.Type()
 	typeDest := valDest.Type()
@@ -29,13 +30,13 @@ func CopyModel[T any](src any) (*T, error) {
 				continue
 			}
 			if fieldDest.Type != fieldSrc.Type {
-				return nil, fmt.Errorf("field has different type: %s", name)
+				panic(fmt.Sprintf("field has different type: %s", name))
 			}
 		}
 		if !valDest.Field(i).CanSet() {
-			return nil, fmt.Errorf("field can't be set, probably unexported: %s", name)
+			panic(fmt.Sprintf("field can't be set, probably unexported: %s", name))
 		}
 		valDest.Field(i).Set(valSrc.FieldByName(name))
 	}
-	return dest, nil
+	return dest
 }

--- a/internal/service/advancedclustertpf/data_source.go
+++ b/internal/service/advancedclustertpf/data_source.go
@@ -72,11 +72,7 @@ func (d *ds) readCluster(ctx context.Context, diags *diag.Diagnostics, modelDS *
 	if diags.HasError() {
 		return nil
 	}
-	modelOutDS, err := conversion.CopyModel[TFModelDS](modelOut)
-	if err != nil {
-		diags.AddError(errorRead, fmt.Sprintf("error setting model: %s", err.Error()))
-		return nil
-	}
+	modelOutDS := conversion.CopyModel[TFModelDS](modelOut)
 	modelOutDS.UseReplicationSpecPerShard = modelDS.UseReplicationSpecPerShard // attrs not in resource model
 	return modelOutDS
 }

--- a/internal/service/advancedclustertpf/plural_data_source.go
+++ b/internal/service/advancedclustertpf/plural_data_source.go
@@ -84,11 +84,7 @@ func (d *pluralDS) readClusters(ctx context.Context, diags *diag.Diagnostics, pl
 		if diags.HasError() {
 			return nil
 		}
-		modelOutDS, err := conversion.CopyModel[TFModelDS](modelOut)
-		if err != nil {
-			diags.AddError(errorList, fmt.Sprintf("error setting model: %s", err.Error()))
-			return nil
-		}
+		modelOutDS := conversion.CopyModel[TFModelDS](modelOut)
 		modelOutDS.UseReplicationSpecPerShard = pluralModel.UseReplicationSpecPerShard // attrs not in resource model
 		outs.Results = append(outs.Results, modelOutDS)
 	}


### PR DESCRIPTION
…structural issue

## Description

Refactors CopyModel to return only the new model.  It panics if there is some structural issue.

Link to any related issue(s): CLOUDP-290704

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
