### PR TITLE
test: Add additional step for ensuring empty plans are encountered when blocks are removed

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedclustertpf"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
 
@@ -213,6 +214,15 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 				}),
 				Check: checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 60, 3, true, true),
 			},
+			// empty plan when analytics block is removed
+			mig.TestStepCheckEmptyPlan(configAWSProvider(t, isAcc, ReplicaSetAWSConfig{
+				ProjectID:          projectID,
+				ClusterName:        clusterName,
+				ClusterType:        "REPLICASET",
+				DiskSizeGB:         60,
+				NodeCountElectable: 3,
+				WithAnalyticsSpecs: false,
+			})),
 			{
 				Config: configAWSProvider(t, isAcc, ReplicaSetAWSConfig{
 					ProjectID:          projectID,
@@ -220,7 +230,7 @@ func replicaSetAWSProviderTestCase(t *testing.T, isAcc bool) resource.TestCase {
 					ClusterType:        "REPLICASET",
 					DiskSizeGB:         50,
 					NodeCountElectable: 5,
-					WithAnalyticsSpecs: false, // removed as part of other updates, computed value is expected to be the same
+					WithAnalyticsSpecs: false, // other update made after removed analytics block, computed value is expected to be the same
 				}),
 				Check: checkReplicaSetAWSProvider(isAcc, projectID, clusterName, 50, 5, true, true),
 			},
@@ -557,8 +567,10 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAutoScaling(t *testing.
 					acc.TestCheckResourceAttrPreviewProviderV2(true, resourceName, "replication_specs.0.region_configs.0.electable_specs.0.disk_size_gb", "10"),   // modified disk size gb in config is ignored
 				),
 			},
+			// empty plan when auto_scaling block is removed
+			mig.TestStepCheckEmptyPlan(configReplicationSpecsAutoScaling(t, true, projectID, clusterName, nil, "M20", 20, 1)),
 			{
-				Config: configReplicationSpecsAutoScaling(t, true, projectID, clusterName, nil, "M10", 10, 2), // auto_scaling block removed together with other changes, preserves previous state
+				Config: configReplicationSpecsAutoScaling(t, true, projectID, clusterName, nil, "M10", 10, 2), // other change after autoscaling block removed, preserves previous state
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrPreviewProviderV2(true, resourceName, "name", clusterName),
@@ -611,8 +623,10 @@ func TestAccClusterAdvancedClusterConfig_replicationSpecsAnalyticsAutoScaling(t 
 					acc.TestCheckResourceAttrPreviewProviderV2(true, resourceName, "replication_specs.0.region_configs.0.analytics_auto_scaling.0.compute_enabled", "true"),
 				),
 			},
+			// empty plan when analytics_auto_scaling block is removed
+			mig.TestStepCheckEmptyPlan(configReplicationSpecsAnalyticsAutoScaling(t, true, projectID, clusterNameUpdated, nil, 1)),
 			{
-				Config: configReplicationSpecsAnalyticsAutoScaling(t, true, projectID, clusterNameUpdated, nil, 2), // analytics_auto_scaling block removed together with other changes, preserves previous state
+				Config: configReplicationSpecsAnalyticsAutoScaling(t, true, projectID, clusterNameUpdated, nil, 2), // other changes after analytics_auto_scaling block removed, preserves previous state
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckExistsCluster(resourceName),
 					acc.TestCheckResourceAttrPreviewProviderV2(true, resourceName, "name", clusterNameUpdated),
@@ -1386,12 +1400,14 @@ func TestAccMockableAdvancedCluster_removeBlocksFromConfig(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configBlocks(t, projectID, clusterName, true),
-				Check:  checkBlocks(true),
+				Config: configBlocks(t, projectID, clusterName, "M10", true),
+				Check:  checkBlocks("M10"),
 			},
+			// removing blocks generates an empty plan
+			mig.TestStepCheckEmptyPlan(configBlocks(t, projectID, clusterName, "M10", false)),
 			{
-				Config: configBlocks(t, projectID, clusterName, false),
-				Check:  checkBlocks(false),
+				Config: configBlocks(t, projectID, clusterName, "M20", false), // applying a change after removing blocks preserves previous state
+				Check:  checkBlocks("M20"),
 			},
 			acc.TestStepImportCluster(resourceName),
 		},
@@ -1491,10 +1507,10 @@ func configSharded(t *testing.T, projectID, clusterName string, withUpdate bool)
 	`, projectID, clusterName, autoScaling, analyticsSpecs, analyticsSpecsForSpec2)) + dataSourcesTFNewSchema
 }
 
-func configBlocks(t *testing.T, projectID, clusterName string, firstStep bool) string {
+func configBlocks(t *testing.T, projectID, clusterName, instanceSize string, defineBlocks bool) string {
 	t.Helper()
 	var extraConfig0, extraConfig1 string
-	autoStr := `
+	autoScalingBlocks := `
 		auto_scaling {
 			disk_gb_enabled            = true
 			compute_enabled            = true
@@ -1510,15 +1526,15 @@ func configBlocks(t *testing.T, projectID, clusterName string, firstStep bool) s
 			compute_scale_down_enabled = true
 		}
 	`
-	instanceSize1 := "M20"
-	if firstStep {
-		instanceSize1 = "M10"
+	if defineBlocks {
+		// read only + autoscaling blocks
 		extraConfig0 = `
 			read_only_specs {
 				instance_size = "M10"
 				node_count    = 2
 			}
-		` + autoStr
+		` + autoScalingBlocks
+		// read only + analytics + autoscaling blocks
 		extraConfig1 = `
 			read_only_specs {
 				instance_size = "M10"
@@ -1528,7 +1544,7 @@ func configBlocks(t *testing.T, projectID, clusterName string, firstStep bool) s
 				instance_size = "M10"
 				node_count    = 4
 			}
-		` + autoStr
+		` + autoScalingBlocks
 	}
 	return acc.ConvertAdvancedClusterToPreviewProviderV2(t, true, fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
@@ -1562,12 +1578,18 @@ func configBlocks(t *testing.T, projectID, clusterName string, firstStep bool) s
 					}
 					%[5]s
 				}
+				region_configs { // region with no electable specs
+					provider_name = "AWS"
+					priority      = 0
+					region_name   = "US_EAST_1"
+					%[4]s
+				}
 			}
 		}
-	`, projectID, clusterName, instanceSize1, extraConfig0, extraConfig1))
+	`, projectID, clusterName, instanceSize, extraConfig0, extraConfig1))
 }
 
-func checkBlocks(firstStep bool) resource.TestCheckFunc {
+func checkBlocks(instanceSize string) resource.TestCheckFunc {
 	checksMap := map[string]string{
 		"replication_specs.0.region_configs.0.electable_specs.0.instance_size": "M10",
 		"replication_specs.0.region_configs.0.electable_specs.0.node_count":    "5",
@@ -1575,16 +1597,15 @@ func checkBlocks(firstStep bool) resource.TestCheckFunc {
 		"replication_specs.0.region_configs.0.read_only_specs.0.node_count":    "2",
 		"replication_specs.0.region_configs.0.analytics_specs.0.node_count":    "0",
 
-		"replication_specs.1.region_configs.0.electable_specs.0.instance_size": "M10",
+		"replication_specs.1.region_configs.0.electable_specs.0.instance_size": instanceSize,
 		"replication_specs.1.region_configs.0.electable_specs.0.node_count":    "3",
-		"replication_specs.1.region_configs.0.read_only_specs.0.instance_size": "M10",
+		"replication_specs.1.region_configs.0.read_only_specs.0.instance_size": instanceSize,
 		"replication_specs.1.region_configs.0.read_only_specs.0.node_count":    "1",
 		"replication_specs.1.region_configs.0.analytics_specs.0.instance_size": "M10",
 		"replication_specs.1.region_configs.0.analytics_specs.0.node_count":    "4",
-	}
-	if !firstStep {
-		checksMap["replication_specs.1.region_configs.0.electable_specs.0.instance_size"] = "M20"
-		checksMap["replication_specs.1.region_configs.0.read_only_specs.0.instance_size"] = "M20"
+
+		"replication_specs.1.region_configs.1.read_only_specs.0.instance_size": "M10",
+		"replication_specs.1.region_configs.1.read_only_specs.0.node_count":    "2",
 	}
 	for repSpecsIdx := range 2 {
 		for _, block := range []string{"auto_scaling", "analytics_auto_scaling"} {


### PR DESCRIPTION
## Description

Link to any related issue(s): follow up tests improvement from CLOUDP-305352

- Adding explicit steps to verify empty plan after removal of blocks
- Adding scenario of removing block in region config that does not have electable_specs defined.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
