### PR TITLE
chore: Adjust value of minimum_enabled_tls_protocol in our cluster acceptance tests

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -163,7 +163,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			advanced_configuration  {
 				fail_index_key_too_long              = false
 				javascript_enabled                   = true
-				minimum_enabled_tls_protocol         = "TLS1_1"
+				minimum_enabled_tls_protocol         = "TLS1_2"
 				no_table_scan                        = false
 				oplog_min_retention_hours 		     = 4
 			}
@@ -176,7 +176,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 			advanced_configuration  {
 				fail_index_key_too_long              = false
 				javascript_enabled                   = true
-				minimum_enabled_tls_protocol         = "TLS1_1"
+				minimum_enabled_tls_protocol         = "TLS1_2"
 				no_table_scan                        = false
 				default_read_concern                 = "available"
 				sample_size_bi_connector			 = 110
@@ -205,7 +205,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_min_retention_hours", "4"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.tls_cipher_config_mode", "DEFAULT"),
@@ -220,7 +220,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -342,7 +342,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 			DefaultWriteConcern:              conversion.StringPtr("0"),
 			FailIndexKeyTooLong:              conversion.Pointer(false),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -373,11 +373,11 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 			},
 			{
 				Config: configAdvanced(t, true, projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated),
-				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_3", processArgsUpdated),
+				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdated),
 			},
 			{
 				Config: configAdvanced(t, true, projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdatedCipherConfig),
-				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_3", processArgsUpdatedCipherConfig),
+				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdatedCipherConfig),
 			},
 		},
 	})
@@ -403,7 +403,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 			DefaultReadConcern:               conversion.StringPtr("available"),
 			DefaultWriteConcern:              conversion.StringPtr("majority"),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -423,7 +423,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 			},
 			{
 				Config: configAdvancedDefaultWrite(t, true, projectID, clusterNameUpdated, processArgsUpdated),
-				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_3"),
+				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_2"),
 			},
 		},
 	})

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -279,7 +279,7 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 			DefaultWriteConcern:              conversion.StringPtr("1"),
 			FailIndexKeyTooLong:              conversion.Pointer(false),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -308,7 +308,7 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 			},
 			{
 				Config: configAdvanced(t, true, projectID, clusterName, "6.0", processArgs20240530, processArgsCipherConfig),
-				Check:  checkAdvanced(true, clusterName, "TLS1_1", processArgsCipherConfig),
+				Check:  checkAdvanced(true, clusterName, "TLS1_2", processArgsCipherConfig),
 			},
 		},
 	})
@@ -325,7 +325,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 			DefaultWriteConcern:              conversion.StringPtr("1"),
 			FailIndexKeyTooLong:              conversion.Pointer(false),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -342,7 +342,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 			DefaultWriteConcern:              conversion.StringPtr("0"),
 			FailIndexKeyTooLong:              conversion.Pointer(false),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -369,15 +369,15 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvanced(t, true, projectID, clusterName, "", processArgs20240530, processArgs),
-				Check:  checkAdvanced(true, clusterName, "TLS1_1", processArgs),
+				Check:  checkAdvanced(true, clusterName, "TLS1_2", processArgs),
 			},
 			{
 				Config: configAdvanced(t, true, projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdated),
-				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdated),
+				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_3", processArgsUpdated),
 			},
 			{
 				Config: configAdvanced(t, true, projectID, clusterNameUpdated, "", processArgs20240530Updated, processArgsUpdatedCipherConfig),
-				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_2", processArgsUpdatedCipherConfig),
+				Check:  checkAdvanced(true, clusterNameUpdated, "TLS1_3", processArgsUpdatedCipherConfig),
 			},
 		},
 	})
@@ -393,7 +393,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 			DefaultReadConcern:               conversion.StringPtr("available"),
 			DefaultWriteConcern:              conversion.StringPtr("1"),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -403,7 +403,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 			DefaultReadConcern:               conversion.StringPtr("available"),
 			DefaultWriteConcern:              conversion.StringPtr("majority"),
 			JavascriptEnabled:                conversion.Pointer(true),
-			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
+			MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
 			NoTableScan:                      conversion.Pointer(false),
 			OplogSizeMB:                      conversion.Pointer(1000),
 			SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -419,11 +419,11 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvancedDefaultWrite(t, true, projectID, clusterName, processArgs),
-				Check:  checkAdvancedDefaultWrite(true, clusterName, "1", "TLS1_1"),
+				Check:  checkAdvancedDefaultWrite(true, clusterName, "1", "TLS1_2"),
 			},
 			{
 				Config: configAdvancedDefaultWrite(t, true, projectID, clusterNameUpdated, processArgsUpdated),
-				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_2"),
+				Check:  checkAdvancedDefaultWrite(true, clusterNameUpdated, "majority", "TLS1_3"),
 			},
 		},
 	})

--- a/internal/service/advancedclustertpf/resource_test_cases_test.go
+++ b/internal/service/advancedclustertpf/resource_test_cases_test.go
@@ -359,7 +359,7 @@ func replicasetAdvConfigUpdate(t *testing.T) *resource.TestCase {
 		default_read_concern                                           = "available"
 		default_write_concern                                          = "majority"
 		javascript_enabled                                             = true
-		minimum_enabled_tls_protocol                                   = "TLS1_0"
+		minimum_enabled_tls_protocol                                   = "TLS1_2"
 		no_table_scan                                                  = true
 		sample_refresh_interval_bi_connector                           = 310
 		sample_size_bi_connector                                       = 110
@@ -386,6 +386,7 @@ func replicasetAdvConfigUpdate(t *testing.T) *resource.TestCase {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "mongo_db_major_version", "8.0"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.change_stream_options_pre_and_post_images_expire_after_seconds", "100"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.minimum_enabled_tls_protocol", "TLS1_2"),
 				),
 			},
 			acc.TestStepImportCluster(resourceName),

--- a/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate.yaml
+++ b/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate.yaml
@@ -149,7 +149,7 @@ steps:
           default_read_concern                                           = "available"
           default_write_concern                                          = "majority"
           javascript_enabled                                             = true
-          minimum_enabled_tls_protocol                                   = "TLS1_0"
+          minimum_enabled_tls_protocol                                   = "TLS1_2"
           no_table_scan                                                  = true
           sample_refresh_interval_bi_connector                           = 310
           sample_size_bi_connector                                       = 110
@@ -169,11 +169,11 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2024-08-05'
-        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
+        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
         responses:
           - response_index: 41
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2023-01-01'
@@ -181,7 +181,7 @@ steps:
         responses:
           - response_index: 42
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
     request_responses:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: GET
@@ -237,7 +237,7 @@ steps:
             text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": null,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": null,\n \"defaultWriteConcern\": null,\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": false,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": null,\n \"sampleSizeBIConnector\": null,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": null\n}"
           - response_index: 53
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: GET
         version: '2024-08-05'
@@ -248,7 +248,7 @@ steps:
             text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": null,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": false,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": null,\n \"sampleSizeBIConnector\": null,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": null\n}"
           - response_index: 54
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: PATCH
         version: '2024-10-23'
@@ -260,11 +260,11 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2024-08-05'
-        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
+        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
         responses:
           - response_index: 41
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2023-01-01'
@@ -272,7 +272,7 @@ steps:
         responses:
           - response_index: 42
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
   - diff_requests:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: DELETE
@@ -321,7 +321,7 @@ steps:
         responses:
           - response_index: 58
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultReadConcern\": \"available\",\n \"defaultWriteConcern\": \"majority\",\n \"failIndexKeyTooLong\": null,\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: GET
         version: '2024-08-05'
@@ -329,7 +329,7 @@ steps:
         responses:
           - response_index: 59
             status: 200
-            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_0\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
+            text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"chunkMigrationConcurrency\": null,\n \"customOpensslCipherConfigTls12\": [],\n \"defaultMaxTimeMS\": null,\n \"defaultWriteConcern\": \"majority\",\n \"javascriptEnabled\": true,\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"oplogMinRetentionHours\": null,\n \"oplogSizeMB\": null,\n \"queryStatsLogVerbosity\": 1,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"tlsCipherConfigMode\": \"DEFAULT\",\n \"transactionLifetimeLimitSeconds\": 300\n}"
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: DELETE
         version: '2023-02-01'

--- a/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate.yaml
+++ b/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate.yaml
@@ -169,7 +169,7 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2024-08-05'
-        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
+        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
         responses:
           - response_index: 41
             status: 200
@@ -260,7 +260,7 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
         method: PATCH
         version: '2024-08-05'
-        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"minimumEnabledTlsProtocol\": \"TLS1_2\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
+        text: "{\n \"changeStreamOptionsPreAndPostImagesExpireAfterSeconds\": 100,\n \"defaultWriteConcern\": \"majority\",\n \"noTableScan\": true,\n \"sampleRefreshIntervalBIConnector\": 310,\n \"sampleSizeBIConnector\": 110,\n \"transactionLifetimeLimitSeconds\": 300\n}"
         responses:
           - response_index: 41
             status: 200

--- a/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate/02_02_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2024-08-05.json
+++ b/internal/service/advancedclustertpf/testdata/TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate/02_02_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2024-08-05.json
@@ -1,7 +1,6 @@
 {
  "changeStreamOptionsPreAndPostImagesExpireAfterSeconds": 100,
  "defaultWriteConcern": "majority",
- "minimumEnabledTlsProtocol": "TLS1_0",
  "noTableScan": true,
  "sampleRefreshIntervalBIConnector": 310,
  "sampleSizeBIConnector": 110,

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -108,7 +108,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 				},
 					&admin.ClusterDescriptionProcessArgs20240805{
 						JavascriptEnabled:                conversion.Pointer(true),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 						NoTableScan:                      conversion.Pointer(false),
 						OplogSizeMB:                      conversion.Pointer(1000),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -121,7 +121,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -145,7 +145,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configAdvancedConfPartial(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_2"),
+					MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_3"),
 					TlsCipherConfigMode:            conversion.StringPtr("DEFAULT"), // To unset TlsCipherConfigMode, user needs to set this to DEFAULT
 					CustomOpensslCipherConfigTls12: &[]string{},
 				}),
@@ -153,7 +153,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -187,7 +187,7 @@ func basicDefaultWriteReadAdvancedConfTestCase(tb testing.TB) *resource.TestCase
 					&admin.ClusterDescriptionProcessArgs20240805{
 						DefaultWriteConcern:              conversion.StringPtr("1"),
 						JavascriptEnabled:                conversion.Pointer(true),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 						NoTableScan:                      conversion.Pointer(false),
 						OplogSizeMB:                      conversion.Pointer(1000),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -200,7 +200,7 @@ func basicDefaultWriteReadAdvancedConfTestCase(tb testing.TB) *resource.TestCase
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -211,14 +211,14 @@ func basicDefaultWriteReadAdvancedConfTestCase(tb testing.TB) *resource.TestCase
 			},
 			{
 				Config: configAdvancedConfPartialDefault(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_2"),
+					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_3"),
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -248,7 +248,7 @@ func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvancedConfPartial(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_2"),
+					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_3"),
 				}),
 			},
 			{
@@ -257,7 +257,7 @@ func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 				},
 					&admin.ClusterDescriptionProcessArgs20240805{
 						JavascriptEnabled:                conversion.Pointer(true),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 						NoTableScan:                      conversion.Pointer(false),
 						OplogSizeMB:                      conversion.Pointer(1000),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -267,7 +267,7 @@ func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -297,7 +297,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 				},
 					&admin.ClusterDescriptionProcessArgs20240805{
 						JavascriptEnabled:                conversion.Pointer(true),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
 						NoTableScan:                      conversion.Pointer(true),
 						OplogSizeMB:                      conversion.Pointer(1000),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -309,7 +309,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),
@@ -324,7 +324,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 				},
 					&admin.ClusterDescriptionProcessArgs20240805{
 						JavascriptEnabled:                conversion.Pointer(false),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_1"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 						NoTableScan:                      conversion.Pointer(false),
 						OplogSizeMB:                      conversion.Pointer(990),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(0),
@@ -337,7 +337,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_1"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "990"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "0"),

--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -145,7 +145,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 			},
 			{
 				Config: configAdvancedConfPartial(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_3"),
+					MinimumEnabledTlsProtocol:      conversion.StringPtr("TLS1_2"),
 					TlsCipherConfigMode:            conversion.StringPtr("DEFAULT"), // To unset TlsCipherConfigMode, user needs to set this to DEFAULT
 					CustomOpensslCipherConfigTls12: &[]string{},
 				}),
@@ -153,7 +153,7 @@ func partialAdvancedConfTestCase(tb testing.TB) *resource.TestCase {
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -211,14 +211,14 @@ func basicDefaultWriteReadAdvancedConfTestCase(tb testing.TB) *resource.TestCase
 			},
 			{
 				Config: configAdvancedConfPartialDefault(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_3"),
+					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_2"),
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_write_concern", "1"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_refresh_interval_bi_connector", "310"),
@@ -248,7 +248,7 @@ func TestAccCluster_emptyAdvancedConf(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configAdvancedConfPartial(projectID, clusterName, "false", &admin.ClusterDescriptionProcessArgs20240805{
-					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_3"),
+					MinimumEnabledTlsProtocol: conversion.StringPtr("TLS1_2"),
 				}),
 			},
 			{
@@ -297,7 +297,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 				},
 					&admin.ClusterDescriptionProcessArgs20240805{
 						JavascriptEnabled:                conversion.Pointer(true),
-						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_3"),
+						MinimumEnabledTlsProtocol:        conversion.StringPtr("TLS1_2"),
 						NoTableScan:                      conversion.Pointer(true),
 						OplogSizeMB:                      conversion.Pointer(1000),
 						SampleRefreshIntervalBIConnector: conversion.Pointer(310),
@@ -309,7 +309,7 @@ func TestAccCluster_basicAdvancedConf(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.fail_index_key_too_long", "false"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.default_read_concern", "available"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.javascript_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_3"),
+					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.minimum_enabled_tls_protocol", "TLS1_2"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.no_table_scan", "true"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.oplog_size_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "advanced_configuration.0.sample_size_bi_connector", "110"),


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-293561

PR adjusts all values of minimum_enabled_tls_protocol attribute in our acceptance tests:
- `TLS1_0` to `TLS1_2`
- `TLS1_1` to `TLS1_2`

Context of why this change is needed and why it has no impact on existing customers can be found in CLOUDP-293561.

Note: I have tried `TLS1_3` but it is still not supported in lower envs.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
