### PR TITLE
refactor: Uses providerName to retry when the upgrade is not completed

### DIFF
--- a/internal/service/advancedclustertpf/common.go
+++ b/internal/service/advancedclustertpf/common.go
@@ -76,11 +76,15 @@ func GenerateFCVPinningWarningForRead(fcvPresentInState bool, apiRespFCVExpirati
 }
 
 func IsFlex(replicationSpecs *[]admin.ReplicationSpec20240805) bool {
+	return getProviderName(replicationSpecs) == flexcluster.FlexClusterType
+}
+
+func getProviderName(replicationSpecs *[]admin.ReplicationSpec20240805) string {
 	regionConfig := getRegionConfig(replicationSpecs)
 	if regionConfig == nil {
-		return false
+		return ""
 	}
-	return regionConfig.GetProviderName() == flexcluster.FlexClusterType
+	return regionConfig.GetProviderName()
 }
 
 func getRegionConfig(replicationSpecs *[]admin.ReplicationSpec20240805) *admin.CloudRegionConfig20240805 {

--- a/internal/service/advancedclustertpf/common_admin_sdk.go
+++ b/internal/service/advancedclustertpf/common_admin_sdk.go
@@ -128,7 +128,7 @@ func UpgradeTenant(ctx context.Context, diags *diag.Diagnostics, client *config.
 		addErrorDiag(diags, operationTenantUpgrade, defaultAPIErrorDetails(waitParams.ClusterName, err))
 		return nil
 	}
-	return AwaitChanges(ctx, client, waitParams, operationTenantUpgrade, diags)
+	return AwaitChangesUpgrade(ctx, client, waitParams, operationTenantUpgrade, diags)
 }
 
 func UpgradeFlexToDedicated(ctx context.Context, diags *diag.Diagnostics, client *config.MongoDBClient, waitParams *ClusterWaitParams, req *admin.AtlasTenantClusterUpgradeRequest20240805) *admin.ClusterDescription20240805 {
@@ -137,7 +137,7 @@ func UpgradeFlexToDedicated(ctx context.Context, diags *diag.Diagnostics, client
 		addErrorDiag(diags, operationFlexUpgrade, defaultAPIErrorDetails(waitParams.ClusterName, err))
 		return nil
 	}
-	return AwaitChanges(ctx, client, waitParams, operationFlexUpgrade, diags)
+	return AwaitChangesUpgrade(ctx, client, waitParams, operationFlexUpgrade, diags)
 }
 
 func PinFCV(ctx context.Context, api admin.ClustersApi, projectID, clusterName, expirationDateStr string) error {

--- a/internal/service/advancedclustertpf/common_await_changes.go
+++ b/internal/service/advancedclustertpf/common_await_changes.go
@@ -10,11 +10,14 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250219001/admin"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/retrystrategy"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/flexcluster"
 )
 
 var (
@@ -28,6 +31,19 @@ type ClusterWaitParams struct {
 	ClusterName string
 	Timeout     time.Duration
 	IsDelete    bool
+}
+
+func AwaitChangesUpgrade(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {
+	upgraded := AwaitChanges(ctx, client, waitParams, errorLocator, diags)
+	if diags.HasError() || upgraded == nil {
+		return nil
+	}
+	providerName := getProviderName(upgraded.ReplicationSpecs)
+	if slices.Contains([]string{flexcluster.FlexClusterType, constant.TENANT}, providerName) {
+		tflog.Warn(ctx, fmt.Sprintf("cluster upgrade unexpected provider %s, retrying", providerName))
+		return AwaitChanges(ctx, client, waitParams, errorLocator, diags)
+	}
+	return upgraded
 }
 
 func AwaitChanges(ctx context.Context, client *config.MongoDBClient, waitParams *ClusterWaitParams, errorLocator string, diags *diag.Diagnostics) *admin.ClusterDescription20240805 {


### PR DESCRIPTION
## Description

Context: Seen a high failure rate for the `TestAccMockableAdvancedCluster_tenantUpgrade` test. Looking at the error the problem is that the cluster state BEFORE upgrade is returned in AwaitChanges. This PR attempts to reduce the flakyness by re-awaiting if `providerName in {"TENANT", "FLEX"}`

- Uses providerName to retry when the upgrade is not completed
- Example failures
  - https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13767655927/job/38498556065?pr=3145
  - https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13766832930/job/38495801378
  - https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13772069784/job/38513193217?pr=3144


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
