### PR TITLE
chore: Refactors test checks to only run for TPF due to `[]` in SDKv2 for computed specs

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1281,7 +1281,7 @@ func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing
 		}
 		checksUpdated = checkAggr(true, nil, checksUpdatedMap)
 	)
-	if config.AdvancedClusterV2Schema() {
+	if config.AdvancedClusterV2Schema() { // SDKv2 don't set "computed" specs in the state
 		checksMap["replication_specs.0.region_configs.0.electable_specs.0.instance_size"] = "M30"
 		checksMap["replication_specs.0.region_configs.0.analytics_specs.0.node_count"] = "0"
 	}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
@@ -1265,8 +1266,6 @@ func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing
 			"state_name": "IDLE",
 			"project_id": projectID,
 			"name":       clusterName,
-			"replication_specs.0.region_configs.0.electable_specs.0.instance_size": "M30",
-			"replication_specs.0.region_configs.0.analytics_specs.0.node_count":    "0",
 		}
 		checksUpdatedMap = map[string]string{
 			"replication_specs.0.region_configs.0.auto_scaling.0.disk_gb_enabled":    "true",
@@ -1280,9 +1279,13 @@ func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing
 			"replication_specs.1.region_configs.0.analytics_specs.0.ebs_volume_type": "PROVISIONED",
 			"replication_specs.1.region_configs.0.analytics_specs.0.disk_iops":       "1000",
 		}
-		checks        = checkAggr(true, nil, checksMap)
 		checksUpdated = checkAggr(true, nil, checksUpdatedMap)
 	)
+	if config.AdvancedClusterV2Schema() {
+		checksMap["replication_specs.0.region_configs.0.electable_specs.0.instance_size"] = "M30"
+		checksMap["replication_specs.0.region_configs.0.analytics_specs.0.node_count"] = "0"
+	}
+	checks := checkAggr(true, nil, checksMap)
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Description

Refactors test checks to only run for TPF due to `[]` in SDKv2 for computed specs:

SDKv2 code where nothing is done unless the analytics specs are defined in config:
[if v, ok := tfMapObject["analytics_specs"]; ok && len(v.([]any)) > 0 {](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/8a2c2aaea039dbe8a1fb582f03e3053a65123430/internal/service/advancedcluster/model_advanced_cluster.go#L728)

Link to any related issue(s): CLOUDP-293895

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
