### PR TITLE
chore: Refactors to use hcl.InitialPos

### DIFF
--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -114,7 +114,7 @@ func addPrimitiveAttributes(b *hclwrite.Body, values map[string]any) {
 func setAttributeHcl(body *hclwrite.Body, tfExpression string) error {
 	src := []byte(tfExpression)
 
-	f, diags := hclwrite.ParseConfig(src, "", hcl.Pos{Line: 1, Column: 1})
+	f, diags := hclwrite.ParseConfig(src, "", hcl.InitialPos)
 	if diags.HasErrors() {
 		return fmt.Errorf("extract attribute error %s\nparsing %s", diags, tfExpression)
 	}

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -85,7 +85,7 @@ func CanonicalHCL(t *testing.T, def string) string {
 
 func GetDefParser(t *testing.T, def string) *hclwrite.File {
 	t.Helper()
-	parser, diags := hclwrite.ParseConfig([]byte(def), "", hcl.Pos{Line: 1, Column: 1})
+	parser, diags := hclwrite.ParseConfig([]byte(def), "", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "failed to parse def: %s", diags.Error())
 	return parser
 }


### PR DESCRIPTION
## Description

Refactors to use hcl.InitialPos

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
