### PR TITLE
doc: Adds warning about using output variables and moved together

### DIFF
--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -56,6 +56,7 @@ The basic experience when using the `moved` block is as follows:
 3. Comment out or delete the `mongodbatlas_cluster` resource definition.
 4. Update the references from your previous cluster resource: `mongodbatlas_cluster.this.XXXX` to the new `mongodbatlas_advanced_cluster.this.XXX`.
    - Double check [output-changes](#output-changes) to ensure the underlying configuration stays unchanged.
+   - If you are using output variables that use the new resource `mongodbatlas_advanced_cluster.this`, the plan output can be more verbose than expected (extra `Note: Objects have changed outside of Terraform` section). Consider adding/updating output variables only **after** performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 5. Add the `moved` block to your configuration file, e.g.:
 ```terraform
 moved {

--- a/examples/migrate_cluster_to_advanced_cluster/basic/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/README.md
@@ -49,7 +49,7 @@ The [CLI Plugin](https://github.com/mongodb-labs/atlas-cli-plugin-terraform) hel
 ## Manual updates to the Terraform configuration
 
 1. Ensure all references are updated (see example of updates in [outputs.tf](outputs.tf))
-   1. Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
+   1. Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to a more verbose plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 2. Comment out the `mongodbatlas_cluster` in `{CLUSTER_IN}.tf`
 3. Add the moved block for each resource migrated in `{CLUSTER_OUT}.tf`
 ```terraform

--- a/examples/migrate_cluster_to_advanced_cluster/basic/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/README.md
@@ -49,7 +49,7 @@ The [CLI Plugin](https://github.com/mongodb-labs/atlas-cli-plugin-terraform) hel
 ## Manual updates to the Terraform configuration
 
 1. Ensure all references are updated (see example of updates in [outputs.tf](outputs.tf))
-   1. TODO: Add warning about output references based on findings in [output investigation](https://jira.mongodb.org/browse/CLOUDP-303685)
+   1. Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 2. Comment out the `mongodbatlas_cluster` in `{CLUSTER_IN}.tf`
 3. Add the moved block for each resource migrated in `{CLUSTER_OUT}.tf`
 ```terraform

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
@@ -83,7 +83,7 @@ moved {
 - Adds `data "mongodbatlas_cluster" "this"` to avoid breaking changes in `outputs.tf` (see below).
 
 ### [`outputs.tf`](v2/outputs.tf)
-- Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
+- Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to a more verbose plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 - Ensure compatibility with `v1` outputs by modifying:
   - `replication_specs`, uses `data.mongodbatlas_cluster.this.replication_specs` to keep the same format.
   - `mongodbatlas_cluster`, uses the `data.mongodbatlas_cluster.this` to keep the same format.
@@ -91,7 +91,7 @@ moved {
 
 ## Step 3: Module `v3` Implementation Changes and Highlights
 This module adds variables to support the latest `mongodbatlas_advanced_cluster` features while staying compatible with the old input variables.
-The module supports standalone usage when there is no existing `mongodbatlas_cluster` and also upgrading from `v1` using a `moved` block. However, upgrading directly from `v1` can encounter unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
+The module supports standalone usage when there is no existing `mongodbatlas_cluster` and also upgrading from `v1` using a `moved` block. However, upgrading directly from `v1` can lead to a more verbose plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 The module also supports changing an existing `mongodbatlas_advanced_cluster` created in `v2`.
 
 ### [`variables.tf`](v3/variables.tf)

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/README.md
@@ -83,15 +83,15 @@ moved {
 - Adds `data "mongodbatlas_cluster" "this"` to avoid breaking changes in `outputs.tf` (see below).
 
 ### [`outputs.tf`](v2/outputs.tf)
-- All outputs can use `mongodbatlas_advanced_cluster` except for:
-  - [TODO: Update with findings](https://jira.mongodb.org/browse/CLOUDP-303685)
-  - `replication_specs`, which uses `data.mongodbatlas_cluster.this.replication_specs` to keep the same format.
-  - `mongodbatlas_cluster`, which uses the `data.mongodbatlas_cluster.this` to keep the same format.
+- Ensure you are not adding any output variables that use the new `mongodbatlas_advanced_cluster` resource. Referencing the new resource before moving can lead to unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
+- Ensure compatibility with `v1` outputs by modifying:
+  - `replication_specs`, uses `data.mongodbatlas_cluster.this.replication_specs` to keep the same format.
+  - `mongodbatlas_cluster`, uses the `data.mongodbatlas_cluster.this` to keep the same format.
 
 
 ## Step 3: Module `v3` Implementation Changes and Highlights
 This module adds variables to support the latest `mongodbatlas_advanced_cluster` features while staying compatible with the old input variables.
-The module supports standalone usage when there is no existing `mongodbatlas_cluster` and also upgrading from `v1` using a `moved` block.
+The module supports standalone usage when there is no existing `mongodbatlas_cluster` and also upgrading from `v1` using a `moved` block. However, upgrading directly from `v1` can encounter unexpected plan output (extra `Note: Objects have changed outside of Terraform` section) when performing the move (see more in the [Github Issue](https://github.com/hashicorp/terraform-plugin-framework/issues/1109)).
 The module also supports changing an existing `mongodbatlas_advanced_cluster` created in `v2`.
 
 ### [`variables.tf`](v3/variables.tf)


### PR DESCRIPTION
## Description

- Adds warning about using output variables and moved together
- See related issue raised in TPF repo: https://github.com/hashicorp/terraform-plugin-framework/issues/1109

Link to any related issue(s): CLOUDP-303685

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
