### PR TITLE
chore: Follow-up changes for PR 3140

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1374,11 +1374,11 @@ func TestAccMockableAdvancedCluster_removeBlocksFromConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configBlocks(t, projectID, clusterName, true),
-				Check:  checkBlocks(projectID, clusterName, true),
+				Check:  checkBlocks(true),
 			},
 			{
 				Config: configBlocks(t, projectID, clusterName, false),
-				Check:  checkBlocks(projectID, clusterName, false),
+				Check:  checkBlocks(false),
 			},
 			acc.TestStepImportCluster(resourceName),
 		},
@@ -1554,7 +1554,7 @@ func configBlocks(t *testing.T, projectID, clusterName string, firstStep bool) s
 	`, projectID, clusterName, instanceSize1, extraConfig0, extraConfig1))
 }
 
-func checkBlocks(projectID, clusterName string, firstStep bool) resource.TestCheckFunc {
+func checkBlocks(firstStep bool) resource.TestCheckFunc {
 	checksMap := map[string]string{
 		"replication_specs.0.region_configs.0.electable_specs.0.instance_size": "M10",
 		"replication_specs.0.region_configs.0.electable_specs.0.node_count":    "5",

--- a/internal/service/advancedclustertpf/plan_modifier.go
+++ b/internal/service/advancedclustertpf/plan_modifier.go
@@ -270,6 +270,7 @@ func copyAttrIfDestNotKnown[T attr.Value](src, dest *T) {
 	}
 }
 
+// isKnown returns true if the attribute is known (not null or unknown). Note that !isKnown is not the same as IsUnknown because null is !isKnown but not IsUnknown
 func isKnown(attribute attr.Value) bool {
 	return !attribute.IsNull() && !attribute.IsUnknown()
 }

--- a/internal/service/advancedclustertpf/plan_modifier.go
+++ b/internal/service/advancedclustertpf/plan_modifier.go
@@ -270,7 +270,7 @@ func copyAttrIfDestNotKnown[T attr.Value](src, dest *T) {
 	}
 }
 
-// isKnown returns true if the attribute is known (not null or unknown). Note that !isKnown is not the same as IsUnknown because null is !isKnown but not IsUnknown
+// isKnown returns true if the attribute is known (not null or unknown). Note that !isKnown is not the same as IsUnknown because null is !isKnown but not IsUnknown.
 func isKnown(attribute attr.Value) bool {
 	return !attribute.IsNull() && !attribute.IsUnknown()
 }


### PR DESCRIPTION
## Description

Follow-up changes for [PR 3140](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3140)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
