### PR TITLE
feat: Supports Flex Clusters in `mongodbatlas_advanced_cluster` resource (TPF)

### DIFF
--- a/internal/service/advancedcluster/model_flex.go
+++ b/internal/service/advancedcluster/model_flex.go
@@ -1,12 +1,9 @@
 package advancedcluster
 
 import (
-	"go.mongodb.org/atlas-sdk/v20241113004/admin"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 )
 
@@ -28,21 +25,4 @@ func isValidUpdateOfFlex(d *schema.ResourceData) bool {
 		return true
 	}
 	return false
-}
-
-// TODO: refactor this. 1. Move to tpf. Instead of d as parameter, pass tags and bool
-func getFlexClusterUpdateRequest(d *schema.ResourceData) *admin.FlexClusterDescriptionUpdate20241113 {
-	return &admin.FlexClusterDescriptionUpdate20241113{
-		Tags:                         conversion.ExpandTagsFromSetSchema(d),
-		TerminationProtectionEnabled: conversion.Pointer(d.Get("termination_protection_enabled").(bool)),
-	}
-}
-
-func getUpgradeToFlexClusterRequest() *admin.LegacyAtlasTenantClusterUpgradeRequest {
-	// WIP: will be finished as part of CLOUDP-296220
-	return &admin.LegacyAtlasTenantClusterUpgradeRequest{
-		ProviderSettings: &admin.ClusterProviderSettings{
-			ProviderName: flexcluster.FlexClusterType,
-		},
-	}
 }

--- a/internal/service/advancedcluster/model_flex.go
+++ b/internal/service/advancedcluster/model_flex.go
@@ -21,8 +21,5 @@ func isValidUpgradeToFlex(d *schema.ResourceData) bool {
 func isValidUpdateOfFlex(d *schema.ResourceData) bool {
 	updatableAttrHaveBeenUpdated := d.HasChange("tags") || d.HasChange("termination_protection_enabled")
 	nonUpdatableAttrHaveNotBeenUpdated := !d.HasChange("cluster_type") && !d.HasChange("replication_specs") && !d.HasChange("project_id") && !d.HasChange("name")
-	if updatableAttrHaveBeenUpdated && nonUpdatableAttrHaveNotBeenUpdated {
-		return true
-	}
-	return false
+	return updatableAttrHaveBeenUpdated && nonUpdatableAttrHaveNotBeenUpdated
 }

--- a/internal/service/advancedcluster/model_flex.go
+++ b/internal/service/advancedcluster/model_flex.go
@@ -10,22 +10,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 )
 
-func NewFlexCreateReq(d *schema.ResourceData, replicationSpecs *[]admin.ReplicationSpec20240805) *admin.FlexClusterDescriptionCreate20241113 {
-	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
-		return nil
-	}
-	regionConfigs := (*replicationSpecs)[0].GetRegionConfigs()[0]
-	return &admin.FlexClusterDescriptionCreate20241113{
-		Name: d.Get("name").(string),
-		ProviderSettings: admin.FlexProviderSettingsCreate20241113{
-			BackingProviderName: regionConfigs.GetBackingProviderName(),
-			RegionName:          regionConfigs.GetRegionName(),
-		},
-		TerminationProtectionEnabled: conversion.Pointer(d.Get("termination_protection_enabled").(bool)),
-		Tags:                         conversion.ExpandTagsFromSetSchema(d),
-	}
-}
-
 func isValidUpgradeToFlex(d *schema.ResourceData) bool {
 	if d.HasChange("replication_specs.0.region_configs.0") {
 		oldProviderName, newProviderName := d.GetChange("replication_specs.0.region_configs.0.provider_name")
@@ -46,6 +30,7 @@ func isValidUpdateOfFlex(d *schema.ResourceData) bool {
 	return false
 }
 
+// TODO: refactor this. 1. Move to tpf. Instead of d as parameter, pass tags and bool
 func getFlexClusterUpdateRequest(d *schema.ResourceData) *admin.FlexClusterDescriptionUpdate20241113 {
 	return &admin.FlexClusterDescriptionUpdate20241113{
 		Tags:                         conversion.ExpandTagsFromSetSchema(d),

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -441,7 +441,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	if advancedclustertpf.IsFlex(replicationSpecs) {
 		clusterName := d.Get("name").(string)
-		flexClusterReq := NewFlexCreateReq(d, replicationSpecs)
+		flexClusterReq := advancedclustertpf.NewFlexCreateReq(clusterName, d.Get("termination_protection_enabled").(bool), conversion.ExpandTagsFromSetSchema(d), replicationSpecs)
 		flexClusterResp, err := flexcluster.CreateFlexCluster(ctx, projectID, clusterName, flexClusterReq, connV2.FlexClustersApi)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf(flexcluster.ErrorCreateFlex, err))

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -849,10 +849,10 @@ func resourceUpdateOrUpgrade(ctx context.Context, d *schema.ResourceData, meta a
 
 	if advancedclustertpf.IsFlex(replicationSpecs) {
 		if isValidUpgradeToFlex(d) {
-			return resourceUpgrade(ctx, getUpgradeToFlexClusterRequest(), d, meta)
+			return resourceUpgrade(ctx, advancedclustertpf.GetUpgradeToFlexClusterRequest(), d, meta)
 		}
 		if isValidUpdateOfFlex(d) {
-			return resourceUpdateFlexCluster(ctx, getFlexClusterUpdateRequest(d), d, meta)
+			return resourceUpdateFlexCluster(ctx, advancedclustertpf.GetFlexClusterUpdateRequest(conversion.ExpandTagsFromSetSchema(d), conversion.Pointer(d.Get("termination_protection_enabled").(bool))), d, meta)
 		}
 		return diag.Errorf("flex cluster update is not supported except for tags and termination_protection_enabled fields")
 	}

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2929,7 +2929,7 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	if tagsCheck {
 		attrMapFlex["tags.testKey"] = "testValue"
-		attrMapAdvCluster["tags.0.key"] = "testKey"
+		attrMapAdvCluster["tags.0.key"] = "testKey" // TODO change condition
 		attrMapAdvCluster["tags.0.value"] = "testValue"
 	}
 	pluralMap := map[string]string{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2860,7 +2860,7 @@ func configFlexCluster(t *testing.T, projectID, clusterName, providerName, regio
 			termination_protection_enabled = false
 		}
 	`, projectID, clusterName, providerName, region, tags)+
-		dataSourcesTFOldSchema+strings.ReplaceAll(acc.FlexDataSource, "mongodbatlas_flex_cluster.", "mongodbatlas_advanced_cluster."))
+		strings.ReplaceAll(acc.FlexDataSource, "mongodbatlas_flex_cluster.", "mongodbatlas_advanced_cluster."))
 }
 
 func TestAccClusterFlexCluster_basic(t *testing.T) {
@@ -2904,8 +2904,8 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	attrSetAdvCluster := []string{
 		"backup_enabled",
-		"connection_strings.0.standard",
-		"connection_strings.0.standard_srv",
+		"connection_strings.standard", //TODO: change automatically .0.
+		"connection_strings.standard_srv",
 		"create_date",
 		"mongo_db_version",
 		"state_name",
@@ -2941,9 +2941,9 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	checks = acc.AddAttrChecks(acc.FlexDataSourcePluralName, checks, pluralMap)
 	checks = acc.AddAttrChecksPrefix(acc.FlexDataSourcePluralName, checks, attrMapFlex, "results.0")
 	checks = acc.AddAttrSetChecksPrefix(acc.FlexDataSourcePluralName, checks, attrSetFlex, "results.0")
-	checks = acc.AddAttrChecks(dataSourcePluralName, checks, pluralMap)
+	// checks = acc.AddAttrChecks(dataSourcePluralName, checks, pluralMap)
 	// Convert string constants to variables so we can take their address
-	ds := dataSourceName
-	dsp := dataSourcePluralName
-	return acc.CheckRSAndDS(resourceName, &ds, &dsp, attrSetAdvCluster, attrMapAdvCluster, checks...)
+	// ds := dataSourceName
+	// dsp := dataSourcePluralName
+	return acc.CheckRSAndDS(resourceName, nil, nil, acc.ConvertToSchemaV2AttrsSet(true, attrSetAdvCluster), acc.ConvertToSchemaV2AttrsMap(true, attrMapAdvCluster), checks...)
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2881,7 +2881,6 @@ func TestAccClusterFlexCluster_basic(t *testing.T) {
 				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", true),
 				Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", true),
 			},
-			acc.TestStepImportCluster(resourceName),
 			{
 				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_2", true),
 				ExpectError: regexp.MustCompile("flex cluster update is not supported except for tags and termination_protection_enabled fields"),

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2932,12 +2932,9 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	if tagsCheck {
 		attrMapFlex["tags.testKey"] = "testValue"
-		if config.AdvancedClusterV2Schema() {
-			attrMapAdvCluster["tags.testKey"] = "testValue"
-		} else {
-			attrMapAdvCluster["tags.0.key"] = "testKey"
-			attrMapAdvCluster["tags.0.value"] = "testValue"
-		}
+		tagsMap := map[string]string{"key": "testKey", "value": "testValue"}
+		tagsCheck := checkKeyValueBlocks(true, !config.AdvancedClusterV2Schema(), "tags", tagsMap)
+		checks = append(checks, tagsCheck)
 	}
 	pluralMap := map[string]string{
 		"project_id": projectID,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2929,8 +2929,12 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	if tagsCheck {
 		attrMapFlex["tags.testKey"] = "testValue"
-		attrMapAdvCluster["tags.0.key"] = "testKey" // TODO change condition
-		attrMapAdvCluster["tags.0.value"] = "testValue"
+		if !config.AdvancedClusterV2Schema() {
+			attrMapAdvCluster["tags.0.key"] = "testKey"
+			attrMapAdvCluster["tags.0.value"] = "testValue"
+		} else {
+			attrMapAdvCluster["tags.testKey"] = "testValue"
+		}
 	}
 	pluralMap := map[string]string{
 		"project_id": projectID,

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2928,11 +2928,11 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	if tagsCheck {
 		attrMapFlex["tags.testKey"] = "testValue"
-		if !config.AdvancedClusterV2Schema() {
+		if config.AdvancedClusterV2Schema() {
+			attrMapAdvCluster["tags.testKey"] = "testValue"
+		} else {
 			attrMapAdvCluster["tags.0.key"] = "testKey"
 			attrMapAdvCluster["tags.0.value"] = "testValue"
-		} else {
-			attrMapAdvCluster["tags.testKey"] = "testValue"
 		}
 	}
 	pluralMap := map[string]string{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2843,6 +2843,10 @@ func configFlexCluster(t *testing.T, projectID, clusterName, providerName, regio
 				value = "testValue"
 			}`
 	}
+	dataSourceConfig := ""
+	if !config.AdvancedClusterV2Schema() {
+		dataSourceConfig = dataSourcesTFOldSchema
+	}
 	return acc.ConvertAdvancedClusterToSchemaV2(t, true, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
 			project_id   = %[1]q
@@ -2859,7 +2863,7 @@ func configFlexCluster(t *testing.T, projectID, clusterName, providerName, regio
 			%[5]s
 			termination_protection_enabled = false
 		}
-	`, projectID, clusterName, providerName, region, tags)+
+	`, projectID, clusterName, providerName, region, tags)+dataSourceConfig+
 		strings.ReplaceAll(acc.FlexDataSource, "mongodbatlas_flex_cluster.", "mongodbatlas_advanced_cluster."))
 }
 
@@ -2951,5 +2955,5 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 		ds = conversion.StringPtr(dataSourceName)
 		dsp = conversion.StringPtr(dataSourcePluralName)
 	}
-	return acc.CheckRSAndDS(resourceName, ds, dsp, acc.ConvertToSchemaV2AttrsSet(true, attrSetAdvCluster), acc.ConvertToSchemaV2AttrsMap(true, attrMapAdvCluster), checks...)
+	return acc.CheckRSAndDSSchemaV2(true, resourceName, ds, dsp, attrSetAdvCluster, attrMapAdvCluster, checks...)
 }

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2904,8 +2904,8 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	}
 	attrSetAdvCluster := []string{
 		"backup_enabled",
-		"connection_strings.standard", //TODO: change automatically .0.
-		"connection_strings.standard_srv",
+		"connection_strings.0.standard",
+		"connection_strings.0.standard_srv",
 		"create_date",
 		"mongo_db_version",
 		"state_name",
@@ -2941,9 +2941,12 @@ func checkFlexClusterConfig(projectID, clusterName, providerName, region string,
 	checks = acc.AddAttrChecks(acc.FlexDataSourcePluralName, checks, pluralMap)
 	checks = acc.AddAttrChecksPrefix(acc.FlexDataSourcePluralName, checks, attrMapFlex, "results.0")
 	checks = acc.AddAttrSetChecksPrefix(acc.FlexDataSourcePluralName, checks, attrSetFlex, "results.0")
-	// checks = acc.AddAttrChecks(dataSourcePluralName, checks, pluralMap)
-	// Convert string constants to variables so we can take their address
-	// ds := dataSourceName
-	// dsp := dataSourcePluralName
-	return acc.CheckRSAndDS(resourceName, nil, nil, acc.ConvertToSchemaV2AttrsSet(true, attrSetAdvCluster), acc.ConvertToSchemaV2AttrsMap(true, attrMapAdvCluster), checks...)
+	var ds *string
+	var dsp *string
+	if !config.AdvancedClusterV2Schema() {
+		checks = acc.AddAttrChecks(dataSourcePluralName, checks, pluralMap)
+		ds = conversion.StringPtr(dataSourceName)
+		dsp = conversion.StringPtr(dataSourcePluralName)
+	}
+	return acc.CheckRSAndDS(resourceName, ds, dsp, acc.ConvertToSchemaV2AttrsSet(true, attrSetAdvCluster), acc.ConvertToSchemaV2AttrsMap(true, attrMapAdvCluster), checks...)
 }

--- a/internal/service/advancedcluster/tpf_adapter.go
+++ b/internal/service/advancedcluster/tpf_adapter.go
@@ -13,6 +13,6 @@ import (
 
 func GetClusterDetails(ctx context.Context, client *config.MongoDBClient, projectID, clusterName string) (cluster *admin.ClusterDescription20240805, flexCluster *admin.FlexClusterDescription20241113, diags v2diag.Diagnostics) {
 	fwdiags := fwdiag.Diagnostics{}
-	cluster, flexCluster = advancedclustertpf.GetClusterDetails(ctx, &fwdiags, projectID, clusterName, client)
+	cluster, flexCluster = advancedclustertpf.GetClusterDetails(ctx, &fwdiags, projectID, clusterName, client, false)
 	return cluster, flexCluster, conversion.FromTPFDiagsToSDKV2Diags(fwdiags)
 }

--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -91,7 +91,7 @@ func getRegionConfig(replicationSpecs *[]admin.ReplicationSpec20240805) *admin.C
 	if replicationSpec.RegionConfigs == nil || len(replicationSpec.GetRegionConfigs()) == 0 {
 		return nil
 	}
-	return &(*replicationSpecs)[0].GetRegionConfigs()[0]
+	return &replicationSpec.GetRegionConfigs()[0]
 }
 
 func GetPriorityOfFlexReplicationSpecs(replicationSpecs *[]admin.ReplicationSpec20240805) *int {

--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -76,13 +76,28 @@ func GenerateFCVPinningWarningForRead(fcvPresentInState bool, apiRespFCVExpirati
 }
 
 func IsFlex(replicationSpecs *[]admin.ReplicationSpec20240805) bool {
-	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
+	regionConfig := getRegionConfig(replicationSpecs)
+	if regionConfig == nil {
 		return false
+	}
+	return regionConfig.GetProviderName() == flexcluster.FlexClusterType
+}
+
+func getRegionConfig(replicationSpecs *[]admin.ReplicationSpec20240805) *admin.CloudRegionConfig20240805 {
+	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
+		return nil
 	}
 	replicationSpec := (*replicationSpecs)[0]
 	if replicationSpec.RegionConfigs == nil || len(replicationSpec.GetRegionConfigs()) == 0 {
-		return false
+		return nil
 	}
-	regionConfig := replicationSpec.GetRegionConfigs()[0]
-	return regionConfig.GetProviderName() == flexcluster.FlexClusterType
+	return &(*replicationSpecs)[0].GetRegionConfigs()[0]
+}
+
+func GetPriorityOfFlexReplicationSpecs(replicationSpecs *[]admin.ReplicationSpec20240805) *int {
+	regionConfig := getRegionConfig(replicationSpecs)
+	if regionConfig == nil {
+		return nil
+	}
+	return regionConfig.Priority
 }

--- a/internal/service/advancedclustertpf/common_admin_sdk.go
+++ b/internal/service/advancedclustertpf/common_admin_sdk.go
@@ -191,17 +191,3 @@ func GetClusterDetails(ctx context.Context, diags *diag.Diagnostics, projectID, 
 	}
 	return clusterDesc, flexClusterResp
 }
-
-func FlexUpgrade(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams, req *admin.LegacyAtlasTenantClusterUpgradeRequest) *admin.FlexClusterDescription20241113 {
-	//TODO: CLOUDP-296220
-	return nil
-}
-
-func GetUpgradeToFlexClusterRequest() *admin.LegacyAtlasTenantClusterUpgradeRequest {
-	// WIP: will be finished as part of CLOUDP-296220
-	return &admin.LegacyAtlasTenantClusterUpgradeRequest{
-		ProviderSettings: &admin.ClusterProviderSettings{
-			ProviderName: flexcluster.FlexClusterType,
-		},
-	}
-}

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -15,7 +15,7 @@ func NewFlexCreateReq(clusterName string, terminationProtectionEnabled bool, tag
 	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
 		return nil
 	}
-	regionConfigs := (*replicationSpecs)[0].GetRegionConfigs()[0]
+	regionConfigs := getRegionConfig(replicationSpecs)
 	return &admin.FlexClusterDescriptionCreate20241113{
 		Name: clusterName,
 		ProviderSettings: admin.FlexProviderSettingsCreate20241113{

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -116,7 +117,7 @@ func FlexDescriptionToClusterDescription(flexCluster *admin.FlexClusterDescripti
 
 func NewTFModelFlex(ctx context.Context, diags *diag.Diagnostics, flexCluster *admin.FlexClusterDescription20241113, priority *int, timeout timeouts.Value) *TFModel {
 	model := NewTFModel(ctx, FlexDescriptionToClusterDescription(flexCluster, priority), timeout, diags, ExtraAPIInfo{UsingLegacySchema: false})
-	AddAdvancedConfig(ctx, model, nil, nil, diags)
+	model.AdvancedConfiguration = types.ObjectNull(AdvancedConfigurationObjType.AttrTypes)
 	return model
 }
 

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
@@ -117,4 +118,18 @@ func NewTFModelFlex(ctx context.Context, diags *diag.Diagnostics, flexCluster *a
 	model := NewTFModel(ctx, FlexDescriptionToClusterDescription(flexCluster, priority), timeout, diags, ExtraAPIInfo{UsingLegacySchema: false})
 	AddAdvancedConfig(ctx, model, nil, nil, diags)
 	return model
+}
+
+func FlexUpgrade(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams, req *admin.LegacyAtlasTenantClusterUpgradeRequest) *admin.FlexClusterDescription20241113 {
+	//TODO: CLOUDP-296220
+	return nil
+}
+
+func GetUpgradeToFlexClusterRequest() *admin.LegacyAtlasTenantClusterUpgradeRequest {
+	// WIP: will be finished as part of CLOUDP-296220
+	return &admin.LegacyAtlasTenantClusterUpgradeRequest{
+		ProviderSettings: &admin.ClusterProviderSettings{
+			ProviderName: flexcluster.FlexClusterType,
+		},
+	}
 }

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -1,0 +1,97 @@
+package advancedclustertpf
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+)
+
+func NewFlexCreateReq(clusterName string, terminationProtectionEnabled bool, tags *[]admin.ResourceTag, replicationSpecs *[]admin.ReplicationSpec20240805) *admin.FlexClusterDescriptionCreate20241113 {
+	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
+		return nil
+	}
+	regionConfigs := (*replicationSpecs)[0].GetRegionConfigs()[0]
+	return &admin.FlexClusterDescriptionCreate20241113{
+		Name: clusterName,
+		ProviderSettings: admin.FlexProviderSettingsCreate20241113{
+			BackingProviderName: regionConfigs.GetBackingProviderName(),
+			RegionName:          regionConfigs.GetRegionName(),
+		},
+		TerminationProtectionEnabled: conversion.Pointer(terminationProtectionEnabled),
+		Tags:                         tags,
+	}
+}
+
+func NewTFModelFlex(ctx context.Context, diags *diag.Diagnostics, flexCluster *admin.FlexClusterDescription20241113) *TFModel {
+	tags := NewTagsObjType(ctx, diags, flexCluster.Tags)
+	replicationSpecs := NewReplicationSpecsObjType(ctx, NewReplicationSpecsFromFlexDescription(flexCluster), diags, &ExtraAPIInfo{UsingLegacySchema: false})
+	connectionStrings := NewConnectionStringsObjType(ctx, NewClusterConnectionStringsFromFlex(flexCluster.ConnectionStrings), diags)
+	if diags.HasError() {
+		return nil
+	}
+	return &TFModel{
+		ClusterType:                  types.StringPointerValue(flexCluster.ClusterType),
+		BackupEnabled:                types.BoolPointerValue(flexCluster.BackupSettings.Enabled),
+		ConnectionStrings:            connectionStrings,
+		CreateDate:                   types.StringValue(conversion.SafeValue(conversion.TimePtrToStringPtr(flexCluster.CreateDate))),
+		MongoDBVersion:               types.StringValue(conversion.SafeValue(flexCluster.MongoDBVersion)),
+		ReplicationSpecs:             replicationSpecs,
+		Name:                         types.StringValue(conversion.SafeValue(flexCluster.Name)),
+		ProjectID:                    types.StringValue(conversion.SafeValue(flexCluster.GroupId)),
+		StateName:                    types.StringValue(conversion.SafeValue(flexCluster.StateName)),
+		Tags:                         tags,
+		TerminationProtectionEnabled: types.BoolPointerValue(flexCluster.TerminationProtectionEnabled),
+		VersionReleaseSystem:         types.StringValue(conversion.SafeValue(flexCluster.VersionReleaseSystem)),
+	}
+}
+
+func NewReplicationSpecsFromFlexDescription(input *admin.FlexClusterDescription20241113) *[]admin.ReplicationSpec20240805 {
+	if input == nil {
+		return nil
+	}
+	return &[]admin.ReplicationSpec20240805{
+		{
+			RegionConfigs: &[]admin.CloudRegionConfig20240805{
+				{
+					BackingProviderName: input.ProviderSettings.BackingProviderName,
+					RegionName:          input.ProviderSettings.RegionName,
+					ProviderName:        input.ProviderSettings.ProviderName,
+				},
+			},
+		},
+	}
+}
+
+func NewClusterConnectionStringsFromFlex(connectionStrings *admin.FlexConnectionStrings20241113) *admin.ClusterConnectionStrings {
+	if connectionStrings == nil {
+		return nil
+	}
+	return &admin.ClusterConnectionStrings{
+		Standard:    connectionStrings.Standard,
+		StandardSrv: connectionStrings.StandardSrv,
+	}
+}
+
+// TODO: TFMOdel
+func isValidUpgradeToFlex(state, plan TFModel) bool {
+	// if d.HasChange("replication_specs.0.region_configs.0") {
+	// 	oldProviderName, newProviderName := d.GetChange("replication_specs.0.region_configs.0.provider_name")
+	// 	oldInstanceSize, newInstanceSize := d.GetChange("replication_specs.0.region_configs.0.electable_specs.instance_size")
+	// 	if oldProviderName == constant.TENANT && newProviderName == flexcluster.FlexClusterType && oldInstanceSize != nil && newInstanceSize == nil {
+	// 		return true
+	// 	}
+	// }
+	return false
+}
+
+func isValidUpdateOfFlex(state, plan TFModel) bool {
+	// updatableAttrHaveBeenUpdated := d.HasChange("tags") || d.HasChange("termination_protection_enabled")
+	// nonUpdatableAttrHaveNotBeenUpdated := !d.HasChange("cluster_type") && !d.HasChange("replication_specs") && !d.HasChange("project_id") && !d.HasChange("name")
+	// if updatableAttrHaveBeenUpdated && nonUpdatableAttrHaveNotBeenUpdated {
+	// 	return true
+	// }
+	return false
+}

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -115,13 +115,13 @@ func FlexDescriptionToClusterDescription(flexCluster *admin.FlexClusterDescripti
 }
 
 func NewTFModelFlex(ctx context.Context, diags *diag.Diagnostics, flexCluster *admin.FlexClusterDescription20241113, priority *int, modelIn *TFModel) *TFModel {
-	model := NewTFModel(ctx, FlexDescriptionToClusterDescription(flexCluster, priority), modelIn.Timeouts, diags, ExtraAPIInfo{UsingLegacySchema: false})
+	modelOut := NewTFModel(ctx, FlexDescriptionToClusterDescription(flexCluster, priority), modelIn.Timeouts, diags, ExtraAPIInfo{UsingLegacySchema: false})
 	if diags.HasError() {
 		return nil
 	}
-	model.AdvancedConfiguration = types.ObjectNull(AdvancedConfigurationObjType.AttrTypes)
-	overrideAttributesWithPrevStateValue(modelIn, model)
-	return model
+	modelOut.AdvancedConfiguration = types.ObjectNull(AdvancedConfigurationObjType.AttrTypes)
+	overrideAttributesWithPrevStateValue(modelIn, modelOut)
+	return modelOut
 }
 
 func FlexUpgrade(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams, req *admin.LegacyAtlasTenantClusterUpgradeRequest) *admin.FlexClusterDescription20241113 {

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -109,6 +109,7 @@ func FlexDescriptionToClusterDescription(flexCluster *admin.FlexClusterDescripti
 		Tags:                         flexCluster.Tags,
 		TerminationProtectionEnabled: flexCluster.TerminationProtectionEnabled,
 		VersionReleaseSystem:         flexCluster.VersionReleaseSystem,
+		ConnectionStrings:            NewClusterConnectionStringsFromFlex(flexCluster.ConnectionStrings),
 	}
 }
 

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -62,8 +62,8 @@ func isValidUpgradeToFlex(stateCluster, planCluster *admin.ClusterDescription202
 	if stateCluster.ReplicationSpecs == nil || planCluster.ReplicationSpecs == nil {
 		return false
 	}
-	oldRegion := stateCluster.GetReplicationSpecs()[0].GetRegionConfigs()[0]
-	newRegion := planCluster.GetReplicationSpecs()[0].GetRegionConfigs()[0]
+	oldRegion := getRegionConfig(stateCluster.ReplicationSpecs)
+	newRegion := getRegionConfig(planCluster.ReplicationSpecs)
 	if oldRegion.ElectableSpecs == nil || newRegion.ElectableSpecs == nil {
 		return false
 	}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -515,6 +515,5 @@ func handleFlexUpdate(ctx context.Context, diags *diag.Diagnostics, client *conf
 	if diags.HasError() {
 		return nil
 	}
-	overrideAttributesWithPrevStateValue(plan, newFlexModel)
 	return newFlexModel
 }

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -213,11 +213,19 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 
 	if IsFlex(planReq.ReplicationSpecs) {
 		if isValidUpgradeToFlex(stateReq, planReq) {
-			diags.Append(resp.State.Set(ctx, handleFlexUpgrade(ctx, diags, r.Client, waitParams, planReq, &plan))...)
+			upgradeModel := handleFlexUpgrade(ctx, diags, r.Client, waitParams, planReq, &plan)
+			if diags.HasError() {
+				return
+			}
+			diags.Append(resp.State.Set(ctx, upgradeModel)...)
 			return
 		}
 		if isValidUpdateOfFlex(stateReq, planReq) {
-			diags.Append(resp.State.Set(ctx, handleFlexUpdate(ctx, diags, r.Client, &plan, planReq))...)
+			updateModel := handleFlexUpdate(ctx, diags, r.Client, &plan, planReq)
+			if diags.HasError() {
+				return
+			}
+			diags.Append(resp.State.Set(ctx, updateModel)...)
 			return
 		}
 		diags.AddError(flexcluster.ErrorNonUpdatableAttributes, "")

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -116,19 +116,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 			diags.AddError(flexcluster.ErrorCreateFlex, err.Error())
 			return
 		}
-
 		newFlexClusterModel := NewTFModelFlex(ctx, diags, flexClusterResp, GetPriorityOfFlexReplicationSpecs(latestReq.ReplicationSpecs), plan.Timeouts)
 		if diags.HasError() {
 			return
 		}
-
-		if conversion.UseNilForEmpty(plan.Tags, newFlexClusterModel.Tags) {
-			newFlexClusterModel.Tags = types.MapNull(types.StringType)
-		}
-		if conversion.UseNilForEmpty(plan.Labels, newFlexClusterModel.Labels) {
-			newFlexClusterModel.Labels = types.MapNull(types.StringType)
-		}
-
+		overrideAttributesWithPrevStateValue(&plan, newFlexClusterModel)
 		diags.Append(resp.State.Set(ctx, newFlexClusterModel)...)
 		return
 	}
@@ -187,6 +179,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 	if flexCluster != nil {
 		newFlexClusterModel := NewTFModelFlex(ctx, diags, flexCluster, nil, state.Timeouts)
+		overrideAttributesWithPrevStateValue(&state, newFlexClusterModel)
 		diags.Append(resp.State.Set(ctx, newFlexClusterModel)...)
 		return
 	}
@@ -237,6 +230,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 				return
 			}
 			newFlexClusterModel := NewTFModelFlex(ctx, diags, flexCluster, GetPriorityOfFlexReplicationSpecs(planReq.ReplicationSpecs), state.Timeouts)
+			overrideAttributesWithPrevStateValue(&plan, newFlexClusterModel)
 			diags.Append(resp.State.Set(ctx, newFlexClusterModel)...)
 			return
 		}

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -178,7 +178,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 		return
 	}
 	if flexCluster != nil {
-		newFlexClusterModel := NewTFModelFlex(ctx, diags, flexCluster, nil, state.Timeouts)
+		newFlexClusterModel := NewTFModelFlex(ctx, diags, flexCluster, GetPriorityOfFlexReplicationSpecs(normalizeFromTFModel(ctx, &state, diags, false).ReplicationSpecs), state.Timeouts)
 		overrideAttributesWithPrevStateValue(&state, newFlexClusterModel)
 		diags.Append(resp.State.Set(ctx, newFlexClusterModel)...)
 		return
@@ -503,9 +503,6 @@ func handleFlexUpdate(ctx context.Context, diags *diag.Diagnostics, client *conf
 		return nil
 	}
 	newFlexModel := NewTFModelFlex(ctx, diags, flexCluster, GetPriorityOfFlexReplicationSpecs(planReq.ReplicationSpecs), timeout)
-	if newFlexModel != nil {
-		newFlexModel.AdvancedConfiguration = types.ObjectNull(AdvancedConfigurationObjType.AttrTypes)
-	}
 	overrideAttributesWithPrevStateValue(plan, newFlexModel)
 	return newFlexModel
 }

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -503,6 +503,9 @@ func handleFlexUpdate(ctx context.Context, diags *diag.Diagnostics, client *conf
 		return nil
 	}
 	newFlexModel := NewTFModelFlex(ctx, diags, flexCluster, GetPriorityOfFlexReplicationSpecs(planReq.ReplicationSpecs), timeout)
+	if newFlexModel != nil {
+		newFlexModel.AdvancedConfiguration = types.ObjectNull(AdvancedConfigurationObjType.AttrTypes)
+	}
 	overrideAttributesWithPrevStateValue(plan, newFlexModel)
 	return newFlexModel
 }

--- a/internal/service/flexcluster/resource.go
+++ b/internal/service/flexcluster/resource.go
@@ -18,14 +18,15 @@ import (
 )
 
 const (
-	resourceName          = "flex_cluster"
-	ErrorUpdateNotAllowed = "update not allowed"
-	FlexClusterType       = "FLEX"
-	ErrorCreateFlex       = "error creating flex cluster: %s"
-	ErrorReadFlex         = "error reading flex cluster (%s): %s"
-	ErrorUpdateFlex       = "error updating flex cluster: %s"
-	ErrorUpgradeFlex      = "error upgrading to a flex cluster: %s"
-	ErrorDeleteFlex       = "error deleting a flex cluster (%s): %s"
+	resourceName                = "flex_cluster"
+	ErrorUpdateNotAllowed       = "update not allowed"
+	FlexClusterType             = "FLEX"
+	ErrorCreateFlex             = "error creating flex cluster: %s"
+	ErrorReadFlex               = "error reading flex cluster (%s): %s"
+	ErrorUpdateFlex             = "error updating flex cluster: %s"
+	ErrorUpgradeFlex            = "error upgrading to a flex cluster: %s"
+	ErrorDeleteFlex             = "error deleting a flex cluster (%s): %s"
+	ErrorNonUpdatableAttributes = "flex cluster update is not supported except for tags and termination_protection_enabled fields"
 )
 
 var _ resource.ResourceWithConfigure = &rs{}

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -80,6 +80,7 @@ var tpfSingleNestedAttrs = []string{
 	"pinned_fcv",
 	"timeouts",
 	"connection_strings",
+	"tags",
 }
 
 func AttrNameToSchemaV2(isAcc bool, name string) string {

--- a/internal/testutil/acc/advanced_cluster_schema_v2.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2.go
@@ -79,6 +79,7 @@ var tpfSingleNestedAttrs = []string{
 	"bi_connector_config",
 	"pinned_fcv",
 	"timeouts",
+	"connection_strings",
 }
 
 func AttrNameToSchemaV2(isAcc bool, name string) string {

--- a/internal/testutil/acc/advanced_cluster_schema_v2_test.go
+++ b/internal/testutil/acc/advanced_cluster_schema_v2_test.go
@@ -19,6 +19,8 @@ func TestConvertToSchemaV2AttrsMapAndAttrsSet(t *testing.T) {
 		"prefixbi_connector_config.0":     "val3",
 		"advanced_configuration.0postfix": "val4",
 		"electable_specs.0advanced_configuration.0bi_connector_config.0": "val5",
+		"connection_strings.0.standard":                                  "val6",
+		"connection_strings.0.standard_srv":                              "val6",
 	}
 	expectedMap := map[string]string{
 		"attr":                          "val1",
@@ -26,6 +28,8 @@ func TestConvertToSchemaV2AttrsMapAndAttrsSet(t *testing.T) {
 		"prefixbi_connector_config":     "val3",
 		"advanced_configurationpostfix": "val4",
 		"electable_specsadvanced_configurationbi_connector_config": "val5",
+		"connection_strings.standard":                              "val6",
+		"connection_strings.standard_srv":                          "val6",
 	}
 	actualMap := acc.ConvertToSchemaV2AttrsMap(true, attrsMap)
 	assert.Equal(t, expectedMap, actualMap)


### PR DESCRIPTION
## Description

Supports create, read, update and delete for flex clusters in `mongodbatlas_advanced_cluster`
Import operation and data sources will be done in a follow-up PR

Link to any related issue(s): CLOUDP-296377

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
