### PR TITLE
chore: use set type for custom DB role's actions block

### DIFF
--- a/internal/service/customdbrole/resource_custom_db_role.go
+++ b/internal/service/customdbrole/resource_custom_db_role.go
@@ -51,7 +51,7 @@ func Resource() *schema.Resource {
 				),
 			},
 			"actions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Description

By using `TypeSet`, any reorders will not generate diffs anymore and addition/removal of `actions` block will generate more understandable diffs on Terraform executions.
I couldn't find why it uses `TypeList`, please let me know if there is a reason for it. This resource was introduced in this PR: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/108

Link to any related issue(s): https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3080

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

I built the provider locally and confirmed that reordering the `actions` block will not generate any diffs.

[MongoDB Atlas Administration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Custom-Database-Roles/operation/updateCustomDatabaseRole) will return the actions in the order they were created. However, this order is not significant and can be unordered by utilizing the `TypeSet` so that it's easier to review the changes.