### PR TITLE
chore: Removes use of verify-changed-files GitHub action

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -19,12 +19,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: Update files
         run:  make tools update-atlas-sdk
-      - name: Verify Changed files
-        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
-        id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}
           title: "chore: Updates Atlas Go SDK"

--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update files
         run:  make tools update-atlas-sdk
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@9437562cb29a5a1120dd9f02cc760ec9e5d4651a
+        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
         id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e

--- a/.github/workflows/update-tf-versions.yml
+++ b/.github/workflows/update-tf-versions.yml
@@ -18,12 +18,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  make update-tf-compatibility-matrix
-      - name: Verify Changed files
-        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
-        id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}
           title: "doc: Updates Terraform Compatibility Matrix documentation"
@@ -43,12 +39,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  make update-tf-version-in-repository
-      - name: Verify Changed files
-        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
-        id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.APIX_BOT_PAT }}
           title: "chore: Updates repository to use supported Terraform versions"

--- a/.github/workflows/update-tf-versions.yml
+++ b/.github/workflows/update-tf-versions.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  make update-tf-compatibility-matrix
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@9437562cb29a5a1120dd9f02cc760ec9e5d4651a
+        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
         id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  make update-tf-version-in-repository
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@9437562cb29a5a1120dd9f02cc760ec9e5d4651a
+        uses: mongodb/apix-action/verify-changed-files@82844ae9e10d8b07686f90f98d9257c4c38b54ca
         id: verify-changed-files
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e


### PR DESCRIPTION
## Description

Removes use of verify-changed-files GitHub action as it's not needed.  As in [peter-evans/create-pull-request GHA](https://github.com/peter-evans/create-pull-request) doc:
```
If there are no changes (i.e. no diff exists with the checked-out base branch), no pull request will be created and the action exits silently.
```

Link to any related issue(s): CLOUDP-306813

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Example of execution: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/14063740133/job/39380819898
```
Create or update the pull request branch
  /usr/bin/git symbolic-ref HEAD --short
  CLOUDP-306813_gha_file_changes
  Working base is branch 'CLOUDP-306813_gha_file_changes'
...
  Resetting working base branch 'CLOUDP-306813_gha_file_changes'
  /usr/bin/git checkout --progress CLOUDP-306813_gha_file_changes --
  Switched to branch 'CLOUDP-306813_gha_file_changes'
  Your branch is up to date with 'origin/CLOUDP-306813_gha_file_changes'.
  /usr/bin/git reset --hard origin/CLOUDP-306813_gha_file_changes
  HEAD is now at 743400f don't detect changes
...
  Pull request branch 'terraform-versions-update' does not exist yet.
  /usr/bin/git checkout --progress -B terraform-versions-update 2f1c5c3e-b2c4-489d-9e21-638b2886963b --
  Switched to a new branch 'terraform-versions-update'
  /usr/bin/git rev-list --right-only --count CLOUDP-306813_gha_file_changes...terraform-versions-update
  0
  Branch 'terraform-versions-update' is not ahead of base 'CLOUDP-306813_gha_file_changes' and will not be created
  /usr/bin/git rev-parse CLOUDP-306813_gha_file_changes
...
  Switched to branch 'CLOUDP-306813_gha_file_changes'
  Your branch is up to date with 'origin/CLOUDP-306813_gha_file_changes'.
```