### PR TITLE
feat: Supports `PRIVATE_LINK` networking type in `mongodbatlas_stream_connection` resource and data sources

### DIFF
--- a/.changelog/2940.txt
+++ b/.changelog/2940.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_stream_connection: Supports PRIVATE_LINK networking type for Kafka Stream Connections
+resource/mongodbatlas_stream_connection: Supports Privatelink networking access type for Kafka Stream Connections
 ```

--- a/.changelog/2940.txt
+++ b/.changelog/2940.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+mongodbatlas_stream_connection: Supports PRIVATE_LINK networking type for Kafka Stream Connections
+```

--- a/.changelog/2940.txt
+++ b/.changelog/2940.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-mongodbatlas_stream_connection: Supports PRIVATE_LINK networking type for Kafka Stream Connections
+resource/mongodbatlas_stream_connection: Supports PRIVATE_LINK networking type for Kafka Stream Connections
 ```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -53,8 +53,9 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `access` - Information about the networking access. See [access](#access).
 
 ### Access
-* `name` - Id of the vpc peer when the type is `VPC`.
-* `type` - Selected networking type. Either `PUBLIC` or `VPC`. Defaults to `PUBLIC`.
+* `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
+* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
+* `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/getStreamConnection) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -54,7 +54,6 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 ### Access
 * `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
-* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
 * `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/getStreamConnection) Documentation.

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -65,8 +65,9 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `access` - Information about the networking access. See [access](#access).
 
 ### Access
-* `name` - Id of the vpc peer when the type is `VPC`.
-* `type` - Networking type. Either `PUBLIC` or `VPC`. Default is `PUBLIC`.
+* `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
+* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
+* `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/listStreamConnections) Documentation.
 The [Terraform Provider Examples Section](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/mongodbatlas_stream_instance/atlas-streams-user-journey.md) also contains details on the overall support for Atlas Streams Processing in Terraform.

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -66,7 +66,6 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 ### Access
 * `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
-* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
 * `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 To learn more, see: [MongoDB Atlas API - Stream Connection](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/listStreamConnections) Documentation.

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -105,7 +105,6 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 
 ### Access
 * `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
-* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
 * `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 ## Import

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -104,8 +104,9 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 * `access` - Information about the networking access. See [access](#access).
 
 ### Access
-* `name` - Id of the vpc peer when the type is `VPC`.
-* `type` - Selected networking type. Either `PUBLIC` or `VPC`. Defaults to `PUBLIC`.
+* `type` - Selected networking type. Either `PUBLIC`, `VPC` or `PRIVATE_LINK`. Defaults to `PUBLIC`.
+* `name` - Name of the Private Link connection when type is `PRIVATE_LINK`.
+* `connection_id` - Id of the Private Link connection when type is `PRIVATE_LINK`.
 
 ## Import
 

--- a/internal/service/streamconnection/data_source_stream_connection.go
+++ b/internal/service/streamconnection/data_source_stream_connection.go
@@ -46,7 +46,7 @@ func (d *streamConnectionDS) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, nil, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, nil, nil, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamconnection/data_source_stream_connection.go
+++ b/internal/service/streamconnection/data_source_stream_connection.go
@@ -46,7 +46,7 @@ func (d *streamConnectionDS) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, nil, nil, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, nil, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -69,7 +69,6 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 			Access: &admin.StreamsKafkaNetworkingAccess{
 				Type:         networkingModel.Access.Type.ValueStringPointer(),
 				ConnectionId: networkingModel.Access.ConnectionID.ValueStringPointer(),
-				Name:         networkingModel.Access.Name.ValueStringPointer(),
 			},
 		}
 	}
@@ -141,7 +140,6 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName string, cur
 		networkingModel, diags := types.ObjectValueFrom(ctx, NetworkingObjectType.AttrTypes, TFNetworkingModel{
 			Access: TFNetworkingAccessModel{
 				Type:         types.StringPointerValue(apiResp.Networking.Access.Type),
-				Name:         types.StringPointerValue(apiResp.Networking.Access.Name),
 				ConnectionID: connectionID,
 			},
 		})

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -67,7 +67,9 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		}
 		streamConnection.Networking = &admin.StreamsKafkaNetworking{
 			Access: &admin.StreamsKafkaNetworkingAccess{
-				Type: networkingModel.Access.Type.ValueStringPointer(),
+				Type:         networkingModel.Access.Type.ValueStringPointer(),
+				ConnectionId: networkingModel.Access.ConnectionID.ValueStringPointer(),
+				Name:         networkingModel.Access.Name.ValueStringPointer(),
 			},
 		}
 	}
@@ -130,7 +132,9 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName string, cur
 	if apiResp.Networking != nil {
 		networkingModel, diags := types.ObjectValueFrom(ctx, NetworkingObjectType.AttrTypes, TFNetworkingModel{
 			Access: TFNetworkingAccessModel{
-				Type: types.StringPointerValue(apiResp.Networking.Access.Type),
+				Type:         types.StringPointerValue(apiResp.Networking.Access.Type),
+				Name:         types.StringPointerValue(apiResp.Networking.Access.Name),
+				ConnectionID: types.StringPointerValue(apiResp.Networking.Access.ConnectionId),
 			},
 		})
 		if diags.HasError() {

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -46,7 +46,7 @@ type sdkToTFModelTestCase struct {
 
 func TestStreamConnectionSDKToTFModel(t *testing.T) {
 	var authConfigWithPasswordDefined = tfAuthenticationObject(t, authMechanism, authUsername, "raw password")
-	var privateLinkNetworkingConfig = tfNetworkingObject(t, privatelinkNetworkingType, nil, &connectionID)
+	var privateLinkNetworkingConfig = tfNetworkingObject(t, privatelinkNetworkingType, &connectionID)
 
 	testCases := []sdkToTFModelTestCase{
 		{
@@ -200,7 +200,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Config:           tfConfigMap(t, configMap),
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
-				Networking:       tfNetworkingObject(t, privatelinkNetworkingType, nil, &connectionID),
+				Networking:       tfNetworkingObject(t, privatelinkNetworkingType, &connectionID),
 			},
 		},
 		{
@@ -311,7 +311,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Config:           tfConfigMap(t, configMap),
 						Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 						DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
-						Networking:       tfNetworkingObject(t, networkingType, nil, nil),
+						Networking:       tfNetworkingObject(t, networkingType, nil),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -532,12 +532,11 @@ func tfDBRoleToExecuteObject(t *testing.T, role, roleType string) types.Object {
 	return auth
 }
 
-func tfNetworkingObject(t *testing.T, networkingType string, name, connectionID *string) types.Object {
+func tfNetworkingObject(t *testing.T, networkingType string, connectionID *string) types.Object {
 	t.Helper()
 	networking, diags := types.ObjectValueFrom(context.Background(), streamconnection.NetworkingObjectType.AttrTypes, streamconnection.TFNetworkingModel{
 		Access: streamconnection.TFNetworkingAccessModel{
 			Type:         types.StringValue(networkingType),
-			Name:         types.StringPointerValue(name),
 			ConnectionID: types.StringPointerValue(connectionID),
 		},
 	})

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -28,25 +28,21 @@ const (
 	privatelinkNetworkingType = "PRIVATE_LINK"
 )
 
-var connectionID = "connectionID"
-
 var configMap = map[string]string{
 	"auto.offset.reset": "earliest",
 }
 
 type sdkToTFModelTestCase struct {
-	SDKResp                  *admin.StreamsConnection
-	providedProjID           string
-	providedInstanceName     string
-	providedAuthConfig       *types.Object
-	providedNetworkingConfig *types.Object
-	expectedTFModel          *streamconnection.TFStreamConnectionModel
-	name                     string
+	SDKResp              *admin.StreamsConnection
+	providedProjID       string
+	providedInstanceName string
+	providedAuthConfig   *types.Object
+	expectedTFModel      *streamconnection.TFStreamConnectionModel
+	name                 string
 }
 
 func TestStreamConnectionSDKToTFModel(t *testing.T) {
 	var authConfigWithPasswordDefined = tfAuthenticationObject(t, authMechanism, authUsername, "raw password")
-	var privateLinkNetworkingConfig = tfNetworkingObject(t, privatelinkNetworkingType, &connectionID)
 
 	testCases := []sdkToTFModelTestCase{
 		{
@@ -60,10 +56,9 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					Type: admin.PtrString(dbRoleType),
 				},
 			},
-			providedProjID:           dummyProjectID,
-			providedInstanceName:     instanceName,
-			providedAuthConfig:       nil,
-			providedNetworkingConfig: nil,
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			providedAuthConfig:   nil,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
 				ProjectID:       types.StringValue(dummyProjectID),
 				InstanceName:    types.StringValue(instanceName),
@@ -93,10 +88,9 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					BrokerPublicCertificate: admin.PtrString(DummyCACert),
 				},
 			},
-			providedProjID:           dummyProjectID,
-			providedInstanceName:     instanceName,
-			providedAuthConfig:       &authConfigWithPasswordDefined,
-			providedNetworkingConfig: nil,
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			providedAuthConfig:   &authConfigWithPasswordDefined,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
 				ProjectID:        types.StringValue(dummyProjectID),
 				InstanceName:     types.StringValue(instanceName),
@@ -116,10 +110,9 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Name: admin.PtrString(connectionName),
 				Type: admin.PtrString("Kafka"),
 			},
-			providedProjID:           dummyProjectID,
-			providedInstanceName:     instanceName,
-			providedAuthConfig:       nil,
-			providedNetworkingConfig: nil,
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			providedAuthConfig:   nil,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
 				ProjectID:       types.StringValue(dummyProjectID),
 				InstanceName:    types.StringValue(instanceName),
@@ -148,10 +141,9 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					BrokerPublicCertificate: admin.PtrString(DummyCACert),
 				},
 			},
-			providedProjID:           dummyProjectID,
-			providedInstanceName:     instanceName,
-			providedAuthConfig:       nil,
-			providedNetworkingConfig: nil,
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			providedAuthConfig:   nil,
 			expectedTFModel: &streamconnection.TFStreamConnectionModel{
 				ProjectID:        types.StringValue(dummyProjectID),
 				InstanceName:     types.StringValue(instanceName),
@@ -163,44 +155,6 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
-			},
-		},
-		{
-			name: "Kafka connection type SDK response with Private link networking config",
-			SDKResp: &admin.StreamsConnection{
-				Name: admin.PtrString(connectionName),
-				Type: admin.PtrString("Kafka"),
-				Authentication: &admin.StreamsKafkaAuthentication{
-					Mechanism: admin.PtrString(authMechanism),
-					Username:  admin.PtrString(authUsername),
-				},
-				BootstrapServers: admin.PtrString(bootstrapServers),
-				Config:           &configMap,
-				Security: &admin.StreamsKafkaSecurity{
-					Protocol:                admin.PtrString(securityProtocol),
-					BrokerPublicCertificate: admin.PtrString(DummyCACert),
-				},
-				Networking: &admin.StreamsKafkaNetworking{
-					Access: &admin.StreamsKafkaNetworkingAccess{
-						Type: admin.PtrString(privatelinkNetworkingType),
-					},
-				},
-			},
-			providedProjID:           dummyProjectID,
-			providedInstanceName:     instanceName,
-			providedAuthConfig:       nil,
-			providedNetworkingConfig: &privateLinkNetworkingConfig,
-			expectedTFModel: &streamconnection.TFStreamConnectionModel{
-				ProjectID:        types.StringValue(dummyProjectID),
-				InstanceName:     types.StringValue(instanceName),
-				ConnectionName:   types.StringValue(connectionName),
-				Type:             types.StringValue("Kafka"),
-				Authentication:   tfAuthenticationObjectWithNoPassword(t, authMechanism, authUsername),
-				BootstrapServers: types.StringValue(bootstrapServers),
-				Config:           tfConfigMap(t, configMap),
-				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
-				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
-				Networking:       tfNetworkingObject(t, privatelinkNetworkingType, &connectionID),
 			},
 		},
 		{
@@ -227,7 +181,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resultModel, diags := streamconnection.NewTFStreamConnection(context.Background(), tc.providedProjID, tc.providedInstanceName, tc.providedAuthConfig, tc.providedNetworkingConfig, tc.SDKResp)
+			resultModel, diags := streamconnection.NewTFStreamConnection(context.Background(), tc.providedProjID, tc.providedInstanceName, tc.providedAuthConfig, tc.SDKResp)
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -264,7 +264,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Config:           tfConfigMap(t, configMap),
 						Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 						DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
-						Networking:       tfNetworkingObject(t, networkingType),
+						Networking:       tfNetworkingObject(t, networkingType, nil, nil),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -485,11 +485,13 @@ func tfDBRoleToExecuteObject(t *testing.T, role, roleType string) types.Object {
 	return auth
 }
 
-func tfNetworkingObject(t *testing.T, networkingType string) types.Object {
+func tfNetworkingObject(t *testing.T, networkingType string, name, connectionID *string) types.Object {
 	t.Helper()
 	networking, diags := types.ObjectValueFrom(context.Background(), streamconnection.NetworkingObjectType.AttrTypes, streamconnection.TFNetworkingModel{
 		Access: streamconnection.TFNetworkingAccessModel{
-			Type: types.StringValue(networkingType),
+			Type:         types.StringValue(networkingType),
+			Name:         types.StringPointerValue(name),
+			ConnectionID: types.StringPointerValue(connectionID),
 		},
 	})
 	if diags.HasError() {

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -534,11 +534,15 @@ func tfDBRoleToExecuteObject(t *testing.T, role, roleType string) types.Object {
 
 func tfNetworkingObject(t *testing.T, networkingType string, connectionID *string) types.Object {
 	t.Helper()
+	networkingAccessModel, diags := types.ObjectValueFrom(context.Background(), streamconnection.NetworkingAccessObjectType.AttrTypes, streamconnection.TFNetworkingAccessModel{
+		Type:         types.StringValue(networkingType),
+		ConnectionID: types.StringPointerValue(connectionID),
+	})
+	if diags.HasError() {
+		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())
+	}
 	networking, diags := types.ObjectValueFrom(context.Background(), streamconnection.NetworkingObjectType.AttrTypes, streamconnection.TFNetworkingModel{
-		Access: streamconnection.TFNetworkingAccessModel{
-			Type:         types.StringValue(networkingType),
-			ConnectionID: types.StringPointerValue(connectionID),
-		},
+		Access: networkingAccessModel,
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -112,6 +112,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							"type": schema.StringAttribute{
 								Required: true,
 							},
+							"name": schema.StringAttribute{
+								Optional: true,
+							},
+							"connection_id": schema.StringAttribute{
+								Optional: true,
+							},
 						},
 					},
 				},

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -112,9 +112,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							"type": schema.StringAttribute{
 								Required: true,
 							},
-							"name": schema.StringAttribute{
-								Optional: true,
-							},
 							"connection_id": schema.StringAttribute{
 								Optional: true,
 							},

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -91,7 +91,7 @@ var NetworkingAccessObjectType = types.ObjectType{AttrTypes: map[string]attr.Typ
 }}
 
 type TFNetworkingModel struct {
-	Access TFNetworkingAccessModel `tfsdk:"access"`
+	Access types.Object `tfsdk:"access"`
 }
 
 var NetworkingObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -126,7 +126,7 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, &streamConnectionPlan.Networking, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -155,7 +155,7 @@ func (r *streamConnectionRS) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionState.Authentication, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionState.Authentication, &streamConnectionState.Networking, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -185,7 +185,7 @@ func (r *streamConnectionRS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, &streamConnectionPlan.Networking, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -81,11 +81,15 @@ var DBRoleToExecuteObjectType = types.ObjectType{AttrTypes: map[string]attr.Type
 }}
 
 type TFNetworkingAccessModel struct {
-	Type types.String `tfsdk:"type"`
+	Type         types.String `tfsdk:"type"`
+	Name         types.String `tfsdk:"name"`
+	ConnectionID types.String `tfsdk:"connection_id"`
 }
 
 var NetworkingAccessObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"type": types.StringType,
+	"type":          types.StringType,
+	"name":          types.StringType,
+	"connection_id": types.StringType,
 }}
 
 type TFNetworkingModel struct {

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -124,7 +124,7 @@ func (r *streamConnectionRS) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, &streamConnectionPlan.Networking, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -153,7 +153,7 @@ func (r *streamConnectionRS) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionState.Authentication, &streamConnectionState.Networking, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionState.Authentication, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -183,7 +183,7 @@ func (r *streamConnectionRS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, &streamConnectionPlan.Networking, apiResp)
+	newStreamConnectionModel, diags := NewTFStreamConnection(ctx, projectID, instanceName, &streamConnectionPlan.Authentication, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -82,13 +82,11 @@ var DBRoleToExecuteObjectType = types.ObjectType{AttrTypes: map[string]attr.Type
 
 type TFNetworkingAccessModel struct {
 	Type         types.String `tfsdk:"type"`
-	Name         types.String `tfsdk:"name"`
 	ConnectionID types.String `tfsdk:"connection_id"`
 }
 
 var NetworkingAccessObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 	"type":          types.StringType,
-	"name":          types.StringType,
 	"connection_id": types.StringType,
 }}
 

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -14,10 +15,11 @@ import (
 
 var (
 	//go:embed testdata/dummy-ca.pem
-	DummyCACert          string
-	networkingTypeVPC    = "VPC"
-	networkingTypePublic = "PUBLIC"
-	kafkaNetworkingVPC   = fmt.Sprintf(`networking = {
+	DummyCACert               string
+	networkingTypeVPC         = "VPC"
+	networkingTypePublic      = "PUBLIC"
+	networkingTypePrivatelink = "PRIVATE_LINK"
+	kafkaNetworkingVPC        = fmt.Sprintf(`networking = {
 			access = {
 				type = %[1]q
 			}
@@ -175,6 +177,49 @@ func TestAccStreamRSStreamConnection_sample(t *testing.T) {
 				ImportStateIdFunc: checkStreamConnectionImportStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
+	var (
+		resourceName               = "mongodbatlas_stream_connection.test"
+		projectID                  = acc.ProjectIDExecution(t)
+		instanceName               = acc.RandomName()
+		vendor                     = "CONFLUENT"
+		provider                   = "AWS"
+		region                     = "us-east-1"
+		awsAccountID               = os.Getenv("AWS_ACCOUNT_ID")
+		networkID                  = os.Getenv("CONFLUENT_CLOUD_NETWORK_ID")
+		privatelinkAccessID        = os.Getenv("CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID")
+		privatelinkConfig          = acc.GetCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID)
+		kafkaNetworkingPrivatelink = fmt.Sprintf(`networking = {
+			access = {
+				type = %[1]q
+				connection_id = mongodbatlas_stream_privatelink_endpoint.test.id
+			}
+		}`, networkingTypePrivatelink)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					%[1]s
+					%[2]s
+				`, privatelinkConfig, kafkaStreamConnectionConfig(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)),
+				Check: kafkaStreamConnectionAttributeChecks(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"authentication.password"},
 			},
 		},
 	})

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -183,6 +183,7 @@ func TestAccStreamRSStreamConnection_sample(t *testing.T) {
 }
 
 func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
+	acc.SkipTestForCI(t) // requires Confluent Cloud resources
 	var (
 		resourceName               = "mongodbatlas_stream_connection.test"
 		projectID                  = acc.ProjectIDExecution(t)

--- a/internal/service/streamprivatelinkendpoint/plural_data_source.go
+++ b/internal/service/streamprivatelinkendpoint/plural_data_source.go
@@ -1,4 +1,3 @@
-//nolint:gocritic
 package streamprivatelinkendpoint
 
 import (

--- a/internal/service/streamprivatelinkendpoint/resource_migration_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_migration_test.go
@@ -3,10 +3,12 @@ package streamprivatelinkendpoint_test
 import (
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
 func TestMigStreamPrivatelinkEndpoint_basic(t *testing.T) {
+	acc.SkipTestForCI(t)
 	mig.SkipIfVersionBelow(t, "1.25.0") // when resource 1st released
 	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithConfluent(), nil)
 }

--- a/internal/service/streamprivatelinkendpoint/resource_migration_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_migration_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMigStreamPrivatelinkEndpoint_basic(t *testing.T) {
-	acc.SkipTestForCI(t)
+	acc.SkipTestForCI(t)                // needs confluent cloud resources
 	mig.SkipIfVersionBelow(t, "1.25.0") // when resource 1st released
 	mig.CreateTestAndRunUseExternalProviderNonParallel(t, basicTestCase(t), mig.ExternalProvidersWithConfluent(), nil)
 }

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -51,7 +50,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		awsAccountID        = os.Getenv("AWS_ACCOUNT_ID")
 		networkID           = os.Getenv("CONFLUENT_CLOUD_NETWORK_ID")
 		privatelinkAccessID = os.Getenv("CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID")
-		config              = getCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID)
+		config              = acc.GetCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID)
 	)
 
 	return &resource.TestCase{
@@ -95,11 +94,11 @@ func failedUpdateTestCase(t *testing.T) *resource.TestCase {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: getCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID),
+				Config: acc.GetCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID),
 				Check:  checksStreamPrivatelinkEndpoint(projectID, provider, region, vendor, false),
 			},
 			{
-				Config:      getCompleteConfluentConfig(true, false, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID),
+				Config:      acc.GetCompleteConfluentConfig(true, false, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID),
 				ExpectError: regexp.MustCompile(`Operation not supported`),
 			},
 		},
@@ -124,7 +123,7 @@ func missingRequiredFieldsTestCase(t *testing.T) *resource.TestCase {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configDataConfluentDedicatedCluster(networkID, privatelinkAccessID) + missingRequiredFieldsConfig(projectID, provider, vendor),
+				Config:      acc.ConfigDataConfluentDedicatedCluster(networkID, privatelinkAccessID) + missingRequiredFieldsConfig(projectID, provider, vendor),
 				ExpectError: regexp.MustCompile(`(?s)^.*?service_endpoint_id is required for vendor CONFLUENT.*?dns_domain is required for vendor CONFLUENT.*?region is required for vendor CONFLUENT.*$`),
 			},
 		},
@@ -138,133 +137,6 @@ func missingRequiredFieldsConfig(projectID, provider, vendor string) string {
 		provider_name       = %[2]q
 		vendor              = %[3]q
 	}`, projectID, provider, vendor)
-}
-
-func configBasic(projectID, provider, region, vendor string, withDNSSubdomains bool) string {
-	dnsSubDomainConfig := ""
-	if withDNSSubdomains {
-		dnsSubDomainConfig = `dns_sub_domain = local.dns_sub_domain_entries`
-	}
-
-	return fmt.Sprintf(`
-	locals {
-		dns_sub_domain_entries = [
-    		for zone in confluent_network.private-link.zones :
-    		"${zone}.${confluent_network.private-link.dns_domain}"
-  		]
-	}	
-
-	resource "mongodbatlas_stream_privatelink_endpoint" "test" {
-		project_id          = %[1]q
-		dns_domain          = confluent_network.private-link.dns_domain
-		provider_name       = %[2]q
-		region              = %[3]q
-		vendor              = %[4]q
-		service_endpoint_id = confluent_network.private-link.aws[0].private_link_endpoint_service
-		%[5]s
-		depends_on = [
-			confluent_kafka_cluster.dedicated
-		]
-	}
-
-	data "mongodbatlas_stream_privatelink_endpoint" "test" {
-		project_id = %[1]q
-		id         = mongodbatlas_stream_privatelink_endpoint.test.id
-		depends_on = [
-    		mongodbatlas_stream_privatelink_endpoint.test
-  		]
-	}
-
-	data "mongodbatlas_stream_privatelink_endpoints" "test" {
-		project_id = %[1]q
-		depends_on = [
-    		mongodbatlas_stream_privatelink_endpoint.test
-  		]
-	}`, projectID, provider, region, vendor, dnsSubDomainConfig)
-}
-
-func configNewConfluentDedicatedCluster(provider, region, awsAccountID string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-	data "confluent_environment" "default_environment" {
-  		display_name = "default"
-	}
-
-	resource "confluent_network" "private-link" {
-		display_name     = "terraform-test-private-link-network"
-		cloud            = %[2]q
-		region           = %[3]q
-		connection_types = ["PRIVATELINK"]
-		zones            = ["use1-az1", "use1-az2", "use1-az4"]
-		environment {
-			id = data.confluent_environment.default_environment.id
-		}
-		dns_config {
-			resolution = "PRIVATE"
-		}
-	}
-
-	resource "confluent_private_link_access" "aws" {
-		display_name = "terraform-test-aws-private-link-access"
-		aws {
-			account = %[4]q
-		}
-		environment {
-			id = data.confluent_environment.default_environment.id
-		}
-		network {
-			id = confluent_network.private-link.id
-		}
-	}
-
-	resource "confluent_kafka_cluster" "dedicated" {
-		display_name = "terraform-test-cluster"
-		availability = "MULTI_ZONE"
-		cloud        = confluent_network.private-link.cloud
-		region       = confluent_network.private-link.region
-		dedicated {
-			cku = 2
-		}
-		environment {
-			id = data.confluent_environment.default_environment.id
-		}
-		network {
-			id = confluent_network.private-link.id
-		}
-	}`, acc.ConfigConfluentProvider(), provider, region, awsAccountID)
-}
-
-func configDataConfluentDedicatedCluster(networkID, privatelinkAccessID string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-	data "confluent_environment" "default_environment" {
-  		display_name = "default"
-	}
-
-	data "confluent_network" "private-link" {
-		id     = %[2]q
-		environment {
-			id = data.confluent_environment.default_environment.id
-		}
-	}
-
-	data "confluent_private_link_access" "aws" {
-		id = %[3]q
-		environment {
-			id = data.confluent_environment.default_environment.id
-		}
-	}`, acc.ConfigConfluentProvider(), networkID, privatelinkAccessID)
-}
-
-func getCompleteConfluentConfig(usesExistingConfluentCluster, withDNSSubdomains bool, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID string) string {
-	if usesExistingConfluentCluster {
-		configBasicUsingDatasources := strings.ReplaceAll(configBasic(projectID, provider, region, vendor, withDNSSubdomains), "confluent_network.private-link", "data.confluent_network.private-link")
-		configBasicUsingDatasourcesWithoutDependsOnCluster := strings.ReplaceAll(configBasicUsingDatasources, "confluent_kafka_cluster.dedicated", "")
-		return configDataConfluentDedicatedCluster(networkID, privatelinkAccessID) + configBasicUsingDatasourcesWithoutDependsOnCluster
-	}
-	return configNewConfluentDedicatedCluster(provider, region, awsAccountID) + configBasic(projectID, provider, region, vendor, true)
 }
 
 func checksStreamPrivatelinkEndpoint(projectID, provider, region, vendor string, dnsSubdomainsCheck bool) resource.TestCheckFunc {

--- a/internal/testutil/acc/stream_privatelink_endpoint.go
+++ b/internal/testutil/acc/stream_privatelink_endpoint.go
@@ -1,0 +1,133 @@
+package acc
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ConfigDataConfluentDedicatedCluster(networkID, privatelinkAccessID string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+	data "confluent_environment" "default_environment" {
+  		display_name = "default"
+	}
+
+	data "confluent_network" "private-link" {
+		id     = %[2]q
+		environment {
+			id = data.confluent_environment.default_environment.id
+		}
+	}
+
+	data "confluent_private_link_access" "aws" {
+		id = %[3]q
+		environment {
+			id = data.confluent_environment.default_environment.id
+		}
+	}`, ConfigConfluentProvider(), networkID, privatelinkAccessID)
+}
+
+func configBasic(projectID, provider, region, vendor string, withDNSSubdomains bool) string {
+	dnsSubDomainConfig := ""
+	if withDNSSubdomains {
+		dnsSubDomainConfig = `dns_sub_domain = local.dns_sub_domain_entries`
+	}
+
+	return fmt.Sprintf(`
+	locals {
+		dns_sub_domain_entries = [
+    		for zone in confluent_network.private-link.zones :
+    		"${zone}.${confluent_network.private-link.dns_domain}"
+  		]
+	}	
+
+	resource "mongodbatlas_stream_privatelink_endpoint" "test" {
+		project_id          = %[1]q
+		dns_domain          = confluent_network.private-link.dns_domain
+		provider_name       = %[2]q
+		region              = %[3]q
+		vendor              = %[4]q
+		service_endpoint_id = confluent_network.private-link.aws[0].private_link_endpoint_service
+		%[5]s
+		depends_on = [
+			confluent_kafka_cluster.dedicated
+		]
+	}
+
+	data "mongodbatlas_stream_privatelink_endpoint" "test" {
+		project_id = %[1]q
+		id         = mongodbatlas_stream_privatelink_endpoint.test.id
+		depends_on = [
+    		mongodbatlas_stream_privatelink_endpoint.test
+  		]
+	}
+
+	data "mongodbatlas_stream_privatelink_endpoints" "test" {
+		project_id = %[1]q
+		depends_on = [
+    		mongodbatlas_stream_privatelink_endpoint.test
+  		]
+	}`, projectID, provider, region, vendor, dnsSubDomainConfig)
+}
+
+func configNewConfluentDedicatedCluster(provider, region, awsAccountID string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+	data "confluent_environment" "default_environment" {
+  		display_name = "default"
+	}
+
+	resource "confluent_network" "private-link" {
+		display_name     = "terraform-test-private-link-network"
+		cloud            = %[2]q
+		region           = %[3]q
+		connection_types = ["PRIVATELINK"]
+		zones            = ["use1-az1", "use1-az2", "use1-az4"]
+		environment {
+			id = data.confluent_environment.default_environment.id
+		}
+		dns_config {
+			resolution = "PRIVATE"
+		}
+	}
+
+	resource "confluent_private_link_access" "aws" {
+		display_name = "terraform-test-aws-private-link-access"
+		aws {
+			account = %[4]q
+		}
+		environment {
+			id = data.confluent_environment.default_environment.id
+		}
+		network {
+			id = confluent_network.private-link.id
+		}
+	}
+
+	resource "confluent_kafka_cluster" "dedicated" {
+		display_name = "terraform-test-cluster"
+		availability = "MULTI_ZONE"
+		cloud        = confluent_network.private-link.cloud
+		region       = confluent_network.private-link.region
+		dedicated {
+			cku = 2
+		}
+		environment {
+			id = data.confluent_environment.default_environment.id
+		}
+		network {
+			id = confluent_network.private-link.id
+		}
+	}`, ConfigConfluentProvider(), provider, region, awsAccountID)
+}
+
+func GetCompleteConfluentConfig(usesExistingConfluentCluster, withDNSSubdomains bool, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID string) string {
+	if usesExistingConfluentCluster {
+		configBasicUsingDatasources := strings.ReplaceAll(configBasic(projectID, provider, region, vendor, withDNSSubdomains), "confluent_network.private-link", "data.confluent_network.private-link")
+		configBasicUsingDatasourcesWithoutDependsOnCluster := strings.ReplaceAll(configBasicUsingDatasources, "confluent_kafka_cluster.dedicated", "")
+		return ConfigDataConfluentDedicatedCluster(networkID, privatelinkAccessID) + configBasicUsingDatasourcesWithoutDependsOnCluster
+	}
+	return configNewConfluentDedicatedCluster(provider, region, awsAccountID) + configBasic(projectID, provider, region, vendor, true)
+}


### PR DESCRIPTION
## Description

Adds support for PRIVATE_LINK networking type in `mongodbatlas_stream_connection` resource and data sources

Link to any related issue(s): CLOUDP-292668


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
