### PR TITLE
fix: Avoids nil pointer error in `data.mongodbatlas_organizations` when getOrganization settings fails

### DIFF
--- a/.changelog/3118.txt
+++ b/.changelog/3118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/mongodbatlas_organizations: Avoids nil pointer error when individual getOrganizationSettings API call fails
+```

--- a/internal/service/organization/data_source_organizations.go
+++ b/internal/service/organization/data_source_organizations.go
@@ -132,7 +132,7 @@ func flattenOrganizations(ctx context.Context, conn *admin.APIClient, organizati
 	for k, organization := range organizations {
 		settings, _, err := conn.OrganizationsApi.GetOrganizationSettings(ctx, *organization.Id).Execute()
 		if err != nil {
-			return nil, fmt.Errorf("Error getting organization settings (orgID: %s, org Name: %s): %s", organization.GetId(), organization.GetName(), err)
+			return nil, fmt.Errorf("error getting organization settings (orgID: %s, org Name: %s): %s", organization.GetId(), organization.GetName(), err)
 		}
 		results[k] = map[string]any{
 			"id":                         organization.Id,

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -188,6 +188,18 @@ func TestAccConfigDSOrganization_basic(t *testing.T) {
 	})
 }
 
+func TestAccConfigDSOrganization_noAccessShouldNotFail(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithPluralDS() + acc.ConfigReadOnlyProvider(),
+				Check:  resource.TestCheckResourceAttrSet("data.mongodbatlas_organizations.test", "results.#"),
+			},
+		},
+	})
+}
+
 func TestAccConfigDSOrganizations_basic(t *testing.T) {
 	var (
 		datasourceName = "data.mongodbatlas_organizations.test"

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -188,13 +188,13 @@ func TestAccConfigDSOrganization_basic(t *testing.T) {
 	})
 }
 
-func TestAccConfigDSOrganization_noAccessShouldNotFail(t *testing.T) {
+func TestAccConfigDSOrganization_noAccessShouldFail(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithPluralDS() + acc.ConfigReadOnlyProvider(),
-				Check:  resource.TestCheckResourceAttrSet("data.mongodbatlas_organizations.test", "results.#"),
+				Config:      configWithPluralDS() + acc.ConfigReadOnlyProvider(),
+				ExpectError: regexp.MustCompile("Error getting organization settings .*"),
 			},
 		},
 	})

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -194,7 +194,7 @@ func TestAccConfigDSOrganization_noAccessShouldFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configWithPluralDS() + acc.ConfigOrgMemberProvider(),
-				ExpectError: regexp.MustCompile("Error getting organization settings .*"),
+				ExpectError: regexp.MustCompile("error getting organization settings .*"),
 			},
 		},
 	})

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -193,7 +193,7 @@ func TestAccConfigDSOrganization_noAccessShouldFail(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configWithPluralDS() + acc.ConfigReadOnlyProvider(),
+				Config:      configWithPluralDS() + acc.ConfigOrgMemberProvider(),
 				ExpectError: regexp.MustCompile("Error getting organization settings .*"),
 			},
 		},

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1070,7 +1070,7 @@ func TestAccProject_slowOperationReadOnly(t *testing.T) {
 		orgID                  = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName            = acc.RandomProjectName()
 		config                 = configBasic(orgID, projectName, "", false, nil, conversion.Pointer(false))
-		providerConfigReadOnly = acc.ConfigReadOnlyProvider()
+		providerConfigReadOnly = acc.ConfigOrgMemberProvider()
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPublicKey2(t) },

--- a/internal/testutil/acc/provider.go
+++ b/internal/testutil/acc/provider.go
@@ -97,7 +97,7 @@ func ConfigGovProvider() string {
 	return configProvider(os.Getenv("MONGODB_ATLAS_GOV_PUBLIC_KEY"), os.Getenv("MONGODB_ATLAS_GOV_PRIVATE_KEY"), os.Getenv("MONGODB_ATLAS_GOV_BASE_URL"))
 }
 
-func ConfigReadOnlyProvider() string {
+func ConfigOrgMemberProvider() string {
 	return configProvider(os.Getenv("MONGODB_ATLAS_PUBLIC_KEY_READ_ONLY"), os.Getenv("MONGODB_ATLAS_PRIVATE_KEY_READ_ONLY"), os.Getenv("MONGODB_ATLAS_BASE_URL"))
 }
 


### PR DESCRIPTION
## Description

- Avoids nil pointer error in `data.mongodbatlas_organizations` when getOrganizationSettings API call fails.
  - The call to `getOrganizationSettings` might fail if the API key doesn't have sufficient permissions

Link to any related issue(s): CLOUDP-302943 & #3113

### New user experience
Example config:
```terraform
terraform {
  required_version = ">=1.4"
  required_providers {
    mongodbatlas = {
        source  = "mongodb/mongodbatlas"
        version = "~>1.21"
    }
  }
}

provider "mongodbatlas" {}

data "mongodbatlas_organizations" "all" {}

```
Logs from `terraform apply`
```log
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Error getting organization settings (orgID: 64808d5f33a0c71e882ef19c, org Name: Terraform Test GitHub): https://cloud-dev.mongodb.com/api/atlas/v2/orgs/64808d5f33a0c71e882ef19c/settings GET: HTTP 401 Unauthorized (Error code: "USER_UNAUTHORIZED") Detail: Current user is not authorized to perform this action. Reason: Unauthorized. Params: [], BadRequestDetail: 
│ 
│   with data.mongodbatlas_organizations.all,
│   on main.tf line 13, in data "mongodbatlas_organizations" "all":
│   13: data "mongodbatlas_organizations" "all" {}
│ 
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### Reproducing
- See initial CI run [here with new test case](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13542168084/job/37845834222?pr=3118#step:5:472) (below code snippet)
- [OK](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13542409148/job/37846626785?pr=3118#step:5:470) CI run after fix

```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b9e3ad]

goroutine 330 [running]:
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/organization.flattenOrganizations({0x2b16f28, 0xc0000416c0}, 0xc000b9bc08, {0xc00078f020, 0x1, 0xc0017d9e60?})
	/home/runner/work/terraform-provider-mongodbatlas/terraform-provider-mongodbatlas/internal/service/organization/data_source_organizations.go:142 +0x4ed
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/organization.pluralDataSourceRead({0x2b16f28, 0xc0000416c0}, 0xc000e7f780, {0x22695e0?, 0xc000a5dc80?})
	/home/runner/work/terraform-provider-mongodbatlas/terraform-provider-mongodbatlas/internal/service/organization/data_source_organizations.go:109 +0x3f4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000b716c0, {0x2b16e80, 0xc000c0c9f0}, 0xc000e7f780, {0x22695e0, 0xc000a5dc80})
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:823 +0x119
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc000b716c0, {0x2b16e80, 0xc000c0c9f0}, 0xc000e7f680, {0x22695e0, 0xc000a5dc80})
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:1043 +0x13a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc000782210, {0x2b16e80?, 0xc000c0c870?}, 0xc000c0c900)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/grpc_provider.go:1436 +0x6aa
github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ReadDataSource({{0x2b29cb8?, 0xc000782210?}}, {0x2b16e80?, 0xc000c0c870?}, 0xc000c0c3c0?)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.17.0/tf5to6server/tf5to6server.go:200 +0x282
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).ReadDataSource(0xc000788a00, {0x2b16e80?, 0xc000c0c450?}, 0xc000c0c3c0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.17.0/tf6muxserver/mux_server_ReadDataSource.go:36 +0x193
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadDataSource(0xc000592140, {0x2b16e80?, 0xc00164d830?}, 0xc0017ce690)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/tf6server/server.go:688 +0x26d
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadDataSource_Handler({0x267d660, 0xc000592140}, {0x2b16e80, 0xc00164d830}, 0xc000e7f[480](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13542168084/job/37845834222?pr=3118#step:5:481), 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:665 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00014e000, {0x2b16e80, 0xc00164d7a0}, {0x2b220e0, 0xc00139ab60}, 0xc0018b3e60, 0xc0009ec810, 0x4158c20, 0x0)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1394 +0xe2b
google.golang.org/grpc.(*Server).handleStream(0xc00014e000, {0x2b220e0, 0xc00139ab60}, 0xc0018b3e60)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1805 +0xe8b
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1029 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 459
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.67.1/server.go:1040 +0x125
FAIL	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/organization
```




## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
