### PR TITLE
chore: Updates provider version in examples for AWS KMS over private networking feature

### DIFF
--- a/examples/mongodbatlas_encryption_at_rest_private_endpoint/aws/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest_private_endpoint/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.27"
+      version = "~> 1.28"
     }
 
     aws = {

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -48,7 +48,7 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 
 func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration
-	mig.SkipIfVersionBelow(t, "1.27.0")
+	mig.SkipIfVersionBelow(t, "1.28.0")
 
 	mig.CreateTestAndRunUseExternalProviderNonParallel(t, testCaseWithRoleBasicAWS(t), mig.ExternalProvidersWithAWS(), nil)
 }


### PR DESCRIPTION
## Description

Updates provider version in examples for AWS KMS over private networking feature

Link to any related issue(s): 
[CLOUDP-302164](https://jira.mongodb.org/browse/CLOUDP-302164)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
