### PR TITLE
feat: Adds support for `future_inbound` and `future_outbound` in `mongodbatlas_project_ip_addresses` data source

### DIFF
--- a/.changelog/2934.txt
+++ b/.changelog/2934.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/mongodbatlas_project_ip_addresses: Adds support for `future_inbound` and `future_outbound` fields
+```

--- a/docs/data-sources/project_ip_addresses.md
+++ b/docs/data-sources/project_ip_addresses.md
@@ -37,9 +37,9 @@ Read-Only:
 Read-Only:
 
 - `cluster_name` (String) Human-readable label that identifies the cluster.
-- `inbound` (List of String) List of inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.
-- `outbound` (List of String) List of outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.
 - `future_inbound` (List of String) List of future inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.
 - `future_outbound` (List of String) List of future outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.
+- `inbound` (List of String) List of inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.
+- `outbound` (List of String) List of outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.
 
 For more information see: [MongoDB Atlas API - Return All IP Addresses for One Project](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/returnAllIPAddresses) Documentation.

--- a/docs/data-sources/project_ip_addresses.md
+++ b/docs/data-sources/project_ip_addresses.md
@@ -39,5 +39,7 @@ Read-Only:
 - `cluster_name` (String) Human-readable label that identifies the cluster.
 - `inbound` (List of String) List of inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.
 - `outbound` (List of String) List of outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.
+- `future_inbound` (List of String) List of future inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.
+- `future_outbound` (List of String) List of future outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.
 
 For more information see: [MongoDB Atlas API - Return All IP Addresses for One Project](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/returnAllIPAddresses) Documentation.

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	go.mongodb.org/atlas v0.37.0
 	go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0
 	go.mongodb.org/atlas-sdk/v20240805005 v20240805005.0.0
-	go.mongodb.org/atlas-sdk/v20241113004 v20241113004.0.0
+	go.mongodb.org/atlas-sdk/v20241113004 v20241113004.1.0
 	go.mongodb.org/realm v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/huandu/xstrings v1.5.0
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/mongodb-forks/digest v1.1.0
-	github.com/mongodb/atlas-sdk-go v1.0.1-0.20241223083721-8ac5cf414bba
+	github.com/mongodb/atlas-sdk-go v1.0.1-0.20241230083710-6269ca486ddc
 	github.com/pb33f/libopenapi v0.18.7
 	github.com/sebdah/goldie/v2 v2.5.5
 	github.com/spf13/cast v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -831,6 +831,8 @@ go.mongodb.org/atlas-sdk/v20240805005 v20240805005.0.0 h1:EGTT54tKbDbkhhK+jH5AqI
 go.mongodb.org/atlas-sdk/v20240805005 v20240805005.0.0/go.mod h1:UTNpAyiKm/7utu+Nl0FafgjgvS+ONNGEoxBT5g/40WM=
 go.mongodb.org/atlas-sdk/v20241113004 v20241113004.0.0 h1:dmIp82dS4foajdKgcKRfr26g0cWE52jQAf+nbgFXr10=
 go.mongodb.org/atlas-sdk/v20241113004 v20241113004.0.0/go.mod h1:z6m7PcfItkgV3+mnLuStlTkdTbfUBQJpRyES8tuHNCk=
+go.mongodb.org/atlas-sdk/v20241113004 v20241113004.1.0 h1:AvrgNUpVMFnqZZJo4m/Bynr0wlDWM4xjhugCSdX/7mM=
+go.mongodb.org/atlas-sdk/v20241113004 v20241113004.1.0/go.mod h1:CABkQ0sbsqRBXR55UwS+0rX91Dx7et0xxq4QBB6qRog=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -657,6 +657,8 @@ github.com/mongodb-forks/digest v1.1.0 h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKk
 github.com/mongodb-forks/digest v1.1.0/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
 github.com/mongodb/atlas-sdk-go v1.0.1-0.20241223083721-8ac5cf414bba h1:qJjgKkLgQCZOXmEqkq9FostE2m6KkKgAHftdzU0iSJM=
 github.com/mongodb/atlas-sdk-go v1.0.1-0.20241223083721-8ac5cf414bba/go.mod h1:WzU2E+/RcJGnhjdnBzXpbGBqq/XbDhFDEaru0UNmbxc=
+github.com/mongodb/atlas-sdk-go v1.0.1-0.20241230083710-6269ca486ddc h1:xI+JEVy5g0ycG9VDeWsPMriPk/z0/TWElki6UoUDgcA=
+github.com/mongodb/atlas-sdk-go v1.0.1-0.20241230083710-6269ca486ddc/go.mod h1:WzU2E+/RcJGnhjdnBzXpbGBqq/XbDhFDEaru0UNmbxc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/internal/service/projectipaddresses/data_source.go
+++ b/internal/service/projectipaddresses/data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -31,7 +32,7 @@ func (d *projectIPAddressesDS) Schema(ctx context.Context, req datasource.Schema
 }
 
 func (d *projectIPAddressesDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	connV2 := d.Client.AtlasV2
+	connV2 := d.Client.AtlasPreview // TODO: revert
 	var databaseDSUserConfig *TFProjectIpAddressesModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &databaseDSUserConfig)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/service/projectipaddresses/data_source.go
+++ b/internal/service/projectipaddresses/data_source.go
@@ -32,7 +32,7 @@ func (d *projectIPAddressesDS) Schema(ctx context.Context, req datasource.Schema
 }
 
 func (d *projectIPAddressesDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	connV2 := d.Client.AtlasPreview // TODO: revert
+	connV2 := d.Client.AtlasV2
 	var databaseDSUserConfig *TFProjectIpAddressesModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &databaseDSUserConfig)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/service/projectipaddresses/data_source_schema.go
+++ b/internal/service/projectipaddresses/data_source_schema.go
@@ -57,9 +57,11 @@ type TFServicesModel struct {
 }
 
 type TFClusterValueModel struct {
-	ClusterName types.String `tfsdk:"cluster_name"`
-	Inbound     types.List   `tfsdk:"inbound"`
-	Outbound    types.List   `tfsdk:"outbound"`
+	ClusterName    types.String `tfsdk:"cluster_name"`
+	Inbound        types.List   `tfsdk:"inbound"`
+	Outbound       types.List   `tfsdk:"outbound"`
+	FutureInbound  types.List   `tfsdk:"future_inbound"`
+	FutureOutbound types.List   `tfsdk:"future_outbound"`
 }
 
 var IPAddressesObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -72,7 +74,9 @@ var ServicesObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 }}
 
 var ClusterIPsObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"cluster_name": types.StringType,
-	"inbound":      types.ListType{ElemType: types.StringType},
-	"outbound":     types.ListType{ElemType: types.StringType},
+	"cluster_name":    types.StringType,
+	"inbound":         types.ListType{ElemType: types.StringType},
+	"outbound":        types.ListType{ElemType: types.StringType},
+	"future_inbound":  types.ListType{ElemType: types.StringType},
+	"future_outbound": types.ListType{ElemType: types.StringType},
 }}

--- a/internal/service/projectipaddresses/data_source_schema.go
+++ b/internal/service/projectipaddresses/data_source_schema.go
@@ -34,6 +34,16 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 									Computed:            true,
 									MarkdownDescription: "List of outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.",
 								},
+								"future_inbound": schema.ListAttribute{
+									ElementType:         types.StringType,
+									Computed:            true,
+									MarkdownDescription: "List of future inbound IP addresses associated with the cluster. If your network allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your application can connect to your Atlas cluster.",
+								},
+								"future_outbound": schema.ListAttribute{
+									ElementType:         types.StringType,
+									Computed:            true,
+									MarkdownDescription: "List of future outbound IP addresses associated with the cluster. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that your Atlas cluster can communicate with your webhooks and KMS.",
+								},
 							},
 						},
 						Computed:            true,

--- a/internal/service/projectipaddresses/model.go
+++ b/internal/service/projectipaddresses/model.go
@@ -3,11 +3,10 @@ package projectipaddresses
 import (
 	"context"
 
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	// "go.mongodb.org/atlas-sdk/v20241113004/admin" // TODO: revert
-	"github.com/mongodb/atlas-sdk-go/admin"
 )
 
 func NewTFProjectIPAddresses(ctx context.Context, ipAddresses *admin.GroupIPAddresses) (*TFProjectIpAddressesModel, diag.Diagnostics) {

--- a/internal/service/projectipaddresses/model.go
+++ b/internal/service/projectipaddresses/model.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+
+	// "go.mongodb.org/atlas-sdk/v20241113004/admin" // TODO: revert
+	"github.com/mongodb/atlas-sdk-go/admin"
 )
 
 func NewTFProjectIPAddresses(ctx context.Context, ipAddresses *admin.GroupIPAddresses) (*TFProjectIpAddressesModel, diag.Diagnostics) {
@@ -14,11 +16,15 @@ func NewTFProjectIPAddresses(ctx context.Context, ipAddresses *admin.GroupIPAddr
 	for i, cluster := range ipAddresses.Services.GetClusters() {
 		inbound, _ := types.ListValueFrom(ctx, types.StringType, cluster.GetInbound())
 		outbound, _ := types.ListValueFrom(ctx, types.StringType, cluster.GetOutbound())
+		futureInbound, _ := types.ListValueFrom(ctx, types.StringType, cluster.GetFutureInbound())
+		futureOutbound, _ := types.ListValueFrom(ctx, types.StringType, cluster.GetFutureOutbound())
 
 		clusterObjs[i] = TFClusterValueModel{
-			ClusterName: types.StringPointerValue(cluster.ClusterName),
-			Inbound:     inbound,
-			Outbound:    outbound,
+			ClusterName:    types.StringPointerValue(cluster.ClusterName),
+			Inbound:        inbound,
+			Outbound:       outbound,
+			FutureInbound:  futureInbound,
+			FutureOutbound: futureOutbound,
 		}
 	}
 

--- a/internal/service/projectipaddresses/model_test.go
+++ b/internal/service/projectipaddresses/model_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+
 	// "go.mongodb.org/atlas-sdk/v20241113004/admin" // TODO: revert
 	"github.com/mongodb/atlas-sdk-go/admin"
 

--- a/internal/service/projectipaddresses/model_test.go
+++ b/internal/service/projectipaddresses/model_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/projectipaddresses"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+	// "go.mongodb.org/atlas-sdk/v20241113004/admin" // TODO: revert
+	"github.com/mongodb/atlas-sdk-go/admin"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/projectipaddresses"
 )
 
 const (
@@ -28,14 +30,18 @@ func TestProjectIPAddressesSDKToTFModel(t *testing.T) {
 				Services: &admin.GroupService{
 					Clusters: &[]admin.ClusterIPAddresses{
 						{
-							ClusterName: admin.PtrString("cluster1"),
-							Inbound:     &[]string{"192.168.1.1", "192.168.1.2"},
-							Outbound:    &[]string{"10.0.0.1", "10.0.0.2"},
+							ClusterName:    admin.PtrString("cluster1"),
+							Inbound:        &[]string{"192.168.1.1", "192.168.1.2"},
+							Outbound:       &[]string{"10.0.0.1", "10.0.0.2"},
+							FutureInbound:  &[]string{"192.168.1.1", "192.168.1.2"},
+							FutureOutbound: &[]string{"10.0.0.1", "10.0.0.2"},
 						},
 						{
-							ClusterName: admin.PtrString("cluster2"),
-							Inbound:     &[]string{"192.168.2.1"},
-							Outbound:    &[]string{"10.0.1.1"},
+							ClusterName:    admin.PtrString("cluster2"),
+							Inbound:        &[]string{"192.168.2.1"},
+							Outbound:       &[]string{"10.0.1.1"},
+							FutureInbound:  &[]string{"192.168.2.1"},
+							FutureOutbound: &[]string{"10.0.1.1"},
 						},
 					},
 				},
@@ -53,6 +59,14 @@ func TestProjectIPAddressesSDKToTFModel(t *testing.T) {
 							types.StringValue("10.0.0.1"),
 							types.StringValue("10.0.0.2"),
 						}),
+						FutureInbound: types.ListValueMust(types.StringType, []attr.Value{
+							types.StringValue("192.168.1.1"),
+							types.StringValue("192.168.1.2"),
+						}),
+						FutureOutbound: types.ListValueMust(types.StringType, []attr.Value{
+							types.StringValue("10.0.0.1"),
+							types.StringValue("10.0.0.2"),
+						}),
 					},
 					{
 						ClusterName: types.StringValue("cluster2"),
@@ -60,6 +74,12 @@ func TestProjectIPAddressesSDKToTFModel(t *testing.T) {
 							types.StringValue("192.168.2.1"),
 						}),
 						Outbound: types.ListValueMust(types.StringType, []attr.Value{
+							types.StringValue("10.0.1.1"),
+						}),
+						FutureInbound: types.ListValueMust(types.StringType, []attr.Value{
+							types.StringValue("192.168.2.1"),
+						}),
+						FutureOutbound: types.ListValueMust(types.StringType, []attr.Value{
 							types.StringValue("10.0.1.1"),
 						}),
 					},
@@ -72,9 +92,11 @@ func TestProjectIPAddressesSDKToTFModel(t *testing.T) {
 				Services: &admin.GroupService{
 					Clusters: &[]admin.ClusterIPAddresses{
 						{
-							ClusterName: admin.PtrString("cluster1"),
-							Inbound:     &[]string{},
-							Outbound:    &[]string{},
+							ClusterName:    admin.PtrString("cluster1"),
+							Inbound:        &[]string{},
+							Outbound:       &[]string{},
+							FutureInbound:  &[]string{},
+							FutureOutbound: &[]string{},
 						},
 					},
 				},
@@ -83,9 +105,11 @@ func TestProjectIPAddressesSDKToTFModel(t *testing.T) {
 				ProjectId: types.StringValue(dummyProjectID),
 				Services: createExpectedServices(t, []projectipaddresses.TFClusterValueModel{
 					{
-						ClusterName: types.StringValue("cluster1"),
-						Inbound:     types.ListValueMust(types.StringType, []attr.Value{}),
-						Outbound:    types.ListValueMust(types.StringType, []attr.Value{}),
+						ClusterName:    types.StringValue("cluster1"),
+						Inbound:        types.ListValueMust(types.StringType, []attr.Value{}),
+						Outbound:       types.ListValueMust(types.StringType, []attr.Value{}),
+						FutureInbound:  types.ListValueMust(types.StringType, []attr.Value{}),
+						FutureOutbound: types.ListValueMust(types.StringType, []attr.Value{}),
 					},
 				}),
 			},

--- a/internal/service/projectipaddresses/model_test.go
+++ b/internal/service/projectipaddresses/model_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-
-	// "go.mongodb.org/atlas-sdk/v20241113004/admin" // TODO: revert
-	"github.com/mongodb/atlas-sdk-go/admin"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/projectipaddresses"
 )


### PR DESCRIPTION
## Description

Adds support for `future_inbound` and `future_outbound` in `mongodbatlas_project_ip_addresses` data source



Link to any related issue(s): [CLOUDP-279222](https://jira.mongodb.org/browse/CLOUDP-279222)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Config:
```
output "ipAddr_inbound" {
  value = data.mongodbatlas_project_ip_addresses.test.services.clusters[0].future_inbound[0]
}

output "ipAddr_outbound" {
  value = data.mongodbatlas_project_ip_addresses.test.services.clusters[0].future_outbound[1]
}
```

TF console output:
```
terraform plan -target data.mongodbatlas_project_ip_addresses.test
data.mongodbatlas_project_ip_addresses.test: Reading...
data.mongodbatlas_project_ip_addresses.test: Read complete after 3s

Changes to Outputs:
  + ipAddr_inbound  = "1.2.3.4"
  + ipAddr_outbound = "5.6.7.8"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```