### PR TITLE
doc: Improve docs and examples of data federation private endpoint for obtaining `service_name`

### DIFF
--- a/docs/resources/privatelink_endpoint_service_data_federation_online_archive.md
+++ b/docs/resources/privatelink_endpoint_service_data_federation_online_archive.md
@@ -15,15 +15,25 @@ resource "mongodbatlas_project" "atlas-project" {
   name   = var.atlas_project_name
 }
 
+resource "aws_vpc_endpoint" "test" {
+  vpc_id             = "vpc-7fc0a543"
+  service_name       = "<SERVICE-NAME>"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = ["subnet-de0406d2"]
+  security_group_ids = ["sg-3f238186"]
+}
+
 resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
-  project_id = mongodbatlas_project.atlas-project.id
-  endpoint_id = "vpce-046cf43c79424d4c9"
+  project_id    = mongodbatlas_project.atlas-project.id
+  endpoint_id   = aws_vpc_endpoint.test.id
   provider_name = "AWS"
-  comment = "Test"
+  comment       = "Test"
   region        = "US_EAST_1"
-  customer_endpoint_dns_name = "vpce-046cf43c79424d4c9-nmls2y9k.vpce-svc-0824460b72e1a420e.us-east-1.vpce.amazonaws.com"
+  customer_endpoint_dns_name = aws_vpc_endpoint.test.dns_entry[0].dns_name
 }
 ```
+
+The `service_name` value for the region in question can be found in the [MongoDB Atlas Administration](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createDataFederationPrivateEndpoint) documentation.
 
 ## Argument Reference
 

--- a/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/README.md
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/README.md
@@ -79,7 +79,6 @@ $ terraform destroy
 
 **What's the resource dependency chain?**
 1. `mongodbatlas_project` must exist for any of the following
-2. `aws_vpc_endpoint` is dependent on the `mongodbatlas_privatelink_endpoint`, and its dependencies.
-3. `mongodbatlas_privatelink_endpoint_service` is dependent on `aws_vpc_endpoint` and its dependencies.
+2. `aws_vpc_endpoint` is dependent on its associated AWS resources and a valid `service_name`.
 4. `mongodbatlas_privatelink_endpoint_service_data_federation_online_archive` is dependent on the `mongodbatlas_project` and `aws_vpc_endpoint`
 

--- a/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/atlas-privatelink.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/atlas-privatelink.tf
@@ -1,9 +1,3 @@
-resource "mongodbatlas_privatelink_endpoint" "pe_east" {
-  project_id    = var.project_id
-  provider_name = "AWS"
-  region        = "us-east-1"
-}
-
 resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
   project_id                 = var.project_id
   endpoint_id                = aws_vpc_endpoint.vpce_east.id

--- a/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/aws-vpc.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/aws-vpc.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc_endpoint" "vpce_east" {
   vpc_id             = aws_vpc.vpc_east.id
-  service_name       = mongodbatlas_privatelink_endpoint.pe_east.endpoint_service_name
+  service_name       = var.service_name
   vpc_endpoint_type  = "Interface"
   subnet_ids         = [aws_subnet.subnet_east_a.id, aws_subnet.subnet_east_b.id]
   security_group_ids = [aws_security_group.sg_east.id]

--- a/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/variables.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/variables.tf
@@ -18,3 +18,8 @@ variable "project_id" {
   description = "Atlas project ID"
   type        = string
 }
+
+variable "service_name" {
+  description = "AWS VPC endpoint service name associated to the specific region. Values can be found in https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createDataFederationPrivateEndpoint."
+  type        = string
+}


### PR DESCRIPTION
## Description

Original PR: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2936

Link to any related issue(s): CLOUDP-294341. This ticket provides additional context of the motivation behind these changes.

### Local testing

Using the service name of region us-east-1 (`com.amazonaws.vpce.us-east-1.vpce-svc-00e311695874992b4`) as mentioned in updated docs I was able to successfully run the example:

```
provider "aws" {
  access_key = "*"
  secret_key = "*"
  token = "*"
  region     = "us-east-1"
}

resource "aws_vpc_endpoint" "test" {
  vpc_id             = "vpc-*"
  service_name       = "com.amazonaws.vpce.us-east-1.vpce-svc-00e311695874992b4"
  vpc_endpoint_type  = "Interface"
  subnet_ids         = ["subnet-*"]
  security_group_ids = ["sg-*"]
}

resource "mongodbatlas_privatelink_endpoint_service_data_federation_online_archive" "test" {
  project_id    = var.project_id
  endpoint_id   = aws_vpc_endpoint.test.id
  provider_name = "AWS"
  comment       = "Test"
  region        = "US_EAST_1"
  customer_endpoint_dns_name = aws_vpc_endpoint.test.dns_entry[0].dns_name
}
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
