### PR TITLE
feat: Supports new Https connection type in streams processing

### DIFF
--- a/.changelog/3141.txt
+++ b/.changelog/3141.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_connection: Adds `Https` connection
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connection: Adds `Https` connection
+```

--- a/.changelog/3141.txt
+++ b/.changelog/3141.txt
@@ -5,3 +5,7 @@ resource/mongodbatlas_stream_connection: Adds `Https` connection
 ```release-note:enhancement
 data-source/mongodbatlas_stream_connection: Adds `Https` connection
 ```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_connections: Adds `Https` connection
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -20,7 +20,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 ## Attributes Reference
 
-* `type` - Type of connection. Can be `Cluster`, `Kafka`, `Sample`, or `AWSLambda`.
+* `type` - Type of connection. Can be `Cluster`, `Kafka`, `Sample`, `Https` or `AWSLambda`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -35,6 +35,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 If `type` is of value `AWSLambda` the following additional attributes are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers.
 
 ### Authentication
 

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -32,7 +32,7 @@ In addition to all arguments above, it also exports the following attributes:
 * `project_id` - Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - Human-readable label that identifies the stream instance.
 * `connection_name` - Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - Type of connection. `Cluster`, `Kafka`, `Sample`, or `AWSLambda`.
+* `type` - Type of connection. `Cluster`, `Kafka`, `Sample`, `Https` or `AWSLambda`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -47,6 +47,10 @@ If `type` is of value `Kafka` the following additional attributes are defined:
 
 If `type` is of value `AWSLambda` the following additional attributes are defined::
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers.
 
 ### Authentication
 

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -81,12 +81,28 @@ resource "mongodbatlas_stream_connection" "test" {
 
 ```
 
+### Example Https Connection
+
+```terraform
+resource "mongodbatlas_stream_connection" "example-https" {
+  project_id      = var.project_id
+  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "https_connection_tf_new"
+  type            = "Https"
+  url             = "https://example.com"
+  headers = {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}
+```
+
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - (Required) Human-readable label that identifies the stream instance.
 * `connection_name` - (Required) Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
-* `type` - (Required) Type of connection. Can be `Cluster`, `Kafka`, `Sample`, or `AWSLambda`.
+* `type` - (Required) Type of connection. Can be `Cluster`, `Kafka`, `Sample`, `Https` or `AWSLambda`.
 
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
@@ -101,6 +117,10 @@ If `type` is of value `Kafka` the following additional arguments are defined:
 
 If `type` is of value `AWSLambda` the following additional arguments are defined:
 * `aws` - The configuration for AWS Lambda connection. See [AWS](#AWS)
+
+If `type` is of value `Https` the following additional attributes are defined:
+* `url` - URL of the HTTPs endpoint that will be used for creating a connection.
+* `headers` - A map of key-value pairs for optional headers.
 
 ### Authentication
 

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -80,6 +80,18 @@ resource "mongodbatlas_stream_connection" "example-aws-lambda" {
   }
 }
 
+resource "mongodbatlas_stream_connection" "example-https" {
+  project_id      = var.project_id
+  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  connection_name = "HttpsConnection"
+  type            = "Https"
+  url             = "https://example.com"
+  headers = {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}
+
 data "mongodbatlas_stream_connection" "example-kafka-ssl" {
   project_id      = var.project_id
   instance_name   = mongodbatlas_stream_instance.example.instance_name

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -87,8 +87,8 @@ resource "mongodbatlas_stream_connection" "example-https" {
   type            = "Https"
   url             = "https://example.com"
   headers = {
-    "key1": "value1",
-    "key2": "value2"
+    "key1" : "value1",
+    "key2" : "value2"
   }
 }
 

--- a/internal/service/streamconnection/data_source_stream_connection_test.go
+++ b/internal/service/streamconnection/data_source_stream_connection_test.go
@@ -85,6 +85,25 @@ func TestAccStreamDSStreamConnection_sample(t *testing.T) {
 	})
 }
 
+func TestAccStreamDSStreamConnection_https(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_stream_connection.test"
+		projectID      = acc.ProjectIDExecution(t)
+		instanceName   = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             CheckDestroyStreamConnection,
+		Steps: []resource.TestStep{
+			{
+				Config: streamConnectionDataSourceConfig(httpsStreamConnectionConfig(projectID, instanceName)),
+				Check:  httpsStreamConnectionAttributeChecks(dataSourceName, instanceName),
+			},
+		},
+	})
+}
+
 func streamConnectionDataSourceConfig(streamConnectionConfig string) string {
 	return fmt.Sprintf(`
 		%s

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -18,6 +18,7 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		Type:             plan.Type.ValueStringPointer(),
 		ClusterName:      plan.ClusterName.ValueStringPointer(),
 		BootstrapServers: plan.BootstrapServers.ValueStringPointer(),
+		Url:              plan.URL.ValueStringPointer(),
 	}
 	if !plan.Authentication.IsNull() {
 		authenticationModel := &TFConnectionAuthenticationModel{}
@@ -87,6 +88,14 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		}
 	}
 
+	if !plan.Headers.IsNull() {
+		headersMap := &map[string]string{}
+		if diags := plan.Headers.ElementsAs(ctx, headersMap, true); diags.HasError() {
+			return nil, diags
+		}
+		streamConnection.Headers = headersMap
+	}
+
 	return &streamConnection, nil
 }
 
@@ -100,6 +109,7 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName string, cur
 		Type:             types.StringPointerValue(apiResp.Type),
 		ClusterName:      types.StringPointerValue(apiResp.ClusterName),
 		BootstrapServers: types.StringPointerValue(apiResp.BootstrapServers),
+		URL:              types.StringPointerValue(apiResp.Url),
 	}
 
 	authModel, diags := newTFConnectionAuthenticationModel(ctx, currAuthConfig, apiResp.Authentication)
@@ -168,6 +178,15 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName string, cur
 			return nil, diags
 		}
 		connectionModel.AWS = aws
+	}
+
+	connectionModel.Headers = types.MapNull(types.StringType)
+	if apiResp.Headers != nil {
+		mapValue, diags := types.MapValueFrom(ctx, types.StringType, apiResp.Headers)
+		if diags.HasError() {
+			return nil, diags
+		}
+		connectionModel.Headers = mapValue
 	}
 
 	return &connectionModel, nil

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -299,13 +299,13 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(5),
+				ItemsPerPage: types.Int64Value(3),
 			},
 			expectedTFModel: &streamconnection.TFStreamConnectionsDSModel{
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(5),
+				ItemsPerPage: types.Int64Value(3),
 				TotalCount:   types.Int64Value(5),
 				Results: []streamconnection.TFStreamConnectionModel{
 					{

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -28,11 +28,17 @@ const (
 	privatelinkNetworkingType = "PRIVATE_LINK"
 	awslambdaConnectionName   = "aws_lambda_connection"
 	sampleRoleArn             = "rn:aws:iam::123456789123:role/sample"
+	httpsURL                  = "https://example.com"
 )
 
-var configMap = map[string]string{
-	"auto.offset.reset": "earliest",
-}
+var (
+	configMap = map[string]string{
+		"auto.offset.reset": "earliest",
+	}
+	headersMap = map[string]string{
+		"header1": "value1",
+	}
+)
 
 type sdkToTFModelTestCase struct {
 	SDKResp              *admin.StreamsConnection
@@ -73,6 +79,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -106,6 +113,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:              types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:          types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -128,6 +136,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -161,6 +170,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:              types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:          types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -182,6 +192,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 		{
@@ -204,6 +215,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 				Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 				AWS:             tfAWSLambdaConfigObject(t, sampleRoleArn),
+				Headers:         types.MapNull(types.StringType),
 			},
 		},
 	}
@@ -274,21 +286,27 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 							RoleArn: admin.PtrString(sampleRoleArn),
 						},
 					},
+					{
+						Name:    admin.PtrString(connectionName),
+						Type:    admin.PtrString("Https"),
+						Url:     admin.PtrString(httpsURL),
+						Headers: &headersMap,
+					},
 				},
-				TotalCount: admin.PtrInt(4),
+				TotalCount: admin.PtrInt(5),
 			},
 			providedConfig: &streamconnection.TFStreamConnectionsDSModel{
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(3),
+				ItemsPerPage: types.Int64Value(5),
 			},
 			expectedTFModel: &streamconnection.TFStreamConnectionsDSModel{
 				ProjectID:    types.StringValue(dummyProjectID),
 				InstanceName: types.StringValue(instanceName),
 				PageNum:      types.Int64Value(1),
-				ItemsPerPage: types.Int64Value(3),
-				TotalCount:   types.Int64Value(4),
+				ItemsPerPage: types.Int64Value(5),
+				TotalCount:   types.Int64Value(5),
 				Results: []streamconnection.TFStreamConnectionModel{
 					{
 						ID:               types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -303,6 +321,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						DBRoleToExecute:  types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 						Networking:       tfNetworkingObject(t, networkingType, nil),
 						AWS:              types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+						Headers:          types.MapNull(types.StringType),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
@@ -317,6 +336,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						DBRoleToExecute: tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
 						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 						AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+						Headers:         types.MapNull(types.StringType),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, sampleConnectionName)),
@@ -331,6 +351,7 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 						AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+						Headers:         types.MapNull(types.StringType),
 					},
 					{
 						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, awslambdaConnectionName)),
@@ -345,6 +366,23 @@ func TestStreamConnectionsSDKToTFModel(t *testing.T) {
 						DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
 						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
 						AWS:             tfAWSLambdaConfigObject(t, sampleRoleArn),
+						Headers:         types.MapNull(types.StringType),
+					},
+					{
+						ID:              types.StringValue(fmt.Sprintf("%s-%s-%s", instanceName, dummyProjectID, connectionName)),
+						ProjectID:       types.StringValue(dummyProjectID),
+						InstanceName:    types.StringValue(instanceName),
+						ConnectionName:  types.StringValue(connectionName),
+						Type:            types.StringValue("Https"),
+						ClusterName:     types.StringNull(),
+						Authentication:  types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+						Config:          types.MapNull(types.StringType),
+						Security:        types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+						DBRoleToExecute: types.ObjectNull(streamconnection.DBRoleToExecuteObjectType.AttrTypes),
+						Networking:      types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+						AWS:             types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+						Headers:         tfConfigMap(t, headersMap),
+						URL:             types.StringValue(httpsURL),
 					},
 				},
 			},
@@ -481,6 +519,23 @@ func TestStreamInstanceTFToSDKCreateModel(t *testing.T) {
 				Aws: &admin.StreamsAWSConnectionConfig{
 					RoleArn: admin.PtrString(sampleRoleArn),
 				},
+			},
+		},
+		{
+			name: "Https type TF state",
+			tfModel: &streamconnection.TFStreamConnectionModel{
+				ProjectID:      types.StringValue(dummyProjectID),
+				InstanceName:   types.StringValue(instanceName),
+				ConnectionName: types.StringValue(connectionName),
+				Type:           types.StringValue("Https"),
+				URL:            types.StringValue(httpsURL),
+				Headers:        tfConfigMap(t, headersMap),
+			},
+			expectedSDKReq: &admin.StreamsConnection{
+				Name:    admin.PtrString(connectionName),
+				Type:    admin.PtrString("Https"),
+				Url:     admin.PtrString(httpsURL),
+				Headers: &headersMap,
 			},
 		},
 	}

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -129,6 +129,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
+
+			// https type specific
+			"url": schema.StringAttribute{
+				Optional: true,
+			},
+			"headers": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
 		},
 	}
 }

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -47,6 +47,9 @@ type TFStreamConnectionModel struct {
 	DBRoleToExecute  types.Object `tfsdk:"db_role_to_execute"`
 	Networking       types.Object `tfsdk:"networking"`
 	AWS              types.Object `tfsdk:"aws"`
+	// https connection
+	Headers types.Map    `tfsdk:"headers"`
+	URL     types.String `tfsdk:"url"`
 }
 
 type TFConnectionAuthenticationModel struct {


### PR DESCRIPTION
## Description
We added a new connection type Https in streams processing. The configuration of the connection needs the `url` field and takes in an optional `headers` field.

Link to any related issue(s):
[Ticket](https://jira.mongodb.org/browse/CLOUDP-301845)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
