### PR TITLE
chore: Updates `mongodbatlas_encryption_at_rest_private_endpoint` tests to support private networking for AWS encryption at rest

### DIFF
--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -39,7 +39,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: mig.ExternalProviders(),
-				Config:            configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking),
+				Config:            acc.ConfigAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -48,7 +48,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
+			mig.TestStepCheckEmptyPlan(acc.ConfigAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
 		},
 	})
 }
@@ -208,7 +208,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProvidersWithAWS("1.11.0"),
-				Config:            configAwsKms(projectID, &awsKms, false, false),
+				Config:            acc.ConfigAwsKms(projectID, &awsKms, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
@@ -217,7 +217,7 @@ func TestMigEncryptionAtRest_basicAWS_from_v1_11_0(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.role_id", awsKms.GetRoleId()),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(configAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
+			mig.TestStepCheckEmptyPlan(acc.ConfigAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking)),
 		},
 	})
 }

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -97,7 +97,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 
 func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
+		projectID = acc.ProjectIDExecution(t)
 
 		azureKeyVault = admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
@@ -244,9 +244,10 @@ func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
 		awsKeyName           = acc.RandomName()
 		awsKms               = admin.AWSKMSConfiguration{
-			Enabled:             conversion.Pointer(true),
-			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
-			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			Enabled:                  conversion.Pointer(true),
+			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			RequirePrivateNetworking: conversion.Pointer(true),
 		}
 	)
 
@@ -605,7 +606,8 @@ resource "mongodbatlas_encryption_at_rest" "test" {
     customer_master_key_id = %[3]q
 	region                 = %[2]q
     role_id                = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
+	require_private_networking = %[4]t
   }
 }
-	`, awsEar.GetEnabled(), awsEar.GetRegion(), awsEar.GetCustomerMasterKeyID())
+	`, awsEar.GetEnabled(), awsEar.GetRegion(), awsEar.GetCustomerMasterKeyID(), awsEar.GetRequirePrivateNetworking())
 }

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -109,7 +109,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER")),
 			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
 			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-			RequirePrivateNetworking: conversion.Pointer(true),
+			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 
 		azureKeyVaultAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVault)
@@ -124,7 +124,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED")),
 			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
 			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-			RequirePrivateNetworking: conversion.Pointer(false),
+			RequirePrivateNetworking: conversion.Pointer(true),
 		}
 
 		azureKeyVaultUpdatedAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVaultUpdated)
@@ -149,7 +149,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, false, true),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -97,7 +97,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 
 func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
+		projectID = acc.ProjectIDExecution(t)
 
 		azureKeyVault = admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
@@ -124,17 +124,14 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED")),
 			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
 			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-			RequirePrivateNetworking: conversion.Pointer(true),
+			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 
 		azureKeyVaultUpdatedAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVaultUpdated)
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acc.PreCheckEncryptionAtRestPrivateEndpoint(t)
-			acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t)
-		},
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
@@ -149,7 +146,7 @@ func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 				),
 			},
 			{
-				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, true, true),
+				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -97,7 +97,7 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 
 func TestAccEncryptionAtRest_basicAzure(t *testing.T) {
 	var (
-		projectID = acc.ProjectIDExecution(t)
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
 
 		azureKeyVault = admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),

--- a/internal/service/encryptionatrestprivateendpoint/model_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/model_test.go
@@ -67,19 +67,7 @@ func TestEncryptionAtRestPrivateEndpointSDKToTFModel(t *testing.T) {
 				ProjectID:                     types.StringValue(testProjectID),
 			},
 		},
-	}
-
-	for testName, tc := range testCases {
-		t.Run(testName, func(t *testing.T) {
-			resultModel := encryptionatrestprivateendpoint.NewTFEarPrivateEndpoint(tc.SDKResp, testProjectID)
-			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
-		})
-	}
-}
-
-// PrivateEndpointConnectionName is not returned for AWS
-func TestEncryptionAtRestPrivateEndpointSDKToTFModel_noPEConnectionName(t *testing.T) {
-	testCases := map[string]sdkToTFModelTestCase{
+		// PrivateEndpointConnectionName is not returned for AWS
 		"nil PrivateEndpointConnectionName": {
 			SDKResp: admin.EARPrivateEndpoint{
 				CloudProvider: admin.PtrString(testCloudProvider),

--- a/internal/service/encryptionatrestprivateendpoint/model_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/model_test.go
@@ -77,6 +77,56 @@ func TestEncryptionAtRestPrivateEndpointSDKToTFModel(t *testing.T) {
 	}
 }
 
+// PrivateEndpointConnectionName is not returned for AWS
+func TestEncryptionAtRestPrivateEndpointSDKToTFModel_noPEConnectionName(t *testing.T) {
+	testCases := map[string]sdkToTFModelTestCase{
+		"nil PrivateEndpointConnectionName": {
+			SDKResp: admin.EARPrivateEndpoint{
+				CloudProvider: admin.PtrString(testCloudProvider),
+				ErrorMessage:  admin.PtrString(""),
+				Id:            admin.PtrString(testID),
+				RegionName:    admin.PtrString(testRegionName),
+				Status:        admin.PtrString(testStatus),
+			},
+			expectedTFModel: encryptionatrestprivateendpoint.TFEarPrivateEndpointModel{
+				CloudProvider:                 types.StringValue(testCloudProvider),
+				ErrorMessage:                  types.StringNull(),
+				ID:                            types.StringValue(testID),
+				RegionName:                    types.StringValue(testRegionName),
+				Status:                        types.StringValue(testStatus),
+				PrivateEndpointConnectionName: types.StringNull(),
+				ProjectID:                     types.StringValue(testProjectID),
+			},
+		},
+		"empty PrivateEndpointConnectionName": {
+			SDKResp: admin.EARPrivateEndpoint{
+				CloudProvider:                 admin.PtrString(testCloudProvider),
+				ErrorMessage:                  admin.PtrString(""),
+				Id:                            admin.PtrString(testID),
+				RegionName:                    admin.PtrString(testRegionName),
+				Status:                        admin.PtrString(testStatus),
+				PrivateEndpointConnectionName: admin.PtrString(""),
+			},
+			expectedTFModel: encryptionatrestprivateendpoint.TFEarPrivateEndpointModel{
+				CloudProvider:                 types.StringValue(testCloudProvider),
+				ErrorMessage:                  types.StringNull(),
+				ID:                            types.StringValue(testID),
+				RegionName:                    types.StringValue(testRegionName),
+				Status:                        types.StringValue(testStatus),
+				PrivateEndpointConnectionName: types.StringNull(),
+				ProjectID:                     types.StringValue(testProjectID),
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resultModel := encryptionatrestprivateendpoint.NewTFEarPrivateEndpoint(tc.SDKResp, testProjectID)
+			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}
+
 type tfToSDKModelTestCase struct {
 	tfModel        *encryptionatrestprivateendpoint.TFEarPrivateEndpointModel
 	expectedSDKReq *admin.EARPrivateEndpoint

--- a/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
@@ -6,8 +6,14 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-func TestMigEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
+func TestMigEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.19.0")
-	testCase := basicTestCase(t)
+	testCase := basicTestCaseAzure(t)
+	mig.CreateAndRunTestNonParallel(t, testCase)
+}
+
+func TestMigEncryptionAtRestPrivateEndpoint_AWS_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.27.0")
+	testCase := basicTestCaseAWS(t)
 	mig.CreateAndRunTestNonParallel(t, testCase)
 }

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -300,7 +300,7 @@ func checkBasic(projectID, cloudProvider, region string, expectApproved bool) re
 	}
 	attrsSet := []string{"id"}
 	if cloudProvider == "AZURE" {
-		attrsSet = []string{"id", "private_endpoint_connection_name"}
+		attrsSet = append(attrsSet, "private_endpoint_connection_name")
 	}
 
 	return acc.CheckRSAndDS(

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -28,11 +28,11 @@ const (
 	earDatasourceName    = "data.mongodbatlas_encryption_at_rest.test"
 )
 
-func TestAccEncryptionAtRestPrivateEndpoint_basic(t *testing.T) {
-	resource.Test(t, *basicTestCase(t))
+func TestAccEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
+	resource.Test(t, *basicTestCaseAzure(t))
 }
 
-func basicTestCase(tb testing.TB) *resource.TestCase {
+func basicTestCaseAzure(tb testing.TB) *resource.TestCase {
 	tb.Helper()
 	var (
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
@@ -58,7 +58,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 		Steps: []resource.TestStep{
 			{
 				Config: configAzureBasic(projectID, azureKeyVault, region, false),
-				Check:  checkAzureBasic(projectID, azureKeyVault, region, false),
+				Check:  checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, false),
 			},
 			{
 				Config:            configAzureBasic(projectID, azureKeyVault, region, false),
@@ -102,7 +102,7 @@ func TestAccEncryptionAtRestPrivateEndpoint_approveEndpointWithAzureProvider(t *
 		Steps: []resource.TestStep{
 			{
 				Config: configAzureBasic(projectID, azureKeyVault, region, false),
-				Check:  checkAzureBasic(projectID, azureKeyVault, region, false),
+				Check:  checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, false),
 			},
 			{
 				Config: configAzureBasic(projectID, azureKeyVault, region, true),
@@ -111,14 +111,14 @@ func TestAccEncryptionAtRestPrivateEndpoint_approveEndpointWithAzureProvider(t *
 				PreConfig:    waitForStatusUpdate,
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkAzureBasic(projectID, azureKeyVault, region, true),
+					checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, true),
 				),
 			},
 		},
 	})
 }
 
-func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork(t *testing.T) {
+func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork_Azure(t *testing.T) {
 	var (
 		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
 		azureKeyVault = &admin.AzureKeyVault{
@@ -160,81 +160,58 @@ func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork(t *
 	})
 }
 
-func TestAccEncryptionAtRest_azure_requirePrivateNetworking(t *testing.T) {
+func TestAccEncryptionAtRestPrivateEndpoint_AWS_basic(t *testing.T) {
+	acc.SkipTestForCI(t) // needs AWS configuration
+	resource.Test(t, *basicTestCaseAWS(t))
+}
+
+func basicTestCaseAWS(tb testing.TB) *resource.TestCase {
+	tb.Helper()
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
 
-		azureKeyVault = admin.AzureKeyVault{
+		awsKms = admin.AWSKMSConfiguration{
 			Enabled:                  conversion.Pointer(true),
-			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID")),
-			AzureEnvironment:         conversion.StringPtr("AZURE"),
-			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
-			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
-			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME")),
-			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER")),
-			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
-			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-			RequirePrivateNetworking: conversion.Pointer(true),
-		}
-
-		azureKeyVaultAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVault)
-
-		azureKeyVaultUpdated = admin.AzureKeyVault{
-			Enabled:                  conversion.Pointer(true),
-			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID")),
-			AzureEnvironment:         conversion.StringPtr("AZURE"),
-			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
-			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
-			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME_UPDATED")),
-			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER_UPDATED")),
-			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
-			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
+			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			RoleId:                   conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
 			RequirePrivateNetworking: conversion.Pointer(false),
 		}
-
-		azureKeyVaultUpdatedAttrMap = acc.ConvertToAzureKeyVaultEARAttrMap(&azureKeyVaultUpdated)
+		awsKmsPrivateNetworking = admin.AWSKMSConfiguration{
+			Enabled:                  conversion.Pointer(true),
+			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			RoleId:                   conversion.StringPtr(os.Getenv("AWS_ROLE_ID")),
+			RequirePrivateNetworking: conversion.Pointer(true),
+		}
+		region = os.Getenv("AWS_PRIVATE_ENDPOINT_REGION")
 	)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acc.PreCheckEncryptionAtRestPrivateEndpoint(t)
-			acc.PreCheckEncryptionAtRestEnvAzureWithUpdate(t)
-		},
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb); acc.PreCheckEncryptionAtRestEnvAWS(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.EARDestroy,
+		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVault, true, true),
+				Config: acc.ConfigAwsKms(projectID, &awsKms, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckEARExists(earResourceName),
-					resource.TestCheckResourceAttr(earResourceName, "project_id", projectID),
-					acc.EARCheckResourceAttr(earResourceName, "azure_key_vault_config.0", azureKeyVaultAttrMap),
-
-					resource.TestCheckResourceAttr(earDatasourceName, "project_id", projectID),
-					acc.EARCheckResourceAttr(earDatasourceName, "azure_key_vault_config", azureKeyVaultAttrMap),
+					resource.TestCheckResourceAttr(earResourceName, "aws_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(earResourceName, "aws_kms_config.0.require_private_networking", "false"),
 				),
 			},
 			{
-				Config: acc.ConfigEARAzureKeyVault(projectID, &azureKeyVaultUpdated, true, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckEARExists(earResourceName),
-					resource.TestCheckResourceAttr(earResourceName, "project_id", projectID),
-					acc.EARCheckResourceAttr(earResourceName, "azure_key_vault_config.0", azureKeyVaultUpdatedAttrMap),
-
-					resource.TestCheckResourceAttr(earDatasourceName, "project_id", projectID),
-					acc.EARCheckResourceAttr(earDatasourceName, "azure_key_vault_config.", azureKeyVaultUpdatedAttrMap),
-				),
+				Config: configAWSBasic(projectID, &awsKmsPrivateNetworking, region),
+				Check:  checkBasic(projectID, "AWS", region, true),
 			},
 			{
-				ResourceName:      earResourceName,
-				ImportStateIdFunc: acc.EARImportStateIDFunc(earResourceName),
+				Config:            configAWSBasic(projectID, &awsKms, region),
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
-				// "azure_key_vault_config.0.secret" is a sensitive value not returned by the API
-				ImportStateVerifyIgnore: []string{"azure_key_vault_config.0.secret"},
 			},
 		},
-	})
+	}
 }
 
 type errMsgTestCase struct {
@@ -319,18 +296,9 @@ func configAzureBasic(projectID string, azure *admin.AzureKeyVault, region strin
 		    region_name = %[2]q
 		}
 
-		data "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
-		    project_id = mongodbatlas_encryption_at_rest_private_endpoint.test.project_id
-			cloud_provider = mongodbatlas_encryption_at_rest_private_endpoint.test.cloud_provider
-		    id = mongodbatlas_encryption_at_rest_private_endpoint.test.id
-		}
+		%[3]s
 
-		data "mongodbatlas_encryption_at_rest_private_endpoints" "test" {
-		    project_id = mongodbatlas_encryption_at_rest_private_endpoint.test.project_id
-			cloud_provider = mongodbatlas_encryption_at_rest_private_endpoint.test.cloud_provider
-		}
-
-	`, encryptionAtRestConfig, region)
+	`, encryptionAtRestConfig, region, configDS())
 
 	if approveWithAzapi {
 		azKeyVaultResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s", azure.GetSubscriptionID(), azure.GetResourceGroupName(), azure.GetKeyVaultName())
@@ -360,23 +328,59 @@ func configAzureBasic(projectID string, azure *admin.AzureKeyVault, region strin
 	return config
 }
 
-func checkAzureBasic(projectID string, azure *admin.AzureKeyVault, region string, expectApproved bool) resource.TestCheckFunc {
+func checkBasic(projectID, cloudProvider, region string, expectApproved bool) resource.TestCheckFunc {
 	expectedStatus := retrystrategy.RetryStrategyPendingAcceptanceState
 	if expectApproved {
 		expectedStatus = retrystrategy.RetryStrategyActiveState
+	}
+	attrsSet := []string{"id"}
+	if cloudProvider == "AZURE" {
+		attrsSet = []string{"id", "private_endpoint_connection_name"}
 	}
 
 	return acc.CheckRSAndDS(
 		resourceName,
 		admin.PtrString(dataSourceName),
 		admin.PtrString(pluralDataSourceName),
-		[]string{"id", "private_endpoint_connection_name"},
+		attrsSet,
 		map[string]string{
 			"project_id":     projectID,
 			"status":         expectedStatus,
 			"region_name":    region,
-			"cloud_provider": *azure.AzureEnvironment,
+			"cloud_provider": cloudProvider,
 		})
+}
+
+func configAWSBasic(projectID string, awsKms *admin.AWSKMSConfiguration, region string) string {
+	encryptionAtRestConfig := acc.ConfigAwsKms(projectID, awsKms, false, true)
+	config := fmt.Sprintf(`
+		%[1]s
+
+		resource "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
+		    project_id = mongodbatlas_encryption_at_rest.test.project_id
+		    cloud_provider = "AWS"
+		    region_name = %[2]q
+		}
+
+		%[3]s
+
+	`, encryptionAtRestConfig, region, configDS())
+
+	return config
+}
+
+func configDS() string {
+	return `
+	data "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
+		project_id = mongodbatlas_encryption_at_rest_private_endpoint.test.project_id
+		cloud_provider = mongodbatlas_encryption_at_rest_private_endpoint.test.cloud_provider
+		id = mongodbatlas_encryption_at_rest_private_endpoint.test.id
+	}
+
+	data "mongodbatlas_encryption_at_rest_private_endpoints" "test" {
+		project_id = mongodbatlas_encryption_at_rest_private_endpoint.test.project_id
+		cloud_provider = mongodbatlas_encryption_at_rest_private_endpoint.test.cloud_provider
+	}`
 }
 
 func checkDestroy(state *terraform.State) error {

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -57,6 +57,13 @@ func basicTestCaseAzure(tb testing.TB) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: acc.ConfigEARAzureKeyVault(projectID, azureKeyVault, false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.require_private_networking", "false"),
+				),
+			},
+			{
 				Config: configAzureBasic(projectID, azureKeyVault, region, false),
 				Check:  checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, false),
 			},
@@ -112,48 +119,6 @@ func TestAccEncryptionAtRestPrivateEndpoint_approveEndpointWithAzureProvider(t *
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, true),
-				),
-			},
-		},
-	})
-}
-
-func TestAccEncryptionAtRestPrivateEndpoint_transitionPublicToPrivateNetwork_Azure(t *testing.T) {
-	var (
-		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
-		azureKeyVault = &admin.AzureKeyVault{
-			Enabled:                  conversion.Pointer(true),
-			RequirePrivateNetworking: conversion.Pointer(true),
-			AzureEnvironment:         conversion.StringPtr("AZURE"),
-			ClientID:                 conversion.StringPtr(os.Getenv("AZURE_CLIENT_ID")),
-			SubscriptionID:           conversion.StringPtr(os.Getenv("AZURE_SUBSCRIPTION_ID")),
-			ResourceGroupName:        conversion.StringPtr(os.Getenv("AZURE_RESOURCE_GROUP_NAME")),
-			KeyVaultName:             conversion.StringPtr(os.Getenv("AZURE_KEY_VAULT_NAME")),
-			KeyIdentifier:            conversion.StringPtr(os.Getenv("AZURE_KEY_IDENTIFIER")),
-			Secret:                   conversion.StringPtr(os.Getenv("AZURE_APP_SECRET")),
-			TenantID:                 conversion.StringPtr(os.Getenv("AZURE_TENANT_ID")),
-		}
-		region = os.Getenv("AZURE_PRIVATE_ENDPOINT_REGION")
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckEncryptionAtRestEnvAzure(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: acc.ConfigEARAzureKeyVault(projectID, azureKeyVault, false, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.enabled", "true"),
-					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.require_private_networking", "false"),
-				),
-			},
-			{
-				Config: configAzureBasic(projectID, azureKeyVault, region, false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(earResourceName, "azure_key_vault_config.0.require_private_networking", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_ACCEPTANCE"),
 				),
 			},
 		},

--- a/internal/testutil/acc/encryption_at_rest.go
+++ b/internal/testutil/acc/encryption_at_rest.go
@@ -43,6 +43,32 @@ func ConfigEARAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useReq
 	return config
 }
 
+func ConfigAwsKms(projectID string, aws *admin.AWSKMSConfiguration, useDatasource, useRequirePrivateNetworking bool) string {
+	requirePrivateNetworkingStr := ""
+	if useRequirePrivateNetworking {
+		requirePrivateNetworkingStr = fmt.Sprintf("require_private_networking = %t", aws.GetRequirePrivateNetworking())
+	}
+	config := fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = %[1]q
+
+		  aws_kms_config {
+				enabled                = %[2]t
+				customer_master_key_id = %[3]q
+				region                 = %[4]q
+				role_id              = %[5]q
+				
+				%[6]s
+			}
+		}
+	`, projectID, aws.GetEnabled(), aws.GetCustomerMasterKeyID(), aws.GetRegion(), aws.GetRoleId(), requirePrivateNetworkingStr)
+
+	if useDatasource {
+		return fmt.Sprintf(`%s %s`, config, EARDatasourceConfig())
+	}
+	return config
+}
+
 func EARDatasourceConfig() string {
 	return `data "mongodbatlas_encryption_at_rest" "test" {
 			project_id = mongodbatlas_encryption_at_rest.test.project_id

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -238,6 +238,17 @@ func PreCheckAwsEnv(tb testing.TB) {
 	}
 }
 
+func PreCheckEncryptionAtRestEnvAWS(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
+		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" ||
+		os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") == "" ||
+		os.Getenv("AWS_PRIVATE_ENDPOINT_REGION") == "" {
+		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID`, `AWS_PRIVATE_ENDPOINT_REGION` and `MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID` must be set for acceptance testing")
+	}
+}
+
 func PreCheckAwsRegionCases(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_REGION_UPPERCASE") == "" ||


### PR DESCRIPTION
## Description

Updates `mongodbatlas_encryption_at_rest_private_endpoint` tests to support private networking for AWS encryption at rest.
This PR also cleans up some existing Azure based tests.

Link to any related issue(s): [CLOUDP-295878](https://jira.mongodb.org/browse/CLOUDP-295878)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
