### PR TITLE
deprecate: Deprecates Serverless and Shared-tier functionality

### DIFF
--- a/.changelog/3012.txt
+++ b/.changelog/3012.txt
@@ -1,0 +1,35 @@
+```release-note:note
+resource/mongodbatlas_serverless_instance: Deprecates resource
+```
+
+```release-note:note
+data-source/mongodbatlas_serverless_instance: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_serverless_instances: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_shared_tier_restore_job: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_shared_tier_restore_jobs: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_shared_tier_snapshot: Deprecates data source
+```
+
+```release-note:note
+data-source/mongodbatlas_shared_tier_snapshot: Deprecates data source
+```
+
+```release-note:note
+resource/mongodbatlas_cluster: Deprecates `M2` and `M5` instance size values for the attribute `provider_instance_size_name`
+```
+
+```release-note:note
+resource/mongodbatlas_advanced_cluster: Deprecates `M2` and `M5` instance size for the attribute `instance_size` inside of `analytics_specs`, `electable_specs` and `read_only_specs`
+```

--- a/docs/data-sources/cloud_provider_shared_tier_restore_job.md
+++ b/docs/data-sources/cloud_provider_shared_tier_restore_job.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_shared_tier_restore_job
 

--- a/docs/data-sources/cloud_provider_shared_tier_restore_job.md
+++ b/docs/data-sources/cloud_provider_shared_tier_restore_job.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_shared_tier_restore_job
 
 `mongodbatlas_shared_tier_restore_job` provides a Cloud Backup Snapshot Restore Job data source for Shared Tier Clusters. Gets the cloud backup snapshot restore jobs for the specified shared tier cluster.

--- a/docs/data-sources/cloud_provider_shared_tier_restore_jobs.md
+++ b/docs/data-sources/cloud_provider_shared_tier_restore_jobs.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_shared_tier_restore_jobs
 

--- a/docs/data-sources/cloud_provider_shared_tier_restore_jobs.md
+++ b/docs/data-sources/cloud_provider_shared_tier_restore_jobs.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_shared_tier_restore_jobs
 
 `mongodbatlas_shared_tier_restore_jobs` provides Cloud Backup Snapshot Restore Jobs data source for Shared Tier Clusters. Gets all the cloud backup snapshot restore jobs for the specified shared tier cluster.

--- a/docs/data-sources/cloud_provider_shared_tier_snapshot.md
+++ b/docs/data-sources/cloud_provider_shared_tier_snapshot.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_shared_tier_snapshot
 

--- a/docs/data-sources/cloud_provider_shared_tier_snapshot.md
+++ b/docs/data-sources/cloud_provider_shared_tier_snapshot.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_shared_tier_snapshot
 
 `mongodbatlas_shared_tier_snapshot` provides an Cloud Backup Snapshot data source for Shared Tier Clusters. Atlas Cloud Backup Snapshots provide localized backup storage using the native snapshot functionality of the cluster’s cloud service.

--- a/docs/data-sources/cloud_provider_shared_tier_snapshots.md
+++ b/docs/data-sources/cloud_provider_shared_tier_snapshots.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_shared_tier_snapshots
 
 `mongodbatlas_shared_tier_snapshots` provides an Cloud Backup Snapshots data source for Shared Tier Clusters. Atlas Cloud Backup Snapshots provide localized backup storage using the native snapshot functionality of the cluster’s cloud service.

--- a/docs/data-sources/cloud_provider_shared_tier_snapshots.md
+++ b/docs/data-sources/cloud_provider_shared_tier_snapshots.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_shared_tier_snapshots
 

--- a/docs/data-sources/serverless_instance.md
+++ b/docs/data-sources/serverless_instance.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_serverless_instance
 
 `mongodbatlas_serverless_instance` describes a single serverless instance. This represents a single serverless instance that have been created.

--- a/docs/data-sources/serverless_instance.md
+++ b/docs/data-sources/serverless_instance.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_serverless_instance
 

--- a/docs/data-sources/serverless_instances.md
+++ b/docs/data-sources/serverless_instances.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Data Source: mongodbatlas_serverless_instances
 
 `mongodbatlas_serverless_instances` describes all serverless instances. This represents serverless instances that have been created for the specified group id.

--- a/docs/data-sources/serverless_instances.md
+++ b/docs/data-sources/serverless_instances.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This data source is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This data source is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Data Source: mongodbatlas_serverless_instances
 

--- a/docs/guides/serverless-shared-migration-guide.md
+++ b/docs/guides/serverless-shared-migration-guide.md
@@ -6,7 +6,7 @@ page_title: "Migration Guide: Transition out of Serverless Instances and Shared-
 
 The goal of this guide is to help users transition from Serverless Instances and Shared-tier clusters (M2/M5) to Free, Flex or Dedicated Clusters. 
 
-Starting in January 2025 or later, all Shared-tier clusters (in both `mongodbatlas_cluster` and `mongodbatlas_advanced_cluster`) will automatically convert to Flex clusters. Similarly, in March 2025 all Serverless instances (`mongodb_serverless_instance`) will be converted into Free/Flex/Dedicated clusters, [depending on your existing configuration](https://www.mongodb.com/docs/atlas/flex-migration/).
+Starting in January 2025 or later, all Shared-tier clusters (in both `mongodbatlas_cluster` and `mongodbatlas_advanced_cluster`) will automatically convert to Flex clusters. Similarly, in March 2025 all Serverless instances (`mongodbatlas_serverless_instance`) will be converted into Free/Flex/Dedicated clusters, [depending on your existing configuration](https://www.mongodb.com/docs/atlas/flex-migration/).
 If a Serverless instance has $0 MRR, it automatically converts into a Free cluster. Else, if it does not fit the constraints of a Flex cluster, it will convert into a Dedicated cluster, resulting in downtime and workload disruption. Otherwise, it will convert to a Flex cluster.
 Some of these conversions will result in configuration drift in Terraform. 
 

--- a/docs/resources/serverless_instance.md
+++ b/docs/resources/serverless_instance.md
@@ -1,3 +1,9 @@
+---
+subcategory: "Deprecated"    
+---
+
+**WARNING:** This resource is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+
 # Resource: mongodbatlas_serverless_instance
 
 `mongodbatlas_serverless_instance` provides a Serverless Instance resource. This allows serverless instances to be created.

--- a/docs/resources/serverless_instance.md
+++ b/docs/resources/serverless_instance.md
@@ -2,7 +2,7 @@
 subcategory: "Deprecated"    
 ---
 
-**WARNING:** This resource is deprecated and will be removed in January 2026. For more datails see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide)
+**WARNING:** This resource is deprecated and will be removed in January 2026. For more details, see [Migration Guide: Transition out of Serverless Instances and Shared-tier clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide).
 
 # Resource: mongodbatlas_serverless_instance
 

--- a/internal/common/constant/deprecation.go
+++ b/internal/common/constant/deprecation.go
@@ -10,5 +10,6 @@ const (
 	DeprecationDataSourceByDateWithReplacement  = "This data source is deprecated and will be removed in %s. Please transition to %s."
 	DeprecationResourceByDateWithExternalLink   = "This resource is deprecated and will be removed in %s. For more details see %s."
 	DeprecationDataSourceByDateWithExternalLink = "This data source is deprecated and will be removed in %s. For more details see %s."
-	DeprecatioParamByDateWithExternalLink       = "This parameter is deprecated and will be removed in %s. For more details see %s."
+	DeprecationParamByDateWithExternalLink      = "This parameter is deprecated and will be removed in %s. For more details see %s."
+	DeprecationSharedTier                       = "Shared-tier instance size are deprecated and will reach End of Life in %s. For more details see %s"
 )

--- a/internal/common/constant/deprecation.go
+++ b/internal/common/constant/deprecation.go
@@ -12,4 +12,5 @@ const (
 	DeprecationDataSourceByDateWithExternalLink = "This data source is deprecated and will be removed in %s. For more details see %s."
 	DeprecationParamByDateWithExternalLink      = "This parameter is deprecated and will be removed in %s. For more details see %s."
 	DeprecationSharedTier                       = "Shared-tier instance size are deprecated and will reach End of Life in %s. For more details see %s"
+	ServerlessSharedEOLDate                     = "January 2026"
 )

--- a/internal/common/customplanmodifier/instance_size_validator.go
+++ b/internal/common/customplanmodifier/instance_size_validator.go
@@ -1,0 +1,38 @@
+package customplanmodifier
+
+import (
+	"context"
+	"fmt"
+
+	planmodifier "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+)
+
+func InstanceSizeStringAttributePlanModifier() planmodifier.String {
+	return &instanceSizeStringAttributePlanModifier{}
+}
+
+type instanceSizeStringAttributePlanModifier struct {
+}
+
+func (d *instanceSizeStringAttributePlanModifier) Description(ctx context.Context) string {
+	return d.MarkdownDescription(ctx)
+}
+
+func (d *instanceSizeStringAttributePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Ensures that a deprecation warning is displayed when instance_size is M2 or M5."
+}
+
+func (d *instanceSizeStringAttributePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	planAttributeValue := req.PlanValue
+	stateAttributeValue := req.StateValue
+
+	if stateAttributeValue.ValueString() == "M2" || stateAttributeValue.ValueString() == "M5" ||
+		planAttributeValue.ValueString() == "M2" || planAttributeValue.ValueString() == "M5" {
+		resp.Diagnostics.AddWarning(
+			fmt.Sprintf(constant.DeprecationSharedTier, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			req.Path.String(),
+		)
+		return
+	}
+}

--- a/internal/common/customplanmodifier/instance_size_validator.go
+++ b/internal/common/customplanmodifier/instance_size_validator.go
@@ -30,7 +30,7 @@ func (d *instanceSizeStringAttributePlanModifier) PlanModifyString(ctx context.C
 	if stateAttributeValue.ValueString() == "M2" || stateAttributeValue.ValueString() == "M5" ||
 		planAttributeValue.ValueString() == "M2" || planAttributeValue.ValueString() == "M5" {
 		resp.Diagnostics.AddWarning(
-			fmt.Sprintf(constant.DeprecationSharedTier, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			fmt.Sprintf(constant.DeprecationSharedTier, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			req.Path.String(),
 		)
 		return

--- a/internal/common/validate/instance_size_validator.go
+++ b/internal/common/validate/instance_size_validator.go
@@ -1,0 +1,25 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+)
+
+func InstanceSizeNameValidator() schema.SchemaValidateDiagFunc {
+	return func(v any, p cty.Path) diag.Diagnostics {
+		value := v.(string)
+		var diags diag.Diagnostics
+		if value == "M2" || value == "M5" {
+			diagError := diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf(constant.DeprecationSharedTier, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			}
+			diags = append(diags, diagError)
+		}
+		return diags
+	}
+}

--- a/internal/common/validate/instance_size_validator.go
+++ b/internal/common/validate/instance_size_validator.go
@@ -16,7 +16,7 @@ func InstanceSizeNameValidator() schema.SchemaValidateDiagFunc {
 		if value == "M2" || value == "M5" {
 			diagError := diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  fmt.Sprintf(constant.DeprecationSharedTier, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+				Summary:  fmt.Sprintf(constant.DeprecationSharedTier, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			}
 			diags = append(diags, diagError)
 		}

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -407,8 +407,9 @@ func schemaSpecs() *schema.Schema {
 					Computed: true,
 				},
 				"instance_size": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: validate.InstanceSizeNameValidator(),
 				},
 				"node_count": {
 					Type:     schema.TypeInt,

--- a/internal/service/advancedclustertpf/schema.go
+++ b/internal/service/advancedclustertpf/schema.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
@@ -418,8 +419,11 @@ func SpecsSchema(markdownDescription string) schema.SingleNestedAttribute {
 				MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
 			},
 			"instance_size": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					customplanmodifier.InstanceSizeStringAttributePlanModifier(),
+				},
 				MarkdownDescription: "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
 			},
 			"node_count": schema.Int64Attribute{

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -151,8 +151,9 @@ func Resource() *schema.Resource {
 				ConflictsWith: []string{"backup_enabled"},
 			},
 			"provider_instance_size_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validate.InstanceSizeNameValidator(),
 			},
 			"provider_name": {
 				Type:             schema.TypeString,

--- a/internal/service/serverlessinstance/data_source_serverless_instance.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instance.go
@@ -14,7 +14,7 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourceRead,
 		Schema:             dataSourceSchema(),
 	}

--- a/internal/service/serverlessinstance/data_source_serverless_instance.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instance.go
@@ -14,8 +14,9 @@ import (
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRead,
-		Schema:      dataSourceSchema(),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourceRead,
+		Schema:             dataSourceSchema(),
 	}
 }
 

--- a/internal/service/serverlessinstance/data_source_serverless_instance.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instance.go
@@ -91,13 +91,13 @@ func dataSourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,
 		},
 		"auto_indexing": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/serverlessinstance/data_source_serverless_instances.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instances.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
@@ -14,7 +15,8 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourcePluralRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/serverlessinstance/data_source_serverless_instances.go
+++ b/internal/service/serverlessinstance/data_source_serverless_instances.go
@@ -15,7 +15,7 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/serverlessinstance/resource_serverless_instance.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance.go
@@ -25,7 +25,7 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		CreateContext:      resourceCreate,
 		ReadContext:        resourceRead,
 		UpdateContext:      resourceUpdate,

--- a/internal/service/serverlessinstance/resource_serverless_instance.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance.go
@@ -25,10 +25,11 @@ const (
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCreate,
-		ReadContext:   resourceRead,
-		UpdateContext: resourceUpdate,
-		DeleteContext: resourceDelete,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationResourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		CreateContext:      resourceCreate,
+		ReadContext:        resourceRead,
+		UpdateContext:      resourceUpdate,
+		DeleteContext:      resourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImport,
 		},

--- a/internal/service/serverlessinstance/resource_serverless_instance.go
+++ b/internal/service/serverlessinstance/resource_serverless_instance.go
@@ -112,13 +112,13 @@ func resourceSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"continuous_backup_enabled": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,
 		},
 		"auto_indexing": {
-			Deprecated: fmt.Sprintf(constant.DeprecatioParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+			Deprecated: fmt.Sprintf(constant.DeprecationParamByDateWithExternalLink, "March 2025", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 			Type:       schema.TypeBool,
 			Optional:   true,
 			Computed:   true,

--- a/internal/service/sharedtier/data_source_cloud_shared_tier_restore_job.go
+++ b/internal/service/sharedtier/data_source_cloud_shared_tier_restore_job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -13,7 +14,8 @@ import (
 // This datasource does not have a resource: we tested it manually
 func DataSourceRestoreJob() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCloudSharedTierRestoreJobsRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourceMongoDBAtlasCloudSharedTierRestoreJobsRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/sharedtier/data_source_cloud_shared_tier_restore_job.go
+++ b/internal/service/sharedtier/data_source_cloud_shared_tier_restore_job.go
@@ -14,7 +14,7 @@ import (
 // This datasource does not have a resource: we tested it manually
 func DataSourceRestoreJob() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourceMongoDBAtlasCloudSharedTierRestoreJobsRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/sharedtier/data_source_cloud_shared_tier_restore_jobs.go
+++ b/internal/service/sharedtier/data_source_cloud_shared_tier_restore_jobs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -16,7 +17,8 @@ import (
 // This datasource does not have a resource: we tested it manually
 func PluralDataSourceRestoreJob() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasCloudSharedTierRestoreJobRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourceMongoDBAtlasCloudSharedTierRestoreJobRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/sharedtier/data_source_cloud_shared_tier_restore_jobs.go
+++ b/internal/service/sharedtier/data_source_cloud_shared_tier_restore_jobs.go
@@ -17,7 +17,7 @@ import (
 // This datasource does not have a resource: we tested it manually
 func PluralDataSourceRestoreJob() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourceMongoDBAtlasCloudSharedTierRestoreJobRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/sharedtier/data_source_shared_tier_snapshot.go
+++ b/internal/service/sharedtier/data_source_shared_tier_snapshot.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -13,7 +14,8 @@ import (
 // This datasource does not have a resource: we tested it manually
 func DataSourceSnapshot() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasSharedTierSnapshotRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourceMongoDBAtlasSharedTierSnapshotRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/sharedtier/data_source_shared_tier_snapshot.go
+++ b/internal/service/sharedtier/data_source_shared_tier_snapshot.go
@@ -14,7 +14,7 @@ import (
 // This datasource does not have a resource: we tested it manually
 func DataSourceSnapshot() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourceMongoDBAtlasSharedTierSnapshotRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {

--- a/internal/service/sharedtier/data_source_shared_tier_snapshots.go
+++ b/internal/service/sharedtier/data_source_shared_tier_snapshots.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -16,7 +17,8 @@ import (
 // This datasource does not have a resource: we tested it manually
 func PluralDataSourceSnapshot() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceMongoDBAtlasSharedTierSnapshotsRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		ReadContext:        dataSourceMongoDBAtlasSharedTierSnapshotsRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/sharedtier/data_source_shared_tier_snapshots.go
+++ b/internal/service/sharedtier/data_source_shared_tier_snapshots.go
@@ -17,7 +17,7 @@ import (
 // This datasource does not have a resource: we tested it manually
 func PluralDataSourceSnapshot() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, "January 2026", "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationDataSourceByDateWithExternalLink, constant.ServerlessSharedEOLDate, "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/serverless-shared-migration-guide"),
 		ReadContext:        dataSourceMongoDBAtlasSharedTierSnapshotsRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {


### PR DESCRIPTION
## Description

Deprecates Serverless and Shared-tier functionality


Warning for Cluster:
<img width="1215" alt="Screenshot 2025-01-29 at 10 43 29" src="https://github.com/user-attachments/assets/2a5bf02d-a341-4696-a7a3-f0f0c670c331" />
Warning for Advanced cluster:
<img width="1221" alt="Screenshot 2025-01-29 at 11 03 12" src="https://github.com/user-attachments/assets/4f025857-ecae-4dfb-a24b-ee3936346095" />


Link to any related issue(s): CLOUDP-297370

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
