### PR TITLE
fix: Handles updates of `mongodbatlas_global_cluster_config`

### DIFF
--- a/.changelog/3060.txt
+++ b/.changelog/3060.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_global_cluster_config: Supports update operation
+```

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -6,7 +6,7 @@
 
 -> **NOTE:** This resource can only be used with Atlas-managed clusters. See doc for `global_cluster_self_managed_sharding` attribute in [`mongodbatlas_advanced_cluster` resource](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) for more info.
 
-~> **IMPORTANT:** A Global Cluster Configuration can be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/). For more details, see [Global Clusters API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters)
+~> **IMPORTANT:** You can update a Global Cluster Configuration to add new custom zone mappings and managed namespaces. However, once configured, you can't modify or partially delete custom zone mappings (you must remove them all at once). You can add or remove, but can't modify, managed namespaces. Any update that changes an existing managed namespace results in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/). For more details, see [Global Clusters API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters)
 
 ## Examples Usage
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -6,7 +6,7 @@
 
 -> **NOTE:** This resource can only be used with Atlas-managed clusters. See doc for `global_cluster_self_managed_sharding` attribute in [`mongodbatlas_advanced_cluster` resource](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) for more info.
 
-~> **IMPORTANT:** A Global Cluster Configuration, once created, can only be deleted. You can recreate the Global Cluster with the same data only in the Atlas UI. This is because the configuration and its related collection with shard key and indexes are managed separately and they would end up in an inconsistent state. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
+~> **IMPORTANT:** A Global Cluster Configuration can now be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
 
 ## Examples Usage
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -6,7 +6,7 @@
 
 -> **NOTE:** This resource can only be used with Atlas-managed clusters. See doc for `global_cluster_self_managed_sharding` attribute in [`mongodbatlas_advanced_cluster` resource](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) for more info.
 
-~> **IMPORTANT:** A Global Cluster Configuration can now be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
+~> **IMPORTANT:** A Global Cluster Configuration can be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
 
 ## Examples Usage
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -6,7 +6,7 @@
 
 -> **NOTE:** This resource can only be used with Atlas-managed clusters. See doc for `global_cluster_self_managed_sharding` attribute in [`mongodbatlas_advanced_cluster` resource](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) for more info.
 
-~> **IMPORTANT:** A Global Cluster Configuration can be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/)
+~> **IMPORTANT:** A Global Cluster Configuration can be updated to add new custom zone mappings and managed namespaces. However, once configured, custom zone mappings cannot be modified or partially deleted (you must remove them all at once), and managed namespaces can be added or removed but cannot be modified. Any update that would change an existing managed namespace will result in an error. [Read more about Global Cluster Configuration](https://www.mongodb.com/docs/atlas/global-clusters/). For more details, see [Global Clusters API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Global-Clusters)
 
 ## Examples Usage
 

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -234,7 +234,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			if newEntry, exists := newMap[key]; exists {
 				// Modification detected: key exists but value differs.
 				if !reflect.DeepEqual(oldEntry, newEntry) {
-					return diag.FromErr(fmt.Errorf("managed namespace for collection '%s' in db '%s' cannot be modified; remove it and add a new entry instead", oldEntry["collection"], oldEntry["db"]))
+					return diag.FromErr(fmt.Errorf("managed namespace for collection '%s' in db '%s' cannot be modified", oldEntry["collection"], oldEntry["db"]))
 				}
 			} else {
 				toRemove = append(toRemove, oldEntry)

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -211,9 +212,92 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return diag.Errorf("Updating a global cluster configuration resource is not allowed as it would " +
-		"leave the index and shard key on the related collection in an inconsistent state.\n" +
-		"Please read our official documentation for more information.")
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	ids := conversion.DecodeStateID(d.Id())
+	projectID := ids["project_id"]
+	clusterName := ids["cluster_name"]
+
+	if d.HasChange("managed_namespaces") {
+		old, newMN := d.GetChange("managed_namespaces")
+		oldList := old.(*schema.Set).List()
+		newList := newMN.(*schema.Set).List()
+
+		// Build maps keyed by composite key: "collection:db"
+		oldMap := buildManagedNamespacesMap(oldList)
+		newMap := buildManagedNamespacesMap(newList)
+
+		var toRemove []map[string]any
+		var toAdd []map[string]any
+
+		// Check for modifications or removals
+		for key, oldEntry := range oldMap {
+			if newEntry, exists := newMap[key]; exists {
+				// Modification detected: key exists but value differs.
+				if !reflect.DeepEqual(oldEntry, newEntry) {
+					return diag.FromErr(fmt.Errorf("managed namespace for collection '%s' in db '%s' cannot be modified; remove it and add a new entry instead", oldEntry["collection"], oldEntry["db"]))
+				}
+			} else {
+				toRemove = append(toRemove, oldEntry)
+			}
+		}
+		// Check for pure additions
+		for key, newEntry := range newMap {
+			if _, exists := oldMap[key]; !exists {
+				toAdd = append(toAdd, newEntry)
+			}
+		}
+
+		if len(toRemove) > 0 {
+			if err := removeManagedNamespaces(ctx, connV2, convertInterfaceSlice(toRemove), projectID, clusterName); err != nil {
+				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
+			}
+		}
+		if len(toAdd) > 0 {
+			if err := addManagedNamespaces(ctx, connV2, convertInterfaceSlice(toAdd), projectID, clusterName); err != nil {
+				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
+			}
+		}
+	}
+
+	if d.HasChange("custom_zone_mappings") {
+		old, newZN := d.GetChange("custom_zone_mappings")
+		oldSet := old.(*schema.Set)
+		newSet := newZN.(*schema.Set)
+
+		removed := oldSet.Difference(newSet).List()
+		added := newSet.Difference(oldSet).List()
+
+		if len(removed) > 0 {
+			// Allow deletion only if all mappings are deleted
+			if newSet.Len() == 0 {
+				if _, _, err := connV2.GlobalClustersApi.DeleteAllCustomZoneMappings(ctx, projectID, clusterName).Execute(); err != nil {
+					return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
+				}
+			} else {
+				// Partial deletion is not allowed
+				return diag.FromErr(fmt.Errorf("partial deletion of custom_zone_mappings is not allowed; remove either all mappings or none"))
+			}
+		}
+
+		// Allow addition of new custom_zone_mappings.
+		if len(added) > 0 {
+			if _, _, err := connV2.GlobalClustersApi.CreateCustomZoneMapping(ctx, projectID, clusterName, &admin.CustomZoneMappings{
+				CustomZoneMappings: newCustomZoneMappings(added),
+			}).Execute(); err != nil {
+				return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
+			}
+		}
+	}
+	return resourceRead(ctx, d, meta)
+}
+
+// Helper function to convert []map[string]any into []any
+func convertInterfaceSlice(input []map[string]any) []any {
+	var out []any
+	for _, v := range input {
+		out = append(out, v)
+	}
+	return out
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -334,4 +418,38 @@ func newCustomZoneMappings(tfList []any) *[]admin.ZoneMapping {
 	}
 
 	return &apiObjects
+}
+
+func addManagedNamespaces(ctx context.Context, connV2 *admin.APIClient, add []any, projectID, clusterName string) error {
+	for _, m := range add {
+		mn := m.(map[string]any)
+
+		addManagedNamespace := &admin.ManagedNamespaces{
+			Collection:     mn["collection"].(string),
+			Db:             mn["db"].(string),
+			CustomShardKey: mn["custom_shard_key"].(string),
+		}
+		if isCustomShardKeyHashed, okCustomShard := mn["is_custom_shard_key_hashed"]; okCustomShard {
+			addManagedNamespace.IsCustomShardKeyHashed = conversion.Pointer[bool](isCustomShardKeyHashed.(bool))
+		}
+		if isShardKeyUnique, okShard := mn["is_shard_key_unique"]; okShard {
+			addManagedNamespace.IsShardKeyUnique = conversion.Pointer[bool](isShardKeyUnique.(bool))
+		}
+		_, _, err := connV2.GlobalClustersApi.CreateManagedNamespace(ctx, projectID, clusterName, addManagedNamespace).Execute()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildManagedNamespacesMap converts a list of managed_namespace entries into a map keyed by "collection:db"
+func buildManagedNamespacesMap(list []any) map[string]map[string]any {
+	namespacesMap := make(map[string]map[string]any)
+	for _, item := range list {
+		m := item.(map[string]any)
+		key := fmt.Sprintf("%s:%s", m["collection"].(string), m["db"].(string))
+		namespacesMap[key] = m
+	}
+	return namespacesMap
 }

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -237,7 +237,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	return resourceRead(ctx, d, meta)
 }
 
-// Helper function to convert []map[string]any into []any
+// convertInterfaceSlice is a helper function that converts []map[string]any into []any
 func convertInterfaceSlice(input []map[string]any) []any {
 	var out []any
 	for _, v := range input {

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -218,8 +218,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	clusterName := ids["cluster_name"]
 
 	if d.HasChange("managed_namespaces") {
-		old, newMN := d.GetChange("managed_namespaces")
-		oldList := old.(*schema.Set).List()
+		oldMN, newMN := d.GetChange("managed_namespaces")
+		oldList := oldMN.(*schema.Set).List()
 		newList := newMN.(*schema.Set).List()
 		if err := updateManagedNamespaces(ctx, connV2, projectID, clusterName, oldList, newList); err != nil {
 			return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))
@@ -227,8 +227,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	if d.HasChange("custom_zone_mappings") {
-		old, newZN := d.GetChange("custom_zone_mappings")
-		oldSet := old.(*schema.Set)
+		oldZN, newZN := d.GetChange("custom_zone_mappings")
+		oldSet := oldZN.(*schema.Set)
 		newSet := newZN.(*schema.Set)
 		if err := updateCustomZoneMappings(ctx, connV2, projectID, clusterName, oldSet, newSet); err != nil {
 			return diag.FromErr(fmt.Errorf(errorGlobalClusterUpdate, clusterName, err))

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -157,6 +157,26 @@ func TestAccGlobalClusterConfig_database(t *testing.T) {
 				),
 			},
 			{
+				Config:      configWithDBConfig(&clusterInfo, customZone),
+				ExpectError: regexp.MustCompile("partial deletion of custom_zone_mappings is not allowed; remove either all mappings or none"),
+			},
+			{
+				Config: configWithDBConfig(&clusterInfo, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil,
+						[]string{"project_id"},
+						map[string]string{
+							"cluster_name":         clusterInfo.Name,
+							"managed_namespaces.#": "5",
+							"managed_namespaces.0.is_custom_shard_key_hashed": "false",
+							"managed_namespaces.0.is_shard_key_unique":        "false",
+							"custom_zone_mapping_zone_id.%":                   "0",
+							"custom_zone_mapping.%":                           "0",
+						}),
+				),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       importStateIDFunc(resourceName),
 				ImportState:             true,

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -61,7 +61,7 @@ func basicTestCase(tb testing.TB, checkZoneID, withBackup bool) *resource.TestCa
 			},
 			{
 				Config:      configBasic(&clusterInfo, true, false),
-				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed"),
+				ExpectError: regexp.MustCompile("managed namespace for collection 'publishers' in db 'mydata' cannot be modified"),
 			},
 		},
 	}
@@ -137,8 +137,24 @@ func TestAccGlobalClusterConfig_database(t *testing.T) {
 				),
 			},
 			{
-				Config:      configWithDBConfig(&clusterInfo, customZoneUpdated),
-				ExpectError: regexp.MustCompile("Updating a global cluster configuration resource is not allowed"),
+				Config: configWithDBConfig(&clusterInfo, customZoneUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					checkZone(0, "US", clusterInfo.ResourceName, true),
+					checkZone(1, "IE", clusterInfo.ResourceName, true),
+					checkZone(2, "DE", clusterInfo.ResourceName, true),
+					checkZone(3, "JP", clusterInfo.ResourceName, true),
+					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil,
+						[]string{"project_id"},
+						map[string]string{
+							"cluster_name":         clusterInfo.Name,
+							"managed_namespaces.#": "5",
+							"managed_namespaces.0.is_custom_shard_key_hashed": "false",
+							"managed_namespaces.0.is_shard_key_unique":        "false",
+							"custom_zone_mapping_zone_id.%":                   "4",
+							"custom_zone_mapping.%":                           "4",
+						}),
+				),
 			},
 			{
 				ResourceName:            resourceName,


### PR DESCRIPTION
## Description

Reverts https://github.com/mongodb/terraform-provider-mongodbatlas/pull/2282 to be able to handle updates of `mongodbatlas_global_cluster_config` but with the following adaptations:
- error if an existing `managed_namespace` entry is being modified. We can manage collection and db fields to do so.
- for new `managed_namespace` entries call the POST for each of them
- for deleted `managed_namespace` entries call the DELETE for each of them
- add new `custom_zone_mappings` and call the POST for each of them
- only allow `custom_zone_mappings` deletion if all of them are being deleted

Link to any related issue(s): CLOUDP-301529

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
