### PR TITLE
feat: Add `error_message`, `provider_account_id`, and `interface_endpoint_name` to Stream PrivateLinkEndpoint models

### DIFF
--- a/.changelog/3139.txt
+++ b/.changelog/3139.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_privatelink_endpoint: Adds `error_message`, `interface_endpoint_name`, and `provider_account_id` attributes
+```

--- a/docs/data-sources/stream_privatelink_endpoint.md
+++ b/docs/data-sources/stream_privatelink_endpoint.md
@@ -93,7 +93,10 @@ output "interface_endpoint_ids" {
 
 - `dns_domain` (String) Domain name of Privatelink connected cluster.
 - `dns_sub_domain` (List of String) Sub-Domain name of Confluent cluster. These are typically your availability zones.
+- `error_message` (String) Error message if the connection is in a failed state.
 - `interface_endpoint_id` (String) Interface endpoint ID that is created from the specified service endpoint ID.
+- `interface_endpoint_name` (String) Interface endpoint name that is created from the specified service endpoint ID.
+- `provider_account_id` (String) Account ID from the cloud provider.
 - `provider_name` (String) Provider where the Kafka cluster is deployed.
 - `region` (String) Domain name of Confluent cluster.
 - `service_endpoint_id` (String) Service Endpoint ID.

--- a/docs/data-sources/stream_privatelink_endpoints.md
+++ b/docs/data-sources/stream_privatelink_endpoints.md
@@ -99,11 +99,14 @@ Read-Only:
 
 - `dns_domain` (String) Domain name of Privatelink connected cluster.
 - `dns_sub_domain` (List of String) Sub-Domain name of Confluent cluster. These are typically your availability zones.
+- `error_message` (String) Error message if the connection is in a failed state.
 - `id` (String) The ID of the Private Link connection.
 - `interface_endpoint_id` (String) Interface endpoint ID that is created from the specified service endpoint ID.
+- `interface_endpoint_name` (String) Interface endpoint name that is created from the specified service endpoint ID.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group or project id remains the same. The resource and corresponding endpoints use the term groups.
+- `provider_account_id` (String) Account ID from the cloud provider.
 - `provider_name` (String) Provider where the Kafka cluster is deployed.
 - `region` (String) Domain name of Confluent cluster.
 - `service_endpoint_id` (String) Service Endpoint ID.

--- a/docs/resources/stream_privatelink_endpoint.md
+++ b/docs/resources/stream_privatelink_endpoint.md
@@ -99,8 +99,11 @@ output "interface_endpoint_ids" {
 
 ### Read-Only
 
+- `error_message` (String) Error message if the connection is in a failed state.
 - `id` (String) The ID of the Private Link connection.
 - `interface_endpoint_id` (String) Interface endpoint ID that is created from the specified service endpoint ID.
+- `interface_endpoint_name` (String) Interface endpoint name that is created from the specified service endpoint ID.
+- `provider_account_id` (String) Account ID from the cloud provider.
 - `state` (String) Status of the connection.
 
 For more information see: [MongoDB Atlas API - Streams Privatelink](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Streams/operation/createPrivateLinkConnection) Documentation.

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -18,7 +18,6 @@ func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPri
 	result := &TFModel{
 		Id:                    types.StringPointerValue(apiResp.Id),
 		DnsDomain:             types.StringPointerValue(apiResp.DnsDomain),
-		DnsSubDomain:          types.ListNull(types.StringType),
 		ErrorMessage:          types.StringPointerValue(apiResp.ErrorMessage),
 		ProjectId:             types.StringPointerValue(&projectID),
 		InterfaceEndpointId:   types.StringPointerValue(apiResp.InterfaceEndpointId),
@@ -31,13 +30,11 @@ func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPri
 		Vendor:                types.StringPointerValue(apiResp.Vendor),
 	}
 
-	if apiResp.DnsSubDomain != nil {
-		subdomain, diags := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
-		if diags.HasError() {
-			return nil, diags
-		}
-		result.DnsSubDomain = subdomain
+	subdomain, diags := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
+	if diags.HasError() {
+		return nil, diags
 	}
+	result.DnsSubDomain = subdomain
 
 	return result, nil
 }

--- a/internal/service/streamprivatelinkendpoint/model.go
+++ b/internal/service/streamprivatelinkendpoint/model.go
@@ -16,16 +16,21 @@ const (
 
 func NewTFModel(ctx context.Context, projectID string, apiResp *admin.StreamsPrivateLinkConnection) (*TFModel, diag.Diagnostics) {
 	result := &TFModel{
-		Id:                  types.StringPointerValue(apiResp.Id),
-		DnsDomain:           types.StringPointerValue(apiResp.DnsDomain),
-		ProjectId:           types.StringPointerValue(&projectID),
-		InterfaceEndpointId: types.StringPointerValue(apiResp.InterfaceEndpointId),
-		Provider:            types.StringPointerValue(apiResp.Provider),
-		Region:              types.StringPointerValue(apiResp.Region),
-		ServiceEndpointId:   types.StringPointerValue(apiResp.ServiceEndpointId),
-		State:               types.StringPointerValue(apiResp.State),
-		Vendor:              types.StringPointerValue(apiResp.Vendor),
+		Id:                    types.StringPointerValue(apiResp.Id),
+		DnsDomain:             types.StringPointerValue(apiResp.DnsDomain),
+		DnsSubDomain:          types.ListNull(types.StringType),
+		ErrorMessage:          types.StringPointerValue(apiResp.ErrorMessage),
+		ProjectId:             types.StringPointerValue(&projectID),
+		InterfaceEndpointId:   types.StringPointerValue(apiResp.InterfaceEndpointId),
+		InterfaceEndpointName: types.StringPointerValue(apiResp.InterfaceEndpointName),
+		Provider:              types.StringPointerValue(apiResp.Provider),
+		ProviderAccountId:     types.StringPointerValue(apiResp.ProviderAccountId),
+		Region:                types.StringPointerValue(apiResp.Region),
+		ServiceEndpointId:     types.StringPointerValue(apiResp.ServiceEndpointId),
+		State:                 types.StringPointerValue(apiResp.State),
+		Vendor:                types.StringPointerValue(apiResp.Vendor),
 	}
+
 	if apiResp.DnsSubDomain != nil {
 		subdomain, diags := types.ListValueFrom(ctx, types.StringType, apiResp.GetDnsSubDomain())
 		if diags.HasError() {

--- a/internal/service/streamprivatelinkendpoint/model_test.go
+++ b/internal/service/streamprivatelinkendpoint/model_test.go
@@ -20,31 +20,35 @@ type sdkToTFModelTestCase struct {
 }
 
 var (
-	projectID           = "projectID"
-	id                  = "id"
-	dnsDomain           = "dnsDomain"
-	dnsSubDomain        = "dnsSubDomain"
-	interfaceEndpointID = "interfaceEndpointId"
-	provider            = "AWS"
-	region              = "us-east-1"
-	serviceEndpointID   = "serviceEndpointId"
-	state               = "DONE"
-	vendor              = "CONFLUENT"
+	projectID             = "projectID"
+	id                    = "id"
+	dnsDomain             = "dnsDomain"
+	dnsSubDomain          = "dnsSubDomain"
+	interfaceEndpointID   = "interfaceEndpointId"
+	interfaceEndpointName = "interfaceEndpointName"
+	provider              = "AWS"
+	providerAccountID     = "providerAccountId"
+	region                = "us-east-1"
+	serviceEndpointID     = "serviceEndpointId"
+	state                 = "DONE"
+	vendor                = "CONFLUENT"
 )
 
 func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
 	testCases := map[string]sdkToTFModelTestCase{
 		"Complete SDK response": {
 			SDKResp: &admin.StreamsPrivateLinkConnection{
-				Id:                  &id,
-				DnsDomain:           &dnsDomain,
-				DnsSubDomain:        conversion.Pointer([]string{dnsSubDomain, dnsSubDomain}),
-				InterfaceEndpointId: &interfaceEndpointID,
-				Provider:            &provider,
-				Region:              &region,
-				ServiceEndpointId:   &serviceEndpointID,
-				State:               &state,
-				Vendor:              &vendor,
+				Id:                    &id,
+				DnsDomain:             &dnsDomain,
+				DnsSubDomain:          conversion.Pointer([]string{dnsSubDomain, dnsSubDomain}),
+				InterfaceEndpointId:   &interfaceEndpointID,
+				InterfaceEndpointName: &interfaceEndpointName,
+				Provider:              &provider,
+				ProviderAccountId:     &providerAccountID,
+				Region:                &region,
+				ServiceEndpointId:     &serviceEndpointID,
+				State:                 &state,
+				Vendor:                &vendor,
 			},
 			projectID: projectID,
 			expectedTFModel: &streamprivatelinkendpoint.TFModel{
@@ -54,13 +58,15 @@ func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
 					types.StringValue(dnsSubDomain),
 					types.StringValue(dnsSubDomain),
 				}),
-				ProjectId:           types.StringValue(projectID),
-				InterfaceEndpointId: types.StringValue(interfaceEndpointID),
-				Provider:            types.StringValue(provider),
-				Region:              types.StringValue(region),
-				ServiceEndpointId:   types.StringValue(serviceEndpointID),
-				State:               types.StringValue(state),
-				Vendor:              types.StringValue(vendor),
+				ProjectId:             types.StringValue(projectID),
+				InterfaceEndpointId:   types.StringValue(interfaceEndpointID),
+				InterfaceEndpointName: types.StringValue(interfaceEndpointName),
+				Provider:              types.StringValue(provider),
+				ProviderAccountId:     types.StringValue(providerAccountID),
+				Region:                types.StringValue(region),
+				ServiceEndpointId:     types.StringValue(serviceEndpointID),
+				State:                 types.StringValue(state),
+				Vendor:                types.StringValue(vendor),
 			},
 		},
 		"SDK response without dns subdomains": {
@@ -78,6 +84,7 @@ func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
 			expectedTFModel: &streamprivatelinkendpoint.TFModel{
 				Id:                  types.StringValue(id),
 				DnsDomain:           types.StringValue(dnsDomain),
+				DnsSubDomain:        types.ListNull(types.StringType),
 				ProjectId:           types.StringValue(projectID),
 				InterfaceEndpointId: types.StringValue(interfaceEndpointID),
 				Provider:            types.StringValue(provider),
@@ -90,7 +97,8 @@ func TestStreamPrivatelinkEndpointSDKToTFModel(t *testing.T) {
 		"Empty SDK response": {
 			SDKResp: &admin.StreamsPrivateLinkConnection{},
 			expectedTFModel: &streamprivatelinkendpoint.TFModel{
-				ProjectId: types.StringValue(""),
+				ProjectId:    types.StringValue(""),
+				DnsSubDomain: types.ListNull(types.StringType),
 			},
 		},
 	}
@@ -121,13 +129,15 @@ func TestStreamPrivatelinkEndpointTFModelToSDK(t *testing.T) {
 					types.StringValue(dnsSubDomain),
 					types.StringValue(dnsSubDomain),
 				}),
-				ProjectId:           types.StringValue(projectID),
-				InterfaceEndpointId: types.StringValue(interfaceEndpointID),
-				Provider:            types.StringValue(provider),
-				Region:              types.StringValue(region),
-				ServiceEndpointId:   types.StringValue(serviceEndpointID),
-				State:               types.StringValue(state),
-				Vendor:              types.StringValue(vendor),
+				ProjectId:             types.StringValue(projectID),
+				InterfaceEndpointId:   types.StringValue(interfaceEndpointID),
+				InterfaceEndpointName: types.StringValue(interfaceEndpointName),
+				Provider:              types.StringValue(provider),
+				ProviderAccountId:     types.StringValue(providerAccountID),
+				Region:                types.StringValue(region),
+				ServiceEndpointId:     types.StringValue(serviceEndpointID),
+				State:                 types.StringValue(state),
+				Vendor:                types.StringValue(vendor),
 			},
 			expectedSDKReq: &admin.StreamsPrivateLinkConnection{
 				DnsDomain:         &dnsDomain,

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -2,9 +2,17 @@ package streamprivatelinkendpoint
 
 import (
 	"context"
+	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var uppercaseValidator = stringvalidator.RegexMatches(
+	regexp.MustCompile("^[A-Z]+$"),
+	"must contain only uppercase characters",
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -23,6 +31,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Sub-Domain name of Confluent cluster. These are typically your availability zones.",
 				ElementType:         types.StringType,
 			},
+			"error_message": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Error message if the connection is in a failed state.",
+			},
 			"project_id": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group or project id remains the same. The resource and corresponding endpoints use the term groups.",
@@ -31,9 +43,20 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Interface endpoint ID that is created from the specified service endpoint ID.",
 			},
+			"interface_endpoint_name": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Interface endpoint name that is created from the specified service endpoint ID.",
+			},
+			"provider_account_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Account ID from the cloud provider.",
+			},
 			"provider_name": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Provider where the Kafka cluster is deployed.",
+				Validators: []validator.String{
+					uppercaseValidator,
+				},
 			},
 			"region": schema.StringAttribute{
 				Optional:            true,
@@ -50,22 +73,28 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"vendor": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Vendor who manages the Kafka cluster.",
+				Validators: []validator.String{
+					uppercaseValidator,
+				},
 			},
 		},
 	}
 }
 
 type TFModel struct {
-	Id                  types.String `tfsdk:"id"`
-	DnsDomain           types.String `tfsdk:"dns_domain"`
-	DnsSubDomain        types.List   `tfsdk:"dns_sub_domain"`
-	ProjectId           types.String `tfsdk:"project_id"`
-	InterfaceEndpointId types.String `tfsdk:"interface_endpoint_id"`
-	Provider            types.String `tfsdk:"provider_name"`
-	Region              types.String `tfsdk:"region"`
-	ServiceEndpointId   types.String `tfsdk:"service_endpoint_id"`
-	State               types.String `tfsdk:"state"`
-	Vendor              types.String `tfsdk:"vendor"`
+	Id                    types.String `tfsdk:"id"`
+	DnsDomain             types.String `tfsdk:"dns_domain"`
+	DnsSubDomain          types.List   `tfsdk:"dns_sub_domain"`
+	ErrorMessage          types.String `tfsdk:"error_message"`
+	ProjectId             types.String `tfsdk:"project_id"`
+	InterfaceEndpointId   types.String `tfsdk:"interface_endpoint_id"`
+	InterfaceEndpointName types.String `tfsdk:"interface_endpoint_name"`
+	Provider              types.String `tfsdk:"provider_name"`
+	ProviderAccountId     types.String `tfsdk:"provider_account_id"`
+	Region                types.String `tfsdk:"region"`
+	ServiceEndpointId     types.String `tfsdk:"service_endpoint_id"`
+	State                 types.String `tfsdk:"state"`
+	Vendor                types.String `tfsdk:"vendor"`
 }
 
 type TFModelDSP struct {

--- a/internal/service/streamprivatelinkendpoint/resource_schema.go
+++ b/internal/service/streamprivatelinkendpoint/resource_schema.go
@@ -2,17 +2,9 @@ package streamprivatelinkendpoint
 
 import (
 	"context"
-	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-)
-
-var uppercaseValidator = stringvalidator.RegexMatches(
-	regexp.MustCompile("^[A-Z]+$"),
-	"must contain only uppercase characters",
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -54,9 +46,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"provider_name": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Provider where the Kafka cluster is deployed.",
-				Validators: []validator.String{
-					uppercaseValidator,
-				},
 			},
 			"region": schema.StringAttribute{
 				Optional:            true,
@@ -73,9 +62,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"vendor": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Vendor who manages the Kafka cluster.",
-				Validators: []validator.String{
-					uppercaseValidator,
-				},
 			},
 		},
 	}

--- a/internal/service/streamprivatelinkendpoint/resource_test.go
+++ b/internal/service/streamprivatelinkendpoint/resource_test.go
@@ -26,6 +26,13 @@ func TestAccStreamPrivatelinkEndpoint_basic(t *testing.T) {
 	resource.Test(t, *tc)
 }
 
+func TestAccStreamPrivateLinkEndpoint_noDNSSubdomains(t *testing.T) {
+	acc.SkipTestForCI(t) // needs confluent cloud resources
+	tc := noDNSSubDomainsTestCase(t)
+	// Tests include testing of plural data source and so cannot be run in parallel
+	resource.Test(t, *tc)
+}
+
 func TestAccStreamPrivatelinkEndpoint_failedUpdate(t *testing.T) {
 	acc.SkipTestForCI(t) // needs confluent cloud resources
 	tc := failedUpdateTestCase(t)
@@ -51,6 +58,40 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		networkID           = os.Getenv("CONFLUENT_CLOUD_NETWORK_ID")
 		privatelinkAccessID = os.Getenv("CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID")
 		config              = acc.GetCompleteConfluentConfig(true, true, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID)
+	)
+
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckConfluentAWSPrivatelink(t) },
+		CheckDestroy:             checkDestroy,
+		ExternalProviders:        acc.ExternalProvidersOnlyConfluent(),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+
+				Config: config,
+				Check:  checksStreamPrivatelinkEndpoint(projectID, provider, region, vendor, true),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	}
+}
+
+func noDNSSubDomainsTestCase(t *testing.T) *resource.TestCase {
+	t.Helper()
+
+	var (
+		projectID           = acc.ProjectIDExecution(t)
+		provider            = "AWS"
+		region              = "us-east-1"
+		awsAccountID        = os.Getenv("AWS_ACCOUNT_ID")
+		networkID           = os.Getenv("CONFLUENT_CLOUD_NETWORK_ID")
+		privatelinkAccessID = os.Getenv("CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID")
+		config              = acc.GetCompleteConfluentConfig(true, false, projectID, provider, region, vendor, awsAccountID, networkID, privatelinkAccessID)
 	)
 
 	return &resource.TestCase{

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -384,6 +384,6 @@ func PreCheckConfluentAWSPrivatelink(tb testing.TB) {
 		os.Getenv("CONFLUENT_CLOUD_API_SECRET") == "" ||
 		os.Getenv("CONFLUENT_CLOUD_NETWORK_ID") == "" ||
 		os.Getenv("CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID") == "" {
-		tb.Fatal("`CONFLUENT_CLOUD_API_KEY`, `CONFLUENT_CLOUD_API_SECRET`, `CONFLUENT_CLOUD_NETWORK_ID`, and `CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID` must be set for Cloud Backup Snapshot Export Bucket acceptance testing")
+		tb.Fatal("`CONFLUENT_CLOUD_API_KEY`, `CONFLUENT_CLOUD_API_SECRET`, `CONFLUENT_CLOUD_NETWORK_ID`, and `CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID` must be set for AWS PrivateLink acceptance testing")
 	}
 }


### PR DESCRIPTION
## Description
Add fields that exist in the Atlas Admin API for Streams PrivateLink Endpoints (error_message, provider_account_id, interface_endpoint_name). Also improve validation around the vendor and provider_name fields to fail faster (during planning) rather than waiting until getting a response from the API that is inconsistent with potential passed in values.

Link to any related issue(s):
https://jira.mongodb.org/browse/CLOUDP-301851 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
