### PR TITLE
doc: Adds outputs documentation to the cluster to advanced_cluster migration guide

### DIFF
--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -30,7 +30,7 @@
     provider_installation {
 
     dev_overrides {
-      "mongodb/mongodbatlas" = "/Users/yourUser/terraform-provider-mongodbatlas/bin" # path to the provider binary
+      "mongodb/mongodbatlas" = "/Users/<YourUser>/terraform-provider-mongodbatlas/bin" # path to the provider binary
     }
 
     direct {} 
@@ -284,22 +284,22 @@ To do this you can:
     ```terraform
     provider_installation {
       filesystem_mirror {
-        path    = "C:\Users\YourUser\Desktop\Tenant_Upgrade\tf_cache"
+        path    = "C:\Users\<YourUser>\Desktop\Tenant_Upgrade\tf_cache"
         include = ["registry.terraform.io/hashicorp/*"]
       }
       direct {
         exclude = ["registry.terraform.io/hashicorp/*"]
       }
     }
-    plugin_cache_dir = "C:\Users\YourUser\Desktop\Tenant_Upgrade\tf_cache"
+    plugin_cache_dir = "C:\Users\<YourUser>\Desktop\Tenant_Upgrade\tf_cache"
     disable_checkpoint=true
     ```
 -	`cd` back up to original directory and `mv` the `.terraform/providers/registry.terraform.io` directory to `tf_cache` 
 
 -	Create required environment variables (modify accordingly to your own local path directory):
     ```bash
-    export TF_PLUGIN_CACHE_DIR=/mnt/c/Users/YourUser/Desktop/Tenant_Upgrade/tf_cache
-    export TF_CLI_CONFIG_FILE=/mnt/c/Users/YourUser/Desktop/Tenant_Upgrade/tf_cache/terraform.rc
+    export TF_PLUGIN_CACHE_DIR=/mnt/c/Users/<YourUser>/Desktop/Tenant_Upgrade/tf_cache
+    export TF_CLI_CONFIG_FILE=/mnt/c/Users/<YourUser>/Desktop/Tenant_Upgrade/tf_cache/terraform.rc
     ```
 -  Delete the `.terraform` and `.terraform.lock.hcl` directories altogether. At this point you should only have the `tf_cache` directory and the `versions.tf` config file remaining. 
 

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -284,22 +284,22 @@ To do this you can:
     ```terraform
     provider_installation {
       filesystem_mirror {
-        path    = "C:\Users\ZuhairAhmed\Desktop\Tenant_Upgrade\tf_cache"
+        path    = "C:\Users\YourUser\Desktop\Tenant_Upgrade\tf_cache"
         include = ["registry.terraform.io/hashicorp/*"]
       }
       direct {
         exclude = ["registry.terraform.io/hashicorp/*"]
       }
     }
-    plugin_cache_dir = "C:\Users\ZuhairAhmed\Desktop\Tenant_Upgrade\tf_cache"
+    plugin_cache_dir = "C:\Users\YourUser\Desktop\Tenant_Upgrade\tf_cache"
     disable_checkpoint=true
     ```
 -	`cd` back up to original directory and `mv` the `.terraform/providers/registry.terraform.io` directory to `tf_cache` 
 
 -	Create required environment variables (modify accordingly to your own local path directory):
     ```bash
-    export TF_PLUGIN_CACHE_DIR=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cache
-    export TF_CLI_CONFIG_FILE=/mnt/c/Users/ZuhairAhmed/Desktop/Tenant_Upgrade/tf_cache/terraform.rc
+    export TF_PLUGIN_CACHE_DIR=/mnt/c/Users/YourUser/Desktop/Tenant_Upgrade/tf_cache
+    export TF_CLI_CONFIG_FILE=/mnt/c/Users/YourUser/Desktop/Tenant_Upgrade/tf_cache/terraform.rc
     ```
 -  Delete the `.terraform` and `.terraform.lock.hcl` directories altogether. At this point you should only have the `tf_cache` directory and the `versions.tf` config file remaining. 
 

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -80,6 +80,9 @@ resource "mongodbatlas_advanced_cluster" "this" {
   - Before: `mongodbatlas_cluster.this.replication_specs[0].container_id` was a flat string, such as: `669644ae01bf814e3d25b963`
   - After: `mongodbatlas_advanced_cluster.this.replication_specs[0].container_id` is a map, such as: `{"AWS:US_EAST_1": "669644ae01bf814e3d25b963"}`
   - If you have a single region you can access the `container_id` directly with: `one(values(mongodbatlas_advanced_cluster.this.replication_specs[0].container_id))`
+- Connection strings:
+  - Before: `srv_address`, `mongo_uri`, `mongo_uri_with_options`, `mongo_uri_updated` attributes were available.
+  - After: They're not available any more, use instead attributes in `connection_strings`.
 
 ## Best Practices Before Migrating
 Before doing any migration create a backup of your [Terraform state file](https://developer.hashicorp.com/terraform/cli/commands/state).

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -6,7 +6,7 @@ page_title: "Migration Guide: Cluster to Advanced Cluster"
 
 **Objective**: This guide explains how to replace the `mongodbatlas_cluster` resource with the `mongodbatlas_advanced_cluster` resource. The data source(s) migration only requires [output changes](#output-changes) as data sources only read clusters.
 
-**Note**: In addition to below options, we are also actively exploring additional migration paths that do not involve Terraform State modifications.
+**Note**: In addition to below options, we are also actively exploring additional migration paths that do not involve Terraform State modifications. If interested to learn more or to test out directly please contact melissa.plunkett@mongodb.com.
 
 ## Main Changes Between `mongodbatlas_cluster` and `mongodbatlas_advanced_cluster`
 

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -81,7 +81,7 @@ resource "mongodbatlas_advanced_cluster" "this" {
   - After: `mongodbatlas_advanced_cluster.this.replication_specs[0].container_id` is a map, such as: `{"AWS:US_EAST_1": "669644ae01bf814e3d25b963"}`
   - If you have a single region you can access the `container_id` directly with: `one(values(mongodbatlas_advanced_cluster.this.replication_specs[0].container_id))`
 - Connection strings:
-  - Before: `srv_address`, `mongo_uri`, `mongo_uri_with_options`, `mongo_uri_updated` attributes were available.
+  - Before: `srv_address`, `mongo_uri`, `mongo_uri_with_options` and `mongo_uri_updated` attributes were available.
   - After: They're not available any more, use instead attributes in `connection_strings`.
 
 ## Best Practices Before Migrating

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -6,7 +6,7 @@ page_title: "Migration Guide: Cluster to Advanced Cluster"
 
 **Objective**: This guide explains how to replace the `mongodbatlas_cluster` resource with the `mongodbatlas_advanced_cluster` resource. The data source(s) migration only requires [output changes](#output-changes) as data sources only read clusters.
 
-**Note**: In addition to below options, we are also actively exploring additional migration paths that do not involve Terraform State modifications. If interested to learn more or to test out directly please contact zuhair.ahmed@mongodb.com.
+**Note**: In addition to below options, we are also actively exploring additional migration paths that do not involve Terraform State modifications.
 
 ## Main Changes Between `mongodbatlas_cluster` and `mongodbatlas_advanced_cluster`
 

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -76,13 +76,16 @@ resource "mongodbatlas_advanced_cluster" "this" {
 
 ### Output Changes
 
+- Connection strings:
+  - Before: `srv_address`, `mongo_uri`, `mongo_uri_with_options` and `mongo_uri_updated` attributes were available.
+  - After: They're not available anymore, use attributes in `connection_strings` instead.
 - `container_id`:
   - Before: `mongodbatlas_cluster.this.replication_specs[0].container_id` was a flat string, such as: `669644ae01bf814e3d25b963`
   - After: `mongodbatlas_advanced_cluster.this.replication_specs[0].container_id` is a map, such as: `{"AWS:US_EAST_1": "669644ae01bf814e3d25b963"}`
   - If you have a single region you can access the `container_id` directly with: `one(values(mongodbatlas_advanced_cluster.this.replication_specs[0].container_id))`
-- Connection strings:
-  - Before: `srv_address`, `mongo_uri`, `mongo_uri_with_options` and `mongo_uri_updated` attributes were available.
-  - After: They're not available any more, use instead attributes in `connection_strings`.
+- `snapshot_backup_policy`:
+  - Before: It was deprecated.
+  - After: Use `mongodbatlas_cloud_backup_schedule` resource instead.
 
 ## Best Practices Before Migrating
 Before doing any migration create a backup of your [Terraform state file](https://developer.hashicorp.com/terraform/cli/commands/state).

--- a/docs/guides/serverless-shared-migration-guide.md
+++ b/docs/guides/serverless-shared-migration-guide.md
@@ -15,7 +15,7 @@ You can migrate from Serverless instances and Shared-tier clusters manually befo
 
 **--> NOTE:** We recommend waiting until March 2025 or later for Serverless instances and Shared-tier clusters to autoconvert.
 
-For Shared-tier clusters, we are working on enhancing the User Experience such that Terraform Atlas Providers users can make even fewer required changes to their scripts from what is shown below. More updates to come over the next few months. For more details reach out to: zuhair.ahmed@mongodb.com
+For Shared-tier clusters, we are working on enhancing the User Experience such that Terraform Atlas Providers users can make even fewer required changes to their scripts from what is shown below. More updates to come over the next few months.
 
 ### Jump to:
 - [Shared-tier to Flex](#from-shared-tier-clusters-to-flex)


### PR DESCRIPTION
## Description

Adds outputs documentation to the cluster to advanced_cluster migration guide

Link to any related issue(s): CLOUDP-298833

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
