### PR TITLE
doc: Document Flex cluster support in `mongodbatlas_advanced_cluster` resource and data sources

### DIFF
--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -88,18 +88,14 @@ data "mongodbatlas_advanced_cluster" "example" {
 resource "mongodbatlas_advanced_cluster" "example-flex" {
   project_id   = "<YOUR-PROJECT-ID>"
   name         = "flex-cluster"
-  cluster_type = "FLEX"
-
+  cluster_type = "REPLICASET"
+  
   replication_specs {
     region_configs {
-      electable_specs {
-        instance_size = "M10"
-      }
-      provider_name         = "TENANT"
+      provider_name = "FLEX"
       backing_provider_name = "AWS"
-      region_name           = "US_EAST_1"
-      // Ensure the priority is set to 7
-      priority              = 7
+      region_name = "US_EAST_1"
+      priority = 7
     }
   }
 }

--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -8,7 +8,7 @@
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).
 <br> &#8226; If your Atlas project contains a custom role that uses actions introduced in a specific MongoDB version, you cannot create a cluster with a MongoDB version less than that version unless you delete the custom role.
 
--> **NOTE:** This data source now also returns Flex clusters.
+-> **NOTE:** This data source also includes Flex clusters.
 
 ## Example Usage
 

--- a/docs/data-sources/advanced_cluster.md
+++ b/docs/data-sources/advanced_cluster.md
@@ -8,6 +8,8 @@
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).
 <br> &#8226; If your Atlas project contains a custom role that uses actions introduced in a specific MongoDB version, you cannot create a cluster with a MongoDB version less than that version unless you delete the custom role.
 
+-> **NOTE:** This data source now also returns Flex clusters.
+
 ## Example Usage
 
 ```terraform
@@ -77,6 +79,34 @@ data "mongodbatlas_advanced_cluster" "example" {
   project_id                     = mongodbatlas_advanced_cluster.example.project_id
   name                           = mongodbatlas_advanced_cluster.example.name
   use_replication_spec_per_shard = true
+}
+```
+
+## Example using Flex cluster
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "example-flex" {
+  project_id   = "<YOUR-PROJECT-ID>"
+  name         = "flex-cluster"
+  cluster_type = "FLEX"
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+      }
+      provider_name         = "TENANT"
+      backing_provider_name = "AWS"
+      region_name           = "US_EAST_1"
+      // Ensure the priority is set to 7
+      priority              = 7
+    }
+  }
+}
+
+data "mongodbatlas_advanced_cluster" "example" {
+  project_id = mongodbatlas_advanced_cluster.example-flex.project_id
+  name       = mongodbatlas_advanced_cluster.example-flex.name
 }
 ```
 

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -8,7 +8,7 @@
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).
 <br> &#8226; If your Atlas project contains a custom role that uses actions introduced in a specific MongoDB version, you cannot create a cluster with a MongoDB version less than that version unless you delete the custom role.
 
--> **NOTE:** This data source now also returns Flex clusters.
+-> **NOTE:** This data source also includes Flex clusters.
 
 ## Example Usage
 

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -101,7 +101,6 @@ resource "mongodbatlas_advanced_cluster" "example-flex" {
 
 data "mongodbatlas_advanced_cluster" "example" {
   project_id = mongodbatlas_advanced_cluster.example-flex.project_id
-  name       = mongodbatlas_advanced_cluster.example-flex.name
 }
 ```
 

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -99,7 +99,7 @@ resource "mongodbatlas_advanced_cluster" "example-flex" {
   }
 }
 
-data "mongodbatlas_advanced_cluster" "example" {
+data "mongodbatlas_advanced_clusters" "example" {
   project_id = mongodbatlas_advanced_cluster.example-flex.project_id
 }
 ```

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -81,6 +81,30 @@ data "mongodbatlas_advanced_cluster" "example-asym" {
 }
 ```
 
+## Example using Flex cluster
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "example-flex" {
+  project_id   = "<YOUR-PROJECT-ID>"
+  name         = "flex-cluster"
+  cluster_type = "REPLICASET"
+  
+  replication_specs {
+    region_configs {
+      provider_name = "FLEX"
+      backing_provider_name = "AWS"
+      region_name = "US_EAST_1"
+      priority = 7
+    }
+  }
+}
+
+data "mongodbatlas_advanced_cluster" "example" {
+  project_id = mongodbatlas_advanced_cluster.example-flex.project_id
+  name       = mongodbatlas_advanced_cluster.example-flex.name
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) The unique ID for the project to get the clusters.

--- a/docs/data-sources/advanced_clusters.md
+++ b/docs/data-sources/advanced_clusters.md
@@ -8,6 +8,8 @@
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).
 <br> &#8226; If your Atlas project contains a custom role that uses actions introduced in a specific MongoDB version, you cannot create a cluster with a MongoDB version less than that version unless you delete the custom role.
 
+-> **NOTE:** This data source now also returns Flex clusters.
+
 ## Example Usage
 
 ```terraform

--- a/docs/data-sources/flex_cluster.md
+++ b/docs/data-sources/flex_cluster.md
@@ -2,6 +2,8 @@
 
 `mongodbatlas_flex_cluster` describes a flex cluster.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
+
 ## Example Usages
 ```terraform
 resource "mongodbatlas_flex_cluster" "example-cluster" {

--- a/docs/data-sources/flex_cluster.md
+++ b/docs/data-sources/flex_cluster.md
@@ -2,7 +2,7 @@
 
 `mongodbatlas_flex_cluster` describes a flex cluster.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve Flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters, but also supports free and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
 
 ## Example Usages
 ```terraform

--- a/docs/data-sources/flex_clusters.md
+++ b/docs/data-sources/flex_clusters.md
@@ -2,6 +2,8 @@
 
 `mongodbatlas_flex_clusters` returns all flex clusters in a project.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_clusters` data source instead of `mongodbatlas_flex_clusters` data source to retrieve flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
+
 ## Example Usages
 ```terraform
 resource "mongodbatlas_flex_cluster" "example-cluster" {

--- a/docs/data-sources/flex_clusters.md
+++ b/docs/data-sources/flex_clusters.md
@@ -2,7 +2,7 @@
 
 `mongodbatlas_flex_clusters` returns all flex clusters in a project.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_clusters` data source instead of `mongodbatlas_flex_clusters` data source to retrieve flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_clusters` data source instead of the `mongodbatlas_flex_clusters` data source to retrieve Flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters, but also supports free and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
 
 ## Example Usages
 ```terraform

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -70,7 +70,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
 **NOTE:** There can only be one M0 cluster per project.
 
-**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Clluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
+**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Cluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
 
 When upgrading from the tenant, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -16,7 +16,7 @@ More information on considerations for using advanced clusters please see [Consi
 
 -> **NOTE:** Groups and projects are synonymous terms. You might find group_id in the official documentation.
 
--> **NOTE:** Flex clusters are now supported by this resource. Additionally, [M0 cluster can be upgraded to Flex](#example-tenant-cluster-upgrade-to-flex) and a [Flex cluster can be upgraded to Dedicated](#Example-Flex-Cluster-Upgrade). When creating a Flex cluster, make sure to set the priority value to 7.
+-> **NOTE:** This resource supports Flex clusters. Additionally, you can upgrade [M0 clusters to Flex](#example-tenant-cluster-upgrade-to-flex) and [Flex clusters to Dedicated](#Example-Flex-Cluster-Upgrade). When creating a Flex cluster, make sure to set the priority value to 7.
 
 ## Example Usage
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -16,6 +16,7 @@ More information on considerations for using advanced clusters please see [Consi
 
 -> **NOTE:** Groups and projects are synonymous terms. You might find group_id in the official documentation.
 
+-> **NOTE:** Flex clusters are now supported by this resource. Additionally, [M0 cluster can be upgraded to Flex](#example-tenant-cluster-upgrade-to-flex) and a [Flex cluster can be upgraded to Dedicated](#Example-Flex-Cluster-Upgrade). When creating a Flex cluster, make sure to set the priority value to 7.
 
 ## Example Usage
 
@@ -69,12 +70,76 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
 **NOTE:** There can only be one M0 cluster per project.
 
-**NOTE**: Upgrading the shared tier is supported. Any change from a shared tier cluster (a tenant) to a different instance size will be considered a tenant upgrade. When upgrading from the shared tier, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a shared tier cluster only to a single provider on an M10-tier cluster or greater. 
+**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Clluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
 
-When upgrading from the shared tier, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
+When upgrading from the tenant, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
 
 
 ### Example Tenant Cluster Upgrade
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = "PROJECT ID"
+  name         = "NAME OF CLUSTER"
+  cluster_type = "REPLICASET"
+
+  replication_specs {
+    region_configs {
+      electable_specs {
+        instance_size = "M10"
+      }
+      provider_name         = "AWS"
+      region_name           = "US_EAST_1"
+      priority              = 7
+    }
+  }
+}
+```
+
+### Example Tenant Cluster Upgrade to Flex
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "example-flex" {
+  project_id   = "PROJECT ID"
+  name         = "NAME OF CLUSTER"
+  cluster_type = "REPLICASET"
+
+  replication_specs {
+    region_configs {
+      provider_name = "FLEX"
+      backing_provider_name = "AWS"
+      region_name = "US_EAST_1"
+      priority = 7
+    }
+  }
+}
+```
+
+### Example Flex Cluster
+
+```terraform
+resource "mongodbatlas_advanced_cluster" "example-flex" {
+  project_id   = "PROJECT ID"
+  name         = "NAME OF CLUSTER"
+  cluster_type = "REPLICASET"
+
+  replication_specs {
+    region_configs {
+      provider_name = "FLEX"
+      backing_provider_name = "AWS"
+      region_name = "US_EAST_1"
+      priority = 7
+    }
+  }
+}
+```
+
+**NOTE**: Upgrading the flex cluster is supported. When upgrading from the flex cluster, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Flex Cluster Upgrade](#Example-Flex-Cluster-Upgrade) below. You can upgrade a flex cluster only to a single provider on an M10-tier cluster or greater. 
+
+When upgrading from a flex cluster, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
+
+
+### Example Flex Cluster Upgrade
 
 ```terraform
 resource "mongodbatlas_advanced_cluster" "test" {

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -134,7 +134,7 @@ resource "mongodbatlas_advanced_cluster" "example-flex" {
 }
 ```
 
-**NOTE**: Upgrading the flex cluster is supported. When upgrading from the flex cluster, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Flex Cluster Upgrade](#Example-Flex-Cluster-Upgrade) below. You can upgrade a flex cluster only to a single provider on an M10-tier cluster or greater. 
+**NOTE**: Upgrading the Flex cluster is supported. When upgrading from a Flex cluster, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Flex Cluster Upgrade](#Example-Flex-Cluster-Upgrade) below. You can upgrade a Flex cluster only to a single provider on an M10-tier cluster or greater. 
 
 When upgrading from a flex cluster, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -70,7 +70,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
 **NOTE:** There can only be one M0 cluster per project.
 
-**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Cluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
+**NOTE**: Upgrading the tenant cluster to  a Flex cluster or a dedicated cluster is supported. When upgrading to a Flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Cluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
 
 When upgrading from the tenant, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -70,7 +70,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
 **NOTE:** There can only be one M0 cluster per project.
 
-**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Clluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` from "TENANT" to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
+**NOTE**: Upgrading the tenant cluster to flex cluster or a dedicated cluster is supported. When upgrading to flex cluster, change the `provider_name` from "TENANT" to "FLEX". See [Example Tenant Clluster Upgrade to Flex](#example-tenant-cluster-upgrade-to-flex) below. When upgrading to a dedicated cluster, change the `provider_name` to your preferred provider (AWS, GCP or Azure) and remove the variable `backing_provider_name`.  See the [Example Tenant Cluster Upgrade](#Example-Tenant-Cluster-Upgrade) below. You can upgrade a tenant cluster only to a single provider on an M10-tier cluster or greater.
 
 When upgrading from the tenant, *only* the upgrade changes will be applied. This helps avoid a corrupt state file in the event that the upgrade succeeds but subsequent updates fail within the same `terraform apply`. To apply additional cluster changes, run a secondary `terraform apply` after the upgrade succeeds.
 

--- a/docs/resources/flex_cluster.md
+++ b/docs/resources/flex_cluster.md
@@ -2,6 +2,8 @@
 
 `mongodbatlas_flex_cluster` provides a Flex Cluster resource. The resource lets you create, update, delete and import a flex cluster.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` resource instead of `mongodbatlas_flex_cluster` resource to create and manage flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
+
 ## Example Usages
 
 ```terraform

--- a/docs/resources/flex_cluster.md
+++ b/docs/resources/flex_cluster.md
@@ -2,7 +2,7 @@
 
 `mongodbatlas_flex_cluster` provides a Flex Cluster resource. The resource lets you create, update, delete and import a flex cluster.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` resource instead of `mongodbatlas_flex_cluster` resource to create and manage flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` resource instead of the `mongodbatlas_flex_cluster` resource to create and manage Flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
 
 ## Example Usages
 

--- a/templates/data-sources/flex_cluster.md.tmpl
+++ b/templates/data-sources/flex_cluster.md.tmpl
@@ -2,7 +2,7 @@
 
 `{{.Name}}` describes a flex cluster.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` data source instead of the `mongodbatlas_flex_cluster` data source to retrieve Flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
 
 ## Example Usages
 {{ tffile (printf "examples/%s/main.tf" .Name )}}

--- a/templates/data-sources/flex_cluster.md.tmpl
+++ b/templates/data-sources/flex_cluster.md.tmpl
@@ -2,6 +2,8 @@
 
 `{{.Name}}` describes a flex cluster.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
+
 ## Example Usages
 {{ tffile (printf "examples/%s/main.tf" .Name )}}
 

--- a/templates/data-sources/flex_cluster.md.tmpl
+++ b/templates/data-sources/flex_cluster.md.tmpl
@@ -2,7 +2,7 @@
 
 `{{.Name}}` describes a flex cluster.
 
-**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` data source instead of the `mongodbatlas_flex_cluster` data source to retrieve Flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` data source instead of `mongodbatlas_flex_cluster` data source to retrieve Flex clusters. The `mongodbatlas_advanced_cluster` data source not only supports Flex clusters, but also supports free and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source.
 
 ## Example Usages
 {{ tffile (printf "examples/%s/main.tf" .Name )}}

--- a/templates/data-sources/flex_clusters.md.tmpl
+++ b/templates/data-sources/flex_clusters.md.tmpl
@@ -2,7 +2,7 @@
 
 `{{.Name}}` returns all flex clusters in a project.
 
-**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_clusters` data source instead of the `mongodbatlas_flex_clusters` data source to retrieve Flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_clusters` data source instead of the `mongodbatlas_flex_clusters` data source to retrieve Flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters, but also supports free and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
 
 ## Example Usages
 {{ tffile (printf "examples/mongodbatlas_flex_cluster/main.tf" )}}

--- a/templates/data-sources/flex_clusters.md.tmpl
+++ b/templates/data-sources/flex_clusters.md.tmpl
@@ -2,6 +2,8 @@
 
 `{{.Name}}` returns all flex clusters in a project.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_clusters` data source instead of `mongodbatlas_flex_clusters` data source to retrieve flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
+
 ## Example Usages
 {{ tffile (printf "examples/mongodbatlas_flex_cluster/main.tf" )}}
 

--- a/templates/data-sources/flex_clusters.md.tmpl
+++ b/templates/data-sources/flex_clusters.md.tmpl
@@ -2,7 +2,7 @@
 
 `{{.Name}}` returns all flex clusters in a project.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_clusters` data source instead of `mongodbatlas_flex_clusters` data source to retrieve flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_clusters` data source instead of the `mongodbatlas_flex_clusters` data source to retrieve Flex clusters. The `mongodbatlas_advanced_clusters` data source not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Clusters](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source.
 
 ## Example Usages
 {{ tffile (printf "examples/mongodbatlas_flex_cluster/main.tf" )}}

--- a/templates/resources/flex_cluster.md.tmpl
+++ b/templates/resources/flex_cluster.md.tmpl
@@ -2,7 +2,7 @@
 
 `{{.Name}}` provides a Flex Cluster resource. The resource lets you create, update, delete and import a flex cluster.
 
-**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` resource instead of `mongodbatlas_flex_cluster` resource to create and manage flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
+**RECOMMENDATION:** We recommend using the `mongodbatlas_advanced_cluster` resource instead of the `mongodbatlas_flex_cluster` resource to create and manage Flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters, but also supports tenant and dedicated clusters, providing easier migration between different cluster types. For more information, see the [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
 
 ## Example Usages
 

--- a/templates/resources/flex_cluster.md.tmpl
+++ b/templates/resources/flex_cluster.md.tmpl
@@ -2,6 +2,8 @@
 
 `{{.Name}}` provides a Flex Cluster resource. The resource lets you create, update, delete and import a flex cluster.
 
+**RECOMMENDATION:** We now recommend using the `mongodbatlas_advanced_cluster` resource instead of `mongodbatlas_flex_cluster` resource to create and manage flex clusters. The `mongodbatlas_advanced_cluster` resource not only supports Flex clusters but also supports tenant and dedicated clusters, providing easier transition between different cluster types. For more information, see [Advanced Cluster](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/advanced_cluster) resource.
+
 ## Example Usages
 
 {{ tffile (printf "examples/%s/main.tf" .Name )}}


### PR DESCRIPTION
## Description

Document Flex cluster support in `mongodbatlas_advanced_cluster` resource and data sources and recommend `mongodbatlas_advanced_cluster` over stand-alone flex cluster resource

Link to any related issue(s): CLOUDP-300269

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
