### PR TITLE
chore: Uses always new schema when moving from cluster

### DIFF
--- a/internal/service/advancedclustertpf/move_upgrade_state.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state.go
@@ -34,10 +34,12 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 	if req.SourceTypeName != "mongodbatlas_cluster" || !strings.HasSuffix(req.SourceProviderAddress, "/mongodbatlas") {
 		return
 	}
+	// Use always new sharding config when moving from cluster to adv_cluster
 	setStateResponse(ctx, &resp.Diagnostics, req.SourceRawState, &resp.TargetState, false)
 }
 
 func stateUpgraderFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	// Use same sharding config as in SDKv2 when upgrading to TPF
 	setStateResponse(ctx, &resp.Diagnostics, req.RawState, &resp.State, true)
 }
 
@@ -94,7 +96,7 @@ func setStateResponse(ctx context.Context, diags *diag.Diagnostics, stateIn *tfp
 		return
 	}
 	setOptionalModelAttrs(ctx, stateObj, model)
-	if allowOldShardingConfig { // use always new sharding config when moving from cluster
+	if allowOldShardingConfig {
 		setReplicationSpecNumShardsAttr(ctx, stateObj, model)
 	}
 	// Set tags and labels to null instead of empty so there is no plan change if there are no tags or labels when Read is called.

--- a/internal/service/advancedclustertpf/move_upgrade_state.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state.go
@@ -34,11 +34,11 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 	if req.SourceTypeName != "mongodbatlas_cluster" || !strings.HasSuffix(req.SourceProviderAddress, "/mongodbatlas") {
 		return
 	}
-	setStateResponse(ctx, &resp.Diagnostics, req.SourceRawState, &resp.TargetState)
+	setStateResponse(ctx, &resp.Diagnostics, req.SourceRawState, &resp.TargetState, false)
 }
 
 func stateUpgraderFromV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	setStateResponse(ctx, &resp.Diagnostics, req.RawState, &resp.State)
+	setStateResponse(ctx, &resp.Diagnostics, req.RawState, &resp.State, true)
 }
 
 // stateAttrs has the attributes needed from source schema.
@@ -65,7 +65,7 @@ var stateAttrs = map[string]tftypes.Type{
 	},
 }
 
-func setStateResponse(ctx context.Context, diags *diag.Diagnostics, stateIn *tfprotov6.RawState, stateOut *tfsdk.State) {
+func setStateResponse(ctx context.Context, diags *diag.Diagnostics, stateIn *tfprotov6.RawState, stateOut *tfsdk.State, allowLegacySchema bool) {
 	rawStateValue, err := stateIn.UnmarshalWithOpts(tftypes.Object{
 		AttributeTypes: stateAttrs,
 	}, tfprotov6.UnmarshalOpts{ValueFromJSONOpts: tftypes.ValueFromJSONOpts{IgnoreUndefinedAttributes: true}})
@@ -94,11 +94,12 @@ func setStateResponse(ctx context.Context, diags *diag.Diagnostics, stateIn *tfp
 		return
 	}
 	setOptionalModelAttrs(ctx, stateObj, model)
-
+	if allowLegacySchema { // don't use legacy schema when moving from cluster, use always new ISS schema
+		setOptionalReplicationSpecsAttrs(ctx, stateObj, model)
+	}
 	// Set tags and labels to null instead of empty so there is no plan change if there are no tags or labels when Read is called.
 	model.Tags = types.MapNull(types.StringType)
 	model.Labels = types.MapNull(types.StringType)
-
 	diags.Append(stateOut.Set(ctx, model)...)
 }
 
@@ -155,20 +156,25 @@ func setOptionalModelAttrs(ctx context.Context, stateObj map[string]tftypes.Valu
 	if mongoDBMajorVersion := getAttrFromStateObj[string](stateObj, "mongo_db_major_version"); mongoDBMajorVersion != nil {
 		model.MongoDBMajorVersion = types.StringPointerValue(mongoDBMajorVersion)
 	}
-	if specsVal := getAttrFromStateObj[[]tftypes.Value](stateObj, "replication_specs"); specsVal != nil {
-		var specModels []TFReplicationSpecsModel
-		for _, specVal := range *specsVal {
-			var specObj map[string]tftypes.Value
-			if err := specVal.As(&specObj); err != nil {
-				continue
-			}
-			if specModel := replicationSpecModelWithNumShards(specObj["num_shards"]); specModel != nil {
-				specModels = append(specModels, *specModel)
-			}
+}
+
+func setOptionalReplicationSpecsAttrs(ctx context.Context, stateObj map[string]tftypes.Value, model *TFModel) {
+	specsVal := getAttrFromStateObj[[]tftypes.Value](stateObj, "replication_specs")
+	if specsVal == nil {
+		return
+	}
+	var specModels []TFReplicationSpecsModel
+	for _, specVal := range *specsVal {
+		var specObj map[string]tftypes.Value
+		if err := specVal.As(&specObj); err != nil {
+			continue
 		}
-		if len(specModels) > 0 {
-			model.ReplicationSpecs, _ = types.ListValueFrom(ctx, ReplicationSpecsObjType, specModels)
+		if specModel := replicationSpecModelWithNumShards(specObj["num_shards"]); specModel != nil {
+			specModels = append(specModels, *specModel)
 		}
+	}
+	if len(specModels) > 0 {
+		model.ReplicationSpecs, _ = types.ListValueFrom(ctx, ReplicationSpecsObjType, specModels)
 	}
 }
 

--- a/internal/service/advancedclustertpf/move_upgrade_state_test.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state_test.go
@@ -148,7 +148,6 @@ func configMoveBasic(projectID, clusterName string, numShards int) string {
 			name = %[2]q
 			cluster_type = %[3]q
 			replication_specs = [%[4]s]
-			}]
 		}
 	`, projectID, clusterName, clusterTypeStr, strings.Join(replicationSpecsStr, ","))
 }

--- a/internal/service/advancedclustertpf/move_upgrade_state_test.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state_test.go
@@ -3,6 +3,7 @@ package advancedclustertpf_test
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -13,8 +14,7 @@ import (
 
 func TestAccAdvancedCluster_moveBasic(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -24,10 +24,36 @@ func TestAccAdvancedCluster_moveBasic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configMoveFirst(projectID, clusterName),
+				Config: configMoveFirst(projectID, clusterName, 1),
 			},
 			{
-				Config: configMoveSecond(projectID, clusterName),
+				Config: configMoveSecond(projectID, clusterName, 1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccAdvancedCluster_moveMultisharding(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 9)
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyCluster,
+		Steps: []resource.TestStep{
+			{
+				Config: configMoveFirst(projectID, clusterName, 3),
+			},
+			{
+				Config: configMoveSecond(projectID, clusterName, 3),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPreRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -40,8 +66,7 @@ func TestAccAdvancedCluster_moveBasic(t *testing.T) {
 
 func TestAccAdvancedCluster_moveInvalid(t *testing.T) {
 	var (
-		projectID   = acc.ProjectIDExecution(t)
-		clusterName = acc.RandomClusterName()
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 0)
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -64,17 +89,21 @@ func TestAccAdvancedCluster_moveInvalid(t *testing.T) {
 	})
 }
 
-func configMoveFirst(projectID, clusterName string) string {
+func configMoveFirst(projectID, clusterName string, numShards int) string {
+	clusterTypeStr := "REPLICASET"
+	if numShards > 1 {
+		clusterTypeStr = "GEOSHARDED"
+	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster" "old" {
 			project_id = %[1]q
 			name = %[2]q
 			disk_size_gb = 10
-			cluster_type                = "REPLICASET"
+			cluster_type                = %[3]q
 			provider_name               = "AWS"
 			provider_instance_size_name = "M10"
 			replication_specs {
-				num_shards = 1
+				num_shards = %[4]d
 				regions_config {
 					region_name     = "US_EAST_1"
 					electable_nodes = 3
@@ -82,7 +111,55 @@ func configMoveFirst(projectID, clusterName string) string {
 				}
 			}
 		}
-	`, projectID, clusterName)
+	`, projectID, clusterName, clusterTypeStr, numShards)
+}
+
+func configMoveBasic(projectID, clusterName string, numShards int) string {
+	clusterTypeStr := "REPLICASET"
+	if numShards > 1 {
+		clusterTypeStr = "GEOSHARDED"
+	}
+	var replicationSpecsStr []string
+	for range numShards {
+		replicationSpecsStr = append(replicationSpecsStr, `
+			{
+				region_configs = [{
+					priority        = 7
+					provider_name = "AWS"
+					region_name     = "US_EAST_1"
+					auto_scaling = {
+						compute_scale_down_enabled = false # necessary to have similar SDKv2 request
+						compute_enabled = false # necessary to have similar SDKv2 request
+						disk_gb_enabled = true
+					}
+					electable_specs = {
+						node_count = 3
+						instance_size = "M10"
+						disk_size_gb = 10
+					}
+				}]
+			}
+		`)
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_advanced_cluster" "test" {
+			project_id = %[1]q
+			name = %[2]q
+			cluster_type = %[3]q
+			replication_specs = [%[4]s]
+			}]
+		}
+	`, projectID, clusterName, clusterTypeStr, strings.Join(replicationSpecsStr, ","))
+}
+
+func configMoveSecond(projectID, clusterName string, numShards int) string {
+	return `
+		moved {
+			from = mongodbatlas_cluster.old
+			to   = mongodbatlas_advanced_cluster.test
+		}
+	` + configMoveBasic(projectID, clusterName, numShards)
 }
 
 func configMoveFirstInvalid(projectID, clusterName string) string {
@@ -100,20 +177,11 @@ func configMoveFirstInvalid(projectID, clusterName string) string {
 	`, projectID, clusterName)
 }
 
-func configMoveSecond(projectID, clusterName string) string {
-	return `
-		moved {
-			from = mongodbatlas_cluster.old
-			to   = mongodbatlas_advanced_cluster.test
-		}
-	` + configBasic(projectID, clusterName, "")
-}
-
 func configMoveSecondInvalid(projectID, clusterName string) string {
 	return `
 		moved {
 			from = mongodbatlas_database_user.old
 			to   = mongodbatlas_advanced_cluster.test
 		}
-	` + configBasic(projectID, clusterName, "")
+	` + configMoveBasic(projectID, clusterName, 1)
 }


### PR DESCRIPTION
## Description

Uses always new schema when moving from cluster

Link to any related issue(s): CLOUDP-295563

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
