### PR TITLE
fix: Removes `interval_min` plan modifier to avoid error on update

### DIFF
--- a/.changelog/3051.txt
+++ b/.changelog/3051.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_alert_configuration: Removes UseStateForUnknown plan modifier for interval_min
+```

--- a/internal/service/alertconfiguration/resource_alert_configuration.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration.go
@@ -283,9 +283,6 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 						"interval_min": schema.Int64Attribute{
 							Optional: true,
 							Computed: true,
-							PlanModifiers: []planmodifier.Int64{
-								int64planmodifier.UseStateForUnknown(),
-							},
 						},
 						"mobile_number": schema.StringAttribute{
 							Optional: true,

--- a/internal/service/alertconfiguration/resource_alert_configuration_test.go
+++ b/internal/service/alertconfiguration/resource_alert_configuration_test.go
@@ -495,7 +495,7 @@ func TestAccConfigRSAlertConfiguration_withEmailToPagerDuty(t *testing.T) {
 				ImportStateIdFunc: importStateProjectIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
-				// service key is not returned by api in import operation
+				// service_key is not returned by api in import operation
 				// integration_id is not returned during Create
 				ImportStateVerifyIgnore: []string{"updated", "notification.0.service_key", "notification.0.integration_id"},
 			},


### PR DESCRIPTION
## Description

avoids error when updating from an email notification to a 'PAGER_DUTY', 'OPS_GENIE' or 'VICTOR_OPS' that require `interval_min` attribute to *not* be set

```
mongodbatlas_alert_configuration.no_primary[0]: Modifying... [id=aWQ=:NjdhYjIwYWVmMTRjZDc2MmNiYjliNDZh-cHJvamVjdF9pZA==:NjZkNmQyYmRiMTgxZjg2NjUyMjI1MDli]
╷
│ Error: error updating Alert Configuration information: %s
│ 
│   with mongodbatlas_alert_configuration.no_primary[0],
│   on main.tf line 131, in resource "mongodbatlas_alert_configuration" "no_primary":
│  131: resource "mongodbatlas_alert_configuration" "no_primary" {
│ 
│ 'interval_min' must not be set if type_name is 'PAGER_DUTY', 'OPS_GENIE' or 'VICTOR_OPS'
╵
```

Link to any related issue(s): HELP-70810

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
