### PR TITLE
fix: Adds cluster with ISS support to `mongodbatlas_global_cluster_config`

### DIFF
--- a/.changelog/3177.txt
+++ b/.changelog/3177.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-resource/mongodbatlas_global_cluster_config: Adds cluster with ISS support
+resource/mongodbatlas_global_cluster_config: Adds support for reading clusters with independent shard scaling
 ```
 
 ```release-note:bug
-data-source/mongodbatlas_global_cluster_config: Adds cluster with ISS support
+data-source/mongodbatlas_global_cluster_config: Adds support for reading clusters with independent shard scaling
 ```

--- a/.changelog/3177.txt
+++ b/.changelog/3177.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/mongodbatlas_global_cluster_config: Adds cluster with ISS support
+```
+
+```release-note:bug
+data-source/mongodbatlas_global_cluster_config: Adds cluster with ISS support
+```

--- a/docs/data-sources/global_cluster_config.md
+++ b/docs/data-sources/global_cluster_config.md
@@ -105,7 +105,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead.
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not used when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
 *  `managed_namespaces` - Add a managed namespaces to a Global Cluster. For more information about managed namespaces, see [Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/). See [Managed Namespace](#managed-namespace) below for more details.
 
 ### Managed Namespace

--- a/docs/data-sources/global_cluster_config.md
+++ b/docs/data-sources/global_cluster_config.md
@@ -105,7 +105,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling. To learn more, see the [Sharding Configuration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide).
 *  `managed_namespaces` - Add a managed namespaces to a Global Cluster. For more information about managed namespaces, see [Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/). See [Managed Namespace](#managed-namespace) below for more details.
 
 ### Managed Namespace

--- a/docs/data-sources/global_cluster_config.md
+++ b/docs/data-sources/global_cluster_config.md
@@ -105,7 +105,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not used when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
 *  `managed_namespaces` - Add a managed namespaces to a Global Cluster. For more information about managed namespaces, see [Global Clusters](https://docs.atlas.mongodb.com/reference/api/global-clusters/). See [Managed Namespace](#managed-namespace) below for more details.
 
 ### Managed Namespace

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -360,9 +360,14 @@ resource "mongodbatlas_advanced_cluster" "test" {
 }
 ```
 
--> **NOTE:** For any cluster leveraging the new sharding configurations and defining independently scaled shards, users should also update corresponding `mongodbatlas_cloud_backup_schedule` resource & data sources. This involves updating any existing Terraform configurations of the resource to use`copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id`. This is needed as `mongodbatlas_advanced_cluster` resource and data source will no longer have `replication_specs.#.id` present when shards are scaled independently. To learn more, review the [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones).
+### Resources and Data Sources Impacted by Independent Shard Scaling
 
--> **NOTE:** The `mongodbatlas_global_cluster_config` and `mongodbatlas_cluster` resources & data sources are also impacted by clusters using independent shard scaling. Remove any `custom_zone_mapping` usage from `mongodbatlas_global_cluster_config` and migrate `mongodbatlas_cluster` to `mongodbatlas_advanced_cluster` (see the [cluster-to-advanced-cluster-migration-guide.](cluster-to-advanced-cluster-migration-guide.md))
+Name | Changes | Transition Guide
+--- | --- | ---
+`mongodbatlas_cloud_backup_schedule` | Use `copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id` (`replication_specs.#.id` not set for ISS enabled `mongodbatlas_advanced_cluster`) | [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones)
+`mongodbatlas_global_cluster_config` | Remove the `custom_zone_mapping` attribute. | -
+`mongodbatlas_cluster` | Resource and Data Source will not work. API error code `ASYMMETRIC_SHARD_UNSUPPORTED`. | [cluster-to-advanced-cluster-migration-guide.](cluster-to-advanced-cluster-migration-guide.md)
+
 
 <a id="use-auto-scaling-per-shard"></a>
 ## Use Auto-Scaling Per Shard

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -360,14 +360,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 }
 ```
 
-### Resources and Data Sources Impacted by Independent Shard Scaling
-
-Name | Changes | Transition Guide
---- | --- | ---
-`mongodbatlas_cloud_backup_schedule` | Use `copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id` (`replication_specs.#.id` not set for ISS enabled `mongodbatlas_advanced_cluster`) | [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones)
-`mongodbatlas_global_cluster_config` | Remove the `custom_zone_mapping` attribute. | -
-`mongodbatlas_cluster` | Resource and Data Source will not work. API error code `ASYMMETRIC_SHARD_UNSUPPORTED`. | [cluster-to-advanced-cluster-migration-guide.](cluster-to-advanced-cluster-migration-guide.md)
-
+-> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources.
 
 <a id="use-auto-scaling-per-shard"></a>
 ## Use Auto-Scaling Per Shard
@@ -444,4 +437,15 @@ While the example initially defines 2 symmetric shards, auto-scaling of `electab
 
 -> **NOTE:** After you upgrade to version 1.23.0 of the provider, you must update the cluster configuration to activate the auto-scaling per shard feature.
 
--> **NOTE:** When auto-scaling per shard, it is possible that the cluster will transition to having asymmetric shards. This will impact the computed attribute `replication_specs.#.id`, which is not populated when shards are scaled independently. Please make sure to update the corresponding `mongodbatlas_cloud_backup_schedule` resource & data sources. This involves updating any existing Terraform configurations of the resource to use `copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id`. To learn more, review the [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones).
+-> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources.
+
+## Resources and Data Sources Impacted by Independent Shard Scaling
+
+Name | Changes | Transition Guide
+--- | --- | ---
+`mongodbatlas_advanced_cluster` | Data source must use the `use_replication_spec_per_shard` attribute. | -
+`mongodbatlas_advanced_cluster` | Use `replication_specs.#.zone_id` instead of `replication_specs.#.id`. | -
+`mongodbatlas_cluster` | Resource and Data Source will not work. API error code `ASYMMETRIC_SHARD_UNSUPPORTED`. | [cluster-to-advanced-cluster-migration-guide.](cluster-to-advanced-cluster-migration-guide.md)
+`mongodbatlas_cloud_backup_schedule` | Use `copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id` | [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones)
+`mongodbatlas_global_cluster_config` | `custom_zone_mapping` is no longer populated, `custom_zone_mapping_zone_id` must be used instead. | -
+

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -360,7 +360,9 @@ resource "mongodbatlas_advanced_cluster" "test" {
 }
 ```
 
--> **NOTE:** For any cluster leveraging the new sharding configurations and defining independently scaled shards, users should also update corresponding `mongodbatlas_cloud_backup_schedule` resource & data sources. This involves updating any existing Terraform configurations of the resource to use `copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id`. This is needed as `mongodbatlas_advanced_cluster` resource and data source will no longer have `replication_specs.#.id` present when shards are scaled independently. To learn more, review the [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones).
+-> **NOTE:** For any cluster leveraging the new sharding configurations and defining independently scaled shards, users should also update corresponding `mongodbatlas_cloud_backup_schedule` resource & data sources. This involves updating any existing Terraform configurations of the resource to use`copy_settings.#.zone_id` instead of `copy_settings.#.replication_spec_id`. This is needed as `mongodbatlas_advanced_cluster` resource and data source will no longer have `replication_specs.#.id` present when shards are scaled independently. To learn more, review the [1.18.0 Migration Guide](1.18.0-upgrade-guide.md#transition-cloud-backup-schedules-for-clusters-to-use-zones).
+
+-> **NOTE:** The `mongodbatlas_global_cluster_config` and `mongodbatlas_cluster` resources & data sources are also impacted by clusters using independent shard scaling. Remove any `custom_zone_mapping` usage from `mongodbatlas_global_cluster_config` and migrate `mongodbatlas_cluster` to `mongodbatlas_advanced_cluster` (see the [cluster-to-advanced-cluster-migration-guide.](cluster-to-advanced-cluster-migration-guide.md))
 
 <a id="use-auto-scaling-per-shard"></a>
 ## Use Auto-Scaling Per Shard

--- a/docs/guides/advanced-cluster-new-sharding-schema.md
+++ b/docs/guides/advanced-cluster-new-sharding-schema.md
@@ -360,7 +360,7 @@ resource "mongodbatlas_advanced_cluster" "test" {
 }
 ```
 
--> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources.
+-> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources when a cluster transitions to independently scaled shards.
 
 <a id="use-auto-scaling-per-shard"></a>
 ## Use Auto-Scaling Per Shard
@@ -437,7 +437,7 @@ While the example initially defines 2 symmetric shards, auto-scaling of `electab
 
 -> **NOTE:** After you upgrade to version 1.23.0 of the provider, you must update the cluster configuration to activate the auto-scaling per shard feature.
 
--> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources.
+-> **NOTE:** See the table [below](#resources-and-data-sources-impacted-by-independent-shard-scaling) for other impacted resources when a cluster transitions to independently scaled shards.
 
 ## Resources and Data Sources Impacted by Independent Shard Scaling
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -93,7 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead.
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not used when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
 
 ## Import
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -93,7 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not used when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
 
 ## Import
 

--- a/docs/resources/global_cluster_config.md
+++ b/docs/resources/global_cluster_config.md
@@ -93,7 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The Terraform's unique identifier used internally for state management.
 * `custom_zone_mapping_zone_id` - A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.zone_id`. Atlas automatically maps each location code to the closest geographical zone. Custom zone mappings allow administrators to override these automatic mappings. If your Global Cluster does not have any custom zone mappings, this document is empty.
-* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling, for more info see the [New Sharding Configuration guide.](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide)
+* `custom_zone_mapping` - (Deprecated) A map of all custom zone mappings defined for the Global Cluster to `replication_specs.*.id`. This attribute is deprecated, use `custom_zone_mapping_zone_id` instead. This attribute is not set when a cluster uses independent shard scaling. To learn more, see the [Sharding Configuration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide).
 
 ## Import
 

--- a/internal/common/validate/cluster_error_checks.go
+++ b/internal/common/validate/cluster_error_checks.go
@@ -4,5 +4,5 @@ import admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 
 // ErrorClusterIsAsymmetrics must be used with the v20240530005 admin.
 func ErrorClusterIsAsymmetrics(err error) bool {
-	return err != nil && admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED")
+	return admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED")
 }

--- a/internal/common/validate/cluster_error_checks.go
+++ b/internal/common/validate/cluster_error_checks.go
@@ -2,6 +2,7 @@ package validate
 
 import admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 
+// ErrorClusterIsAsymmetrics must be used with the v20240530005 admin.
 func ErrorClusterIsAsymmetrics(err error) bool {
 	return err != nil && admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED")
 }

--- a/internal/common/validate/cluster_error_checks.go
+++ b/internal/common/validate/cluster_error_checks.go
@@ -1,0 +1,7 @@
+package validate
+
+import admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
+
+func ErrorClusterIsAsymmetrics(err error) bool {
+	return err != nil && admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED")
+}

--- a/internal/service/advancedclustertpf/resource_compatiblity.go
+++ b/internal/service/advancedclustertpf/resource_compatiblity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	admin20240530 "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	"go.mongodb.org/atlas-sdk/v20250219001/admin"
@@ -60,7 +61,7 @@ func resolveAPIInfo(ctx context.Context, diags *diag.Diagnostics, client *config
 	)
 	clusterRespOld, _, err := api20240530.GetCluster(ctx, projectID, clusterName).Execute()
 	if err != nil {
-		if admin20240530.IsErrorCode(err, "ASYMMETRIC_SHARD_UNSUPPORTED") {
+		if validate.ErrorClusterIsAsymmetrics(err) {
 			useOldShardingConfigFailed = !useReplicationSpecPerShard
 		} else {
 			diags.AddError(errorReadLegacy20240530, defaultAPIErrorDetails(clusterName, err))

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -212,6 +212,10 @@ func readGlobalClusterConfig(ctx context.Context, meta any, projectID, clusterNa
 			return true, nil
 		}
 		if validate.ErrorClusterIsAsymmetrics(err) {
+			// Avoid non-empty plan by setting an empty custom_zone_mapping.
+			if err := d.Set("custom_zone_mapping", map[string]string{}); err != nil {
+				return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
+			}
 			return false, nil
 		}
 		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)

--- a/internal/service/globalclusterconfig/resource_global_cluster_config.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config.go
@@ -175,40 +175,51 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
-	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
+	notFound, err := readGlobalClusterConfig(ctx, meta, projectID, clusterName, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if notFound {
+		d.SetId("")
+	}
+	return nil
+}
+
+func readGlobalClusterConfig(ctx context.Context, meta any, projectID, clusterName string, d *schema.ResourceData) (notFound bool, err error) {
+	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	connV220240530 := meta.(*config.MongoDBClient).AtlasV220240530
 	resp, httpResp, err := connV2.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if validate.StatusNotFound(httpResp) {
-			d.SetId("")
-			return nil
+			return true, nil
 		}
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
+		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
 	}
+	if err := d.Set("managed_namespaces", flattenManagedNamespaces(resp.GetManagedNamespaces())); err != nil {
+		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
+	}
+	if err := d.Set("custom_zone_mapping_zone_id", resp.GetCustomZoneMapping()); err != nil {
+		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
+	}
+
 	oldResp, httpResp, err := connV220240530.GlobalClustersApi.GetManagedNamespace(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if validate.StatusNotFound(httpResp) {
-			d.SetId("")
-			return nil
+			return true, nil
 		}
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
-	}
-
-	if err := d.Set("managed_namespaces", flattenManagedNamespaces(resp.GetManagedNamespaces())); err != nil {
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
-	}
-	if err := d.Set("custom_zone_mapping_zone_id", resp.GetCustomZoneMapping()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
+		if validate.ErrorClusterIsAsymmetrics(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
 	}
 	if err := d.Set("custom_zone_mapping", oldResp.GetCustomZoneMapping()); err != nil {
-		return diag.FromErr(fmt.Errorf(errorGlobalClusterRead, clusterName, err))
+		return false, fmt.Errorf(errorGlobalClusterRead, clusterName, err)
 	}
-
-	return nil
+	return false, nil
 }
 
 func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -65,7 +65,7 @@ func TestAccGlobalClusterConfig_iss(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configIss(&clusterInfo, false, false, zone1, zone2),
+				Config: configISS(&clusterInfo, false, false, zone1, zone2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil, []string{"project_id"}, attrsMap),
@@ -368,7 +368,7 @@ func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
 	`, info.TerraformNameRef, info.ProjectID, zones, info.ResourceName) + dataSourceConfig
 }
 
-func configIss(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool, zone1, zone2 string) string {
+func configISS(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool, zone1, zone2 string) string {
 	return info.TerraformStr + fmt.Sprintf(`
 		resource "mongodbatlas_global_cluster_config" "config" {
 			cluster_name     = %[1]s

--- a/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
+++ b/internal/service/globalclusterconfig/resource_global_cluster_config_test.go
@@ -14,8 +14,15 @@ import (
 )
 
 const (
-	resourceName   = "mongodbatlas_global_cluster_config.config"
-	dataSourceName = "data.mongodbatlas_global_cluster_config.config"
+	resourceName     = "mongodbatlas_global_cluster_config.config"
+	dataSourceName   = "data.mongodbatlas_global_cluster_config.config"
+	dataSourceConfig = `
+	data "mongodbatlas_global_cluster_config" "config" {
+		project_id   = mongodbatlas_global_cluster_config.config.project_id
+		cluster_name = mongodbatlas_global_cluster_config.config.cluster_name
+		depends_on   = [mongodbatlas_global_cluster_config.config]
+	}
+	`
 )
 
 func TestAccGlobalClusterConfig_basic(t *testing.T) {
@@ -24,6 +31,42 @@ func TestAccGlobalClusterConfig_basic(t *testing.T) {
 
 func TestAccGlobalClusterConfig_withBackup(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t, true, true))
+}
+
+func TestAccGlobalClusterConfig_iss(t *testing.T) {
+	var (
+		replicationSpec1 = acc.ReplicationSpecRequest{
+			ZoneName:     "Zone 1",
+			Region:       "US_EAST_1",
+			InstanceSize: "M30",
+		}
+		replicationSpec2 = acc.ReplicationSpecRequest{
+			ZoneName:     "Zone 2",
+			Region:       "US_EAST_2",
+			InstanceSize: "M10",
+		}
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{Geosharded: true, ReplicationSpecs: []acc.ReplicationSpecRequest{replicationSpec1, replicationSpec2}})
+		attrsMap    = map[string]string{
+			"cluster_name":         clusterInfo.Name,
+			"managed_namespaces.#": "1",
+			"managed_namespaces.0.is_custom_shard_key_hashed": "false",
+			"managed_namespaces.0.is_shard_key_unique":        "false",
+		}
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 acc.PreCheckBasicSleep(t, &clusterInfo, "", ""),
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configIss(&clusterInfo, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil, []string{"project_id"}, attrsMap),
+				),
+			},
+		},
+	})
 }
 
 func basicTestCase(tb testing.TB, checkZoneID, withBackup bool) *resource.TestCase {
@@ -278,13 +321,7 @@ func configBasic(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool) st
 
 			depends_on = [%[5]s]
 		}
-
-		data "mongodbatlas_global_cluster_config" "config" {
-			project_id       = mongodbatlas_global_cluster_config.config.project_id			
-			cluster_name     = mongodbatlas_global_cluster_config.config.cluster_name
-			depends_on = [mongodbatlas_global_cluster_config.config]
-		}	
-	`, info.TerraformNameRef, info.ProjectID, isCustomShard, isShardKeyUnique, info.ResourceName)
+	`, info.TerraformNameRef, info.ProjectID, isCustomShard, isShardKeyUnique, info.ResourceName) + dataSourceConfig
 }
 
 func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
@@ -322,11 +359,23 @@ func configWithDBConfig(info *acc.ClusterInfo, zones string) string {
 
 			depends_on = [%[4]s]
 		}
+	`, info.TerraformNameRef, info.ProjectID, zones, info.ResourceName) + dataSourceConfig
+}
 
-		data "mongodbatlas_global_cluster_config" "config" {
-			project_id       = mongodbatlas_global_cluster_config.config.project_id			
-			cluster_name     = mongodbatlas_global_cluster_config.config.cluster_name
-			depends_on = [mongodbatlas_global_cluster_config.config]
-		}	
-	`, info.TerraformNameRef, info.ProjectID, zones, info.ResourceName)
+func configIss(info *acc.ClusterInfo, isCustomShard, isShardKeyUnique bool) string {
+	return info.TerraformStr + fmt.Sprintf(`
+		resource "mongodbatlas_global_cluster_config" "config" {
+			cluster_name     = %[1]s
+			project_id       = %[2]q
+
+			managed_namespaces {
+				db               		   = "mydata"
+				collection       		   = "publishers"
+				custom_shard_key		   = "city"
+				is_custom_shard_key_hashed = %[3]t
+				is_shard_key_unique 	   = %[4]t
+			}
+			depends_on = [%[5]s]
+		}
+	`, info.TerraformNameRef, info.ProjectID, isCustomShard, isShardKeyUnique, info.ResourceName) + dataSourceConfig
 }


### PR DESCRIPTION
## Description

When we read the managed namespaces with `v2/groups/{groupId}/clusters/{clusterName}/globalWrites` we must handle the case where the API returns `ASYMMETRIC_SHARD_UNSUPPORTED`

- [x] reproduce failure
- [x] add fix

Link to any related issue(s): CLOUDP-306826 & HELP-72478

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
