### PR TITLE
doc: Uses weekly option in cloud backup schedule documentation

### DIFF
--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -234,7 +234,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `export` - Policy for automatically exporting Cloud Backup Snapshots. See [below](#export)
 ### export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
-* `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `montly`, `yearly`, `daily` (requires reaching out to Customer Support)
+* `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `monthly`, `yearly`, `daily` (requires reaching out to Customer Support)
 
 ### policy_item_hourly
 * `id` - Unique identifier of the backup policy item.

--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -234,7 +234,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `export` - Policy for automatically exporting Cloud Backup Snapshots. See [below](#export)
 ### export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
-* `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `daily` (requires reaching out to Customer Support)
+* `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `montly`, `yearly`, `daily` (requires reaching out to Customer Support)
 
 ### policy_item_hourly
 * `id` - Unique identifier of the backup policy item.

--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -234,7 +234,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `export` - Policy for automatically exporting Cloud Backup Snapshots. See [below](#export)
 ### export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
-* `frequency_type` - Frequency associated with the export snapshot item.
+* `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `daily` (requires reaching out to Customer Support)
 
 ### policy_item_hourly
 * `id` - Unique identifier of the backup policy item.

--- a/docs/resources/cloud_backup_snapshot_export_job.md
+++ b/docs/resources/cloud_backup_snapshot_export_job.md
@@ -49,7 +49,7 @@ resource "mongodbatlas_cloud_backup_schedule" "backup" {
   auto_export_enabled = true
   export {
     export_bucket_id = mongodbatlas_cloud_backup_snapshot_export_bucket.export.export_bucket_id
-    frequency_type = "daily"
+    frequency_type = "weekly"
   }
   use_org_and_group_names_in_export_prefix = true
 


### PR DESCRIPTION
## Description

Uses weekly option in cloud backup schedule documentation
The `daily` value requires reaching out to TSE

Link to any related issue(s): CLOUDP-281590

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
