### PR TITLE
doc: Adds remaining work to migrate_cluster_to_advanced_cluster examples

### DIFF
--- a/examples/migrate_cluster_to_advanced_cluster/basic/outputs.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/outputs.tf
@@ -1,4 +1,5 @@
 output "connection_string_standard" {
+  description = "Public connection string that you can use to connect to this cluster. This connection string uses the `mongodb://` protocol."
   # value = mongodbatlas_cluster.this.connection_strings[0].standard # BEFORE
   value = mongodbatlas_advanced_cluster.this.connection_strings.standard # AFTER
 }
@@ -8,6 +9,7 @@ output "connection_string_standard" {
 # }
 
 output "container_id" {
+  description = "The Network Peering Container ID of the configuration specified in `region_configs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created. Example `AWS:US_EAST_1\" = \"61e0797dde08fb498ca11a71`"
   # value = mongodbatlas_cluster.this.container_id # BEFORE
   value = mongodbatlas_advanced_cluster.this.replication_specs[0].container_id["AWS:US_EAST_1"] # AFTER
 }

--- a/examples/migrate_cluster_to_advanced_cluster/basic/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/variables.tf
@@ -1,15 +1,19 @@
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "instance_size" {
-  type = string
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }

--- a/examples/migrate_cluster_to_advanced_cluster/basic/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.26" # TODO: Update me
+      version = "~> 1.26" # todo: PLACEHOLDER_TPF_RELEASE
     }
   }
-  required_version = ">= 1.5" # TODO: Update me
+  required_version = ">= 1.8" # Minimum moved block supported version
 }

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
@@ -59,7 +59,7 @@ The module supports standalone usage when there is no existing `mongodbatlas_clu
 - `mongodbatlas.version` bumped to `1.27.0` for new `mongodbatlas_advanced_cluster` v2 schema support
 
 ### [`main.tf`](v2/main.tf)
-- `locals.replication_specs` an intermediate variable transforming the `variables` to a compatible [replication_specs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_clusters%2520%2528preview%2520provider%2520v2%2529#replication_specs-1) for `mongodbatlas_advanced_cluster`
+- `locals.replication_specs` an intermediate variable transforming the `variables` to a compatible [replication_specs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster%2520%2528preview%2520provider%2520v2%2529#replication_specs-1) for `mongodbatlas_advanced_cluster`
   - We use the Terraform builtin [range](https://developer.hashicorp.com/terraform/language/functions/range) function (`range(old_spec.num_shards)`) to flatten `num_shards`
   - We expand `read_only_specs` and `electable_specs` into nested attributes
   - We use the `var.provider_name` in the `region_configs.*.instance_size`

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
@@ -55,12 +55,11 @@ The module supports standalone usage when there is no existing `mongodbatlas_clu
 
 ### [`variables.tf`](v2/variables.tf) unchanged from `v1`
 ### [`versions.tf`](v2/versions.tf)
-- `required_version` of Terraform CLI bumped to `# todo: minimum moved block supported version` for `moved` block support
-- `mongodbatlas.version` bumped to `# todo: PLACEHOLDER_TPF_RELEASE` for new `mongodbatlas_advanced_cluster` v2 schema support
+- `required_version` of Terraform CLI bumped to `1.8` for `moved` block [support](https://developer.hashicorp.com/terraform/plugin/framework/resources/state-move) between resource types
+- `mongodbatlas.version` bumped to `1.27.0` for new `mongodbatlas_advanced_cluster` v2 schema support
 
 ### [`main.tf`](v2/main.tf)
-<!-- TODO: Update link to (schema v2) docs page -->
-- `locals.replication_specs` an intermediate variable transforming the `variables` to a compatible [replication_specs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster#replication_specs-1) for `mongodbatlas_advanced_cluster`
+- `locals.replication_specs` an intermediate variable transforming the `variables` to a compatible [replication_specs](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_clusters%2520%2528preview%2520provider%2520v2%2529#replication_specs-1) for `mongodbatlas_advanced_cluster`
   - We use the Terraform builtin [range](https://developer.hashicorp.com/terraform/language/functions/range) function (`range(old_spec.num_shards)`) to flatten `num_shards`
   - We expand `read_only_specs` and `electable_specs` into nested attributes
   - We use the `var.provider_name` in the `region_configs.*.instance_size`

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/outputs.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/outputs.tf
@@ -1,6 +1,6 @@
 output "mongodb_connection_strings" {
   value       = mongodbatlas_cluster.this.connection_strings
-  description = "These are the MongoDB Atlas connection strings. Note that these do not show the connection mechanism of the database details"
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
 }
 
 output "cluster_name" {

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/variables.tf
@@ -53,7 +53,7 @@ variable "replication_specs" {
   type = list(object({
     num_shards = number
     zone_name  = string
-    regions_config = set(object({
+    regions_config = list(object({
       region_name     = string
       electable_nodes = number
       priority        = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/variables.tf
@@ -1,45 +1,55 @@
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 variable "instance_size" {
-  type = string
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 variable "provider_name" {
-  type = string
+  description = "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
+  type        = string
 }
 
 # OPTIONAL VARIABLES
 
 variable "disk_size" {
-  type    = number
-  default = 0
+  description = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
+  type        = number
+  default     = 0
 }
 
 variable "auto_scaling_disk_gb_enabled" {
-  type    = bool
-  default = false
+  description = "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 variable "replication_specs" {
+  description = "List of replication specifications in mongodbatlas_cluster format"
   type = list(object({
     num_shards = number
     zone_name  = string

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/outputs.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/outputs.tf
@@ -1,6 +1,6 @@
 output "mongodb_connection_strings" {
   value       = mongodbatlas_advanced_cluster.this.connection_strings
-  description = "This is the MongoDB Atlas connection strings. Note, these do not show the connection mechanism of the database details"
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
 }
 
 output "cluster_name" {

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/variables.tf
@@ -53,7 +53,7 @@ variable "replication_specs" {
   type = list(object({
     num_shards = number
     zone_name  = string
-    regions_config = set(object({
+    regions_config = list(object({
       region_name     = string
       electable_nodes = number
       priority        = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/variables.tf
@@ -1,45 +1,55 @@
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 variable "instance_size" {
-  type = string
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 variable "provider_name" {
-  type = string
+  description = "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
+  type        = string
 }
 
 # OPTIONAL VARIABLES
 
 variable "disk_size" {
-  type    = number
-  default = 0
+  description = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
+  type        = number
+  default     = 0
 }
 
 variable "auto_scaling_disk_gb_enabled" {
-  type    = bool
-  default = false
+  description = "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 variable "replication_specs" {
+  description = "List of replication specifications in mongodbatlas_cluster format"
   type = list(object({
     num_shards = number
     zone_name  = string

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/outputs.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/outputs.tf
@@ -1,6 +1,6 @@
 output "mongodb_connection_strings" {
   value       = mongodbatlas_advanced_cluster.this.connection_strings
-  description = "This is the MongoDB Atlas connection strings. Note, these do not show the connection mechanism of the database details"
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
 }
 
 output "cluster_name" {

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/variables.tf
@@ -56,7 +56,7 @@ variable "replication_specs" {
   type = list(object({
     num_shards = number
     zone_name  = string
-    regions_config = set(object({
+    regions_config = list(object({
       region_name     = string
       electable_nodes = number
       priority        = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/variables.tf
@@ -1,48 +1,57 @@
 # v1 & v2 variables
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 # OPTIONAL VARIABLES
 variable "instance_size" {
-  type    = string
-  default = "" # optional in v3
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
+  default     = "" # optional in v3
 }
 variable "provider_name" {
-  type    = string
-  default = "" # optional in v3
+  description = "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
+  type        = string
+  default     = "" # optional in v3
 }
 
 variable "disk_size" {
-  type    = number
-  default = 0
+  description = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
+  type        = number
+  default     = 0
 }
 
 variable "auto_scaling_disk_gb_enabled" {
-  type    = bool
-  default = false
+  description = "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 variable "replication_specs" {
-  description = "List of replication specifications in legacy mongodbatlas_cluster format"
+  description = "List of replication specifications in mongodbatlas_cluster format"
   default     = []
   type = list(object({
     num_shards = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/README.md
@@ -26,9 +26,7 @@ The rest of this example is a step by step guide on how to migrate from `mongodb
 - [Cleanup with `terraform destroy`](#cleanup-with-terraform-destroy)
 
 ## Dependencies
-<!-- TODO: Update XX versions -->
-<!-- TODO: Update the `versions.tf` inside each vX -->
-- Terraform CLI >= 1.X
+- Terraform CLI >= 1.8
 - Terraform MongoDB Atlas Provider `>=v1.27.0`
 - A MongoDB Atlas account
 - Configure the provider (can also be done by configuring `public_key` and `private_key` in a `provider.tfvars`)

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v1/main.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v1/main.tf
@@ -19,5 +19,6 @@ module "cluster" {
 }
 
 output "mongodb_connection_strings" {
-  value = module.cluster.mongodb_connection_strings
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
+  value       = module.cluster.mongodb_connection_strings
 }

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v1/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v1/variables.tf
@@ -65,7 +65,7 @@ variable "replication_specs" {
   type = list(object({
     num_shards = number
     zone_name  = string
-    regions_config = set(object({
+    regions_config = list(object({
       region_name     = string
       electable_nodes = number
       priority        = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v1/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v1/variables.tf
@@ -11,47 +11,57 @@ variable "private_key" {
 
 # v1 & v2 variables
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 variable "instance_size" {
-  type = string
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 variable "provider_name" {
-  type = string
+  description = "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
+  type        = string
 }
 
 # OPTIONAL VARIABLES
 
 variable "disk_size" {
-  type    = number
-  default = 0
+  description = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
+  type        = number
+  default     = 0
 }
 
 variable "auto_scaling_disk_gb_enabled" {
-  type    = bool
-  default = false
+  description = "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 variable "replication_specs" {
+  description = "List of replication specifications in mongodbatlas_cluster format"
   type = list(object({
     num_shards = number
     zone_name  = string

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v2/main.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v2/main.tf
@@ -19,5 +19,6 @@ module "cluster" {
 }
 
 output "mongodb_connection_strings" {
-  value = module.cluster.mongodb_connection_strings
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
+  value       = module.cluster.mongodb_connection_strings
 }

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v2/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v2/variables.tf
@@ -65,7 +65,7 @@ variable "replication_specs" {
   type = list(object({
     num_shards = number
     zone_name  = string
-    regions_config = set(object({
+    regions_config = list(object({
       region_name     = string
       electable_nodes = number
       priority        = number

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v2/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v2/variables.tf
@@ -11,47 +11,57 @@ variable "private_key" {
 
 # v1 & v2 variables
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 variable "instance_size" {
-  type = string
+  description = "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 variable "provider_name" {
-  type = string
+  description = "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
+  type        = string
 }
 
 # OPTIONAL VARIABLES
 
 variable "disk_size" {
-  type    = number
-  default = 0
+  description = "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
+  type        = number
+  default     = 0
 }
 
 variable "auto_scaling_disk_gb_enabled" {
-  type    = bool
-  default = false
+  description = "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 variable "replication_specs" {
+  description = "List of replication specifications in mongodbatlas_cluster format"
   type = list(object({
     num_shards = number
     zone_name  = string

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v3/main.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v3/main.tf
@@ -15,5 +15,6 @@ module "cluster" {
 }
 
 output "mongodb_connection_strings" {
-  value = module.cluster.mongodb_connection_strings
+  description = "Collection of Uniform Resource Locators that point to the MongoDB database."
+  value       = module.cluster.mongodb_connection_strings
 }

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v3/variables.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v3/variables.tf
@@ -11,24 +11,29 @@ variable "private_key" {
 
 # v1 & v2 variables
 variable "project_id" {
-  type = string
+  description = "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
+  type        = string
 }
 
 variable "cluster_name" {
-  type = string
+  description = "Human-readable label that identifies this cluster."
+  type        = string
 }
 
 variable "cluster_type" {
-  type = string
+  description = "Configuration of nodes that comprise the cluster."
+  type        = string
 }
 
 variable "mongo_db_major_version" {
-  type = string
+  description = "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
+  type        = string
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  description = "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
+  type        = map(string)
+  default     = {}
 }
 
 # NEW variable
@@ -68,6 +73,6 @@ variable "replication_specs_new" {
       })
     }))
   }))
-  description = "List of replication specifications for different regions"
+  description = "List of replication specifications using new mongodbatlas_advanced_cluster format"
   default     = []
 }


### PR DESCRIPTION
## Description

Adds remaining work to migrate_cluster_to_advanced_cluster examples:

- [x] Add descriptions to all variables
- [x] Handle TODOs
- [ ] Docs copywrite review

Link to any related issue(s): CLOUDP-299314

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

### Variable descriptions (from `advancedclustertpf/schema.go`)
```yaml
project_id: "Unique 24-hexadecimal digit string that identifies your project. Use the `/groups` at https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects endpoint to retrieve all projects to which the authenticated user has access.  **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups"
cluster_name: "Human-readable label that identifies this cluster."
instance_size: 'Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as "base nodes") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.'
mongo_db_major_version: "MongoDB major version of the cluster.  On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/getProjectLtsVersions.   On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version."
cluster_type: "Configuration of nodes that comprise the cluster."
provider_name: "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`."
disk_size: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.   This value must be equal for all shards and node types.   This value is not configurable on M0/M2/M5 clusters.   MongoDB Cloud requires this parameter if you set **replicationSpecs**.   If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.    Storage charge calculations depend on whether you choose the default value or a custom value.   The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier."
auto_scaling_disk_gb_enabled: "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling."
tags: "Map that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster."
replication_specs: "List of replication specifications in mongodbatlas_cluster format"
replication_specs_new: "List of replication specifications using new mongodbatlas_advanced_cluster format"
public_key: Public API key to authenticate to Atlas
private_key: Private API key to authenticate to Atlas
```

### Output descriptions
```yaml
mongodb_connection_strings: "Collection of Uniform Resource Locators that point to the MongoDB database."
connection_string_standard: "Public connection string that you can use to connect to this cluster. This connection string uses the `mongodb://` protocol."
container_id: "The Network Peering Container ID of the configuration specified in `region_configs`. The Container ID is the id of the container either created programmatically by the user before any clusters existed in a project or when the first cluster in the region (AWS/Azure) or project (GCP) was created. Example `AWS:US_EAST_1\" = \"61e0797dde08fb498ca11a71`"
cluster_name: MongoDB Atlas cluster name
project_id: MongoDB Atlas project id
```