### PR TITLE
removing the "resp.Diagnostics.AddError("resource not found", err.Err…

### DIFF
--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -266,7 +266,6 @@ func (r *databaseUserRS) Read(ctx context.Context, req resource.ReadRequest, res
 		// deleted in the backend case
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.AddError("resource not found", err.Error())
 			return
 		}
 		resp.Diagnostics.AddError("error getting database user information", err.Error())


### PR DESCRIPTION
## Description

I have removed the `resp.Diagnostics.AddError("resource not found", err.Error())` from the following snippet in [terraform-provider-mongodbatlas/internal/service/databaseuser/resource_database_user.go](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/internal/service/databaseuser/resource_database_user.go#L267):
```
dbUser, httpResponse, err := connV2.DatabaseUsersApi.GetDatabaseUser(ctx, projectID, authDatabaseName, username).Execute()
	if err != nil {
		// case 404
		// deleted in the backend case
		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
			resp.State.RemoveResource(ctx)
			resp.Diagnostics.AddError("resource not found", err.Error())
			return
		}
		resp.Diagnostics.AddError("error getting database user information", err.Error())
		return
	}
```
This line `resp.Diagnostics.AddError("resource not found", err.Error())` adds an error to the response's diagnostics. In Terraform's framework, any error added to the Diagnostics object is treated as a blocking error, which stops further execution for the resource. This behavior caused the bug reported in [#3063](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3063).

The error was unnecessarily blocking the provider from continuing execution when the database user had been deleted manually. As a result, the resource was not being re-created even though it should have been.

By removing the line, the provider now correctly handles this scenario. I tested the following use cases successfully:

1. Creating a user through the provider.
2. Manually deleting the user outside the provider.
3. Re-creating the user via the provider without errors.

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3063

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
