### PR TITLE
refactor: Removes unused RootDiskSize field and simplify ExtraAPIInfo construction

### DIFF
--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -22,7 +22,6 @@ const (
 type ExtraAPIInfo struct {
 	ZoneNameNumShards          map[string]int64
 	ZoneNameReplicationSpecIDs map[string]string
-	RootDiskSize               *float64
 	ContainerIDs               map[string]string
 	UsingLegacySchema          bool
 	ForceLegacySchemaFailed    bool

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -42,7 +42,6 @@ func findNumShardsUpdates(ctx context.Context, state, plan *TFModel, diags *diag
 func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, plan *TFModel, clusterLatest *admin.ClusterDescription20240805, forceLegacySchema bool) *ExtraAPIInfo {
 	var (
 		api20240530             = client.AtlasV220240530.ClustersApi
-		rootDiskSize            = conversion.NilForUnknown(plan.DiskSizeGB, plan.DiskSizeGB.ValueFloat64Pointer())
 		projectID               = plan.ProjectID.ValueString()
 		clusterName             = plan.Name.ValueString()
 		forceLegacySchemaFailed = false
@@ -56,28 +55,18 @@ func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config
 			return nil
 		}
 	}
-	if rootDiskSize == nil {
-		rootDiskSize = findRegionRootDiskSize(clusterLatest.ReplicationSpecs)
-	}
 	containerIDs, err := resolveContainerIDs(ctx, projectID, clusterLatest, client.AtlasV2.NetworkPeeringApi)
 	if err != nil {
 		diags.AddError(errorResolveContainerIDs, fmt.Sprintf("cluster name = %s, error details: %s", clusterName, err.Error()))
 		return nil
 	}
-	info := &ExtraAPIInfo{
+	return &ExtraAPIInfo{
 		ContainerIDs:               containerIDs,
-		RootDiskSize:               rootDiskSize,
 		ZoneNameReplicationSpecIDs: replicationSpecIDsFromOldAPI(clusterRespOld),
 		ForceLegacySchemaFailed:    forceLegacySchemaFailed,
+		ZoneNameNumShards:          numShardsMapFromOldAPI(clusterRespOld),
+		UsingLegacySchema:          forceLegacySchema || usingLegacySchema(ctx, plan.ReplicationSpecs, diags),
 	}
-	if forceLegacySchema {
-		info.UsingLegacySchema = true
-		info.ZoneNameNumShards = numShardsMapFromOldAPI(clusterRespOld) // plan is empty in data source Read when forcing legacy, so we get num_shards from the old API
-	} else {
-		info.UsingLegacySchema = usingLegacySchema(ctx, plan.ReplicationSpecs, diags)
-		info.ZoneNameNumShards = numShardsMap(ctx, plan.ReplicationSpecs, diags)
-	}
-	return info
 }
 
 // instead of using `num_shards` explode the replication specs, and set disk_size_gb


### PR DESCRIPTION
## Description

Removes unused RootDiskSize field and simplify ExtraAPIInfo construction

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
