### PR TITLE
test: Migration tests for all SDKv2 and TPF paths

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -412,14 +412,37 @@ jobs:
         run: make testmact
       - name: Acceptance Tests
         env:
-          MONGODB_ATLAS_LAST_VERSION: '1.28.0' # Fix mig test version until CLOUDP-296406 is resolved
-          HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: |
             ./internal/service/advancedcluster
             ./internal/service/advancedclustertpf
         run: make testacc
  
+  advanced_cluster_tpf_mig_from_sdkv2:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ inputs.reduced_tests == false && (needs.change-detection.outputs.advanced_cluster_tpf == 'true' || inputs.test_group == 'advanced_cluster_tpf') }}
+    env:
+      MONGODB_ATLAS_PREVIEW_PROVIDER_V2_ADVANCED_CLUSTER: 'true'
+      MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'true'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false  
+      - name: Acceptance Tests
+        env:
+          ACCTEST_REGEX_RUN: '^TestMig'
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
+        run: make testacc
+
   assume_role:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -412,6 +412,7 @@ jobs:
         run: make testmact
       - name: Acceptance Tests
         env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: |
             ./internal/service/advancedcluster
@@ -439,6 +440,7 @@ jobs:
           terraform_wrapper: false  
       - name: Acceptance Tests
         env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_REGEX_RUN: '^TestMig'
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -381,6 +381,7 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -381,7 +381,6 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
@@ -414,6 +413,7 @@ jobs:
       - name: Acceptance Tests
         env:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
           ACCTEST_PACKAGES: |
             ./internal/service/advancedcluster

--- a/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_migration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -14,29 +15,24 @@ import (
 const versionBeforeISSRelease = "1.17.6"
 
 func TestMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
-	testCase := replicaSetAWSProviderTestCase(t, false)
-	mig.CreateAndRunTest(t, &testCase)
+	migTest(t, replicaSetAWSProviderTestCase)
 }
 
 func TestMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
-	testCase := replicaSetMultiCloudTestCase(t, false)
-	mig.CreateAndRunTest(t, &testCase)
+	migTest(t, replicaSetMultiCloudTestCase)
 }
 
 func TestMigAdvancedCluster_singleShardedMultiCloud(t *testing.T) {
-	testCase := singleShardedMultiCloudTestCase(t, false)
-	mig.CreateAndRunTest(t, &testCase)
+	migTest(t, singleShardedMultiCloudTestCase)
 }
 
 func TestMigAdvancedCluster_symmetricGeoShardedOldSchema(t *testing.T) {
-	testCase := symmetricGeoShardedOldSchemaTestCase(t, false)
-	mig.CreateAndRunTest(t, &testCase)
+	migTest(t, symmetricGeoShardedOldSchemaTestCase)
 }
 
 func TestMigAdvancedCluster_asymmetricShardedNewSchema(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.23.0") // version where sharded cluster tier auto-scaling was introduced
-	testCase := asymmetricShardedNewSchemaTestCase(t, false)
-	mig.CreateAndRunTest(t, &testCase)
+	migTest(t, asymmetricShardedNewSchemaTestCase)
 }
 
 func TestMigAdvancedCluster_replicaSetAWSProviderUpdate(t *testing.T) {
@@ -281,4 +277,16 @@ func configPartialAdvancedConfig(projectID, clusterName, extraArgs, autoScaling 
 			%[3]s
 		}
 	`, projectID, clusterName, extraArgs, autoScaling)
+}
+
+// migTest is a helper function to run migration tests in normal case (SDKv2 -> SDKv2, TPF -> TPF), or in mixed case (SDKv2 -> TPF).
+func migTest(t *testing.T, testCaseFunc func(t *testing.T, isAcc bool) resource.TestCase) {
+	t.Helper()
+	isAcc := config.PreviewProviderV2AdvancedCluster()
+	if acc.IsTestSDKv2ToTPF() {
+		isAcc = false
+		t.Log("Running test SDKv2 to TPF")
+	}
+	testCase := testCaseFunc(t, isAcc)
+	mig.CreateAndRunTest(t, &testCase)
 }

--- a/internal/testutil/acc/advanced_cluster_preview_provider_v2.go
+++ b/internal/testutil/acc/advanced_cluster_preview_provider_v2.go
@@ -1,6 +1,8 @@
 package acc
 
 import (
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -13,6 +15,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+// IsTestSDKv2ToTPF returns if we want to run migration tests from SDKv2 to TPF.
+func IsTestSDKv2ToTPF() bool {
+	env, _ := strconv.ParseBool(os.Getenv("MONGODB_ATLAS_TEST_SDKV2_TO_TPF"))
+	return env
+}
 
 func CheckRSAndDSPreviewProviderV2(isAcc bool, resourceName string, dataSourceName, pluralDataSourceName *string, attrsSet []string, attrsMap map[string]string, extra ...resource.TestCheckFunc) resource.TestCheckFunc {
 	modifiedSet := ConvertToPreviewProviderV2AttrsSet(isAcc, attrsSet)

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -2,21 +2,32 @@ package acc
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	MaxClusterNodesPerProject = 30 // Choose to be conservative, 40 clusters per project is the limit before `CROSS_REGION_NETWORK_PERMISSIONS_LIMIT_EXCEEDED` error, see https://www.mongodb.com/docs/atlas/reference/atlas-limits/
+	testSDKv2ToTPFEnvVar      = "MONGODB_ATLAS_TEST_SDKV2_TO_TPF"
 )
+
+// IsTestSDKv2ToTPF returns if we want to run migration tests from SDKv2 to TPF.
+func IsTestSDKv2ToTPF() bool {
+	env, _ := strconv.ParseBool(os.Getenv(testSDKv2ToTPFEnvVar))
+	return env
+}
 
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
 // It returns the cleanup function that must be called at the end of TestMain.
 func SetupSharedResources() func() {
 	sharedInfo.init = true
+	setupTestsSDKv2ToTPF()
 	return cleanupSharedResources
 }
 
@@ -165,4 +176,13 @@ func NextProjectIDClusterName(totalNodeCount int, projectCreator func(string) st
 		sharedInfo.projects[len(sharedInfo.projects)-1].nodeCount += totalNodeCount
 	}
 	return project.id, RandomClusterName()
+}
+
+// setupTestsSDKv2ToTPF sets the Preview environment variable to false so the previous version in migration tests uses SDKv2.
+func setupTestsSDKv2ToTPF() {
+	_ = config.PreviewProviderV2AdvancedCluster() // Makes sure that the Preview environment variable is read
+	enabled, _ := strconv.ParseBool(os.Getenv(testSDKv2ToTPFEnvVar))
+	if enabled {
+		os.Setenv(config.PreviewProviderV2AdvancedClusterEnvVar, "false")
+	}
 }

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -171,7 +171,7 @@ func NextProjectIDClusterName(totalNodeCount int, projectCreator func(string) st
 }
 
 // setupTestsSDKv2ToTPF sets the Preview environment variable to false so the previous version in migration tests uses SDKv2.
-// However the current version will use TPF as the variable was read when it was true.
+// However the current version will use TPF as the variable is only read once during import when it was true.
 func setupTestsSDKv2ToTPF() {
 	if IsTestSDKv2ToTPF() && config.PreviewProviderV2AdvancedCluster() {
 		os.Setenv(config.PreviewProviderV2AdvancedClusterEnvVar, "false")

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -3,7 +3,6 @@ package acc
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -14,14 +13,7 @@ import (
 
 const (
 	MaxClusterNodesPerProject = 30 // Choose to be conservative, 40 clusters per project is the limit before `CROSS_REGION_NETWORK_PERMISSIONS_LIMIT_EXCEEDED` error, see https://www.mongodb.com/docs/atlas/reference/atlas-limits/
-	testSDKv2ToTPFEnvVar      = "MONGODB_ATLAS_TEST_SDKV2_TO_TPF"
 )
-
-// IsTestSDKv2ToTPF returns if we want to run migration tests from SDKv2 to TPF.
-func IsTestSDKv2ToTPF() bool {
-	env, _ := strconv.ParseBool(os.Getenv(testSDKv2ToTPFEnvVar))
-	return env
-}
 
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
 // It returns the cleanup function that must be called at the end of TestMain.
@@ -181,8 +173,7 @@ func NextProjectIDClusterName(totalNodeCount int, projectCreator func(string) st
 // setupTestsSDKv2ToTPF sets the Preview environment variable to false so the previous version in migration tests uses SDKv2.
 func setupTestsSDKv2ToTPF() {
 	_ = config.PreviewProviderV2AdvancedCluster() // Makes sure that the Preview environment variable is read
-	enabled, _ := strconv.ParseBool(os.Getenv(testSDKv2ToTPFEnvVar))
-	if enabled {
+	if IsTestSDKv2ToTPF() {
 		os.Setenv(config.PreviewProviderV2AdvancedClusterEnvVar, "false")
 	}
 }

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -171,9 +171,9 @@ func NextProjectIDClusterName(totalNodeCount int, projectCreator func(string) st
 }
 
 // setupTestsSDKv2ToTPF sets the Preview environment variable to false so the previous version in migration tests uses SDKv2.
+// However the current version will use TPF as the variable was read when it was true.
 func setupTestsSDKv2ToTPF() {
-	_ = config.PreviewProviderV2AdvancedCluster() // Makes sure that the Preview environment variable is read
-	if IsTestSDKv2ToTPF() {
+	if IsTestSDKv2ToTPF() && config.PreviewProviderV2AdvancedCluster() {
 		os.Setenv(config.PreviewProviderV2AdvancedClusterEnvVar, "false")
 	}
 }


### PR DESCRIPTION
## Description

Migration tests for all SDKv2 and TPF paths.

Test groups are:
- advanced_cluster: Runs SDKv2 to SDKv2 mig tests
- advanced_cluster_tpf: Runs TPF to TPF mig tests
- advanced_cluster_tpf_mig_from_sdkv2: Runs SDKv2 to TPF mig test

Note that PR checks don't run advanced_cluster_tpf_mig_from_sdkv2 test group as it only runs tests with prefix TestAccMockable.

Full advanced_cluster execution [here](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13997486473/job/39196113819)

Full advanced_cluster_tpf & advanced_cluster_tpf_mig_from_sdkv2 execution [here](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/13997492041/job/39196123819)

Link to any related issue(s): CLOUDP-296406


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

These are the failing tests, **IMPORTANT**: these tests are also failing in master.

- PR Check (TPF)
  - TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate: 
```
 produced an
  | unexpected new value: .mongo_db_version: was cty.StringVal("8.0.6"), but now
  | cty.StringVal("8.1.0-rc0").
```
- SDKv2
  - TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate:  
```Attribute 'mongo_db_major_version' expected "8.0", got "8.1"```
  - TestAccClusterAdvancedCluster_unpausedToPaused: OPERATION_INVALID_MEMBER_REPLICATION_LAG
- TPF
  - TestAccMockableAdvancedCluster_replicasetAdvConfigUpdate
 ```
 produced an
  | unexpected new value: .mongo_db_version: was cty.StringVal("8.0.6"), but now
  | cty.StringVal("8.1.0-rc0").
```
  - TestAccClusterAdvancedCluster_unpausedToPaused: OPERATION_INVALID_MEMBER_REPLICATION_LAG
  - TestAccMockableAdvancedCluster_tenantUpgrade
```
 unexpected new value: .replication_specs[0].region_configs[0].provider_name:
  | was cty.StringVal("AWS"), but now cty.StringVal("TENANT").
```