### PR TITLE
fix: Adds PENDING status for update and delete operations in `mongodbatlas_advanced_cluster` and `mongodbatlas_cluster` resource

### DIFF
--- a/.changelog/3034.txt
+++ b/.changelog/3034.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Adds `PENDING` status for update and delete operations
+```

--- a/.changelog/3034.txt
+++ b/.changelog/3034.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/mongodbatlas_advanced_cluster: Adds `PENDING` status for update and delete operations
 ```
+
+```release-note:bug
+resource/mongodbatlas_cluster: Adds `PENDING` status for update and delete operations
+```

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -1251,7 +1251,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func DeleteStateChangeConfig(ctx context.Context, connV2 *admin.APIClient, projectID, name string, timeout time.Duration) retry.StateChangeConf {
 	return retry.StateChangeConf{
-		Pending:    []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "DELETING"},
+		Pending:    []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "DELETING", "PENDING"},
 		Target:     []string{"DELETED"},
 		Refresh:    resourceRefreshFunc(ctx, name, projectID, connV2),
 		Timeout:    timeout,
@@ -1299,7 +1299,7 @@ func upgradeCluster(ctx context.Context, connV2 *admin.APIClient, request *admin
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"CREATING", "UPDATING", "REPAIRING"},
+		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "PENDING"},
 		Target:     []string{"IDLE"},
 		Refresh:    UpgradeRefreshFunc(ctx, name, projectID, connV2.ClustersApi),
 		Timeout:    timeout,

--- a/internal/service/advancedcluster/resource_advanced_cluster.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster.go
@@ -1251,7 +1251,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func DeleteStateChangeConfig(ctx context.Context, connV2 *admin.APIClient, projectID, name string, timeout time.Duration) retry.StateChangeConf {
 	return retry.StateChangeConf{
-		Pending:    []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "DELETING", "PENDING"},
+		Pending:    []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "DELETING", "PENDING", "REPEATING"},
 		Target:     []string{"DELETED"},
 		Refresh:    resourceRefreshFunc(ctx, name, projectID, connV2),
 		Timeout:    timeout,
@@ -1299,7 +1299,7 @@ func upgradeCluster(ctx context.Context, connV2 *admin.APIClient, request *admin
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "PENDING"},
+		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "PENDING", "REPEATING"},
 		Target:     []string{"IDLE"},
 		Refresh:    UpgradeRefreshFunc(ctx, name, projectID, connV2.ClustersApi),
 		Timeout:    timeout,
@@ -1398,7 +1398,7 @@ func getUpgradeRequest(d *schema.ResourceData) *admin.LegacyAtlasTenantClusterUp
 
 func waitForUpdateToFinish(ctx context.Context, connV2 *admin.APIClient, projectID, name string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"CREATING", "UPDATING", "REPAIRING"},
+		Pending:    []string{"CREATING", "UPDATING", "REPAIRING", "PENDING", "REPEATING"},
 		Target:     []string{"IDLE"},
 		Refresh:    resourceRefreshFunc(ctx, name, projectID, connV2),
 		Timeout:    timeout,


### PR DESCRIPTION
## Description

Adds PENDING status for update and delete operations in `mongodbatlas_advanced_cluster`
This is a fix to avoid errors like below during update/delete operations if backend responds with 503:
` Error: error updating advanced cluster (test-acc-tf-c-...): unexpected state 'PENDING', wanted target 'IDLE' `. See test run https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13147445685/job/36688589003 for details. 

This status is currently returned from the refreshFunc in case of 503:
https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3034/files#diff-317cbb5ab8946cb906d1e81141844344600ded4bb8b6620e3a617b94ff30aaa4R1350 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
