### PR TITLE
chore: Updates `mongodbatlas_encryption_at_rest` tests to use `aws_kms_config.require_private_networking` field

### DIFF
--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -29,7 +29,8 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
-		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
+		useDatasource               = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
+		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.26.0") // require_private_networking introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -38,7 +39,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            configAwsKms(projectID, &awsKms, useDatasource),
+				Config:            configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -47,7 +48,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource)),
+			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
 		},
 	})
 }
@@ -197,7 +198,8 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
-		useDatasource = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
+		useDatasource               = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
+		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.26.0") // require_private_networking introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -206,7 +208,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProvidersWithAWS("1.11.0"),
-				Config:            configAwsKms(projectID, &awsKms, useDatasource),
+				Config:            configAwsKms(projectID, &awsKms, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -215,7 +217,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource)),
+			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
 		},
 	})
 }

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -21,7 +21,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),
@@ -188,7 +188,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -30,7 +30,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
 		useDatasource               = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
-		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.26.0") // require_private_networking introduced in this version
+		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.27.0") // require_private_networking introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -199,7 +199,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 			RoleId:              conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 		}
 		useDatasource               = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
-		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.26.0") // require_private_networking introduced in this version
+		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.27.0") // require_private_networking introduced in this version
 	)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -31,7 +31,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:                  conversion.Pointer(true),

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -31,14 +31,14 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
 
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:                  conversion.Pointer(true),
 			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
 			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
 			RoleId:                   conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
-			RequirePrivateNetworking: conversion.Pointer(false),
+			RequirePrivateNetworking: conversion.Pointer(true),
 		}
 		awsKmsAttrMap = acc.ConvertToAwsKmsEARAttrMap(&awsKms)
 
@@ -511,9 +511,10 @@ func configAwsKms(projectID string, aws *admin.AWSKMSConfiguration, useDatasourc
 				customer_master_key_id = %[3]q
 				region                 = %[4]q
 				role_id              = %[5]q
+				require_private_networking = %[6]t
 			}
 		}
-	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId())
+	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId(), aws.GetRequirePrivateNetworking())
 
 	if useDatasource {
 		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())


### PR DESCRIPTION
## Description

Updates `mongodbatlas_encryption_at_rest` tests to use `aws_kms_config.require_private_networking` field

Link to any related issue(s): [CLOUDP-295879](https://jira.mongodb.org/browse/CLOUDP-295879)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
