### PR TITLE
chore: Implement "Infrastructure Tool" label behavior

### DIFF
--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -411,7 +411,7 @@ func FormatMongoDBMajorVersion(val any) string {
 func flattenLabels(l []admin.ComponentLabel) []map[string]string {
 	labels := make([]map[string]string, 0, len(l))
 	for _, item := range l {
-		if item.GetKey() == advancedclustertpf.IgnoreLabelKey {
+		if item.GetKey() == advancedclustertpf.LegacyIgnoredLabelKey {
 			continue
 		}
 		labels = append(labels, map[string]string{
@@ -960,8 +960,8 @@ func expandLabelSliceFromSetSchema(d *schema.ResourceData) ([]admin.ComponentLab
 	for i, val := range list.List() {
 		v := val.(map[string]any)
 		key := v["key"].(string)
-		if key == advancedclustertpf.IgnoreLabelKey {
-			return nil, diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
+		if key == advancedclustertpf.LegacyIgnoredLabelKey {
+			return nil, diag.FromErr(advancedclustertpf.ErrLegacyIgnoreLabel)
 		}
 		res[i] = admin.ComponentLabel{
 			Key:   conversion.StringPtr(key),

--- a/internal/service/advancedcluster/model_advanced_cluster.go
+++ b/internal/service/advancedcluster/model_advanced_cluster.go
@@ -411,7 +411,7 @@ func FormatMongoDBMajorVersion(val any) string {
 func flattenLabels(l []admin.ComponentLabel) []map[string]string {
 	labels := make([]map[string]string, 0, len(l))
 	for _, item := range l {
-		if item.GetKey() == ignoreLabel {
+		if item.GetKey() == advancedclustertpf.IgnoreLabelKey {
 			continue
 		}
 		labels = append(labels, map[string]string{
@@ -960,8 +960,8 @@ func expandLabelSliceFromSetSchema(d *schema.ResourceData) ([]admin.ComponentLab
 	for i, val := range list.List() {
 		v := val.(map[string]any)
 		key := v["key"].(string)
-		if key == ignoreLabel {
-			return nil, diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
+		if key == advancedclustertpf.IgnoreLabelKey {
+			return nil, diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
 		}
 		res[i] = admin.ComponentLabel{
 			Key:   conversion.StringPtr(key),

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -42,7 +42,6 @@ const (
 	ErrorAdvancedClusterListStatus = "error awaiting MongoDB ClusterAdvanced List IDLE: %s"
 	ErrorOperationNotPermitted     = "error operation not permitted"
 	ErrorDefaultMaxTimeMinVersion  = "default_max_time_ms can not be set for mongo_db_major_version lower than 8.0"
-	ignoreLabel                    = "Infrastructure Tool"
 	DeprecationOldSchemaAction     = "Please refer to our examples, documentation, and 1.18.0 migration guide for more details at https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/1.18.0-upgrade-guide.html.markdown"
 	V20240530                      = "(v20240530)"
 )

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -648,7 +648,7 @@ func TestAccClusterAdvancedCluster_withLabelIgnored(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "labels", acc.ClusterLabelsMapIgnored),
-				ExpectError: regexp.MustCompile(advancedclustertpf.ErrIgnoreLabel.Error()),
+				ExpectError: regexp.MustCompile(advancedclustertpf.ErrLegacyIgnoreLabel.Error()),
 			},
 		},
 	})

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -635,6 +635,25 @@ func TestAccClusterAdvancedCluster_withLabels(t *testing.T) {
 	})
 }
 
+func TestAccClusterAdvancedCluster_withLabelIgnored(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		clusterName = acc.RandomClusterName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config:      configWithKeyValueBlocks(t, true, orgID, projectName, clusterName, "labels", acc.ClusterLabelsMapIgnored),
+				ExpectError: regexp.MustCompile(advancedclustertpf.ErrIgnoreLabel.Error()),
+			},
+		},
+	})
+}
+
 func TestAccClusterAdvancedClusterConfig_selfManagedSharding(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)

--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	IgnoreLabelKey = "Infrastructure Tool"
+	LegacyIgnoredLabelKey = "Infrastructure Tool"
 )
 
 var (
-	ErrIgnoreLabel = fmt.Errorf("you should not set `%s` label, it is used for internal purposes", IgnoreLabelKey)
+	ErrLegacyIgnoreLabel = fmt.Errorf("label `%s` is not supported as it is reserved for internal purposes", LegacyIgnoredLabelKey)
 )
 
 func FormatMongoDBMajorVersion(version string) string {

--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	IgnoreLabelKey   = "Infrastructure Tool"
-	IgnoreLabelValue = "MongoDB Atlas Terraform Provider"
+	IgnoreLabelKey = "Infrastructure Tool"
 )
 
 var (

--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -13,6 +13,15 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
+const (
+	IgnoreLabelKey   = "Infrastructure Tool"
+	IgnoreLabelValue = "MongoDB Atlas Terraform Provider"
+)
+
+var (
+	ErrIgnoreLabel = fmt.Errorf("you should not set `%s` label, it is used for internal purposes", IgnoreLabelKey)
+)
+
 func FormatMongoDBMajorVersion(version string) string {
 	if strings.Contains(version, ".") {
 		return version

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -104,12 +104,14 @@ func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags 
 	if input == nil {
 		return types.SetNull(LabelsObjType)
 	}
-	tfModels := make([]TFLabelsModel, len(*input))
-	for i, item := range *input {
-		tfModels[i] = TFLabelsModel{
-			Key:   types.StringValue(conversion.SafeValue(item.Key)),
-			Value: types.StringValue(conversion.SafeValue(item.Value)),
+	tfModels := make([]TFLabelsModel, 0, len(*input))
+	for _, item := range *input {
+		key := conversion.SafeValue(item.Key)
+		value := conversion.SafeValue(item.Value)
+		if key == IgnoreLabelKey {
+			continue
 		}
+		tfModels = append(tfModels, TFLabelsModel{Key: types.StringValue(key), Value: types.StringValue(value)})
 	}
 	setType, diagsLocal := types.SetValueFrom(ctx, LabelsObjType, tfModels)
 	diags.Append(diagsLocal...)

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -108,7 +108,7 @@ func NewLabelsObjType(ctx context.Context, input *[]admin.ComponentLabel, diags 
 	for _, item := range *input {
 		key := conversion.SafeValue(item.Key)
 		value := conversion.SafeValue(item.Value)
-		if key == IgnoreLabelKey {
+		if key == LegacyIgnoredLabelKey {
 			continue
 		}
 		tfModels = append(tfModels, TFLabelsModel{Key: types.StringValue(key), Value: types.StringValue(value)})

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -72,6 +72,10 @@ func newComponentLabel(ctx context.Context, input types.Set, diags *diag.Diagnos
 	resp := make([]admin.ComponentLabel, len(input.Elements()))
 	for i := range elements {
 		item := &elements[i]
+		if item.Key.ValueString() == IgnoreLabelKey {
+			diags.AddError(ErrIgnoreLabel.Error(), ErrIgnoreLabel.Error())
+			return nil
+		}
 		resp[i] = admin.ComponentLabel{
 			Key:   item.Key.ValueStringPointer(),
 			Value: item.Value.ValueStringPointer(),

--- a/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_to_ClusterDescription20240805.go
@@ -72,8 +72,8 @@ func newComponentLabel(ctx context.Context, input types.Set, diags *diag.Diagnos
 	resp := make([]admin.ComponentLabel, len(input.Elements()))
 	for i := range elements {
 		item := &elements[i]
-		if item.Key.ValueString() == IgnoreLabelKey {
-			diags.AddError(ErrIgnoreLabel.Error(), ErrIgnoreLabel.Error())
+		if item.Key.ValueString() == LegacyIgnoredLabelKey {
+			diags.AddError(ErrLegacyIgnoreLabel.Error(), ErrLegacyIgnoreLabel.Error())
 			return nil
 		}
 		resp[i] = admin.ComponentLabel{

--- a/internal/service/advancedclustertpf/move_upgrade_state_test.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state_test.go
@@ -6,12 +6,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
-)
-
-const (
-	resourceName = "mongodbatlas_advanced_cluster.test"
 )
 
 func TestAccAdvancedCluster_moveBasic(t *testing.T) {
@@ -31,10 +28,11 @@ func TestAccAdvancedCluster_moveBasic(t *testing.T) {
 			},
 			{
 				Config: configMoveSecond(projectID, clusterName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/internal/service/advancedclustertpf/move_upgrade_state_test.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state_test.go
@@ -29,7 +29,7 @@ func TestAccAdvancedCluster_moveBasic(t *testing.T) {
 			{
 				Config: configMoveSecond(projectID, clusterName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPostRefresh: []plancheck.PlanCheck{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
 					},
 				},

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -37,7 +37,7 @@ const (
 	ErrorSnapshotBackupPolicyRead = "error getting a Cloud Provider Snapshot Backup Policy for the cluster(%s): %s"
 )
 
-var defaultLabel = matlas.Label{Key: advancedclustertpf.IgnoreLabelKey, Value: advancedclustertpf.IgnoreLabelValue}
+var defaultLabel = matlas.Label{Key: advancedclustertpf.IgnoreLabelKey, Value: "MongoDB Atlas Terraform Provider"}
 
 func Resource() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -37,7 +37,7 @@ const (
 	ErrorSnapshotBackupPolicyRead = "error getting a Cloud Provider Snapshot Backup Policy for the cluster(%s): %s"
 )
 
-var defaultLabel = matlas.Label{Key: advancedclustertpf.IgnoreLabelKey, Value: "MongoDB Atlas Terraform Provider"}
+var defaultLabel = matlas.Label{Key: advancedclustertpf.LegacyIgnoredLabelKey, Value: "MongoDB Atlas Terraform Provider"}
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
@@ -521,7 +521,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
-		return diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
+		return diag.FromErr(advancedclustertpf.ErrLegacyIgnoreLabel)
 	}
 
 	clusterRequest.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
@@ -962,7 +962,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if d.HasChange("labels") {
 		if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
-			return diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
+			return diag.FromErr(advancedclustertpf.ErrLegacyIgnoreLabel)
 		}
 
 		cluster.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -37,7 +37,7 @@ const (
 	ErrorSnapshotBackupPolicyRead = "error getting a Cloud Provider Snapshot Backup Policy for the cluster(%s): %s"
 )
 
-var defaultLabel = matlas.Label{Key: "Infrastructure Tool", Value: "MongoDB Atlas Terraform Provider"}
+var defaultLabel = matlas.Label{Key: advancedclustertpf.IgnoreLabelKey, Value: advancedclustertpf.IgnoreLabelValue}
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
@@ -521,7 +521,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
-		return diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
+		return diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
 	}
 
 	clusterRequest.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)
@@ -962,7 +962,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if d.HasChange("labels") {
 		if containsLabelOrKey(expandLabelSliceFromSetSchema(d), defaultLabel) {
-			return diag.FromErr(fmt.Errorf("you should not set `Infrastructure Tool` label, it is used for internal purposes"))
+			return diag.FromErr(advancedclustertpf.ErrIgnoreLabel)
 		}
 
 		cluster.Labels = append(expandLabelSliceFromSetSchema(d), defaultLabel)

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -44,7 +44,7 @@ var (
 	}
 
 	ClusterLabelsMapIgnored = map[string]string{
-		"key":   advancedclustertpf.IgnoreLabelKey,
+		"key":   advancedclustertpf.LegacyIgnoredLabelKey,
 		"value": "value",
 	}
 )

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
@@ -39,6 +40,11 @@ var (
 	ClusterLabelsMap3 = map[string]string{
 		"key":   "label key 3",
 		"value": "label value 3",
+	}
+
+	ClusterLabelsMapIgnored = map[string]string{
+		"key":   advancedclustertpf.IgnoreLabelKey,
+		"value": "value",
 	}
 )
 


### PR DESCRIPTION
## Description

Implement "Infrastructure Tool" label behavior in TPF the same as in SDKv2 adv_cluster:
- Ignore the label coming from Atlas.
- Throw an error if set by the user.
- This PR allows to use moved block from cluster to TPF adv_cluster with no plan changes. Before this, a plan change would suggest to delete this label as it's created in cluster resources.

Link to any related issue(s): CLOUDP-295200

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
