### PR TITLE
fix: Avoids error in `mongodbatlas_maintenance_window` creation when `hour_of_day` is set to zero or empty

### DIFF
--- a/.changelog/3086.txt
+++ b/.changelog/3086.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_maintenance_window: Avoids error in creation when `hour_of_day` is set to zero or not defined
+```

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -101,13 +101,10 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	params := new(admin.GroupMaintenanceWindow)
 
-	if dayOfWeek, ok := d.GetOk("day_of_week"); ok {
-		params.DayOfWeek = cast.ToInt(dayOfWeek)
-	}
+	params.DayOfWeek = cast.ToInt(d.Get("day_of_week"))
 
-	if hourOfDay, ok := d.GetOk("hour_of_day"); ok {
-		params.HourOfDay = conversion.Pointer(cast.ToInt(hourOfDay))
-	}
+	hourOfDay := d.Get("hour_of_day")
+	params.HourOfDay = conversion.Pointer(cast.ToInt(hourOfDay)) // during creation of maintenance window hourOfDay needs to be set in PATCH to avoid errors, 0 value is sent when absent
 
 	if autoDeferOnceEnabled, ok := d.GetOk("auto_defer_once_enabled"); ok {
 		params.AutoDeferOnceEnabled = conversion.Pointer(autoDeferOnceEnabled.(bool))

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/spf13/cast"
@@ -16,7 +17,7 @@ func TestMigConfigMaintenanceWindow_basic(t *testing.T) {
 		projectName = acc.RandomProjectName()
 		dayOfWeek   = 7
 		hourOfDay   = 3
-		config      = configBasic(orgID, projectName, dayOfWeek, hourOfDay)
+		config      = configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay))
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -21,7 +21,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		orgID            = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName      = acc.RandomProjectName()
 		dayOfWeek        = 7
-		hourOfDay        = 3
+		hourOfDay        = 0
 		dayOfWeekUpdated = 4
 		hourOfDayUpdated = 5
 	)
@@ -31,6 +31,7 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
+				// testing hour_of_day set to 0 during creation phase does not return errors
 				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay)),
 				Check:  checkBasic(dayOfWeek, hourOfDay),
 			},
@@ -51,25 +52,6 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccConfigRSMaintenanceWindow_explicitZeroForHourOfDay(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		dayOfWeek   = 7
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(0)),
-				Check:  checkBasic(dayOfWeek, 0),
 			},
 		},
 	})

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -32,43 +32,19 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeek, hourOfDay),
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDayUpdated)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDayUpdated)),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeek, hourOfDayUpdated),
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeekUpdated, conversion.Pointer(hourOfDay)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeekUpdated)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeekUpdated, hourOfDay),
 			},
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeek, hourOfDay),
 			},
 			{
 				ResourceName:      resourceName,
@@ -93,13 +69,7 @@ func TestAccConfigRSMaintenanceWindow_explicitZeroForHourOfDay(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(0)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", "0"),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeek, 0),
 			},
 		},
 	})
@@ -118,13 +88,7 @@ func TestAccConfigRSMaintenanceWindow_emptyHourOfDay(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBasic(orgID, projectName, dayOfWeek, nil),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
-					resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
-					resource.TestCheckResourceAttr(resourceName, "hour_of_day", "0"),
-					resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
-				),
+				Check:  checkBasic(dayOfWeek, 0),
 			},
 		},
 	})
@@ -215,4 +179,14 @@ func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay 
 			hour_of_day = %[4]d
 			auto_defer_once_enabled = true
 		}`, orgID, projectName, dayOfWeek, hourOfDay)
+}
+
+func checkBasic(dayOfWeek, hourOfDay int) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkExists(resourceName),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttr(resourceName, "day_of_week", cast.ToString(dayOfWeek)),
+		resource.TestCheckResourceAttr(resourceName, "hour_of_day", cast.ToString(hourOfDay)),
+		resource.TestCheckResourceAttr(resourceName, "number_of_deferrals", "0"),
+	)
 }


### PR DESCRIPTION
## Description

Link to any related issue(s): HELP-71152

**API context**
When a maintenance window has never been configured (new project or [resetMaintenanceWindow](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/resetMaintenanceWindow) was called) when the initial PATCH is called `hourOfDay` must be provided or an error is returned from the API. [PATCH API docs](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/updateMaintenanceWindow) is currently unclear on this and upstream team has created a ticket to address this.

**Terraform changes**
Customer was failing to create a maintenance window with `hour_of_day = 0`. The same error is faced if `hour_of_day` is not defined (currently our schema marks it as optional). 
```
--- FAIL: TestAccConfigRSMaintenanceWindow_explicitZeroForHourOfDay (7.31s)
    /Users/agustin.bettati/mongodb/terraform-provider-mongodbatlas/internal/service/maintenancewindow/resource_maintenance_window_test.go:66: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating the MongoDB Atlas Maintenance Window (67b5b3111cabe66f710d1efb): https://cloud-dev.mongodb.com/api/atlas/v2/groups/67b5b3111cabe66f710d1efb/maintenanceWindow PATCH: HTTP 400 Bad Request (Error code: "ATLAS_INVALID_MAINTENANCE_WINDOW_HOUR_OF_DAY") Detail: Invalid Hour of Day. Value should be between 0 and 23. Reason: Bad Request. Params: [], BadRequestDetail: 
        
          with mongodbatlas_maintenance_window.test,
          on terraform_plugin_test.tf line 16, in resource "mongodbatlas_maintenance_window" "test":
          16: 		resource "mongodbatlas_maintenance_window" "test" {
```
Since resource is in SDK v2 we must treat these 2 cases equally.

The fix introduced is to always send a value for `hourOfDay` in the create operation, ensuring a 0 is sent for both cases. Potentially this attribute could be marked as required (same as `day_of_week`) in the schema however this would be a breaking change which could generate more impact.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
