### PR TITLE
chore: Temporary fix on tenant cluster test passing zone name explicitly

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -141,6 +141,7 @@ func TestAccAdvancedCluster_basicTenant(t *testing.T) {
 				Check:  checkTenant(true, projectID, clusterName),
 			},
 			{
+				// zone name is hardcoded directly as a temporary fix, depends on CLOUDP-300819 or CLOUDP-301101
 				Config: configTenant(t, true, projectID, clusterNameUpdated, "Zone 1"),
 				Check:  checkTenant(true, projectID, clusterNameUpdated),
 			},

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -136,11 +136,12 @@ func TestAccAdvancedCluster_basicTenant(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configTenant(t, true, projectID, clusterName, ""),
+				// zone name is hardcoded directly as a temporary fix, depends on CLOUDP-300819 or CLOUDP-301101
+				Config: configTenant(t, true, projectID, clusterName, "Zone 1"),
 				Check:  checkTenant(true, projectID, clusterName),
 			},
 			{
-				Config: configTenant(t, true, projectID, clusterNameUpdated, ""),
+				Config: configTenant(t, true, projectID, clusterNameUpdated, "Zone 1"),
 				Check:  checkTenant(true, projectID, clusterNameUpdated),
 			},
 			acc.TestStepImportCluster(resourceName),


### PR DESCRIPTION
## Description

Link to any related issue(s): related to CLOUDP-301101

Ran test locally
```
^TestAccAdvancedCluster_basicTenant$ github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster

ok  	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster	521.168s
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
