### PR TITLE
chore: Simplifies getBasicClusterModel to make it easier to call from data sources and flex

### DIFF
--- a/internal/service/advancedclustertpf/common_admin_sdk.go
+++ b/internal/service/advancedclustertpf/common_admin_sdk.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
-func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, req *admin.ClusterDescription20240805, waitParams *ClusterWaitParams, usingOldShardingConfiguration bool) *admin.ClusterDescription20240805 {
+func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, req *admin.ClusterDescription20240805, waitParams *ClusterWaitParams, usingNewShardingConfiguration bool) *admin.ClusterDescription20240805 {
 	var (
 		pauseAfter  = req.GetPaused()
 		clusterResp *admin.ClusterDescription20240805
@@ -21,11 +21,11 @@ func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.
 	if pauseAfter {
 		req.Paused = nil
 	}
-	if usingOldShardingConfiguration {
-		legacyReq := ConvertClusterDescription20241023to20240805(req)
-		clusterResp = createCluster20240805(ctx, diags, client, legacyReq, waitParams)
-	} else {
+	if usingNewShardingConfiguration {
 		clusterResp = createClusterLatest(ctx, diags, client, req, waitParams)
+	} else {
+		oldReq := ConvertClusterDescription20241023to20240805(req)
+		clusterResp = createCluster20240805(ctx, diags, client, oldReq, waitParams)
 	}
 	if diags.HasError() {
 		return nil

--- a/internal/service/advancedclustertpf/common_admin_sdk.go
+++ b/internal/service/advancedclustertpf/common_admin_sdk.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
-func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, req *admin.ClusterDescription20240805, waitParams *ClusterWaitParams, usingNewShardingConfiguration bool) *admin.ClusterDescription20240805 {
+func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, req *admin.ClusterDescription20240805, waitParams *ClusterWaitParams, usingNewShardingConfig bool) *admin.ClusterDescription20240805 {
 	var (
 		pauseAfter  = req.GetPaused()
 		clusterResp *admin.ClusterDescription20240805
@@ -21,7 +21,7 @@ func CreateCluster(ctx context.Context, diags *diag.Diagnostics, client *config.
 	if pauseAfter {
 		req.Paused = nil
 	}
-	if usingNewShardingConfiguration {
+	if usingNewShardingConfig {
 		clusterResp = createClusterLatest(ctx, diags, client, req, waitParams)
 	} else {
 		oldReq := ConvertClusterDescription20241023to20240805(req)

--- a/internal/service/advancedclustertpf/data_source.go
+++ b/internal/service/advancedclustertpf/data_source.go
@@ -66,7 +66,7 @@ func (d *ds) readCluster(ctx context.Context, diags *diag.Diagnostics, modelDS *
 	if diags.HasError() {
 		return nil
 	}
-	if extraInfo.ForceLegacySchemaFailed {
+	if extraInfo.UseOldShardingConfigFailed {
 		diags.AddError(errorReadDatasourceForceAsymmetric, fmt.Sprintf(errorReadDatasourceForceAsymmetricDetail, clusterName, DeprecationOldSchemaAction))
 		return nil
 	}

--- a/internal/service/advancedclustertpf/data_source.go
+++ b/internal/service/advancedclustertpf/data_source.go
@@ -62,11 +62,7 @@ func (d *ds) readCluster(ctx context.Context, diags *diag.Diagnostics, modelDS *
 		diags.AddError(errorReadDatasource, defaultAPIErrorDetails(clusterName, err))
 		return nil
 	}
-	modelIn := &TFModel{
-		ProjectID: modelDS.ProjectID,
-		Name:      modelDS.Name,
-	}
-	modelOut, extraInfo := getBasicClusterModel(ctx, diags, d.Client, clusterResp, modelIn, !useReplicationSpecPerShard)
+	modelOut, extraInfo := getBasicClusterModel(ctx, diags, d.Client, clusterResp, useReplicationSpecPerShard)
 	if diags.HasError() {
 		return nil
 	}

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -22,8 +22,8 @@ type ExtraAPIInfo struct {
 	ZoneNameNumShards          map[string]int64
 	ZoneNameReplicationSpecIDs map[string]string
 	ContainerIDs               map[string]string
-	UseReplicationSpecPerShard bool
-	ForceLegacySchemaFailed    bool
+	UseReplicationSpecPerShard bool // true: ISS schema, false: pre-ISS schema (numShards > 1)
+	ForceLegacySchemaFailed    bool // !UseReplicationSpecPerShard and failed to read from old API
 }
 
 func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, diags *diag.Diagnostics, apiInfo ExtraAPIInfo) *TFModel {

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -27,7 +26,7 @@ type ExtraAPIInfo struct {
 	ForceLegacySchemaFailed    bool
 }
 
-func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, timeout timeouts.Value, diags *diag.Diagnostics, apiInfo ExtraAPIInfo) *TFModel {
+func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, diags *diag.Diagnostics, apiInfo ExtraAPIInfo) *TFModel {
 	biConnector := NewBiConnectorConfigObjType(ctx, input.BiConnector, diags)
 	connectionStrings := NewConnectionStringsObjType(ctx, input.ConnectionStrings, diags)
 	labels := NewLabelsObjType(ctx, diags, input.Labels)
@@ -66,7 +65,6 @@ func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, ti
 		TerminationProtectionEnabled:     types.BoolValue(conversion.SafeValue(input.TerminationProtectionEnabled)),
 		VersionReleaseSystem:             types.StringValue(conversion.SafeValue(input.VersionReleaseSystem)),
 		PinnedFCV:                        pinnedFCV,
-		Timeouts:                         timeout,
 	}
 }
 

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -22,8 +22,8 @@ type ExtraAPIInfo struct {
 	ZoneNameNumShards          map[string]int64
 	ZoneNameReplicationSpecIDs map[string]string
 	ContainerIDs               map[string]string
-	UseReplicationSpecPerShard bool // true: ISS schema, false: pre-ISS schema (numShards > 1)
-	ForceLegacySchemaFailed    bool // !UseReplicationSpecPerShard and failed to read from old API
+	UseNewShardingConfig       bool
+	UseOldShardingConfigFailed bool
 }
 
 func NewTFModel(ctx context.Context, input *admin.ClusterDescription20240805, diags *diag.Diagnostics, apiInfo ExtraAPIInfo) *TFModel {
@@ -118,7 +118,7 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		return types.ListNull(ReplicationSpecsObjType)
 	}
 	var tfModels *[]TFReplicationSpecsModel
-	if apiInfo.UseReplicationSpecPerShard {
+	if apiInfo.UseNewShardingConfig {
 		tfModels = convertReplicationSpecs(ctx, input, diags, apiInfo)
 	} else {
 		tfModels = convertReplicationSpecsLegacy(ctx, input, diags, apiInfo)

--- a/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
+++ b/internal/service/advancedclustertpf/model_ClusterDescription20240805.go
@@ -23,7 +23,7 @@ type ExtraAPIInfo struct {
 	ZoneNameNumShards          map[string]int64
 	ZoneNameReplicationSpecIDs map[string]string
 	ContainerIDs               map[string]string
-	UsingLegacySchema          bool
+	UseReplicationSpecPerShard bool
 	ForceLegacySchemaFailed    bool
 }
 
@@ -120,10 +120,10 @@ func NewReplicationSpecsObjType(ctx context.Context, input *[]admin.ReplicationS
 		return types.ListNull(ReplicationSpecsObjType)
 	}
 	var tfModels *[]TFReplicationSpecsModel
-	if apiInfo.UsingLegacySchema {
-		tfModels = convertReplicationSpecsLegacy(ctx, input, diags, apiInfo)
-	} else {
+	if apiInfo.UseReplicationSpecPerShard {
 		tfModels = convertReplicationSpecs(ctx, input, diags, apiInfo)
+	} else {
+		tfModels = convertReplicationSpecsLegacy(ctx, input, diags, apiInfo)
 	}
 	if diags.HasError() {
 		return types.ListNull(ReplicationSpecsObjType)

--- a/internal/service/advancedclustertpf/move_upgrade_state.go
+++ b/internal/service/advancedclustertpf/move_upgrade_state.go
@@ -87,10 +87,11 @@ func setStateResponse(ctx context.Context, diags *diag.Diagnostics, stateIn *tfp
 	model := NewTFModel(ctx, &admin.ClusterDescription20240805{
 		GroupId: projectID,
 		Name:    name,
-	}, getTimeoutFromStateObj(stateObj), diags, ExtraAPIInfo{})
+	}, diags, ExtraAPIInfo{})
 	if diags.HasError() {
 		return
 	}
+	model.Timeouts = getTimeoutFromStateObj(stateObj)
 	AddAdvancedConfig(ctx, model, nil, nil, diags)
 	if diags.HasError() {
 		return

--- a/internal/service/advancedclustertpf/plural_data_source.go
+++ b/internal/service/advancedclustertpf/plural_data_source.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -71,11 +70,7 @@ func (d *pluralDS) readClusters(ctx context.Context, diags *diag.Diagnostics, pl
 	}
 	for i := range list {
 		clusterResp := &list[i]
-		modelIn := &TFModel{
-			ProjectID: pluralModel.ProjectID,
-			Name:      types.StringValue(clusterResp.GetName()),
-		}
-		modelOut, extraInfo := getBasicClusterModel(ctx, diags, d.Client, clusterResp, modelIn, !useReplicationSpecPerShard)
+		modelOut, extraInfo := getBasicClusterModel(ctx, diags, d.Client, clusterResp, useReplicationSpecPerShard)
 		if diags.HasError() {
 			if DiagsHasOnlyClusterNotFoundErrors(diags) {
 				diags = ResetClusterNotFoundErrors(diags)

--- a/internal/service/advancedclustertpf/plural_data_source.go
+++ b/internal/service/advancedclustertpf/plural_data_source.go
@@ -78,7 +78,7 @@ func (d *pluralDS) readClusters(ctx context.Context, diags *diag.Diagnostics, pl
 			}
 			return nil, diags
 		}
-		if extraInfo.ForceLegacySchemaFailed {
+		if extraInfo.UseOldShardingConfigFailed {
 			continue
 		}
 		updateModelAdvancedConfig(ctx, diags, d.Client, modelOut, nil, nil)

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -456,13 +456,13 @@ func resolveTimeout(ctx context.Context, t *timeouts.Value, operationName string
 }
 
 func findClusterDiff(ctx context.Context, state, plan *TFModel, diags *diag.Diagnostics, options *update.PatchOptions) (*admin.ClusterDescription20240805, *admin.LegacyAtlasTenantClusterUpgradeRequest) {
-	stateUsingNew := usingNewShardingConfig(ctx, state.ReplicationSpecs, diags)
-	planUsingNew := usingNewShardingConfig(ctx, plan.ReplicationSpecs, diags)
-	if stateUsingNew && !planUsingNew {
+	stateUsingNewSharding := usingNewShardingConfig(ctx, state.ReplicationSpecs, diags)
+	planUsingNewSharding := usingNewShardingConfig(ctx, plan.ReplicationSpecs, diags)
+	if stateUsingNewSharding && !planUsingNewSharding {
 		diags.AddError(errorSchemaDowngrade, fmt.Sprintf(errorSchemaDowngradeDetail, plan.Name.ValueString()))
 		return nil, nil
 	}
-	isShardingConfigUpgrade := !stateUsingNew && planUsingNew // pre-ISS (num_shards > 1) to post-ISS
+	isShardingConfigUpgrade := !stateUsingNewSharding && planUsingNewSharding // old sharding config  (num_shards > 1) to new one
 	stateReq := normalizeFromTFModel(ctx, state, diags, false)
 	planReq := normalizeFromTFModel(ctx, plan, diags, isShardingConfigUpgrade)
 	if diags.HasError() {

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -37,7 +37,7 @@ func overrideMapStringWithPrevStateValue(mapIn, mapOut *types.Map) {
 }
 
 func findNumShardsUpdates(ctx context.Context, state, plan *TFModel, diags *diag.Diagnostics) map[string]int64 {
-	if !usingLegacyShardingConfig(ctx, plan.ReplicationSpecs, diags) {
+	if usingNewShardingConfig(ctx, plan.ReplicationSpecs, diags) {
 		return nil
 	}
 	stateCounts := numShardsMap(ctx, state.ReplicationSpecs, diags)
@@ -53,15 +53,15 @@ func findNumShardsUpdates(ctx context.Context, state, plan *TFModel, diags *diag
 
 func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, clusterLatest *admin.ClusterDescription20240805, useReplicationSpecPerShard bool) *ExtraAPIInfo {
 	var (
-		api20240530             = client.AtlasV220240530.ClustersApi
-		projectID               = clusterLatest.GetGroupId()
-		clusterName             = clusterLatest.GetName()
-		forceLegacySchemaFailed = false
+		api20240530                = client.AtlasV220240530.ClustersApi
+		projectID                  = clusterLatest.GetGroupId()
+		clusterName                = clusterLatest.GetName()
+		useOldShardingConfigFailed = false
 	)
 	clusterRespOld, _, err := api20240530.GetCluster(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED") {
-			forceLegacySchemaFailed = !useReplicationSpecPerShard
+			useOldShardingConfigFailed = !useReplicationSpecPerShard
 		} else {
 			diags.AddError(errorReadLegacy20240530, defaultAPIErrorDetails(clusterName, err))
 			return nil
@@ -75,9 +75,9 @@ func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config
 	return &ExtraAPIInfo{
 		ContainerIDs:               containerIDs,
 		ZoneNameReplicationSpecIDs: replicationSpecIDsFromOldAPI(clusterRespOld),
-		ForceLegacySchemaFailed:    forceLegacySchemaFailed,
+		UseOldShardingConfigFailed: useOldShardingConfigFailed,
 		ZoneNameNumShards:          numShardsMapFromOldAPI(clusterRespOld),
-		UseReplicationSpecPerShard: useReplicationSpecPerShard,
+		UseNewShardingConfig:       useReplicationSpecPerShard,
 	}
 }
 
@@ -155,12 +155,12 @@ func numShardsCounts(ctx context.Context, input types.List, diags *diag.Diagnost
 	return counts
 }
 
-func usingLegacyShardingConfig(ctx context.Context, input types.List, diags *diag.Diagnostics) bool {
+func usingNewShardingConfig(ctx context.Context, input types.List, diags *diag.Diagnostics) bool {
 	counts := numShardsCounts(ctx, input, diags)
 	if diags.HasError() {
-		return false
+		return true
 	}
-	return isNumShardsGreaterThanOne(counts)
+	return !isNumShardsGreaterThanOne(counts)
 }
 
 func numShardsMap(ctx context.Context, input types.List, diags *diag.Diagnostics) map[string]int64 {

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -51,11 +51,11 @@ func findNumShardsUpdates(ctx context.Context, state, plan *TFModel, diags *diag
 	return planCounts
 }
 
-func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, plan *TFModel, clusterLatest *admin.ClusterDescription20240805, useReplicationSpecPerShard bool) *ExtraAPIInfo {
+func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, clusterLatest *admin.ClusterDescription20240805, useReplicationSpecPerShard bool) *ExtraAPIInfo {
 	var (
 		api20240530             = client.AtlasV220240530.ClustersApi
-		projectID               = plan.ProjectID.ValueString()
-		clusterName             = plan.Name.ValueString()
+		projectID               = clusterLatest.GetGroupId()
+		clusterName             = clusterLatest.GetName()
 		forceLegacySchemaFailed = false
 	)
 	clusterRespOld, _, err := api20240530.GetCluster(ctx, projectID, clusterName).Execute()


### PR DESCRIPTION
## Description

refactor: Simplifies getBasicClusterModel to make it easier to call from data sources and flex

Link to any related issue(s): CLOUDP-295443

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
