### PR TITLE
chore: Deprecates tenant_id for `mongodbatlas_cloud_backup_snapshot_export_bucket`

### DIFF
--- a/docs/data-sources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_bucket.md
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
 
 
 

--- a/docs/data-sources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_bucket.md
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
 
 
 

--- a/docs/data-sources/cloud_backup_snapshot_export_buckets.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_buckets.md
@@ -38,13 +38,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ### CloudProviderSnapshotExportBucket
 * `project_id` - The unique identifier of the project for the Atlas cluster.
-* `export_bucket_id` -	Unique identifier of the snapshot bucket id.
+* `export_bucket_id` - Unique identifier of the snapshot bucket id.
 * `iam_role_id` - Unique identifier of the role that Atlas can use to access the bucket.
 * `bucket_name` - Name of the bucket that the provided role ID is authorized to access.
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
 
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/create-one-export-bucket/)

--- a/docs/data-sources/cloud_backup_snapshot_export_buckets.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_buckets.md
@@ -23,7 +23,7 @@ data "mongodbatlas_cloud_backup_snapshot_export_buckets" "test" {
 ## Argument Reference
 
 * `project_id` - (Required) The unique identifier of the project for the Atlas cluster.
-* `page_num` - (Optional)  	The page to return. Defaults to `1`.
+* `page_num` - (Optional)   The page to return. Defaults to `1`.
 * `items_per_page` - (Optional) Number of items to return per page, up to a maximum of 500. Defaults to `100`.
 
 
@@ -44,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
 
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/create-one-export-bucket/)

--- a/docs/resources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/resources/cloud_backup_snapshot_export_bucket.md
@@ -1,6 +1,6 @@
 # Resource: mongodbatlas_cloud_backup_snapshot_export_bucket
 
-`mongodbatlas_cloud_backup_snapshot_export_bucket` allows you to create an export snapshot bucket for the specified project. 
+`mongodbatlas_cloud_backup_snapshot_export_bucket` allows you to create an export snapshot bucket for the specified project.
 
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
@@ -39,20 +39,20 @@ resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
 * `iam_role_id` - Unique identifier of the role that Atlas can use to access the bucket. Required if `cloud_provider` is set to `AWS`.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container. Required if `cloud_provider` is set to `AZURE`.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account. Required if `cloud_provider` is set to `AZURE`.
-* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `export_bucket_id` -	Unique identifier of the snapshot export bucket.
+* `export_bucket_id` - Unique identifier of the snapshot export bucket.
 
 ## Import
 
 Cloud Backup Snapshot Export Backup entries can be imported using project project_id, and bucket_id (Unique identifier of the snapshot export bucket), in the format `PROJECTID-BUCKETID`, e.g.
 
 ```
-$ terraform import mongodbatlas_cloud_backup_snapshot_export_bucket.test 5d0f1f73cf09a29120e173cf-5d116d82014b764445b2f9b5
+terraform import mongodbatlas_cloud_backup_snapshot_export_bucket.test 5d0f1f73cf09a29120e173cf-5d116d82014b764445b2f9b5
 ```
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/create-one-export-bucket/)

--- a/docs/resources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/resources/cloud_backup_snapshot_export_bucket.md
@@ -26,7 +26,6 @@ resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
   project_id   = "{PROJECT_ID}"
   role_id = "{ROLE_ID}"
   service_url = "{SERVICE_URL}"
-  tenant_id = "{TENANT_ID}"
   bucket_name = "example-bucket"
   cloud_provider = "AZURE"
 }
@@ -40,7 +39,7 @@ resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
 * `iam_role_id` - Unique identifier of the role that Atlas can use to access the bucket. Required if `cloud_provider` is set to `AWS`.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container. Required if `cloud_provider` is set to `AZURE`.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account. Required if `cloud_provider` is set to `AZURE`.
-* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID. Required if `cloud_provider` is set to `AZURE`.
+* `tenant_id` - (Deprecated) This field is ignored; the tenantId of the Cloud Provider Access role (from roleId) is used. UUID that identifies the Azure Active Directory Tenant ID.
 
 ## Attributes Reference
 

--- a/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/azure/main.tf
+++ b/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/azure/main.tf
@@ -21,10 +21,9 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
 
 
 resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
-  project_id     = var.tenant_id
+  project_id     = var.project_id
   bucket_name    = azurerm_storage_container.test_storage_container.name
   cloud_provider = "AZURE"
   service_url    = azurerm_storage_account.test_storage_account.primary_blob_endpoint
   role_id        = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
-  tenant_id      = var.tenant_id
 }

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -76,7 +76,7 @@ func Schema() map[string]*schema.Schema {
 			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " The tenant_id is found using the `mongodbatlas_cloud_provider_access_authorization` and will have no effect.",
 			Type:       schema.TypeString,
 			Optional:   true,
-			ForceNew:   true,
+			Computed:   true,
 		},
 	}
 }
@@ -87,7 +87,6 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	projectID := d.Get("project_id").(string)
 
 	cloudProvider := d.Get("cloud_provider").(string)
-
 	request := &admin.DiskBackupSnapshotExportBucketRequest{
 		IamRoleId:     conversion.StringPtr(d.Get("iam_role_id").(string)),
 		BucketName:    d.Get("bucket_name").(string),
@@ -95,7 +94,6 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		ServiceUrl:    conversion.StringPtr(d.Get("service_url").(string)),
 		CloudProvider: cloudProvider,
 	}
-
 	bucketResponse, _, err := conn.CloudBackupsApi.CreateExportBucket(ctx, projectID, request).Execute()
 	if err != nil {
 		return diag.Errorf("error creating snapshot export bucket: %s", err)

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -92,6 +92,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		BucketName:    d.Get("bucket_name").(string),
 		RoleId:        conversion.StringPtr(d.Get("role_id").(string)),
 		ServiceUrl:    conversion.StringPtr(d.Get("service_url").(string)),
+		TenantId:      conversion.StringPtr(d.Get("tenant_id").(string)),
 		CloudProvider: cloudProvider,
 	}
 	bucketResponse, _, err := conn.CloudBackupsApi.CreateExportBucket(ctx, projectID, request).Execute()

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -73,7 +73,7 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " The tenant_id is found using the `mongodbatlas_cloud_provider_access_authorization` and will have no effect.",
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " The tenantId of the Cloud Provider Access role (from roleId) is used.",
 			Type:       schema.TypeString,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -72,9 +73,10 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " The tenant_id is found using the `mongodbatlas_cloud_provider_access_authorization` and will have no effect.",
+			Type:       schema.TypeString,
+			Optional:   true,
+			ForceNew:   true,
 		},
 	}
 }
@@ -91,7 +93,6 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		BucketName:    d.Get("bucket_name").(string),
 		RoleId:        conversion.StringPtr(d.Get("role_id").(string)),
 		ServiceUrl:    conversion.StringPtr(d.Get("service_url").(string)),
-		TenantId:      conversion.StringPtr(d.Get("tenant_id").(string)),
 		CloudProvider: cloudProvider,
 	}
 

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -73,7 +73,7 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " The tenantId of the Cloud Provider Access role (from roleId) is used.",
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead.",
 			Type:       schema.TypeString,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -91,7 +91,6 @@ func basicAzureTestCase(t *testing.T) *resource.TestCase {
 			"project_id":     projectID,
 			"bucket_name":    bucketName,
 			"service_url":    serviceURL,
-			"tenant_id":      tenantID,
 			"cloud_provider": "AZURE",
 		}
 		pluralAttrMapCheck = map[string]string{
@@ -99,7 +98,6 @@ func basicAzureTestCase(t *testing.T) *resource.TestCase {
 			"results.#":                "1",
 			"results.0.bucket_name":    bucketName,
 			"results.0.service_url":    serviceURL,
-			"results.0.tenant_id":      tenantID,
 			"results.0.cloud_provider": "AZURE",
 		}
 		attrsSet = []string{
@@ -291,7 +289,6 @@ func configAzureBasic(projectID, atlasAzureAppID, servicePrincipalID, tenantID, 
             cloud_provider = "AZURE"
 			service_url	   = %[6]q
 			role_id		   = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
-			tenant_id	   = %[4]q
         }
 
         data "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {


### PR DESCRIPTION
## Description

Deprecates tenant_id for `mongodbatlas_cloud_backup_snapshot_export_bucket`

Link to any related issue(s): CLOUDP-280210

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
