### PR TITLE
test: Tenant clusters with disk_size_gb is always 5 now

### DIFF
--- a/internal/service/cluster/resource_cluster_test.go
+++ b/internal/service/cluster/resource_cluster_test.go
@@ -1023,41 +1023,6 @@ func TestAccCluster_withAutoScalingAWS(t *testing.T) {
 func TestAccCluster_tenant(t *testing.T) {
 	var (
 		resourceName           = "mongodbatlas_cluster.tenant"
-		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 3)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps: []resource.TestStep{
-			{
-				Config: configTenant(projectID, clusterName, "M2", "2"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "2"),
-					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
-				),
-			},
-			{
-				Config: configTenantUpdated(projectID, clusterName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckExistsCluster(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
-					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
-					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCluster_tenant_m5(t *testing.T) {
-	var (
-		resourceName           = "mongodbatlas_cluster.tenant"
 		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 1)
 	)
 
@@ -1073,6 +1038,16 @@ func TestAccCluster_tenant_m5(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
 					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
+				),
+			},
+			{
+				Config: configTenantUpdated(projectID, clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acc.CheckExistsCluster(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "disk_size_gb", "10"),
 					resource.TestCheckResourceAttrSet(resourceName, "mongo_uri"),
 				),
 			},

--- a/internal/testutil/unit/http_mocker_api_paths_test.go
+++ b/internal/testutil/unit/http_mocker_api_paths_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApiPathsParsing(t *testing.T) {
 	specParts := unit.ReadAPISpecPaths()
-	assert.Len(t, specParts, 5)
+	assert.GreaterOrEqual(t, len(specParts), 5)
 	assert.Contains(t, specParts, "GET")
 	processArgsPath := "/api/atlas/v2/groups/6746ceed6f62fc3c122a3e0e/clusters/test-acc-tf-c-7871793563057636102/processArgs"
 	getPaths := specParts["GET"]


### PR DESCRIPTION
## Description

Tenant clusters with disk_size_gb is always 5 now.
Since the shimming logic is in place, all M2 and M5 clusters are flex clusters which have `disk_size_gb` 5. Changing the relevant tests accordingly

```
TestAccCluster_tenant
    resource_cluster_test.go:1029: Step 1/2 error: Check failed: Check 4/5 error: mongodbatlas_cluster.tenant: Attribute 'disk_size_gb' expected "2", got "5"
```

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
