### PR TITLE
feat: Supports new Https connection type in streams processing

### DIFF
--- a/.changelog/3138.txt
+++ b/.changelog/3138.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds `Https` connection
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connection: Adds `Https` connection
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -20,7 +20,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 ## Attributes Reference
 
-* `type` - Type of connection. Can be either `Cluster`, `Kafka` or `Sample`.
+* `type` - Type of connection. Can be either `Cluster`, `Kafka`, `Https` or `Sample`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -32,6 +32,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `config` - A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
 * `security` - Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers. 
 
 ### Authentication
 

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -32,7 +32,7 @@ In addition to all arguments above, it also exports the following attributes:
 * `project_id` - Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - Human-readable label that identifies the stream instance.
 * `connection_name` - Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - Type of connection. Can be either `Cluster`, `Kafka` or `Sample`.
+* `type` - Type of connection. Can be either `Cluster`, `Kafka`, `Https` or `Sample`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -44,6 +44,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 * `config` - A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
 * `security` - Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers.
 
 ### Authentication
 

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -66,12 +66,28 @@ resource "mongodbatlas_stream_connection" "test" {
 }
 ```
 
+### Example Https Connection
+
+```terraform
+resource "mongodbatlas_stream_connection" "example-https" {
+  project_id      = var.project_id
+  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "https_connection_tf_new"
+  type            = "Https"
+  url             = "https://example.com"
+  headers = {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - (Required) Human-readable label that identifies the stream instance.
 * `connection_name` - (Required) Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - (Required) Type of connection. Can be either `Cluster`, `Kafka` or `Sample`.
+* `type` - (Required) Type of connection. Can be either `Cluster`, `Kafka`, `Https` or `Sample`.
 
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -83,6 +99,10 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 * `config` - A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.
 * `security` - Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use. See [security](#security).
 * `networking` - Networking Access Type can either be `PUBLIC` (default) or `VPC`. See [networking](#networking).
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers.
 
 ### Authentication
 

--- a/examples/mongodbatlas_stream_connection/README.md
+++ b/examples/mongodbatlas_stream_connection/README.md
@@ -1,6 +1,6 @@
 # MongoDB Atlas Provider - Atlas Stream Instance defined in a Project
 
-This example shows how to create Atlas Stream Connections in Terraform. It also creates a stream instance, which is a prerequisite. Both Kafka and Cluster connections types are defined to showcase their usage.
+This example shows how to create Atlas Stream Connections in Terraform. It also creates a stream instance, which is a prerequisite. The Kafka, HTTPs and Cluster connections types are defined to showcase their usage.
 
 You must set the following variables:
 

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -70,6 +70,18 @@ resource "mongodbatlas_stream_connection" "example-sample" {
   type            = "Sample"
 }
 
+resource "mongodbatlas_stream_connection" "example-https" {
+  project_id      = var.project_id
+  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "HttpsConnection"
+  type            = "Https"
+  url             = "https://example.com"
+  headers = {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}
+
 data "mongodbatlas_stream_connection" "example-kafka-ssl" {
   project_id      = var.project_id
   instance_name   = mongodbatlas_stream_instance.example.instance_name

--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -85,6 +85,25 @@ func TestAccStreamDSStreamConnection_sample(t *testing.T) {
 	})
 }
 
+func TestAccStreamDSStreamConnection_https(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_stream_connection.test"
+		projectID      = acc.ProjectIDExecution(t)
+		instanceName   = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: streamConnectionDataSourceConfig(httpsStreamConnectionConfig(projectID, instanceName)),
+				Check:  httpsStreamConnectionAttributeChecks(dataSourceName, instanceName),
+			},
+		},
+	})
+}
+
 func streamConnectionDataSourceConfig(streamConnectionConfig string) string {
 	return fmt.Sprintf(`
 		%s

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -26,11 +26,17 @@ const (
 	sampleConnectionName      = "sample_stream_solar"
 	networkingType            = "PUBLIC"
 	privatelinkNetworkingType = "PRIVATE_LINK"
+	httpsURL                  = "https://example.com"
 )
 
-var configMap = map[string]string{
-	"auto.offset.reset": "earliest",
-}
+var (
+	configMap = map[string]string{
+		"auto.offset.reset": "earliest",
+	}
+	headersMap = map[string]string{
+		"header1": "value1",
+	}
+)
 
 type sdkToTFModelTestCase struct {
 	SDKResp              *admin.StreamsConnection
@@ -70,6 +76,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
 				DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -102,6 +109,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				Headers:          types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -123,6 +131,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
 				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -155,6 +164,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				Headers:          types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -175,6 +185,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
 				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 	}
@@ -238,21 +249,27 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Name: admin.PtrString(sampleConnectionName),
 						Type: admin.PtrString("Sample"),
 					},
+					{
+						Name:    admin.PtrString(connectionName),
+						Type:    admin.PtrString("Https"),
+						Url:     admin.PtrString(httpsURL),
+						Headers: &headersMap,
+					},
 				},
-				TotalCount: admin.PtrInt(3),
+				TotalCount: admin.PtrInt(4),
 			},
 			providedConfig: &streamconnection.TFStreamConnectionsDSModel{
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(3),
+				ItemsPerPage: types.Int64Value(4),
 			},
 			expectedTFModel: &streamconnection.TFStreamConnectionsDSModel{
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(3),
-				TotalCount:   types.Int64Value(3),
+				ItemsPerPage: types.Int64Value(4),
+				TotalCount:   types.Int64Value(4),
 				Results: []streamconnection.TFStreamConnectionModel{
 					{
 						ID:               types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -266,6 +283,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
 						DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 						Networking:       tfNetworkingObject(t, networkingType, nil),
+						Headers:          types.MapNull(types.StringType),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -279,6 +297,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
 						DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+						Headers:         types.MapNull(types.StringType),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, sampleConnectionName)),
@@ -292,6 +311,22 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
 						DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+						Headers:         types.MapNull(types.StringType),
+					},
+					{
+						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
+						ProjectID:       types.StringValue(dummyProjectID),
+						InstanceName:    types.StringValue(instanceName),
+						ConnectionName:  types.StringValue(connectionName),
+						Type:            types.StringValue("Https"),
+						ClusterName:     types.StringNull(),
+						Authentication:  types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+						Config:          types.MapNull(types.StringType),
+						Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+						DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
+						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+						Headers:         tfConfigMap(t, headersMap),
+						URL:             types.StringValue(httpsURL),
 					},
 				},
 			},
@@ -411,6 +446,23 @@ func TestStreamInstanceTFToSDKCreateModel(t *testing.T) {
 			expectedSDKReq: &admin.StreamsConnection{
 				Name: admin.PtrString(connectionName),
 				Type: admin.PtrString("Sample"),
+			},
+		},
+		{
+			name: "Https type TF state",
+			tfModel: &streamconnection.TFStreamConnectionModel{
+				ProjectID:      types.StringValue(dummyProjectID),
+				InstanceName:   types.StringValue(instanceName),
+				ConnectionName: types.StringValue(connectionName),
+				Type:           types.StringValue("Https"),
+				URL:            types.StringValue(httpsURL),
+				Headers:        tfConfigMap(t, headersMap),
+			},
+			expectedSDKReq: &admin.StreamsConnection{
+				Name:    admin.PtrString(connectionName),
+				Type:    admin.PtrString("Https"),
+				Url:     admin.PtrString(httpsURL),
+				Headers: &headersMap,
 			},
 		},
 	}

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -119,6 +119,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
+
+			// https type specific
+			"url": schema.StringAttribute{
+				Optional: true,
+			},
+			"headers": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
 		},
 	}
 }

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -46,6 +46,9 @@ type TFStreamConnectionModel struct {
 	Security         types.Object `tfsdk:"security"`
 	DBRoleToExecute  types.Object `tfsdk:"db_role_to_execute"`
 	Networking       types.Object `tfsdk:"networking"`
+	// https connection
+	Headers types.Map    `tfsdk:"headers"`
+	URL     types.String `tfsdk:"url"`
 }
 
 type TFConnectionAuthenticationModel struct {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -191,6 +191,31 @@ func TestAccStreamRSStreamConnection_sample(t *testing.T) {
 	})
 }
 
+func TestAccStreamRSStreamConnection_https(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_stream_connection.test"
+		projectID    = acc.ProjectIDExecution(t)
+		instanceName = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: httpsStreamConnectionConfig(projectID, instanceName),
+				Check:  httpsStreamConnectionAttributeChecks(resourceName, instanceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: checkStreamConnectionImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 	acc.SkipTestForCI(t) // requires Confluent Cloud resources
 	var (
@@ -299,6 +324,20 @@ func sampleStreamConnectionAttributeChecks(
 	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
 }
 
+func httpsStreamConnectionAttributeChecks(resourceName, instanceName string) resource.TestCheckFunc {
+	resourceChecks := []resource.TestCheckFunc{
+		checkStreamConnectionExists(),
+		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+		resource.TestCheckResourceAttr(resourceName, "instance_name", instanceName),
+		resource.TestCheckResourceAttr(resourceName, "connection_name", "ConnectionNameHttps"),
+		resource.TestCheckResourceAttr(resourceName, "type", "Https"),
+		resource.TestCheckResourceAttr(resourceName, "url", "https://example.com"),
+		resource.TestCheckResourceAttr(resourceName, "headers.Authorization", "Bearer token"),
+		resource.TestCheckResourceAttr(resourceName, "headers.key1", "value1"),
+	}
+	return resource.ComposeAggregateTestCheckFunc(resourceChecks...)
+}
+
 func kafkaStreamConnectionAttributeChecks(
 	resourceName, instanceName, username, password, bootstrapServers, configValue, networkingType string, usesSSL, checkPassword bool) resource.TestCheckFunc {
 	resourceChecks := []resource.TestCheckFunc{
@@ -352,6 +391,31 @@ func clusterStreamConnectionConfig(projectID, instanceName, clusterName string) 
 			}
 		}
 	`, projectID, instanceName, clusterName)
+}
+
+func httpsStreamConnectionConfig(projectID, instanceName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_stream_instance" "test" {
+			project_id = %[1]q
+			instance_name = %[2]q
+			data_process_region = {
+				region = "VIRGINIA_USA"
+				cloud_provider = "AWS"
+			}
+		}
+			
+		resource "mongodbatlas_stream_connection" "test" {
+			project_id = mongodbatlas_stream_instance.test.project_id
+			instance_name = mongodbatlas_stream_instance.test.instance_name
+			connection_name = "ConnectionNameHttps"
+			type = "Https"
+			url = "https://example.com"
+			headers = {
+				"Authorization" : "Bearer token",
+				"key1" : "value1"
+			} 
+		}
+	`, projectID, instanceName)
 }
 
 func clusterStreamConnectionAttributeChecks(resourceName, clusterName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Description
We added a new connection type Https in streams processing. The configuration of the connection needs the `url` field and takes in an optional `headers` field.

Link to any related issue(s):
[Ticket](https://jira.mongodb.org/browse/CLOUDP-301845)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
