### PR TITLE
chore: Avoids null pointer error when region_configs are null in tpf advanced_cluster

### DIFF
--- a/internal/service/advancedclustertpf/schema_test.go
+++ b/internal/service/advancedclustertpf/schema_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
-func TestAdvancedCluster_ValidationErrors(t *testing.T) {
+func TestAccAdvancedCluster_ValidationErrors(t *testing.T) {
 	const (
 		projectID   = "111111111111111111111111"
 		clusterName = "test"

--- a/internal/service/advancedclustertpf/schema_test.go
+++ b/internal/service/advancedclustertpf/schema_test.go
@@ -19,6 +19,10 @@ func TestAdvancedCluster_ValidationErrors(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
+				Config:      nullRegionConfigs, // can happen when using moved block, panic: runtime error: invalid memory address or nil pointer dereference
+				ExpectError: regexp.MustCompile("Missing Configuration for Required Attribute"),
+			},
+			{
 				Config:      acc.ConvertAdvancedClusterToSchemaV2(t, true, invalidRegionConfigsPriorities),
 				ExpectError: regexp.MustCompile("priority values in region_configs must be in descending order"),
 			},
@@ -152,5 +156,17 @@ resource "mongodbatlas_advanced_cluster" "test" {
 			}
 		}
 	}
+}
+`
+var nullRegionConfigs = `
+resource "mongodbatlas_advanced_cluster" "test" {
+	project_id     = "111111111111111111111111"
+	name           = "test-acc-tf-c-2670522663699021050"
+	cluster_type   = "REPLICASET"
+	backup_enabled = false
+
+	replication_specs = [{
+		region_configs = null
+	}]
 }
 `

--- a/internal/service/advancedclustertpf/validate_schema.go
+++ b/internal/service/advancedclustertpf/validate_schema.go
@@ -95,7 +95,7 @@ func (v RegionSpecPriorityOrderDecreasingValidator) MarkdownDescription(_ contex
 func (v RegionSpecPriorityOrderDecreasingValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
 	diags := &resp.Diagnostics
 	regionConfigs := newCloudRegionConfig20240805(ctx, req.ConfigValue, diags)
-	if diags.HasError() {
+	if diags.HasError() || regionConfigs == nil {
 		return
 	}
 	configs := *regionConfigs


### PR DESCRIPTION
## Description

Avoids null pointer error when region_configs are null.

Link to any related issue(s): WRITING-29208

## Error traceback
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x10406c094]

goroutine 40 [running]:
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf.RegionSpecPriorityOrderDecreasingValidator.ValidateList({}, {0x1054b56b0?, 0x1400053a1b0?}, {{{0x14000728b00, 0x3, 0x4}}, {0x1, {0x14000728b40, 0x3, 0x4}}, ...}, ...)
        /Users/espen.albert/code/go/src/github.com/mongodb/tf-provider2/internal/service/advancedclustertpf/validate_schema.go:102 +0xb4
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.AttributeValidateList({0x1054b56b0, 0x1400053a1b0}, {0x10709d5f8, 0x14000c12680}, {{{0x14000728b00, 0x3, 0x4}}, {0x1, {0x14000728b40, 0x3, ...}}, ...}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/attribute_validation.go:547 +0x424
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.AttributeValidate({0x1054b56b0, 0x140003016b0}, {0x1054c2038, 0x14000c12680}, {{{0x14000728b00, 0x3, 0x4}}, {0x1, {0x14000728b40, 0x3, ...}}, ...}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/attribute_validation.go:123 +0xb80
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.NestedAttributeObjectValidate({0x1054b56b0, 0x140003016b0}, {0x1054b5990, 0x14000d07a90}, {{{0x14000d0a560, 0x2, 0x2}}, {0x1, {0x14000d0a580, 0x2, ...}}, ...}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/attribute_validation.go:1188 +0x200
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.AttributeValidateNestedAttributes({0x1054b56b0, 0x140003016b0}, {0x1054c2038?, 0x14000c12750}, {{{0x14000b15880, 0x1, 0x1}}, {0x1, {0x14000b158a0, 0x1, ...}}, ...}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/attribute_validation.go:998 +0x1090
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.AttributeValidate({0x1054b56b0, 0x14000c991a0}, {0x1054c2038, 0x14000c12750}, {{{0x14000b15880, 0x1, 0x1}}, {0x1, {0x14000b158a0, 0x1, ...}}, ...}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/attribute_validation.go:138 +0x3e0
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.SchemaValidate({0x1054b56b0, 0x14000c991a0}, {0x1054c32e0, 0x14000d066e0}, {{{{0x1054be750, 0x140006b6630}, {0x104ff8b20, 0x14000727170}}, {0x1054c32e0, 0x14000d066e0}}}, ...)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/schema_validation.go:51 +0x13c
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ValidateResourceConfig(0x14000a56008, {0x1054b56b0, 0x14000c991a0}, 0x14000c047f8, 0x14000835580)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/fwserver/server_validateresourceconfig.go:106 +0x6e0
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ValidateResourceConfig(0x14000a56008, {0x1054b56b0?, 0x14000c990e0?}, 0x14000c04780)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.13.0/internal/proto6server/server_validateresourceconfig.go:47 +0x364
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).ValidateResourceConfig(0x14000314e00, {0x1054b56b0?, 0x14000c98e40?}, 0x14000c04780)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.17.0/tf6muxserver/mux_server_ValidateResourceConfig.go:36 +0x184
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ValidateResourceConfig(0x1400012e500, {0x1054b56b0?, 0x14000c98330?}, 0x14000728180)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:724 +0x250
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ValidateResourceConfig_Handler({0x1053e27a0, 0x1400012e500}, {0x1054b56b0, 0x14000c98330}, 0x140007c8000, 0x0)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:503 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000221200, {0x1054b56b0, 0x14000c982a0}, {0x1054c10c0, 0x140006581a0}, 0x14000001200, 0x1400011c9c0, 0x106b06348, 0x0)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
google.golang.org/grpc.(*Server).handleStream(0x14000221200, {0x1054c10c0, 0x140006581a0}, 0x14000001200)
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 144
        /Users/espen.albert/.asdf/installs/golang/1.22.2/packages/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c
FAIL    github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf  2.640s
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
