### PR TITLE
chore: Takes electable_specs in TPF adv_cluster from state if it was in config

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1500,7 +1500,7 @@ func configSharded(t *testing.T, projectID, clusterName string, withUpdate bool)
 
 func configBlocks(t *testing.T, projectID, clusterName, instanceSize string, defineBlocks bool) string {
 	t.Helper()
-	var extraConfig0, extraConfig1 string
+	var extraConfig0, extraConfig1, electableSpecs0 string
 	autoScalingBlocks := `
 		auto_scaling {
 			disk_gb_enabled            = true
@@ -1518,6 +1518,12 @@ func configBlocks(t *testing.T, projectID, clusterName, instanceSize string, def
 		}
 	`
 	if defineBlocks {
+		electableSpecs0 = `
+			electable_specs {
+				instance_size   = "M10"
+				node_count      = 5
+			}
+		`
 		// read only + autoscaling blocks
 		extraConfig0 = `
 			read_only_specs {
@@ -1549,10 +1555,7 @@ func configBlocks(t *testing.T, projectID, clusterName, instanceSize string, def
 					provider_name = "AWS"
 					priority      = 7
 					region_name   = "US_EAST_1"
-					electable_specs {
-						instance_size   = "M10"
-						node_count      = 5
-					}
+					%[6]s
 					%[4]s
 				}
 			}
@@ -1577,7 +1580,7 @@ func configBlocks(t *testing.T, projectID, clusterName, instanceSize string, def
 				}
 			}
 		}
-	`, projectID, clusterName, instanceSize, extraConfig0, extraConfig1))
+	`, projectID, clusterName, instanceSize, extraConfig0, extraConfig1, electableSpecs0))
 }
 
 func checkBlocks(instanceSize string) resource.TestCheckFunc {

--- a/internal/service/advancedclustertpf/plan_modifier.go
+++ b/internal/service/advancedclustertpf/plan_modifier.go
@@ -119,9 +119,14 @@ func AdjustRegionConfigsChildren(ctx context.Context, diags *diag.Diagnostics, s
 			return
 		}
 		for j := range minLen(planRegionConfigsTF, stateRegionConfigsTF) {
+			stateElectableSpecs := TFModelObject[TFSpecsModel](ctx, stateRegionConfigsTF[j].ElectableSpecs)
+			planElectableSpecs := TFModelObject[TFSpecsModel](ctx, planRegionConfigsTF[j].ElectableSpecs)
+			if planElectableSpecs == nil && stateElectableSpecs != nil && stateElectableSpecs.NodeCount.ValueInt64() > 0 {
+				planRegionConfigsTF[j].ElectableSpecs = stateRegionConfigsTF[j].ElectableSpecs
+				planElectableSpecs = stateElectableSpecs
+			}
 			stateReadOnlySpecs := TFModelObject[TFSpecsModel](ctx, stateRegionConfigsTF[j].ReadOnlySpecs)
 			planReadOnlySpecs := TFModelObject[TFSpecsModel](ctx, planRegionConfigsTF[j].ReadOnlySpecs)
-			planElectableSpecs := TFModelObject[TFSpecsModel](ctx, planRegionConfigsTF[j].ElectableSpecs)
 			if stateReadOnlySpecs != nil { // read_only_specs is present in state
 				// logic below ensures that if read only specs is present in state but not in the plan, plan will be populated so that read only spec configuration is not removed on update operations
 				newPlanReadOnlySpecs := planReadOnlySpecs

--- a/internal/service/advancedclustertpf/plan_modifier_test.go
+++ b/internal/service/advancedclustertpf/plan_modifier_test.go
@@ -40,11 +40,9 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 				},
 			},
 			{
-				ConfigFilename: "main_removed_blocks_from_config_electable_specs_and_instance_change.tf",
+				ConfigFilename: "main_removed_blocks_from_config_and_instance_change.tf",
 				Checks: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("instance_size"), knownvalue.StringExact("M10")),
-					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("node_count"), knownvalue.Int64Exact(5)),
 					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("read_only_specs").AtMapKey("instance_size"), knownvalue.StringExact("M10")),
 					plancheck.ExpectKnownValue(resourceName, regionConfig1.AtMapKey("read_only_specs").AtMapKey("instance_size"), knownvalue.StringExact("M20")),
 					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("auto_scaling"), autoScalingEnabled),

--- a/internal/service/advancedclustertpf/plan_modifier_test.go
+++ b/internal/service/advancedclustertpf/plan_modifier_test.go
@@ -40,9 +40,11 @@ func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 				},
 			},
 			{
-				ConfigFilename: "main_removed_blocks_from_config_and_instance_change.tf",
+				ConfigFilename: "main_removed_blocks_from_config_electable_specs_and_instance_change.tf",
 				Checks: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("instance_size"), knownvalue.StringExact("M10")),
+					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("electable_specs").AtMapKey("node_count"), knownvalue.Int64Exact(5)),
 					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("read_only_specs").AtMapKey("instance_size"), knownvalue.StringExact("M10")),
 					plancheck.ExpectKnownValue(resourceName, regionConfig1.AtMapKey("read_only_specs").AtMapKey("instance_size"), knownvalue.StringExact("M20")),
 					plancheck.ExpectKnownValue(resourceName, regionConfig0.AtMapKey("auto_scaling"), autoScalingEnabled),

--- a/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_and_instance_change.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_and_instance_change.tf
@@ -6,10 +6,6 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
   replication_specs = [{
     region_configs = [{
-      electable_specs = {
-        instance_size = "M10"
-        node_count    = 5
-      }
       priority      = 7
       provider_name = "AWS"
       region_name   = "US_EAST_1"

--- a/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_and_instance_change.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_and_instance_change.tf
@@ -6,6 +6,10 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
   replication_specs = [{
     region_configs = [{
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 5
+      }
       priority      = 7
       provider_name = "AWS"
       region_name   = "US_EAST_1"

--- a/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_electable_specs_and_instance_change.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterTwoRepSpecsWithAutoScalingAndSpecs/main_removed_blocks_from_config_electable_specs_and_instance_change.tf
@@ -6,10 +6,6 @@ resource "mongodbatlas_advanced_cluster" "test" {
 
   replication_specs = [{
     region_configs = [{
-      electable_specs = {
-        instance_size = "M10"
-        node_count    = 5
-      }
       priority      = 7
       provider_name = "AWS"
       region_name   = "US_EAST_1"


### PR DESCRIPTION
## Description

Takes electable_specs in TPF adv_cluster from state if it was in config

Link to any related issue(s): CLOUDP-306111

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
