### PR TITLE
chore: Uses Terraform setup before unit tests

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -30,6 +30,12 @@ jobs:
       pull-requests: write # Needed by sticky-pull-request-comment
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # Avoid: cannot run Terraform provider tests: error calling terraform version command: fork/exec /tmp/plugintest-terraformXXX/terraform: text file busy also speeds up the tests as terraform will already exist on path.
+      # Also speeds up the tests
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: '1.11.x'
+          terraform_wrapper: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version-file: 'go.mod'

--- a/scripts/update-tf-version-in-repository.sh
+++ b/scripts/update-tf-version-in-repository.sh
@@ -20,6 +20,7 @@ TF_VERSIONS_ARR=$(./scripts/get-terraform-supported-versions.sh "false")
 
 TEST_SUITE_YAML_FILE=".github/workflows/test-suite.yml"
 ACCEPTANCE_TESTS_YAML_FILE=".github/workflows/acceptance-tests.yml"
+CODE_HEALTH_YAML_FILE=".github/workflows/code-health.yml"
 EXAMPLES_YAML_FILE=".github/workflows/examples.yml"
 TOOL_VERSIONS_FILE=".tool-versions"
 DOC_SCRIPT="scripts/generate-doc.sh"
@@ -33,6 +34,9 @@ sed -i.bak -E "s|schedule_terraform_matrix: '.*'|schedule_terraform_matrix: '[\"
 
 # Update Terraform version in examples.yml
 sed -i.bak -E "s|terraform_version: '.*'|terraform_version: '$LATEST_TF_VERSION'|" "$EXAMPLES_YAML_FILE"
+
+# Update Terraform version in code-health.yml
+sed -i.bak -E "s|terraform_version: '.*'|terraform_version: '$LATEST_TF_VERSION'|" "$CODE_HEALTH_YAML_FILE"
 
 # Update Terraform version in acceptance-tests.yml
 sed -i.bak -E "s~terraform_version \|\| '[0-9]+\.[0-9]+\.x'~terraform_version \|\| '$LATEST_TF_VERSION'~" "$ACCEPTANCE_TESTS_YAML_FILE"


### PR DESCRIPTION
## Description

After seeing a few unit test failures due to:

> Avoid: cannot run Terraform provider tests: error calling terraform version command: fork/exec /tmp/plugintest-terraform3208628588/terraform: text file busy also speeds up the tests as terraform will already exist on path.

This PR uses Terraform setup before unit tests to avoid each acceptance tests run at unit test stage to download their own terraform version

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
