### PR TITLE
fix: Avoids import error for database_user when both username and auth database contain hyphens

### DIFF
--- a/.changelog/2928.txt
+++ b/.changelog/2928.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_database_user: Avoids import error for database_user when both username and auth database contain hyphens
+```

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -180,8 +180,8 @@ In addition to all arguments above, the following attributes are exported:
 
 Database users can be imported using project ID, username, and auth database name in the format:
 
-1.  `project_id`-`username`-`auth_database_name`
-2.  `project_id`/`username`/`auth_database_name`
+1. `project_id`-`username`-`auth_database_name` Only works if no `-` are used for `username`/`auth_database_name`. For example `my-username` should use (2).
+2.  `project_id`/`username`/`auth_database_name` Works in all cases (introduced after (1))
 
 ```
 terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user-admin # (1)

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -178,10 +178,14 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Database users can be imported using project ID and username, in the format `project_id`-`username`-`auth_database_name`, e.g.
+Database users can be imported using project ID, username, and auth database name in the format:
+
+1.  `project_id`-`username`-`auth_database_name`
+2.  `project_id`/`username`/`auth_database_name`
 
 ```
-$ terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user-admin
+terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934-my_user-admin # (1)
+terraform import mongodbatlas_database_user.my_user 1112222b3bf99403840e8934/my-username-dash/my-db-name # (2)
 ```
 
 ~> **NOTE:** Terraform will want to change the password after importing the user if a `password` argument is specified.

--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -10,6 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+func ImportSplit3(importRaw string) (bool, string, string, string) {
+	parts := strings.Split(importRaw, "/")
+	if len(parts) != 3 {
+		return false, "", "", ""
+	}
+	return true, parts[0], parts[1], parts[2]
+}
+
 func ImportStateProjectIDClusterName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, attrNameProjectID, attrNameClusterName string) {
 	parts := strings.SplitN(req.ID, "-", 2)
 	if len(parts) != 2 {

--- a/internal/common/conversion/import_state.go
+++ b/internal/common/conversion/import_state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-func ImportSplit3(importRaw string) (bool, string, string, string) {
+func ImportSplit3(importRaw string) (ok bool, part1, part2, part3 string) {
 	parts := strings.Split(importRaw, "/")
 	if len(parts) != 3 {
 		return false, "", "", ""

--- a/internal/common/conversion/import_state_test.go
+++ b/internal/common/conversion/import_state_test.go
@@ -27,10 +27,10 @@ func TestValidateClusterName(t *testing.T) {
 func TestImportSplit3(t *testing.T) {
 	tests := map[string]struct {
 		importRaw string
-		expected  bool
 		part1     string
 		part2     string
 		part3     string
+		expected  bool
 	}{
 		"valid input": {
 			importRaw: "part1/part2/part3",

--- a/internal/common/conversion/import_state_test.go
+++ b/internal/common/conversion/import_state_test.go
@@ -23,3 +23,52 @@ func TestValidateClusterName(t *testing.T) {
 	assert.Contains(t, err.Error(), "_invalidClusterName")
 	assert.Contains(t, err.Error(), "cluster_name must be a string with length between 1 and 64, starting and ending with an alphanumeric character, and containing only alphanumeric characters and hyphens")
 }
+
+func TestImportSplit3(t *testing.T) {
+	tests := map[string]struct {
+		importRaw string
+		expected  bool
+		part1     string
+		part2     string
+		part3     string
+	}{
+		"valid input": {
+			importRaw: "part1/part2/part3",
+			expected:  true,
+			part1:     "part1",
+			part2:     "part2",
+			part3:     "part3",
+		},
+		"invalid input with more parts": {
+			importRaw: "part1/part2/part3/part4",
+			expected:  false,
+			part1:     "",
+			part2:     "",
+			part3:     "",
+		},
+		"invalid input with two parts": {
+			importRaw: "part1/part2",
+			expected:  false,
+			part1:     "",
+			part2:     "",
+			part3:     "",
+		},
+		"invalid input with one part": {
+			importRaw: "part1",
+			expected:  false,
+			part1:     "",
+			part2:     "",
+			part3:     "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ok, part1, part2, part3 := conversion.ImportSplit3(tc.importRaw)
+			assert.Equal(t, tc.expected, ok)
+			assert.Equal(t, tc.part1, part1)
+			assert.Equal(t, tc.part2, part2)
+			assert.Equal(t, tc.part3, part3)
+		})
+	}
+}

--- a/internal/service/databaseuser/model_database_user_test.go
+++ b/internal/service/databaseuser/model_database_user_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/databaseuser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
@@ -420,9 +421,9 @@ func TestSplitDatabaseUserImportID(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			part1, part2, part3, err := databaseuser.SplitDatabaseUserImportID(tc.importID)
 			if tc.errorString != "" {
-				assert.EqualError(t, err, tc.errorString)
+				require.EqualError(t, err, tc.errorString)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tc.projectID, part1)
 			assert.Equal(t, tc.username, part2)

--- a/internal/service/databaseuser/model_database_user_test.go
+++ b/internal/service/databaseuser/model_database_user_test.go
@@ -367,7 +367,6 @@ func getDatabaseUserModel(roles, labels, scopes basetypes.SetValue, password typ
 }
 
 func TestSplitDatabaseUserImportID(t *testing.T) {
-	const invalidDefaultString = "import format error: to import a Database User, use the format {project_id}-{username}-{auth_database_name} OR {project_id}/{username}/{auth_database_name}"
 	tests := map[string]struct {
 		importID    string
 		projectID   string
@@ -399,21 +398,21 @@ func TestSplitDatabaseUserImportID(t *testing.T) {
 			projectID:   "",
 			username:    "",
 			authDBName:  "",
-			errorString: invalidDefaultString,
+			errorString: databaseuser.ErrorImportFormat,
 		},
 		"invalid input with less parts": {
 			importID:    "part1/part2",
 			projectID:   "",
 			username:    "",
 			authDBName:  "",
-			errorString: invalidDefaultString,
+			errorString: databaseuser.ErrorImportFormat,
 		},
 		"empty input": {
 			importID:    "",
 			projectID:   "",
 			username:    "",
 			authDBName:  "",
-			errorString: invalidDefaultString,
+			errorString: databaseuser.ErrorImportFormat,
 		},
 	}
 

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	databaseUserResourceName = "database_user"
+	ErrorImportFormat        = "import format error: to import a Database User, use the format {project_id}-{username}-{auth_database_name} OR {project_id}/{username}/{auth_database_name}"
 )
 
 var _ resource.ResourceWithConfigure = &databaseUserRS{}
@@ -355,7 +356,7 @@ func SplitDatabaseUserImportID(id string) (projectID, username, authDatabaseName
 	var re = regexp.MustCompile(`(?s)^([0-9a-fA-F]{24})-(.*)-([$a-z]{1,15})$`)
 	parts := re.FindStringSubmatch(id)
 	if len(parts) != 4 {
-		err = errors.New("import format error: to import a Database User, use the format {project_id}-{username}-{auth_database_name} OR {project_id}/{username}/{auth_database_name}")
+		err = errors.New(ErrorImportFormat)
 		return
 	}
 	projectID = parts[1]


### PR DESCRIPTION
## Description

- Avoids import error for database_user when both username and auth database contain hyphens
- Adds ImportSplit3 helper function for splitting `id` by `/`. See details on why `/` in issue

Link to any related issue(s): CLOUDP-289266 #2876

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
