### PR TITLE
fix: Doesn't send `analyzers` field in search_index if absent in the definition

### DIFF
--- a/.changelog/2994.txt
+++ b/.changelog/2994.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_search_index: Don't send empty `analyzers` attribute to Atlas
+```

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -72,7 +72,7 @@ func unmarshalSearchIndexFields(str string) ([]map[string]any, diag.Diagnostics)
 	return fields, nil
 }
 
-func unmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyzer, diag.Diagnostics) {
+func UnmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyzer, diag.Diagnostics) {
 	fields := []admin.AtlasSearchAnalyzer{}
 	if str == "" {
 		return nil, nil // don't send analyzers field to Atlas if empty

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -75,7 +75,7 @@ func unmarshalSearchIndexFields(str string) ([]map[string]any, diag.Diagnostics)
 func unmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyzer, diag.Diagnostics) {
 	fields := []admin.AtlasSearchAnalyzer{}
 	if str == "" {
-		return fields, nil
+		return nil, nil // don't send analyzers field to Atlas if empty
 	}
 	dec := json.NewDecoder(bytes.NewReader([]byte(str)))
 	dec.DisallowUnknownFields()

--- a/internal/service/searchindex/model_search_index_test.go
+++ b/internal/service/searchindex/model_search_index_test.go
@@ -1,0 +1,81 @@
+package searchindex_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/searchindex"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+)
+
+func TestUnmarshalSearchIndexAnalyzersFields(t *testing.T) {
+	tc := map[string]struct {
+		input             string
+		expected          []admin.AtlasSearchAnalyzer
+		expectedHasErrors bool
+	}{
+		"empty string returns nil not empty slice": {
+			input:    "",
+			expected: nil,
+		},
+		"valid input": {
+			input: `
+				[{
+					"name": "index_analyzer_test_name",
+					"charFilters": [{
+						"type": "mapping",
+						"mappings": {"\\" : "/"}
+					}],
+					"tokenizer": {
+						"type": "nGram",
+						"minGram": 2,
+						"maxGram": 5
+					},
+					"tokenFilters": [{
+						"type": "length",
+						"min": 20,
+						"max": 33
+					}]
+				}]
+			`,
+			expected: []admin.AtlasSearchAnalyzer{
+				{
+					Name: "index_analyzer_test_name",
+					CharFilters: &[]any{
+						map[string]any{
+							"type": "mapping",
+							"mappings": map[string]any{
+								"\\": "/",
+							},
+						},
+					},
+					Tokenizer: map[string]any{
+						"type":    "nGram",
+						"minGram": float64(2),
+						"maxGram": float64(5),
+					},
+					TokenFilters: &[]any{
+						map[string]any{
+							"type": "length",
+							"min":  float64(20),
+							"max":  float64(33),
+						},
+					},
+				},
+			},
+		},
+		"invalid input": {
+			input:             "{bad json format",
+			expectedHasErrors: true,
+		},
+	}
+	for name, tc := range tc {
+		t.Run(name, func(t *testing.T) {
+			actual, diags := searchindex.UnmarshalSearchIndexAnalyzersFields(tc.input)
+			assert.Equal(t, tc.expectedHasErrors, diags.HasError())
+			if !diags.HasError() {
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -221,7 +221,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if d.HasChange("analyzers") {
-		analyzers, err := unmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string))
+		analyzers, err := UnmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string))
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		searchIndexRequest.Definition.Fields = conversion.ToAnySlicePointer(&fields)
 	} else {
-		analyzers, err := unmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string))
+		analyzers, err := UnmarshalSearchIndexAnalyzersFields(d.Get("analyzers").(string))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Doesn't send `analyzers` field in search_index if absent in the definition. It fixes HELP-70041.

In this way Atlas UI won't show an error when editing the index in JSON as happening now:
![index3](https://github.com/user-attachments/assets/6f99a0f6-55e8-41be-9211-319361bb4262)


Link to any related issue(s): CLOUDP-296191

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
