### PR TITLE
Update docs to clarify where `service_name` can be found

### DIFF
--- a/docs/resources/privatelink_endpoint_service_data_federation_online_archive.md
+++ b/docs/resources/privatelink_endpoint_service_data_federation_online_archive.md
@@ -15,15 +15,25 @@ resource "mongodbatlas_project" "atlas-project" {
   name   = var.atlas_project_name
 }
 
+resource "aws_vpc_endpoint" "test" {
+  vpc_id             = "vpc-7fc0a543"
+  service_name       = "<SERVICE-NAME>"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = ["subnet-de0406d2"]
+  security_group_ids = ["sg-3f238186"]
+}
+
 resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
-  project_id = mongodbatlas_project.atlas-project.id
-  endpoint_id = "vpce-046cf43c79424d4c9"
+  project_id    = mongodbatlas_project.atlas-project.id
+  endpoint_id   = aws_vpc_endpoint.test.id
   provider_name = "AWS"
-  comment = "Test"
+  comment       = "Test"
   region        = "US_EAST_1"
-  customer_endpoint_dns_name = "vpce-046cf43c79424d4c9-nmls2y9k.vpce-svc-0824460b72e1a420e.us-east-1.vpce.amazonaws.com"
+  customer_endpoint_dns_name = aws_vpc_endpoint.test.dns_entry[0].dns_name
 }
 ```
+
+The `service_name` value for the region in question can be found in the [MongoDB Atlas Administration](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createDataFederationPrivateEndpoint) documentation.
 
 ## Argument Reference
 


### PR DESCRIPTION
## Description

Currently, our federated endpoint docs do not indicate where the VPC endpoint service name can be found.

This commit adds an example `aws_vpc_endpoint` resource and links to the Atlas Admin API docs that list the different available service names.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
