### PR TITLE
chore: Unify lifecycle ingore path syntax in test so same utility function can be used

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -2066,8 +2066,8 @@ func configReplicationSpecsAutoScaling(t *testing.T, isAcc bool, projectID, clus
 		lifecycleIgnoreChanges = `
 		lifecycle {
 			ignore_changes = [
-				replication_specs[0].region_configs[0].electable_specs[0].instance_size,
-				replication_specs[0].region_configs[0].electable_specs[0].disk_size_gb
+				replication_specs.0.region_configs.0.electable_specs.0.instance_size,
+				replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb
 			]
         }`
 	}

--- a/internal/testutil/acc/advanced_cluster_preview_provider_v2.go
+++ b/internal/testutil/acc/advanced_cluster_preview_provider_v2.go
@@ -93,13 +93,6 @@ func AttrNameToPreviewProviderV2(isAcc bool, name string) string {
 	return name
 }
 
-func attrReferenceToPreviewProviderV2(name string) string {
-	for _, singleAttrName := range tpfSingleNestedAttrs {
-		name = strings.ReplaceAll(name, singleAttrName+"[0]", singleAttrName)
-	}
-	return name
-}
-
 func ConvertAdvancedClusterToPreviewProviderV2(t *testing.T, isAcc bool, def string) string {
 	t.Helper()
 	if skipPreviewProviderV2Work(isAcc) {
@@ -122,7 +115,7 @@ func ConvertAdvancedClusterToPreviewProviderV2(t *testing.T, isAcc bool, def str
 		convertKeyValueAttrs(t, "tags", writeBody)
 	}
 	result := string(parse.Bytes())
-	result = attrReferenceToPreviewProviderV2(result) // useful for lifecycle ingore definitions
+	result = AttrNameToPreviewProviderV2(isAcc, result) // useful for lifecycle ingore definitions
 	return result
 }
 


### PR DESCRIPTION
## Description

Small follow up from https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3136#discussion_r1984880230

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
