### PR TITLE
refactor: Reuses tpf common_sdk in advanced_cluster SDKv2

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
-	admin20240805 "go.mongodb.org/atlas-sdk/v20240805005/admin"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -30,6 +29,11 @@ import (
 )
 
 const (
+	operationCreate       = "create"
+	operationCreateFinal  = "create final"
+	operationUpdate       = "update"
+	operationUpdateLegacy = "update (legacy schema)"
+
 	errorCreate                    = "error creating advanced cluster: %s"
 	errorRead                      = "error reading  advanced cluster (%s): %s"
 	errorDelete                    = "error deleting advanced cluster (%s): %s"
@@ -425,10 +429,10 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(fmt.Errorf("accept_data_risks_and_force_replica_set_reconfig can not be set in creation, only in update"))
 		}
 	}
-	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
-	connV220240805 := meta.(*config.MongoDBClient).AtlasV220240805
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	client := meta.(*config.MongoDBClient)
+	connV2 := client.AtlasV2
 	projectID := d.Get("project_id").(string)
+	clusterName := d.Get("name").(string)
 
 	var rootDiskSizeGB *float64
 	if v, ok := d.GetOk("disk_size_gb"); ok {
@@ -440,7 +444,9 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		ClusterType:      conversion.StringPtr(cast.ToString(d.Get("cluster_type"))),
 		ReplicationSpecs: expandAdvancedReplicationSpecs(d.Get("replication_specs").([]any), rootDiskSizeGB),
 	}
-
+	if v := d.Get("paused").(bool); v {
+		params.Paused = conversion.Pointer(v)
+	}
 	if v, ok := d.GetOk("backup_enabled"); ok {
 		params.BackupEnabled = conversion.Pointer(v.(bool))
 	}
@@ -507,59 +513,24 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(err)
 	}
 
-	var clusterName string
-	var clusterID string
-	var err error
-	// With old sharding config we call older API (2024-08-05) to avoid cluster having asymmetric autoscaling mode. Old sharding config can only represent symmetric clusters.
-	if isUsingOldShardingConfiguration(d) {
-		var cluster20240805 *admin20240805.ClusterDescription20240805
-		cluster20240805, _, err = connV220240805.ClustersApi.CreateCluster(ctx, projectID, advancedclustertpf.ConvertClusterDescription20241023to20240805(params)).Execute()
-		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorCreate, err))
-		}
-		clusterName = cluster20240805.GetName()
-		clusterID = cluster20240805.GetId()
-	} else {
-		var cluster *admin.ClusterDescription20240805
-		cluster, _, err = connV2.ClustersApi.CreateCluster(ctx, projectID, params).Execute()
-		if err != nil {
-			return diag.FromErr(fmt.Errorf(errorCreate, err))
-		}
-		clusterName = cluster.GetName()
-		clusterID = cluster.GetId()
+	waitParams := &advancedclustertpf.ClusterWaitParams{
+		ProjectID:   projectID,
+		ClusterName: clusterName,
+		Timeout:     d.Timeout(schema.TimeoutCreate),
 	}
-
-	timeout := d.Timeout(schema.TimeoutCreate)
-	stateConf := CreateStateChangeConfig(ctx, connV2, projectID, d.Get("name").(string), timeout)
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf(errorCreate, err))
+	diags := new(diag.Diagnostics)
+	cluster := CreateCluster(ctx, diags, client, params, waitParams, isUsingOldShardingConfiguration(d))
+	if diags.HasError() {
+		return *diags
 	}
-
 	if ac, ok := d.GetOk("advanced_configuration"); ok {
 		if aclist, ok := ac.([]any); ok && len(aclist) > 0 {
 			params20240530, params := expandProcessArgs(d, aclist[0].(map[string]any), params.MongoDBMajorVersion)
-			_, _, err := connV220240530.ClustersApi.UpdateClusterAdvancedConfiguration(ctx, projectID, clusterName, &params20240530).Execute()
-			if err != nil {
-				return diag.FromErr(fmt.Errorf(errorConfigUpdate, clusterName, err))
-			}
-			_, _, err = connV2.ClustersApi.UpdateClusterAdvancedConfiguration(ctx, projectID, clusterName, &params).Execute()
-			if err != nil {
-				return diag.FromErr(fmt.Errorf(errorConfigUpdate, clusterName, err))
+			_, _, _ = UpdateAdvancedConfiguration(ctx, diags, client, &params20240530, &params, waitParams)
+			if diags.HasError() {
+				return *diags
 			}
 		}
-	}
-
-	var waitForChanges bool
-	if v := d.Get("paused").(bool); v {
-		request := &admin.ClusterDescription20240805{
-			Paused: conversion.Pointer(v),
-		}
-		// can call latest API (2024-10-23 or newer) as replications specs (with nested autoscaling property) is not specified
-		if _, _, err := connV2.ClustersApi.UpdateCluster(ctx, projectID, d.Get("name").(string), request).Execute(); err != nil {
-			return diag.FromErr(fmt.Errorf(errorUpdate, d.Get("name").(string), err))
-		}
-		waitForChanges = true
 	}
 
 	if pinnedFCVBlock, _ := d.Get("pinned_fcv").([]any); len(pinnedFCVBlock) > 0 {
@@ -568,17 +539,12 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		if err := advancedclustertpf.PinFCV(ctx, connV2.ClustersApi, projectID, clusterName, expDateStr); err != nil {
 			return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
 		}
-		waitForChanges = true
-	}
-
-	if waitForChanges {
-		if err = waitForUpdateToFinish(ctx, connV2, projectID, d.Get("name").(string), timeout); err != nil {
-			return diag.FromErr(fmt.Errorf(errorUpdate, d.Get("name").(string), err))
+		if diags := AwaitChanges(ctx, client, waitParams, operationCreateFinal); diags.HasError() {
+			return diags
 		}
 	}
-
 	d.SetId(conversion.EncodeStateID(map[string]string{
-		"cluster_id":   clusterID,
+		"cluster_id":   cluster.GetId(),
 		"project_id":   projectID,
 		"cluster_name": clusterName,
 	}))
@@ -820,7 +786,8 @@ func resourceUpdateOrUpgrade(ctx context.Context, d *schema.ResourceData, meta a
 }
 
 func resourceUpgrade(ctx context.Context, upgradeRequest *admin.LegacyAtlasTenantClusterUpgradeRequest, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	client := meta.(*config.MongoDBClient)
+	connV2 := client.AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
@@ -841,11 +808,17 @@ func resourceUpgrade(ctx context.Context, upgradeRequest *admin.LegacyAtlasTenan
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	client := meta.(*config.MongoDBClient)
+	connV220240530 := client.AtlasV220240530
+	connV2 := client.AtlasV2
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
+	waitParams := &advancedclustertpf.ClusterWaitParams{
+		ProjectID:   projectID,
+		ClusterName: clusterName,
+		Timeout:     d.Timeout(schema.TimeoutUpdate),
+	}
 
 	if v, err := isUpdateAllowed(d); !v {
 		return diag.FromErr(fmt.Errorf("%s: %s", ErrorOperationNotPermitted, err))
@@ -893,8 +866,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			waitOnUpdate = true
 		}
 		if waitOnUpdate {
-			if err := waitForUpdateToFinish(ctx, connV2, projectID, clusterName, timeout); err != nil {
-				return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
+			if diags := AwaitChanges(ctx, client, waitParams, operationUpdateLegacy); diags.HasError() {
+				return diags
 			}
 		}
 	} else {
@@ -910,8 +883,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			if _, _, err := connV2.ClustersApi.UpdateCluster(ctx, projectID, clusterName, req).Execute(); err != nil {
 				return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
 			}
-			if err := waitForUpdateToFinish(ctx, connV2, projectID, clusterName, timeout); err != nil {
-				return diag.FromErr(fmt.Errorf(errorUpdate, clusterName, err))
+			if diags := AwaitChanges(ctx, client, waitParams, operationUpdate); diags.HasError() {
+				return diags
 			}
 		}
 	}

--- a/internal/service/advancedcluster/tpf_adapter.go
+++ b/internal/service/advancedcluster/tpf_adapter.go
@@ -1,0 +1,35 @@
+package advancedcluster
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	sdkv2diag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	tpf "github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
+	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+)
+
+func AwaitChanges(ctx context.Context, client *config.MongoDBClient, waitParams *tpf.ClusterWaitParams, lastOperation string) sdkv2diag.Diagnostics {
+	diags := new(diag.Diagnostics)
+	_ = tpf.AwaitChanges(ctx, client, waitParams, lastOperation, diags)
+	return conversion.FromTPFDiagsToSDKV2Diags(*diags)
+}
+
+func CreateCluster(ctx context.Context, diags *sdkv2diag.Diagnostics, client *config.MongoDBClient, req *admin.ClusterDescription20240805, waitParams *tpf.ClusterWaitParams, usingOldShardingConfiguration bool) *admin.ClusterDescription20240805 {
+	diagsTPF := new(diag.Diagnostics)
+	cluster := tpf.CreateCluster(ctx, diagsTPF, client, req, waitParams, usingOldShardingConfiguration)
+	localDiags := conversion.FromTPFDiagsToSDKV2Diags(*diagsTPF)
+	*diags = append(*diags, localDiags...)
+	return cluster
+}
+
+func UpdateAdvancedConfiguration(ctx context.Context, diags *sdkv2diag.Diagnostics, client *config.MongoDBClient, reqLegacy *admin20240530.ClusterDescriptionProcessArgs, reqNew *admin.ClusterDescriptionProcessArgs20240805, waitParams *tpf.ClusterWaitParams) (legacy *admin20240530.ClusterDescriptionProcessArgs, latest *admin.ClusterDescriptionProcessArgs20240805, changed bool) {
+	diagsTPF := new(diag.Diagnostics)
+	legacy, latest, changed = tpf.UpdateAdvancedConfiguration(ctx, diagsTPF, client, reqLegacy, reqNew, waitParams)
+	localDiags := conversion.FromTPFDiagsToSDKV2Diags(*diagsTPF)
+	*diags = append(*diags, localDiags...)
+	return legacy, latest, changed
+}


### PR DESCRIPTION
## Description

Reuses tpf common_sdk in advanced_cluster SDKv2

Link to any related issue(s): CLOUDP-295900

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
