### PR TITLE
chore: Adds deprecation notice for `tenant_id` attribute in `mongodbatlas_cloud_backup_snapshot_export_bucket` and remove deprecation on attribute to avoid warnings

### DIFF
--- a/.changelog/2932.txt
+++ b/.changelog/2932.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Deprecates `tenant_id` attribute as the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead
+```

--- a/.changelog/2932.txt
+++ b/.changelog/2932.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Deprecates `tenant_id` attribute as the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead
+resource/mongodbatlas_cloud_backup_snapshot_export_bucket: Deprecates `tenant_id` argument as the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead
 ```

--- a/docs/data-sources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_bucket.md
@@ -35,7 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID.
 
 
 

--- a/docs/data-sources/cloud_backup_snapshot_export_buckets.md
+++ b/docs/data-sources/cloud_backup_snapshot_export_buckets.md
@@ -44,7 +44,7 @@ In addition to all arguments above, the following attributes are exported:
 * `cloud_provider` - Name of the provider of the cloud service where Atlas can access the S3 bucket.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account.
-* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID.
 
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/reference/api/cloud-backup/export/create-one-export-bucket/)

--- a/docs/resources/cloud_backup_snapshot_export_bucket.md
+++ b/docs/resources/cloud_backup_snapshot_export_bucket.md
@@ -39,13 +39,14 @@ resource "mongodbatlas_cloud_backup_snapshot_export_bucket" "test" {
 * `iam_role_id` - Unique identifier of the role that Atlas can use to access the bucket. Required if `cloud_provider` is set to `AWS`.
 * `role_id` - Unique identifier of the Azure Service Principal that Atlas can use to access the Azure Blob Storage Container. Required if `cloud_provider` is set to `AZURE`.
 * `service_url` - URL that identifies the blob Endpoint of the Azure Blob Storage Account. Required if `cloud_provider` is set to `AZURE`.
-* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. UUID that identifies the Azure Active Directory Tenant ID.
+* `tenant_id` - (Deprecated) This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead and returned as an attribute. UUID that identifies the Azure Active Directory Tenant ID.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `export_bucket_id` - Unique identifier of the snapshot export bucket.
+* `tenant_id` - UUID that identifies the Azure Active Directory Tenant ID.
 
 ## Import
 

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -73,7 +73,7 @@ func Schema() map[string]*schema.Schema {
 		},
 		"tenant_id": {
 			Type:     schema.TypeString,
-			Optional: true,
+			Optional: true, // attribute is only used as a computed, this is called out in docs and configuration of optional argument can be eventually removed implying a breaking change. To be removed in https://jira.mongodb.org/browse/CLOUDP-293142
 			Computed: true,
 		},
 	}

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -73,7 +73,6 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " This argument is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. The attribute exist but it is computed only.",
 			Type:       schema.TypeString,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -73,7 +73,7 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " This field is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead.",
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByVersion, "1.27.0") + " This argument is ignored; the `mongodbatlas_cloud_provider_access_authorization.azure.tenant_id` is used instead. The attribute exist but it is computed only.",
 			Type:       schema.TypeString,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -73,9 +72,9 @@ func Schema() map[string]*schema.Schema {
 			ForceNew: true,
 		},
 		"tenant_id": {
-			Type:       schema.TypeString,
-			Optional:   true,
-			Computed:   true,
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket_test.go
@@ -91,6 +91,7 @@ func basicAzureTestCase(t *testing.T) *resource.TestCase {
 			"project_id":     projectID,
 			"bucket_name":    bucketName,
 			"service_url":    serviceURL,
+			"tenant_id":      tenantID,
 			"cloud_provider": "AZURE",
 		}
 		pluralAttrMapCheck = map[string]string{
@@ -99,6 +100,7 @@ func basicAzureTestCase(t *testing.T) *resource.TestCase {
 			"results.0.bucket_name":    bucketName,
 			"results.0.service_url":    serviceURL,
 			"results.0.cloud_provider": "AZURE",
+			"results.0.tenant_id":      tenantID,
 		}
 		attrsSet = []string{
 			"role_id",


### PR DESCRIPTION
## Description

- Adds deprecation notice for `tenant_id` attribute in `mongodbatlas_cloud_backup_snapshot_export_bucket`
- Remove deprecation of attribute to avoid warnings

Link to any related issue(s): CLOUDP-280210

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
