### PR TITLE
chore: Correct `dnsSubDomain` value sent in the API request when empty in the configuration

### DIFF
--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -56,7 +56,6 @@ func NewAtlasReq(ctx context.Context, plan *TFModel) (*admin.StreamsPrivateLinkC
 
 	result := &admin.StreamsPrivateLinkConnection{
 		DnsDomain:         plan.DnsDomain.ValueStringPointer(),
-		DnsSubDomain:      &[]string{},
 		Provider:          plan.Provider.ValueStringPointer(),
 		Region:            plan.Region.ValueStringPointer(),
 		ServiceEndpointId: plan.ServiceEndpointId.ValueStringPointer(),

--- a/internal/service/streamprivatelinkendpoint/model_test.go
+++ b/internal/service/streamprivatelinkendpoint/model_test.go
@@ -153,7 +153,6 @@ func TestStreamPrivatelinkEndpointTFModelToSDK(t *testing.T) {
 			},
 			expectedSDKReq: &admin.StreamsPrivateLinkConnection{
 				DnsDomain:         &dnsDomain,
-				DnsSubDomain:      &[]string{},
 				Provider:          &provider,
 				Region:            &region,
 				ServiceEndpointId: &serviceEndpointID,


### PR DESCRIPTION
## Description

Correct `dnsSubDomain` value sent in the API request when empty in the configuration

Link to any related issue(s): CLOUDP-290328

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
