### PR TITLE
refactor: Updates tests to use ProjectIDExecutionWithCluster and fix plural data source errors for TPF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ testmact: ## Run MacT tests (mocked acc tests)
 	@$(eval export HTTP_MOCKER_CAPTURE?=false)
 	@$(eval export MONGODB_ATLAS_ORG_ID?=111111111111111111111111)
 	@$(eval export MONGODB_ATLAS_PROJECT_ID?=111111111111111111111111)
+	@$(eval export MONGODB_ATLAS_CLUSTER_NAME?=mocked-cluster)
 	@$(eval export MONGODB_ATLAS_ADVANCED_CLUSTER_V2_SCHEMA?=true)
 	@if [ "$(ACCTEST_PACKAGES)" = "./..." ]; then \
 		echo "Error: ACCTEST_PACKAGES must be explicitly set for testmact target, './...' is not allowed"; \

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -71,7 +71,7 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 
 func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 12)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -94,7 +94,7 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
 
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -116,7 +116,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 
 func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -226,7 +226,7 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 
 func TestMigAdvancedCluster_newSchemaFromAutoscalingDisabledToEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     acc.PreCheckBasicSleep(t, nil, projectID, clusterName),

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -2,7 +2,6 @@ package advancedcluster_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -72,11 +71,7 @@ func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
 
 func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -84,12 +79,12 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configGeoShardedOldSchema(t, false, orgID, projectName, clusterName, 2, 2, false),
+				Config:            configGeoShardedOldSchema(t, false, projectID, clusterName, 2, 2, false),
 				Check:             checkGeoShardedOldSchema(false, clusterName, 2, 2, false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configGeoShardedOldSchema(t, false, orgID, projectName, clusterName, 2, 1, false),
+				Config:                   configGeoShardedOldSchema(t, false, projectID, clusterName, 2, 1, false),
 				Check:                    checkGeoShardedOldSchema(false, clusterName, 2, 1, true, false),
 			},
 		},
@@ -98,11 +93,8 @@ func TestMigAdvancedCluster_geoShardedOldSchemaUpdate(t *testing.T) {
 
 func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -110,12 +102,12 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, false, false),
+				Config:            configShardedTransitionOldToNewSchema(t, false, projectID, clusterName, false, false),
 				Check:             checkShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true, false),
+				Config:                   configShardedTransitionOldToNewSchema(t, false, projectID, clusterName, true, false),
 				Check:                    checkShardedTransitionOldToNewSchema(false, true),
 			},
 		},
@@ -124,11 +116,7 @@ func TestMigAdvancedCluster_shardedMigrationFromOldToNewSchema(t *testing.T) {
 
 func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // This test is specific to the legacy schema
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { mig.PreCheckBasic(t) },
@@ -136,12 +124,12 @@ func TestMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders(versionBeforeISSRelease),
-				Config:            configGeoShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, false),
+				Config:            configGeoShardedTransitionOldToNewSchema(t, false, projectID, clusterName, false),
 				Check:             checkGeoShardedTransitionOldToNewSchema(false, false),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configGeoShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true),
+				Config:                   configGeoShardedTransitionOldToNewSchema(t, false, projectID, clusterName, true),
 				Check:                    checkGeoShardedTransitionOldToNewSchema(false, true),
 			},
 		},
@@ -238,24 +226,20 @@ func TestMigAdvancedCluster_partialAdvancedConf(t *testing.T) {
 
 func TestMigAdvancedCluster_newSchemaFromAutoscalingDisabledToEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     acc.PreCheckBasicSleep(t, nil, orgID, projectName),
+		PreCheck:     acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviders("1.22.0"), // last version before cluster tier auto-scaling per shard was introduced
-				Config:            configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true, false),
+				Config:            configShardedTransitionOldToNewSchema(t, false, projectID, clusterName, true, false),
 				Check:             acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   configShardedTransitionOldToNewSchema(t, false, orgID, projectName, clusterName, true, true),
+				Config:                   configShardedTransitionOldToNewSchema(t, false, projectID, clusterName, true, true),
 				Check:                    acc.CheckIndependentShardScalingMode(resourceName, clusterName, "SHARD"),
 			},
 		},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -127,9 +127,8 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_basicTenant(t *testing.T) {
 	var (
-		projectID          = acc.ProjectIDExecution(t)
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
 	)
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -151,9 +150,8 @@ func TestAccMockableAdvancedCluster_basicTenant(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	var (
-		projectID       = acc.ProjectIDExecution(t)
-		clusterName     = acc.RandomClusterName()
-		defaultZoneName = "Zone 1" // Uses backend default to avoid non-empty plan, see CLOUDP-294339
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		defaultZoneName        = "Zone 1" // Uses backend default to avoid non-empty plan, see CLOUDP-294339
 	)
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -179,8 +177,7 @@ func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
 	)
 
 	return resource.TestCase{
@@ -265,10 +262,9 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 
 func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 	var (
-		projectID           = acc.ProjectIDExecution(t)
-		clusterName         = acc.RandomClusterName()
-		instanceSize        = "M10"
-		anotherInstanceSize = "M20"
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		instanceSize           = "M10"
+		anotherInstanceSize    = "M20"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -295,9 +291,8 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 	var (
-		projectID    = acc.ProjectIDExecution(t)
-		clusterName  = acc.RandomClusterName()
-		instanceSize = "M10"
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		instanceSize           = "M10"
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -328,8 +323,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: default_max_time_ms not implemented in TPF yet
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
 
 		processArgs20240530 = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
@@ -374,10 +368,9 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: default_max_time_ms not implemented in TPF yet
 	var (
-		projectID           = acc.ProjectIDExecution(t)
-		clusterName         = acc.RandomClusterName()
-		clusterNameUpdated  = acc.RandomClusterName()
-		processArgs20240530 = &admin20240530.ClusterDescriptionProcessArgs{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
+		processArgs20240530    = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
 			DefaultWriteConcern:              conversion.StringPtr("1"),
 			FailIndexKeyTooLong:              conversion.Pointer(false),
@@ -443,10 +436,9 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: tls_cipher_config_mode not implemented in TPF yet
 	var (
-		projectID          = acc.ProjectIDExecution(t)
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
-		processArgs        = &admin20240530.ClusterDescriptionProcessArgs{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
+		processArgs            = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
 			DefaultWriteConcern:              conversion.StringPtr("1"),
 			JavascriptEnabled:                conversion.Pointer(true),
@@ -488,10 +480,9 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.T) {
 	var (
-		projectID          = acc.ProjectIDExecution(t)
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
-		autoScaling        = &admin.AdvancedAutoScalingSettings{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
+		autoScaling            = &admin.AdvancedAutoScalingSettings{
 			Compute: &admin.AdvancedComputeAutoScaling{Enabled: conversion.Pointer(false), MaxInstanceSize: conversion.StringPtr("")},
 			DiskGB:  &admin.DiskGBAutoScaling{Enabled: conversion.Pointer(true)},
 		}
@@ -531,10 +522,9 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t *testing.T) {
 	var (
-		projectID          = acc.ProjectIDExecution(t)
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
-		autoScaling        = &admin.AdvancedAutoScalingSettings{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
+		autoScaling            = &admin.AdvancedAutoScalingSettings{
 			Compute: &admin.AdvancedComputeAutoScaling{Enabled: conversion.Pointer(false), MaxInstanceSize: conversion.StringPtr("")},
 			DiskGB:  &admin.DiskGBAutoScaling{Enabled: conversion.Pointer(true)},
 		}
@@ -683,8 +673,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1044,8 +1033,7 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -1174,9 +1162,8 @@ func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingDisabledToEnabled(t *te
 
 func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		checksMap   = map[string]string{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		checksMap              = map[string]string{
 			"state_name": "IDLE",
 		}
 		checksSet = []string{
@@ -1260,9 +1247,8 @@ func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
-		checksMap   = map[string]string{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		checksMap              = map[string]string{
 			"state_name": "IDLE",
 			"project_id": projectID,
 			"name":       clusterName,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1192,7 +1192,7 @@ func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 				Config: configBasicReplicaset(t, projectID, clusterName, fullUpdate),
 				Check:  checksUpdate,
 			},
-			acc.TestStepImportCluster(resourceName, acc.ImportIgnoredFields()...),
+			acc.TestStepImportCluster(resourceName, importIgnoredFields()...),
 		},
 	})
 }
@@ -1235,7 +1235,7 @@ func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing
 				Config: configSharded(t, projectID, clusterName, true),
 				Check:  checksUpdated,
 			},
-			acc.TestStepImportCluster(resourceName, acc.ImportIgnoredFields()...),
+			acc.TestStepImportCluster(resourceName, importIgnoredFields()...),
 		},
 	})
 }
@@ -2786,4 +2786,15 @@ func configFCVPinning(orgID, projectName, clusterName string, pinningExpirationD
 		}
 
 	`, orgID, projectName, clusterName, mongoDBMajorVersion, pinnedFCVAttr) + dataSourcesTFNewSchema
+}
+
+func importIgnoredFields() []string {
+	if config.AdvancedClusterV2Schema() {
+		return []string{}
+	}
+	return []string{
+		"replication_specs.0.region_configs.0.read_only_specs",
+		"replication_specs.0.region_configs.0.analytics_specs",
+		"replication_specs.0.region_configs.0.electable_specs.0.ebs_volume_type",
+	}
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -127,7 +127,7 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_basicTenant(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 1)
 		clusterNameUpdated     = acc.RandomClusterName()
 	)
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
@@ -150,7 +150,7 @@ func TestAccMockableAdvancedCluster_basicTenant(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
 		defaultZoneName        = "Zone 1" // Uses backend default to avoid non-empty plan, see CLOUDP-294339
 	)
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
@@ -177,7 +177,7 @@ func TestAccClusterAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
 func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)
 	)
 
 	return resource.TestCase{
@@ -236,7 +236,7 @@ func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 7)
 		clusterNameUpdated     = acc.RandomClusterName()
 	)
 
@@ -260,7 +260,7 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 
 func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		instanceSize           = "M10"
 		anotherInstanceSize    = "M20"
 	)
@@ -289,7 +289,7 @@ func TestAccClusterAdvancedCluster_unpausedToPaused(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		instanceSize           = "M10"
 	)
 
@@ -321,7 +321,7 @@ func TestAccClusterAdvancedCluster_pausedToUnpaused(t *testing.T) {
 func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: default_max_time_ms not implemented in TPF yet
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 
 		processArgs20240530 = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
@@ -366,7 +366,7 @@ func TestAccClusterAdvancedCluster_advancedConfig_oldMongoDBVersion(t *testing.T
 func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: default_max_time_ms not implemented in TPF yet
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		clusterNameUpdated     = acc.RandomClusterName()
 		processArgs20240530    = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
@@ -434,7 +434,7 @@ func TestAccClusterAdvancedCluster_advancedConfig(t *testing.T) {
 func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t) // TODO: tls_cipher_config_mode not implemented in TPF yet
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		clusterNameUpdated     = acc.RandomClusterName()
 		processArgs            = &admin20240530.ClusterDescriptionProcessArgs{
 			DefaultReadConcern:               conversion.StringPtr("available"),
@@ -478,7 +478,7 @@ func TestAccClusterAdvancedCluster_defaultWrite(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		clusterNameUpdated     = acc.RandomClusterName()
 		autoScaling            = &admin.AdvancedAutoScalingSettings{
 			Compute: &admin.AdvancedComputeAutoScaling{Enabled: conversion.Pointer(false), MaxInstanceSize: conversion.StringPtr("")},
@@ -520,7 +520,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 
 func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 		clusterNameUpdated     = acc.RandomClusterName()
 		autoScaling            = &admin.AdvancedAutoScalingSettings{
 			Compute: &admin.AdvancedComputeAutoScaling{Enabled: conversion.Pointer(false), MaxInstanceSize: conversion.StringPtr("")},
@@ -560,7 +560,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 }
 
 func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpectsError(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 9)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -637,7 +637,7 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)
 		checks                 = []resource.TestCheckFunc{
 			acc.CheckExistsCluster(resourceName),
 			acc.TestCheckResourceAttrSchemaV2(true, resourceName, "global_cluster_self_managed_sharding", "true"),
@@ -665,7 +665,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 1)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -683,7 +683,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 
 func TestAccMockableAdvancedCluster_symmetricShardedOldSchema(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 12)
 	)
 
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
@@ -709,7 +709,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing
 
 func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 18)
 
 	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -733,7 +733,7 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 }
 
 func TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 6)
 
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -809,7 +809,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemovingShard(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 9)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -832,7 +832,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 }
 
 func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -854,7 +854,7 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 }
 
 func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -935,7 +935,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 
 // TestAccClusterAdvancedCluster_priorityOldSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 6)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -964,7 +964,7 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 
 // TestAccClusterAdvancedCluster_priorityNewSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 3)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
@@ -993,7 +993,7 @@ func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
 
 func TestAccClusterAdvancedCluster_biConnectorConfig(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 4)
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -1068,7 +1068,7 @@ func TestAccClusterAdvancedCluster_pinnedFCVWithVersionUpgradeAndDowngrade(t *te
 
 func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -1089,7 +1089,7 @@ func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T) {
 
 func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingDisabledToEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
@@ -1114,7 +1114,7 @@ func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingDisabledToEnabled(t *te
 
 func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
 		checksMap              = map[string]string{
 			"state_name": "IDLE",
 		}
@@ -1199,7 +1199,7 @@ func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 
 func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing.T) {
 	var (
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 8)
 		checksMap              = map[string]string{
 			"state_name": "IDLE",
 			"project_id": projectID,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1719,8 +1719,7 @@ func checkShardedOldSchemaMultiCloud(isAcc bool, name string, numShards int, ana
 			acc.TestCheckResourceAttrSetSchemaV2(isAcc, resourceName, "config_server_type"),
 			acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourceName, "config_server_management_mode", *configServerManagementMode),
 			acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourceName, "config_server_type"),
-			acc.TestCheckResourceAttrSchemaV2(isAcc, dataSourcePluralName, "results.0.config_server_management_mode", *configServerManagementMode),
-			acc.TestCheckResourceAttrSetSchemaV2(isAcc, dataSourcePluralName, "results.0.config_server_type"))
+		)
 	}
 
 	return checkAggr(isAcc,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -751,22 +751,27 @@ func TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectab
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAddingRemovingShard(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedNewSchema(t, true, projectID, clusterName, 50, "M10", "M10", nil, nil, false),
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false),
 				Check:  checkShardedNewSchema(true, 50, "M10", "M10", nil, nil, false, false),
 			},
 			{
-				Config: configShardedNewSchema(t, true, projectID, clusterName, 55, "M10", "M20", nil, nil, true), // add middle replication spec and transition to asymmetric
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true), // add middle replication spec and transition to asymmetric
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, true),
 			},
 			{
-				Config: configShardedNewSchema(t, true, projectID, clusterName, 55, "M10", "M20", nil, nil, false), // removes middle replication spec
+				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false), // removes middle replication spec
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, false),
 			},
 		},
@@ -779,7 +784,11 @@ func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T
 
 func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
 
 	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -787,7 +796,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedNewSchema(t, isAcc, projectID, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false),
+				Config: configShardedNewSchema(t, isAcc, orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkShardedNewSchema(isAcc, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
 					resource.TestCheckResourceAttr("data.mongodbatlas_advanced_clusters.test-replication-specs-per-shard-false", "results.#", "0"),
@@ -863,7 +872,11 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -871,19 +884,19 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "WORKLOAD_TYPE", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "SEQUENTIAL", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "SEQUENTIAL", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", false),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "NODE_TYPE", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "NODE_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -891,7 +904,11 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -899,15 +916,15 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "WORKLOAD_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", false),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "SEQUENTIAL", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "SEQUENTIAL", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "NODE_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -2115,7 +2132,7 @@ func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) r
 		})
 }
 
-func configShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
+func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
 	t.Helper()
 	var thirdReplicationSpec string
 	if includeMiddleSpec {
@@ -2154,24 +2171,29 @@ func configShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, di
 		`, *lastDiskIOPS)
 	}
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = %[1]q
-			name = %[2]q
+			project_id = mongodbatlas_project.cluster_project.id
+			name = %[3]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
 
 			replication_specs {
 				region_configs {
 					electable_specs {
-						instance_size = %[3]q
+						instance_size = %[4]q
 						node_count    = 3
-						disk_size_gb  = %[8]d
-						%[5]s
+						disk_size_gb  = %[9]d
+						%[6]s
 					}
 					analytics_specs {
-						instance_size = %[3]q
+						instance_size = %[4]q
 						node_count    = 1
-						disk_size_gb  = %[8]d
+						disk_size_gb  = %[9]d
 					}
 					provider_name = "AWS"
 					priority      = 7
@@ -2179,20 +2201,20 @@ func configShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, di
 				}
 			}
 
-			%[7]s
+			%[8]s
 
 			replication_specs {
 				region_configs {
 					electable_specs {
-						instance_size = %[4]q
+						instance_size = %[5]q
 						node_count    = 3
-						disk_size_gb  = %[8]d
-						%[6]s
+						disk_size_gb  = %[9]d
+						%[7]s
 					}
 					analytics_specs {
-						instance_size = %[4]q
+						instance_size = %[5]q
 						node_count    = 1
-						disk_size_gb  = %[8]d
+						disk_size_gb  = %[9]d
 					}
 					provider_name = "AWS"
 					priority      = 7
@@ -2216,7 +2238,7 @@ func configShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, di
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			use_replication_spec_per_shard = true
 		}
-	`, projectID, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB))
+	`, orgID, projectName, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB))
 }
 
 func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIops, lastDiskIops *int, isAsymmetricCluster, includeMiddleSpec bool) resource.TestCheckFunc {
@@ -2518,16 +2540,21 @@ func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.
 	)
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc bool, projectID, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = %[1]q
-			name = %[2]q
+			project_id = mongodbatlas_project.cluster_project.id
+			name = %[3]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
-			replica_set_scaling_strategy = %[3]q
-			redact_client_log_data = %[4]t
+			replica_set_scaling_strategy = %[4]q
+			redact_client_log_data = %[5]t
 
 			replication_specs {
 				region_configs {
@@ -2547,19 +2574,24 @@ func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc b
 				}
 			}
 		}
-	`, projectID, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFNewSchema
+	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFNewSchema
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T, isAcc bool, projectID, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
+		resource "mongodbatlas_project" "cluster_project" {
+			org_id = %[1]q
+			name   = %[2]q
+		}
+
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = %[1]q
-			name = %[2]q
+			project_id = mongodbatlas_project.cluster_project.id
+			name = %[3]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
-			replica_set_scaling_strategy = %[3]q
-			redact_client_log_data = %[4]t
+			replica_set_scaling_strategy = %[4]q
+			redact_client_log_data = %[5]t
 
 			replication_specs {
 				num_shards = 2
@@ -2580,7 +2612,7 @@ func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T
 				}
 			}
 		}
-	`, projectID, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFOldSchema
+	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFOldSchema
 }
 
 func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSetScalingStrategy string, redactClientLogData bool) resource.TestCheckFunc {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -205,10 +205,8 @@ func TestAccClusterAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
 	)
 
 	return resource.TestCase{
@@ -217,11 +215,11 @@ func replicaSetMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicaSetMultiCloud(t, isAcc, orgID, projectName, clusterName),
+				Config: configReplicaSetMultiCloud(t, isAcc, projectID, clusterName),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterName, 3),
 			},
 			{
-				Config: configReplicaSetMultiCloud(t, isAcc, orgID, projectName, clusterNameUpdated),
+				Config: configReplicaSetMultiCloud(t, isAcc, projectID, clusterNameUpdated),
 				Check:  checkReplicaSetMultiCloud(isAcc, clusterNameUpdated, 3),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs", "retain_backups_enabled"),
@@ -236,10 +234,8 @@ func TestAccClusterAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
 func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
 	var (
-		orgID              = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName        = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName        = acc.RandomClusterName()
-		clusterNameUpdated = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		clusterNameUpdated     = acc.RandomClusterName()
 	)
 
 	return resource.TestCase{
@@ -248,11 +244,11 @@ func singleShardedMultiCloudTestCase(t *testing.T, isAcc bool) resource.TestCase
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedOldSchemaMultiCloud(t, isAcc, orgID, projectName, clusterName, 1, "M10", nil),
+				Config: configShardedOldSchemaMultiCloud(t, isAcc, projectID, clusterName, 1, "M10", nil),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterName, 1, "M10", true, nil),
 			},
 			{
-				Config: configShardedOldSchemaMultiCloud(t, isAcc, orgID, projectName, clusterNameUpdated, 1, "M10", nil),
+				Config: configShardedOldSchemaMultiCloud(t, isAcc, projectID, clusterNameUpdated, 1, "M10", nil),
 				Check:  checkShardedOldSchemaMultiCloud(isAcc, clusterNameUpdated, 1, "M10", true, nil),
 			},
 			acc.TestStepImportCluster(resourceName, "replication_specs"),
@@ -562,11 +558,7 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 }
 
 func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpectsError(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -574,11 +566,11 @@ func TestAccClusterAdvancedClusterConfig_singleShardedTransitionToOldSchemaExpec
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, false),
+				Config: configGeoShardedOldSchema(t, true, projectID, clusterName, 1, 1, false),
 				Check:  checkGeoShardedOldSchema(true, clusterName, 1, 1, true, true),
 			},
 			{
-				Config:      configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 2, false),
+				Config:      configGeoShardedOldSchema(t, true, projectID, clusterName, 1, 2, false),
 				ExpectError: regexp.MustCompile(advancedcluster.ErrorOperationNotPermitted),
 			},
 		},
@@ -643,10 +635,8 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 
 func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-		checks      = []resource.TestCheckFunc{
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
+		checks                 = []resource.TestCheckFunc{
 			acc.CheckExistsCluster(resourceName),
 			acc.TestCheckResourceAttrSchemaV2(true, resourceName, "global_cluster_self_managed_sharding", "true"),
 			acc.TestCheckResourceAttrSchemaV2(true, dataSourceName, "global_cluster_self_managed_sharding", "true"),
@@ -659,12 +649,12 @@ func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, true),
+				Config: configGeoShardedOldSchema(t, true, projectID, clusterName, 1, 1, true),
 				Check: resource.ComposeAggregateTestCheckFunc(checks...,
 				),
 			},
 			{
-				Config:      configGeoShardedOldSchema(t, true, orgID, projectName, clusterName, 1, 1, false),
+				Config:      configGeoShardedOldSchema(t, true, projectID, clusterName, 1, 1, false),
 				ExpectError: regexp.MustCompile("CANNOT_MODIFY_GLOBAL_CLUSTER_MANAGEMENT_SETTING"),
 			},
 		},
@@ -691,9 +681,7 @@ func TestAccClusterAdvancedClusterConfig_selfManagedShardingIncorrectType(t *tes
 
 func TestAccMockableAdvancedCluster_symmetricShardedOldSchema(t *testing.T) {
 	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t)
 	)
 
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
@@ -702,11 +690,11 @@ func TestAccMockableAdvancedCluster_symmetricShardedOldSchema(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedOldSchemaMultiCloud(t, true, orgID, projectName, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated),
+				Config: configShardedOldSchemaMultiCloud(t, true, projectID, clusterName, 2, "M10", &configServerManagementModeFixedToDedicated),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M10", false, &configServerManagementModeFixedToDedicated),
 			},
 			{
-				Config: configShardedOldSchemaMultiCloud(t, true, orgID, projectName, clusterName, 2, "M20", &configServerManagementModeAtlasManaged),
+				Config: configShardedOldSchemaMultiCloud(t, true, projectID, clusterName, 2, "M20", &configServerManagementModeAtlasManaged),
 				Check:  checkShardedOldSchemaMultiCloud(true, clusterName, 2, "M20", false, &configServerManagementModeAtlasManaged),
 			},
 		},
@@ -719,11 +707,7 @@ func TestAccClusterAdvancedClusterConfig_symmetricGeoShardedOldSchema(t *testing
 
 func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -731,13 +715,13 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configGeoShardedOldSchema(t, isAcc, orgID, projectName, clusterName, 2, 2, false),
+				Config: configGeoShardedOldSchema(t, isAcc, projectID, clusterName, 2, 2, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkGeoShardedOldSchema(isAcc, clusterName, 2, 2, true, false),
 					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
 			},
 			{
-				Config: configGeoShardedOldSchema(t, isAcc, orgID, projectName, clusterName, 3, 3, false),
+				Config: configGeoShardedOldSchema(t, isAcc, projectID, clusterName, 3, 3, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkGeoShardedOldSchema(isAcc, clusterName, 3, 3, true, false),
 					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
@@ -747,11 +731,7 @@ func symmetricGeoShardedOldSchemaTestCase(t *testing.T, isAcc bool) resource.Tes
 }
 
 func TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	unit.CaptureOrMockTestCaseAndRun(t, mockConfig, &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -759,11 +739,11 @@ func TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectab
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, orgID, projectName, clusterName, 50),
+				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, projectID, clusterName, 50),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 50),
 			},
 			{
-				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, orgID, projectName, clusterName, 55),
+				Config: configShardedOldSchemaDiskSizeGBElectableLevel(t, true, projectID, clusterName, 55),
 				Check:  checkShardedOldSchemaDiskSizeGBElectableLevel(true, 55),
 			},
 		},
@@ -771,27 +751,22 @@ func TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectab
 }
 
 func TestAccClusterAdvancedClusterConfig_symmetricShardedNewSchemaToAsymmetricAddingRemovingShard(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
-
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 50, "M10", "M10", nil, nil, false),
+				Config: configShardedNewSchema(t, true, projectID, clusterName, 50, "M10", "M10", nil, nil, false),
 				Check:  checkShardedNewSchema(true, 50, "M10", "M10", nil, nil, false, false),
 			},
 			{
-				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, true), // add middle replication spec and transition to asymmetric
+				Config: configShardedNewSchema(t, true, projectID, clusterName, 55, "M10", "M20", nil, nil, true), // add middle replication spec and transition to asymmetric
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, true),
 			},
 			{
-				Config: configShardedNewSchema(t, true, orgID, projectName, clusterName, 55, "M10", "M20", nil, nil, false), // removes middle replication spec
+				Config: configShardedNewSchema(t, true, projectID, clusterName, 55, "M10", "M20", nil, nil, false), // removes middle replication spec
 				Check:  checkShardedNewSchema(true, 55, "M10", "M20", nil, nil, true, false),
 			},
 		},
@@ -804,11 +779,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricShardedNewSchema(t *testing.T
 
 func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestCase {
 	t.Helper()
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	return resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -816,7 +787,7 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedNewSchema(t, isAcc, orgID, projectName, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false),
+				Config: configShardedNewSchema(t, isAcc, projectID, clusterName, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkShardedNewSchema(isAcc, 50, "M30", "M40", admin.PtrInt(2000), admin.PtrInt(2500), true, false),
 					resource.TestCheckResourceAttr("data.mongodbatlas_advanced_clusters.test-replication-specs-per-shard-false", "results.#", "0"),
@@ -827,26 +798,22 @@ func asymmetricShardedNewSchemaTestCase(t *testing.T, isAcc bool) resource.TestC
 }
 
 func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemovingShard(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, false),
+				Config: configGeoShardedNewSchema(t, true, projectID, clusterName, false),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 			{
-				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, true),
+				Config: configGeoShardedNewSchema(t, true, projectID, clusterName, true),
 				Check:  checkGeoShardedNewSchema(true, true),
 			},
 			{
-				Config: configGeoShardedNewSchema(t, true, orgID, projectName, clusterName, false),
+				Config: configGeoShardedNewSchema(t, true, projectID, clusterName, false),
 				Check:  checkGeoShardedNewSchema(true, false),
 			},
 		},
@@ -854,11 +821,7 @@ func TestAccClusterAdvancedClusterConfig_asymmetricGeoShardedNewSchemaAddingRemo
 }
 
 func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -866,13 +829,13 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false, false),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkShardedTransitionOldToNewSchema(true, false),
 					acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER")),
 			},
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true, false),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, false),
 				Check:  checkShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -880,11 +843,7 @@ func TestAccClusterAdvancedClusterConfig_shardedTransitionFromOldToNewSchema(t *
 }
 
 func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -892,11 +851,11 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configGeoShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false),
+				Config: configGeoShardedTransitionOldToNewSchema(t, true, projectID, clusterName, false),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, false),
 			},
 			{
-				Config: configGeoShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true),
+				Config: configGeoShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true),
 				Check:  checkGeoShardedTransitionOldToNewSchema(true, true),
 			},
 		},
@@ -904,11 +863,7 @@ func TestAccClusterAdvancedClusterConfig_geoShardedTransitionFromOldToNewSchema(
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -916,19 +871,19 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "WORKLOAD_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "SEQUENTIAL", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "SEQUENTIAL", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", false),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "NODE_TYPE", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogData(t, true, projectID, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -936,11 +891,7 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogData(t *t
 }
 
 func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -948,15 +899,15 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "WORKLOAD_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "WORKLOAD_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "WORKLOAD_TYPE", false),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "SEQUENTIAL", true),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "SEQUENTIAL", true),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "SEQUENTIAL", true),
 			},
 			{
-				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, orgID, projectName, clusterName, "NODE_TYPE", false),
+				Config: configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t, true, projectID, clusterName, "NODE_TYPE", false),
 				Check:  checkReplicaSetScalingStrategyAndRedactClientLogData(true, "NODE_TYPE", false),
 			},
 		},
@@ -965,32 +916,27 @@ func TestAccAdvancedCluster_replicaSetScalingStrategyAndRedactClientLogDataOldSc
 
 // TestAccClusterAdvancedCluster_priorityOldSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
-
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      configPriority(t, true, orgID, projectName, clusterName, true, true),
+				Config:      configPriority(t, true, projectID, clusterName, true, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: configPriority(t, true, orgID, projectName, clusterName, true, false),
+				Config: configPriority(t, true, projectID, clusterName, true, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      configPriority(t, true, orgID, projectName, clusterName, true, true),
+				Config:      configPriority(t, true, projectID, clusterName, true, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			// Extra step added to allow deletion, otherwise we get `Error running post-test destroy` since validation of TF fails
 			{
-				Config: configPriority(t, true, orgID, projectName, clusterName, true, false),
+				Config: configPriority(t, true, projectID, clusterName, true, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 		},
@@ -999,32 +945,27 @@ func TestAccClusterAdvancedCluster_priorityOldSchema(t *testing.T) {
 
 // TestAccClusterAdvancedCluster_priorityNewSchema will be able to be simplied or deleted in CLOUDP-275825
 func TestAccClusterAdvancedCluster_priorityNewSchema(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName() // No ProjectIDExecution to avoid cross-region limits because multi-region
-		clusterName = acc.RandomClusterName()
-	)
-
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config:      configPriority(t, true, orgID, projectName, clusterName, false, true),
+				Config:      configPriority(t, true, projectID, clusterName, false, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			{
-				Config: configPriority(t, true, orgID, projectName, clusterName, false, false),
+				Config: configPriority(t, true, projectID, clusterName, false, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 			{
-				Config:      configPriority(t, true, orgID, projectName, clusterName, false, true),
+				Config:      configPriority(t, true, projectID, clusterName, false, true),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
 			// Extra step added to allow deletion, otherwise we get `Error running post-test destroy` since validation of TF fails
 			{
-				Config: configPriority(t, true, orgID, projectName, clusterName, false, false),
+				Config: configPriority(t, true, projectID, clusterName, false, false),
 				Check:  acc.TestCheckResourceAttrSchemaV2(true, resourceName, "replication_specs.0.region_configs.#", "2"),
 			},
 		},
@@ -1108,23 +1049,19 @@ func TestAccClusterAdvancedCluster_pinnedFCVWithVersionUpgradeAndDowngrade(t *te
 
 func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, orgID, projectName),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false, true),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, false, true),
 				Check:  acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
 			},
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true, true),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true),
 				Check:  acc.CheckIndependentShardScalingMode(resourceName, clusterName, "SHARD"),
 			},
 		},
@@ -1133,27 +1070,23 @@ func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T) {
 
 func TestAccAdvancedCluster_oldToNewSchemaWithAutoscalingDisabledToEnabled(t *testing.T) {
 	acc.SkipIfAdvancedClusterV2Schema(t)
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		clusterName = acc.RandomClusterName()
-	)
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, orgID, projectName),
+		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, false, false),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, false, false),
 				Check:  acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
 			},
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true, false),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, false),
 				Check:  acc.CheckIndependentShardScalingMode(resourceName, clusterName, "CLUSTER"),
 			},
 			{
-				Config: configShardedTransitionOldToNewSchema(t, true, orgID, projectName, clusterName, true, true),
+				Config: configShardedTransitionOldToNewSchema(t, true, projectID, clusterName, true, true),
 				Check:  acc.CheckIndependentShardScalingMode(resourceName, clusterName, "SHARD"),
 			},
 		},
@@ -1627,17 +1560,12 @@ func configIncorrectTypeGobalClusterSelfManagedSharding(t *testing.T, isAcc bool
 	`, projectID, name))
 }
 
-func configReplicaSetMultiCloud(t *testing.T, isAcc bool, orgID, projectName, name string) string {
+func configReplicaSetMultiCloud(t *testing.T, isAcc bool, projectID, name string) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			cluster_type = "REPLICASET"
 			retain_backups_enabled = false
 
@@ -1677,7 +1605,7 @@ func configReplicaSetMultiCloud(t *testing.T, isAcc bool, orgID, projectName, na
 				}
 			}
 		}
-	`, orgID, projectName, name)) + dataSourcesTFNewSchema
+	`, projectID, name)) + dataSourcesTFNewSchema
 }
 
 func checkReplicaSetMultiCloud(isAcc bool, name string, regionConfigs int) resource.TestCheckFunc {
@@ -1699,7 +1627,7 @@ func checkReplicaSetMultiCloud(isAcc bool, name string, regionConfigs int) resou
 	)
 }
 
-func configShardedOldSchemaMultiCloud(t *testing.T, isAcc bool, orgID, projectName, name string, numShards int, analyticsSize string, configServerManagementMode *string) string {
+func configShardedOldSchemaMultiCloud(t *testing.T, isAcc bool, projectID, name string, numShards int, analyticsSize string, configServerManagementMode *string) string {
 	t.Helper()
 	var rootConfig string
 	if configServerManagementMode != nil {
@@ -1712,26 +1640,21 @@ func configShardedOldSchemaMultiCloud(t *testing.T, isAcc bool, orgID, projectNa
 		`, *configServerManagementMode)
 	}
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}	
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id   = mongodbatlas_project.cluster_project.id
-			name         = %[3]q
+			project_id   = %[1]q
+			name         = %[2]q
 			cluster_type = "SHARDED"
-			%[6]s
+			%[5]s
 
 			replication_specs {
-				num_shards = %[4]d
+				num_shards = %[3]d
 				region_configs {
 					electable_specs {
 						instance_size = "M10"
 						node_count    = 3
 					}
 					analytics_specs {
-						instance_size = %[5]q
+						instance_size = %[4]q
 						node_count    = 1
 					}
 					provider_name = "AWS"
@@ -1749,7 +1672,7 @@ func configShardedOldSchemaMultiCloud(t *testing.T, isAcc bool, orgID, projectNa
 				}
 			}
 		}
-	`, orgID, projectName, name, numShards, analyticsSize, rootConfig)) + dataSourcesTFOldSchema
+	`, projectID, name, numShards, analyticsSize, rootConfig)) + dataSourcesTFOldSchema
 }
 
 func checkShardedOldSchemaMultiCloud(isAcc bool, name string, numShards int, analyticsSize string, verifyExternalID bool, configServerManagementMode *string) resource.TestCheckFunc {
@@ -2066,26 +1989,21 @@ func configReplicationSpecsAnalyticsAutoScaling(t *testing.T, isAcc bool, projec
 	`, projectID, clusterName, p.Compute.GetEnabled(), p.DiskGB.GetEnabled(), p.Compute.GetMaxInstanceSize()))
 }
 
-func configGeoShardedOldSchema(t *testing.T, isAcc bool, orgID, projectName, name string, numShardsFirstZone, numShardsSecondZone int, selfManagedSharding bool) string {
+func configGeoShardedOldSchema(t *testing.T, isAcc bool, projectID, name string, numShardsFirstZone, numShardsSecondZone int, selfManagedSharding bool) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			mongo_db_major_version = "7.0"
 			cluster_type   = "GEOSHARDED"
-			global_cluster_self_managed_sharding = %[6]t
+			global_cluster_self_managed_sharding = %[5]t
 			disk_size_gb  = 60
 
 			replication_specs {
 				zone_name  = "zone n1"
-				num_shards = %[4]d
+				num_shards = %[3]d
 
 				region_configs {
 				electable_specs {
@@ -2104,7 +2022,7 @@ func configGeoShardedOldSchema(t *testing.T, isAcc bool, orgID, projectName, nam
 
 			replication_specs {
 				zone_name  = "zone n2"
-				num_shards = %[5]d
+				num_shards = %[4]d
 
 				region_configs {
 				electable_specs {
@@ -2122,7 +2040,7 @@ func configGeoShardedOldSchema(t *testing.T, isAcc bool, orgID, projectName, nam
 			}
 		}
 
-	`, orgID, projectName, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding)) + dataSourcesTFOldSchema
+	`, projectID, name, numShardsFirstZone, numShardsSecondZone, selfManagedSharding)) + dataSourcesTFOldSchema
 }
 
 func checkGeoShardedOldSchema(isAcc bool, name string, numShardsFirstZone, numShardsSecondZone int, isLatestProviderVersion, verifyExternalID bool) resource.TestCheckFunc {
@@ -2153,17 +2071,12 @@ func checkGeoShardedOldSchema(isAcc bool, name string, numShardsFirstZone, numSh
 	)
 }
 
-func configShardedOldSchemaDiskSizeGBElectableLevel(t *testing.T, isAcc bool, orgID, projectName, name string, diskSizeGB int) string {
+func configShardedOldSchemaDiskSizeGBElectableLevel(t *testing.T, isAcc bool, projectID, name string, diskSizeGB int) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			mongo_db_major_version = "7.0"
 			cluster_type   = "SHARDED"
@@ -2175,12 +2088,12 @@ func configShardedOldSchemaDiskSizeGBElectableLevel(t *testing.T, isAcc bool, or
 				electable_specs {
 					instance_size = "M10"
 					node_count    = 3
-					disk_size_gb  = %[4]d
+					disk_size_gb  = %[3]d
 				}
 				analytics_specs {
 					instance_size = "M10"
 					node_count    = 0
-					disk_size_gb  = %[4]d
+					disk_size_gb  = %[3]d
 				}
 				provider_name = "AWS"
 				priority      = 7
@@ -2188,7 +2101,7 @@ func configShardedOldSchemaDiskSizeGBElectableLevel(t *testing.T, isAcc bool, or
 				}
 			}
 		}
-	`, orgID, projectName, name, diskSizeGB)) + dataSourcesTFOldSchema
+	`, projectID, name, diskSizeGB)) + dataSourcesTFOldSchema
 }
 
 func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) resource.TestCheckFunc {
@@ -2202,7 +2115,7 @@ func checkShardedOldSchemaDiskSizeGBElectableLevel(isAcc bool, diskSizeGB int) r
 		})
 }
 
-func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
+func configShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIOPS, lastDiskIOPS *int, includeMiddleSpec bool) string {
 	t.Helper()
 	var thirdReplicationSpec string
 	if includeMiddleSpec {
@@ -2241,29 +2154,24 @@ func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name s
 		`, *lastDiskIOPS)
 	}
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
 
 			replication_specs {
 				region_configs {
 					electable_specs {
-						instance_size = %[4]q
+						instance_size = %[3]q
 						node_count    = 3
-						disk_size_gb  = %[9]d
-						%[6]s
+						disk_size_gb  = %[8]d
+						%[5]s
 					}
 					analytics_specs {
-						instance_size = %[4]q
+						instance_size = %[3]q
 						node_count    = 1
-						disk_size_gb  = %[9]d
+						disk_size_gb  = %[8]d
 					}
 					provider_name = "AWS"
 					priority      = 7
@@ -2271,20 +2179,20 @@ func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name s
 				}
 			}
 
-			%[8]s
+			%[7]s
 
 			replication_specs {
 				region_configs {
 					electable_specs {
-						instance_size = %[5]q
+						instance_size = %[4]q
 						node_count    = 3
-						disk_size_gb  = %[9]d
-						%[7]s
+						disk_size_gb  = %[8]d
+						%[6]s
 					}
 					analytics_specs {
-						instance_size = %[5]q
+						instance_size = %[4]q
 						node_count    = 1
-						disk_size_gb  = %[9]d
+						disk_size_gb  = %[8]d
 					}
 					provider_name = "AWS"
 					priority      = 7
@@ -2308,7 +2216,7 @@ func configShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name s
 			project_id = mongodbatlas_advanced_cluster.test.project_id
 			use_replication_spec_per_shard = true
 		}
-	`, orgID, projectName, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB))
+	`, projectID, name, firstInstanceSize, lastInstanceSize, firstDiskIOPSAttrs, lastDiskIOPSAttrs, thirdReplicationSpec, diskSizeGB))
 }
 
 func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastInstanceSize string, firstDiskIops, lastDiskIops *int, isAsymmetricCluster, includeMiddleSpec bool) resource.TestCheckFunc {
@@ -2364,7 +2272,7 @@ func checkShardedNewSchema(isAcc bool, diskSizeGB int, firstInstanceSize, lastIn
 	)
 }
 
-func configGeoShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, includeThirdShardInFirstZone bool) string {
+func configGeoShardedNewSchema(t *testing.T, isAcc bool, projectID, name string, includeThirdShardInFirstZone bool) string {
 	t.Helper()
 	var thirdReplicationSpec string
 	if includeThirdShardInFirstZone {
@@ -2384,13 +2292,9 @@ func configGeoShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, nam
 		`
 	}
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			mongo_db_major_version = "7.0"
 			cluster_type   = "GEOSHARDED"
@@ -2406,7 +2310,7 @@ func configGeoShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, nam
 				region_name   = "US_EAST_1"
 				}
 			}
-			%[4]s
+			%[3]s
 			replication_specs {
 				zone_name  = "zone n2"
 				region_configs {
@@ -2420,7 +2324,7 @@ func configGeoShardedNewSchema(t *testing.T, isAcc bool, orgID, projectName, nam
 				}
 			}
     	}
-	`, orgID, projectName, name, thirdReplicationSpec)) + dataSourcesTFNewSchema
+	`, projectID, name, thirdReplicationSpec)) + dataSourcesTFNewSchema
 }
 
 func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource.TestCheckFunc {
@@ -2438,7 +2342,7 @@ func checkGeoShardedNewSchema(isAcc, includeThirdShardInFirstZone bool) resource
 	return checkAggr(isAcc, []string{}, clusterChecks)
 }
 
-func configShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, useNewSchema, autoscaling bool) string {
+func configShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, projectID, name string, useNewSchema, autoscaling bool) string {
 	t.Helper()
 	var numShardsStr string
 	if !useNewSchema {
@@ -2488,21 +2392,16 @@ func configShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, proj
 	}
 
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
 
-			%[4]s
+			%[3]s
 		}
 
-	`, orgID, projectName, name, replicationSpecs)) + dataSources
+	`, projectID, name, replicationSpecs)) + dataSources
 }
 
 func checkShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
@@ -2535,7 +2434,7 @@ func checkShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.Tes
 	)
 }
 
-func configGeoShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, projectName, name string, useNewSchema bool) string {
+func configGeoShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, projectID, name string, useNewSchema bool) string {
 	t.Helper()
 	var numShardsStr string
 	if !useNewSchema {
@@ -2583,20 +2482,15 @@ func configGeoShardedTransitionOldToNewSchema(t *testing.T, isAcc bool, orgID, p
 	}
 
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			cluster_type   = "GEOSHARDED"
 
-			%[4]s
+			%[3]s
 		}
-	`, orgID, projectName, name, replicationSpecs)) + dataSources
+	`, projectID, name, replicationSpecs)) + dataSources
 }
 
 func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.TestCheckFunc {
@@ -2624,21 +2518,16 @@ func checkGeoShardedTransitionOldToNewSchema(isAcc, useNewSchema bool) resource.
 	)
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc bool, projectID, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
-			replica_set_scaling_strategy = %[4]q
-			redact_client_log_data = %[5]t
+			replica_set_scaling_strategy = %[3]q
+			redact_client_log_data = %[4]t
 
 			replication_specs {
 				region_configs {
@@ -2658,24 +2547,19 @@ func configReplicaSetScalingStrategyAndRedactClientLogData(t *testing.T, isAcc b
 				}
 			}
 		}
-	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFNewSchema
+	`, projectID, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFNewSchema
 }
 
-func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T, isAcc bool, orgID, projectName, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
+func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T, isAcc bool, projectID, name, replicaSetScalingStrategy string, redactClientLogData bool) string {
 	t.Helper()
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "cluster_project" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id = mongodbatlas_project.cluster_project.id
-			name = %[3]q
+			project_id = %[1]q
+			name = %[2]q
 			backup_enabled = false
 			cluster_type   = "SHARDED"
-			replica_set_scaling_strategy = %[4]q
-			redact_client_log_data = %[5]t
+			replica_set_scaling_strategy = %[3]q
+			redact_client_log_data = %[4]t
 
 			replication_specs {
 				num_shards = 2
@@ -2696,7 +2580,7 @@ func configReplicaSetScalingStrategyAndRedactClientLogDataOldSchema(t *testing.T
 				}
 			}
 		}
-	`, orgID, projectName, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFOldSchema
+	`, projectID, name, replicaSetScalingStrategy, redactClientLogData)) + dataSourcesTFOldSchema
 }
 
 func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSetScalingStrategy string, redactClientLogData bool) resource.TestCheckFunc {
@@ -2716,7 +2600,7 @@ func checkReplicaSetScalingStrategyAndRedactClientLogData(isAcc bool, replicaSet
 	)
 }
 
-func configPriority(t *testing.T, isAcc bool, orgID, projectName, clusterName string, oldSchema, swapPriorities bool) string {
+func configPriority(t *testing.T, isAcc bool, projectID, clusterName string, oldSchema, swapPriorities bool) string {
 	t.Helper()
 	const (
 		config7 = `
@@ -2752,23 +2636,18 @@ func configPriority(t *testing.T, isAcc bool, orgID, projectName, clusterName st
 	}
 
 	return acc.ConvertAdvancedClusterToSchemaV2(t, isAcc, fmt.Sprintf(`
-		resource "mongodbatlas_project" "test" {
-			org_id = %[1]q
-			name   = %[2]q
-		}
-
 		resource "mongodbatlas_advanced_cluster" "test" {
-			project_id   = mongodbatlas_project.test.id
-			name         = %[3]q
-			cluster_type   = %[4]q
+			project_id   = %[1]q
+			name         = %[2]q
+			cluster_type   = %[3]q
 			backup_enabled = false
 			
 			replication_specs {
+ 					%[4]s
  					%[5]s
- 					%[6]s
 			}
 		}
-	`, orgID, projectName, clusterName, strType, strNumShards, strConfigs))
+	`, projectID, clusterName, strType, strNumShards, strConfigs))
 }
 
 func configBiConnectorConfig(t *testing.T, isAcc bool, projectID, name string, enabled bool) string {

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1192,7 +1192,7 @@ func TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate(t *testing.T) {
 				Config: configBasicReplicaset(t, projectID, clusterName, fullUpdate),
 				Check:  checksUpdate,
 			},
-			acc.TestStepImportCluster(resourceName),
+			acc.TestStepImportCluster(resourceName, acc.ImportIgnoredFields()...),
 		},
 	})
 }
@@ -1235,7 +1235,7 @@ func TestAccMockableAdvancedCluster_shardedAddAnalyticsAndAutoScaling(t *testing
 				Config: configSharded(t, projectID, clusterName, true),
 				Check:  checksUpdated,
 			},
-			acc.TestStepImportCluster(resourceName),
+			acc.TestStepImportCluster(resourceName, acc.ImportIgnoredFields()...),
 		},
 	})
 }

--- a/internal/service/advancedclustertpf/plural_data_source.go
+++ b/internal/service/advancedclustertpf/plural_data_source.go
@@ -101,6 +101,9 @@ func (d *pluralDS) readClusters(ctx context.Context, diags *diag.Diagnostics, pl
 }
 
 func DiagsHasOnlyClusterNotFound(diags *diag.Diagnostics) bool {
+	if !diags.HasError() {
+		return false
+	}
 	for _, d := range *diags {
 		if d.Severity() != diag.SeverityError || strings.Contains(d.Detail(), "CLUSTER_NOT_FOUND") {
 			continue

--- a/internal/service/advancedclustertpf/plural_data_source_test.go
+++ b/internal/service/advancedclustertpf/plural_data_source_test.go
@@ -15,7 +15,7 @@ func TestDiagsHasOnlyClusterNotFound(t *testing.T) {
 	}{
 		"empty diagnostics": {
 			diags:    diag.Diagnostics{},
-			expected: true,
+			expected: false,
 		},
 		"single cluster not found": {
 			diags: diag.Diagnostics{

--- a/internal/service/advancedclustertpf/plural_data_source_test.go
+++ b/internal/service/advancedclustertpf/plural_data_source_test.go
@@ -1,0 +1,55 @@
+package advancedclustertpf_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiagsHasOnlyClusterNotFound(t *testing.T) {
+	tests := map[string]struct {
+		diags    diag.Diagnostics
+		expected bool
+	}{
+		"empty diagnostics": {
+			diags:    diag.Diagnostics{},
+			expected: true,
+		},
+		"single cluster not found": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Cluster Not Found", "CLUSTER_NOT_FOUND"),
+			},
+			expected: true,
+		},
+		"multiple errors with cluster not found": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Other Error", "Some other error"),
+				diag.NewErrorDiagnostic("Cluster Not Found", "CLUSTER_NOT_FOUND"),
+			},
+			expected: false,
+		},
+		"other errors only": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error 1", "Some error"),
+				diag.NewErrorDiagnostic("Error 2", "Another error"),
+			},
+			expected: false,
+		},
+		"warnings with cluster not found error": {
+			diags: diag.Diagnostics{
+				diag.NewWarningDiagnostic("Warning", "Some warning"),
+				diag.NewErrorDiagnostic("Cluster Not Found", "CLUSTER_NOT_FOUND"),
+			},
+			expected: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := advancedclustertpf.DiagsHasOnlyClusterNotFound(&tc.diags)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
@@ -42,17 +41,6 @@ var (
 		"value": "label value 3",
 	}
 )
-
-func ImportIgnoredFields() []string {
-	if config.AdvancedClusterV2Schema() {
-		return []string{}
-	}
-	return []string{
-		"replication_specs.0.region_configs.0.read_only_specs",
-		"replication_specs.0.region_configs.0.analytics_specs",
-		"replication_specs.0.region_configs.0.electable_specs.0.ebs_volume_type",
-	}
-}
 
 func TestStepImportCluster(resourceName string, ignoredFields ...string) resource.TestStep {
 	return resource.TestStep{

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
@@ -41,6 +42,17 @@ var (
 		"value": "label value 3",
 	}
 )
+
+func ImportIgnoredFields() []string {
+	if config.AdvancedClusterV2Schema() {
+		return []string{}
+	}
+	return []string{
+		"replication_specs.0.region_configs.0.read_only_specs",
+		"replication_specs.0.region_configs.0.analytics_specs",
+		"replication_specs.0.region_configs.0.electable_specs.0.ebs_volume_type",
+	}
+}
 
 func TestStepImportCluster(resourceName string, ignoredFields ...string) resource.TestStep {
 	return resource.TestStep{

--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -105,16 +105,3 @@ func projectIDLocal(tb testing.TB) string {
 	tb.Logf("Using MONGODB_ATLAS_PROJECT_ID: %s", id)
 	return id
 }
-
-func clusterNameLocal(tb testing.TB) string {
-	tb.Helper()
-	name := os.Getenv("MONGODB_ATLAS_CLUSTER_NAME")
-	if name == "" {
-		return ""
-	}
-	if InCI() {
-		tb.Fatal("MONGODB_ATLAS_CLUSTER_NAME can't be used in CI")
-	}
-	tb.Logf("Using MONGODB_ATLAS_CLUSTER_NAME: %s", name)
-	return name
-}

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MaxClustersPerProject = 6
+	MaxClustersPerProject = 5
 )
 
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MaxClustersPerProject = 10
+	MaxClustersPerProject = 8
 )
 
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -61,7 +61,7 @@ func ProjectIDExecution(tb testing.TB) string {
 	return sharedInfo.projectID
 }
 
-// ProjectIDExecutionWithCluster creates a project and reuses it `MaxClustersPerProject` times. The clusterName is always unique.
+// ProjectIDExecutionWithCluster creates a project and reuses it for  `MaxClusterNodesPerProject ` nodes. The clusterName is always unique.
 // TotalNodeCount = sum(specs.node_count) * num_shards (1 if new schema)
 // This avoids the `CROSS_REGION_NETWORK_PERMISSIONS_LIMIT_EXCEEDED` error when creating too many clusters within the same project.
 // When `MONGODB_ATLAS_PROJECT_ID` and `MONGODB_ATLAS_CLUSTER_NAME` are defined, they are used instead of creating a project and clusterName.

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -142,23 +142,15 @@ func NextProjectIDClusterName(projectCreator func(string) string) (projectID, cl
 	sharedInfo.mu.Lock()
 	defer sharedInfo.mu.Unlock()
 	var project projectInfo
-	if len(sharedInfo.projects) == 0 {
+	if len(sharedInfo.projects) == 0 || sharedInfo.projects[len(sharedInfo.projects)-1].clusterCount == MaxClustersPerProject {
 		project = projectInfo{
 			name: RandomProjectName(),
+			clusterCount: 1,
 		}
-	} else {
-		project = sharedInfo.projects[len(sharedInfo.projects)-1]
-	}
-	if project.clusterCount == MaxClustersPerProject {
-		project = projectInfo{
-			name: RandomProjectName(),
-		}
-	}
-	if project.id == "" {
-		project.clusterCount++
 		project.id = projectCreator(project.name)
 		sharedInfo.projects = append(sharedInfo.projects, project)
 	} else {
+		project = sharedInfo.projects[len(sharedInfo.projects)-1]
 		sharedInfo.projects[len(sharedInfo.projects)-1].clusterCount++
 	}
 	return project.id, RandomClusterName()

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -144,7 +144,7 @@ func NextProjectIDClusterName(projectCreator func(string) string) (projectID, cl
 	var project projectInfo
 	if len(sharedInfo.projects) == 0 || sharedInfo.projects[len(sharedInfo.projects)-1].clusterCount == MaxClustersPerProject {
 		project = projectInfo{
-			name: RandomProjectName(),
+			name:         RandomProjectName(),
 			clusterCount: 1,
 		}
 		project.id = projectCreator(project.name)

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MaxClustersPerProject = 8
+	MaxClustersPerProject = 6
 )
 
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
@@ -62,6 +62,7 @@ func ProjectIDExecution(tb testing.TB) string {
 }
 
 // ProjectIDExecutionWithCluster creates a project and reuses it `MaxClustersPerProject` times. The clusterName is always unique.
+// This avoids the `CROSS_REGION_NETWORK_PERMISSIONS_LIMIT_EXCEEDED` error when creating too many clusters within the same project.
 // When `MONGODB_ATLAS_PROJECT_ID` and `MONGODB_ATLAS_CLUSTER_NAME` are defined, they are used instead of creating a project and clusterName.
 func ProjectIDExecutionWithCluster(tb testing.TB) (projectID, clusterName string) {
 	tb.Helper()

--- a/internal/testutil/acc/shared_resource_test.go
+++ b/internal/testutil/acc/shared_resource_test.go
@@ -15,17 +15,20 @@ func Test_NextProjectIDClusterName(t *testing.T) {
 	projectIDs := map[string]int{}
 	clusterNames := map[string]int{}
 
-	addProjectIDClusterName := func() {
-		projectID, clusterName := acc.NextProjectIDClusterName(projectIDReturner)
+	addProjectIDClusterName := func(nodeCount int) {
+		projectID, clusterName := acc.NextProjectIDClusterName(nodeCount, projectIDReturner)
 		projectIDs[projectID]++
 		clusterNames[clusterName]++
 	}
-	for range acc.MaxClustersPerProject {
-		addProjectIDClusterName()
+	for range acc.MaxClusterNodesPerProject {
+		addProjectIDClusterName(1)
 	}
 	assert.Len(t, projectIDs, 1)
-	assert.Len(t, clusterNames, acc.MaxClustersPerProject)
-	addProjectIDClusterName()
+	assert.Len(t, clusterNames, acc.MaxClusterNodesPerProject)
+	addProjectIDClusterName(1)
 	assert.Len(t, projectIDs, 2)
-	assert.Len(t, clusterNames, acc.MaxClustersPerProject+1)
+	assert.Len(t, clusterNames, acc.MaxClusterNodesPerProject+1)
+	addProjectIDClusterName(acc.MaxClusterNodesPerProject)
+	assert.Len(t, projectIDs, 3)
+	assert.Len(t, clusterNames, acc.MaxClusterNodesPerProject+2)
 }

--- a/internal/testutil/acc/shared_resource_test.go
+++ b/internal/testutil/acc/shared_resource_test.go
@@ -1,0 +1,31 @@
+package acc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NextProjectIDClusterName(t *testing.T) {
+	projectIDReturner := func(name string) string {
+		return fmt.Sprintf("%s-name", name)
+	}
+	projectIDs := map[string]int{}
+	clusterNames := map[string]int{}
+
+	addProjectIDClusterName := func() {
+		projectID, clusterName := acc.NextProjectIDClusterName(projectIDReturner)
+		projectIDs[projectID]++
+		clusterNames[clusterName]++
+	}
+	for range acc.MaxClustersPerProject {
+		addProjectIDClusterName()
+	}
+	assert.Len(t, projectIDs, 1)
+	assert.Len(t, clusterNames, acc.MaxClustersPerProject)
+	addProjectIDClusterName()
+	assert.Len(t, projectIDs, 2)
+	assert.Len(t, clusterNames, acc.MaxClustersPerProject+1)
+}


### PR DESCRIPTION
## Description

- Updates tests to use ProjectIDExecutionWithCluster to avoid CROSS_REGION_NETWORK_PERMISSIONS_LIMIT_EXCEEDED
- Handles CLUSTER_NOT_FOUND errors when resolving the list of clusters read from server
- Ignores certain attributes for SDKv2 implementation import
- A follow up PR will be used to change the `mongodbatlas_cluster` tests

Link to any related issue(s): CLOUDP-294694

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
