### PR TITLE
chore: Selects container_ids based on provider name and regions used in replication spec for adv_cluster TPF

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2227,9 +2227,10 @@ func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource
 		amtOfReplicationSpecs = 2
 	}
 	clusterChecks := map[string]string{
-		"replication_specs.#": fmt.Sprintf("%d", amtOfReplicationSpecs),
+		"replication_specs.#":                fmt.Sprintf("%d", amtOfReplicationSpecs),
+		"replication_specs.0.container_id.%": "1",
+		"replication_specs.1.container_id.%": "1",
 	}
-
 	return checkAggr(isAcc, []string{}, clusterChecks)
 }
 

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -144,17 +144,35 @@ func convertReplicationSpecs(ctx context.Context, input *[]admin.ReplicationSpec
 			return &tfModels
 		}
 		legacyID := apiInfo.ZoneNameReplicationSpecIDs[zoneName]
+		containerIDs := selectContainerIDs(&item, apiInfo.ContainerIDs)
 		tfModels[i] = TFReplicationSpecsModel{
 			Id:            types.StringValue(legacyID),
 			ExternalId:    types.StringValue(conversion.SafeValue(item.Id)),
 			NumShards:     types.Int64Value(1),
-			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &apiInfo.ContainerIDs),
+			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &containerIDs),
 			RegionConfigs: regionConfigs,
 			ZoneId:        types.StringValue(conversion.SafeValue(item.ZoneId)),
 			ZoneName:      types.StringValue(conversion.SafeValue(item.ZoneName)),
 		}
 	}
 	return &tfModels
+}
+
+func selectContainerIDs(spec *admin.ReplicationSpec20240805, allIDs map[string]string) map[string]string {
+	containerIDs := map[string]string{}
+	regions := spec.GetRegionConfigs()
+	for i := range regions {
+		regionConfig := regions[i]
+		providerName := regionConfig.GetProviderName()
+		key := containerIDKey(providerName, regionConfig.GetRegionName())
+		value := allIDs[key]
+		// Should be no hard failure if not found, as it is not required for TENANT
+		if value == "" {
+			continue
+		}
+		containerIDs[key] = value
+	}
+	return containerIDs
 }
 
 func convertReplicationSpecsLegacy(ctx context.Context, input *[]admin.ReplicationSpec20240805, diags *diag.Diagnostics, apiInfo *ExtraAPIInfo) *[]TFReplicationSpecsModel {
@@ -188,8 +206,9 @@ func convertReplicationSpecsLegacy(ctx context.Context, input *[]admin.Replicati
 				tfModelsSkipIndexes = append(tfModelsSkipIndexes, i+j)
 			}
 		}
+		containerIDs := selectContainerIDs(&item, apiInfo.ContainerIDs)
 		tfModels = append(tfModels, TFReplicationSpecsModel{
-			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &apiInfo.ContainerIDs),
+			ContainerId:   conversion.ToTFMapOfString(ctx, diags, &containerIDs),
 			ExternalId:    types.StringValue(conversion.SafeValue(item.Id)),
 			Id:            types.StringValue(legacyID),
 			RegionConfigs: regionConfigs,

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -166,7 +166,7 @@ func selectContainerIDs(spec *admin.ReplicationSpec20240805, allIDs map[string]s
 		providerName := regionConfig.GetProviderName()
 		key := containerIDKey(providerName, regionConfig.GetRegionName())
 		value := allIDs[key]
-		// Should be no hard failure if not found, as it is not required for TENANT
+		// Should be no hard failure if not found, as it is not required for TENANT, error responsibility in resolveContainerIDs
 		if value == "" {
 			continue
 		}


### PR DESCRIPTION
## Description

Selects container_ids based on provider name and regions used in replication spec

SDKv2 on the LEFT and TPF on the RIGHT. Before this fix
![image](https://github.com/user-attachments/assets/003cbc01-f4d4-4426-82c9-39f55d990038)


Link to any related issue(s): CLOUDP-288855

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
