### PR TITLE
chore: Set default priority (7) for imported flex clusters in mongodbatlas_advanced_cluster

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2905,6 +2905,7 @@ func TestAccClusterFlexCluster_basic(t *testing.T) {
 				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", true),
 				Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", true),
 			},
+			acc.TestStepImportCluster(resourceName),
 			{
 				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_2", true),
 				ExpectError: regexp.MustCompile("flex cluster update is not supported except for tags and termination_protection_enabled fields"),

--- a/internal/service/advancedclustertpf/model_flex.go
+++ b/internal/service/advancedclustertpf/model_flex.go
@@ -13,6 +13,8 @@ import (
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
+const defaultPriority int = 7
+
 func NewFlexCreateReq(clusterName string, terminationProtectionEnabled bool, tags *[]admin.ResourceTag, replicationSpecs *[]admin.ReplicationSpec20240805) *admin.FlexClusterDescriptionCreate20241113 {
 	if replicationSpecs == nil || len(*replicationSpecs) == 0 {
 		return nil
@@ -124,6 +126,9 @@ func NewTFModelFlexResource(ctx context.Context, diags *diag.Diagnostics, flexCl
 }
 
 func NewTFModelFlex(ctx context.Context, diags *diag.Diagnostics, flexCluster *admin.FlexClusterDescription20241113, priority *int) *TFModel {
+	if priority == nil {
+		priority = conversion.Pointer(defaultPriority)
+	}
 	modelOut := NewTFModel(ctx, FlexDescriptionToClusterDescription(flexCluster, priority), diags, ExtraAPIInfo{UseNewShardingConfig: true})
 	if diags.HasError() {
 		return nil


### PR DESCRIPTION
## Description

Set default priority (7) for imported flex clusters in mongodbatlas_advanced_cluster

Link to any related issue(s): CLOUDP-296377

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
