### PR TITLE
chore: Removes todo section from readme in tpf package

### DIFF
--- a/internal/service/advancedcluster/README.md
+++ b/internal/service/advancedcluster/README.md
@@ -1,9 +1,0 @@
-# advancedcluster package
-
-This package contains current exposed implementation of `mongodbatlas_advanced_cluster`. 
-
-**Note:** This file and complete package will be deleted once the TPF update in `advancedclustertpf` is ready.
-
-If you change something in this package, please:
-- Do the same change in `advancedclustertpf` package
-- Or if you can't, add a note to [`advancedclustertpf` README.md file](../advancedclustertpf/README.md#changes-in-advancedcluster-that-needs-to-be-added-here)

--- a/internal/service/advancedclustertpf/README.md
+++ b/internal/service/advancedclustertpf/README.md
@@ -1,5 +1,0 @@
-# advancedclustertpf package
-
-This package contains the WIP for `mongodbatlas_advanced_cluster` in TPF. Current exposed implementation is in `advancedcluster` package.
-
-**Note:** This file will be deleted once the update is complete and `advancedcluster` package will be deleted.

--- a/internal/service/advancedclustertpf/README.md
+++ b/internal/service/advancedclustertpf/README.md
@@ -1,13 +1,5 @@
 # advancedclustertpf package
 
-This package contains the WIP for `mongodbatlas_advanced_cluster` in TPF. Current exposed implementation is in `advancedcluster` package. 
+This package contains the WIP for `mongodbatlas_advanced_cluster` in TPF. Current exposed implementation is in `advancedcluster` package.
 
 **Note:** This file will be deleted once the update is complete and `advancedcluster` package will be deleted.
-
-## Changes in advancedcluster that needs to be added here
-(list changes done in advancedcluster which couldn't also be done here at that moment)
-- [PR #2825](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2825) Add new `advanced_configuration.0.default_max_time_ms` attribute to mongodbatlas_advanced_cluster resource and data sources.
-- feat: Ensures asymmetric auto-scaling is not defined in the cluster when using the old sharding configuration in mongodbatlas_advanced_cluster (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2836)
-- `pinned_fcv` attribute was a recently added attribute in `advanced_cluster`. It has been defined in the new tpf schema but we need to make sure that the implementation is also present.
-- [PR #2872](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2872) Adds support for Customer Cipher Configuration for Data Plane Connections.
-


### PR DESCRIPTION
## Description

Removes todo section from readme in tpf package

Link to any related issue(s): CLOUDP-288332

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
