### PR TITLE
fix: Handle the deleted on the backend case correctly for `mongodbatlas_database_user` resource

### DIFF
--- a/.changelog/3069.txt
+++ b/.changelog/3069.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_database_user: Don't fail on deleted in the backend case
+resource/mongodbatlas_database_user: Avoid error in read if resource no longer exists
 ```

--- a/.changelog/3069.txt
+++ b/.changelog/3069.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_database_user: Avoid error in read if resource no longer exists
+resource/mongodbatlas_database_user: Avoids error in read if resource no longer exists
 ```

--- a/.changelog/3069.txt
+++ b/.changelog/3069.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_database_user: Don't fail on deleted in the backend case
+```

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -3,7 +3,6 @@ package databaseuser
 import (
 	"context"
 	"errors"
-	"net/http"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -264,7 +264,7 @@ func (r *databaseUserRS) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		// case 404
 		// deleted in the backend case
-		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
+		if validate.StatusNotFound(httpResponse) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/service/databaseuser/resource_database_user.go
+++ b/internal/service/databaseuser/resource_database_user.go
@@ -266,7 +266,6 @@ func (r *databaseUserRS) Read(ctx context.Context, req resource.ReadRequest, res
 		// deleted in the backend case
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.AddError("resource not found", err.Error())
 			return
 		}
 		resp.Diagnostics.AddError("error getting database user information", err.Error())


### PR DESCRIPTION
## Description

Don't fail on the deleted on the backend case for `mongodbatlas_database_user` resource.
Thanks to @chagitgong for spotting the issue and creating the fix https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3067. I have created this PR, cherry-picking the commit from the original PR so that the CI checks can run

Link to any related issue(s): CLOUDP-300284

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
