### PR TITLE
chore: Define conversion function for setting API response values into TF Model (non-nested)

### DIFF
--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -1,0 +1,6 @@
+package autogeneration
+
+// Unmarshal get a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
+func Unmarshal(raw []byte, to any) error {
+	return nil
+}

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -44,14 +44,14 @@ func mapField(nameAttrSrc string, valueAttrSrc any, valDest reflect.Value) error
 	}
 	switch v := valueAttrSrc.(type) {
 	case string:
-		return assignField(fieldDest, types.StringValue(v))
+		return assignField(nameDest, fieldDest, types.StringValue(v))
 	case bool:
-		return assignField(fieldDest, types.BoolValue(v))
+		return assignField(nameDest, fieldDest, types.BoolValue(v))
 	case float64: // number: try int or float
-		if assignField(fieldDest, types.Float64Value(v)) == nil {
+		if assignField(nameDest, fieldDest, types.Float64Value(v)) == nil {
 			return nil
 		}
-		return assignField(fieldDest, types.Int64Value(int64(v)))
+		return assignField(nameDest, fieldDest, types.Int64Value(int64(v)))
 	case nil:
 		return nil // skip nil values, no need to set anything
 	default:
@@ -59,10 +59,10 @@ func mapField(nameAttrSrc string, valueAttrSrc any, valDest reflect.Value) error
 	}
 }
 
-func assignField(fieldDest reflect.Value, valueDest attr.Value) error {
+func assignField(nameDest string, fieldDest reflect.Value, valueDest attr.Value) error {
 	valObj := reflect.ValueOf(valueDest)
 	if !fieldDest.Type().AssignableTo(valObj.Type()) {
-		return fmt.Errorf("can't assign value to model field %s", fieldDest.Type().Name())
+		return fmt.Errorf("can't assign value to model field %s", nameDest)
 	}
 	fieldDest.Set(valObj)
 	return nil

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -1,6 +1,51 @@
 package autogeneration
 
-// Unmarshal get a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
-func Unmarshal(raw []byte, to any) error {
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/huandu/xstrings"
+)
+
+// Unmarshal gets a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
+func Unmarshal(raw []byte, dest any) error {
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	return mapFields(fields, dest)
+}
+
+func mapFields(fields map[string]any, dest any) error {
+	valDest := reflect.ValueOf(dest)
+	if valDest.Kind() != reflect.Ptr {
+		panic("dest must be pointer")
+	}
+	valDest = valDest.Elem()
+	if valDest.Kind() != reflect.Struct {
+		panic("dest must be pointer to struct")
+	}
+	for nameSrc, valueSrc := range fields {
+		nameDest := xstrings.ToPascalCase(nameSrc)
+		fieldDest := valDest.FieldByName(nameDest)
+		if !fieldDest.CanSet() {
+			continue // skip fields that cannot be set, are invalid or not found
+		}
+		switch v := valueSrc.(type) {
+		case bool:
+			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
+		case float64:
+			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
+		case string:
+			valObj := reflect.ValueOf(types.StringValue(v))
+			fieldDest.Set(valObj)
+		case nil:
+			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
+		default:
+			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
+		}
+	}
 	return nil
 }

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -5,20 +5,21 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/huandu/xstrings"
 )
 
 // Unmarshal gets a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
 func Unmarshal(raw []byte, dest any) error {
-	var fields map[string]any
-	if err := json.Unmarshal(raw, &fields); err != nil {
+	var src map[string]any
+	if err := json.Unmarshal(raw, &src); err != nil {
 		return err
 	}
-	return mapFields(fields, dest)
+	return mapFields(src, dest)
 }
 
-func mapFields(fields map[string]any, dest any) error {
+func mapFields(src map[string]any, dest any) error {
 	valDest := reflect.ValueOf(dest)
 	if valDest.Kind() != reflect.Ptr {
 		panic("dest must be pointer")
@@ -27,25 +28,39 @@ func mapFields(fields map[string]any, dest any) error {
 	if valDest.Kind() != reflect.Struct {
 		panic("dest must be pointer to struct")
 	}
-	for nameSrc, valueSrc := range fields {
-		nameDest := xstrings.ToPascalCase(nameSrc)
-		fieldDest := valDest.FieldByName(nameDest)
-		if !fieldDest.CanSet() {
-			continue // skip fields that cannot be set, are invalid or not found
-		}
-		switch v := valueSrc.(type) {
-		case bool:
-			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
-		case float64:
-			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
-		case string:
-			valObj := reflect.ValueOf(types.StringValue(v))
-			fieldDest.Set(valObj)
-		case nil:
-			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
-		default:
-			return fmt.Errorf("not supported yet type %T for field %s", v, nameSrc)
+	for nameAttrSrc, valueAttrSrc := range src {
+		if err := mapField(nameAttrSrc, valueAttrSrc, valDest); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func mapField(nameAttrSrc string, valueAttrSrc any, valDest reflect.Value) error {
+	nameDest := xstrings.ToPascalCase(nameAttrSrc)
+	fieldDest := valDest.FieldByName(nameDest)
+	if !fieldDest.CanSet() {
+		return nil // skip fields that cannot be set, are invalid or not found
+	}
+	switch v := valueAttrSrc.(type) {
+	case string:
+		return assignField(fieldDest, types.StringValue(v))
+	case bool:
+		return assignField(fieldDest, types.BoolValue(v))
+	case float64:
+		return fmt.Errorf("not supported yet type %T for field %s", v, nameAttrSrc)
+	case nil:
+		return nil // skip nil values, no need to set anything
+	default:
+		return fmt.Errorf("not supported yet type %T for field %s", v, nameAttrSrc)
+	}
+}
+
+func assignField(fieldDest reflect.Value, valueDest attr.Value) error {
+	valObj := reflect.ValueOf(valueDest)
+	if !fieldDest.Type().AssignableTo(valObj.Type()) {
+		return fmt.Errorf("can't assign value to model field %s", fieldDest.Type().Name())
+	}
+	fieldDest.Set(valObj)
 	return nil
 }

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Unmarshal gets a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
+// It supports the following Terraform model types: String, Bool, Int64, Float64.
 func Unmarshal(raw []byte, dest any) error {
 	var src map[string]any
 	if err := json.Unmarshal(raw, &src); err != nil {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -47,8 +47,11 @@ func mapField(nameAttrSrc string, valueAttrSrc any, valDest reflect.Value) error
 		return assignField(fieldDest, types.StringValue(v))
 	case bool:
 		return assignField(fieldDest, types.BoolValue(v))
-	case float64:
-		return fmt.Errorf("not supported yet type %T for field %s", v, nameAttrSrc)
+	case float64: // number: try int or float
+		if assignField(fieldDest, types.Float64Value(v)) == nil {
+			return nil
+		}
+		return assignField(fieldDest, types.Int64Value(int64(v)))
 	case nil:
 		return nil // skip nil values, no need to set anything
 	default:

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -52,8 +52,8 @@ func TestUnmarshalBasic(t *testing.T) {
 func TestUnmarshalErrors(t *testing.T) {
 	const errorStr = "can't assign value to model field Attr"
 	testCases := map[string]struct {
-		responseJSON string
 		model        any
+		responseJSON string
 	}{
 		"response ints are not converted to model strings": {
 			responseJSON: `{"attr": 123}`, //

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -92,3 +92,56 @@ func TestUnmarshalErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestUnmarshalUnsupportedModel has Terraform types not supported yet.
+// It will be updated when we add support for them.
+func TestUnmarshalUnsupportedModel(t *testing.T) {
+	testCases := map[string]struct {
+		model        any
+		responseJSON string
+	}{
+		"Int32 not supported yet as it's not being used in any model": {
+			responseJSON: `{"attr": 1}`,
+			model: &struct {
+				Attr types.Int32
+			}{},
+		},
+		"Float32 not supported yet as it's not being used in any model": {
+			responseJSON: `{"attr": 1}`,
+			model: &struct {
+				Attr types.Float32
+			}{},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, autogeneration.Unmarshal([]byte(tc.responseJSON), tc.model))
+		})
+	}
+}
+
+// TestUnmarshalUnsupportedResponse has JSON response types not supported yet.
+// It will be updated when we add support for them.
+func TestUnmarshalUnsupportedResponse(t *testing.T) {
+	var model struct {
+		Attr types.String
+	}
+	testCases := map[string]struct {
+		responseJSON string
+		errorStr     string
+	}{
+		"JSON objects not support yet": {
+			responseJSON: `{"attr": {"key": "value"}}`,
+			errorStr:     "not supported yet type map[string]interface {} for field att",
+		},
+		"JSON arrays not supported yet": {
+			responseJSON: `{"attr": [{"key": "value"}]}`,
+			errorStr:     "not supported yet type []interface {} for field att",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.ErrorContains(t, autogeneration.Unmarshal([]byte(tc.responseJSON), &model), tc.errorStr)
+		})
+	}
+}

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -5,22 +5,29 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshal(t *testing.T) {
 	var model tfModelTest
 	require.NoError(t, autogeneration.Unmarshal([]byte(tfResponseJSON), &model))
-	require.Equal(t, "value_string", model.AttributeString.ValueString())
+	assert.Equal(t, "value_string", model.AttributeString.ValueString())
+	assert.True(t, model.AttributeTrue.ValueBool())
+	assert.False(t, model.AttributeFalse.ValueBool())
 }
 
 type tfModelTest struct {
 	AttributeString types.String `tfsdk:"attribute_string"`
+	AttributeTrue   types.Bool   `tfsdk:"attribute_true"`
+	AttributeFalse  types.Bool   `tfsdk:"attribute_false"`
 }
 
 const tfResponseJSON = `
 {
 	"attribute_string": "value_string",
+	"attribute_true": true,
+	"attribute_false": false,
 	"attribute_not_in_model": "val"
 }
 `

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -10,19 +10,17 @@ import (
 
 func TestUnmarshal(t *testing.T) {
 	var model tfModelTest
-	require.NoError(t, autogeneration.Unmarshal([]byte(tfModelJSON), &model))
-	require.Equal(t, "value_bucket", model.BucketName.ValueString())
-	require.Equal(t, "value_date", model.CreateDate.ValueString())
+	require.NoError(t, autogeneration.Unmarshal([]byte(tfResponseJSON), &model))
+	require.Equal(t, "value_string", model.AttributeString.ValueString())
 }
 
 type tfModelTest struct {
-	BucketName types.String `tfsdk:"bucket_name"`
-	CreateDate types.String `tfsdk:"create_date"`
+	AttributeString types.String `tfsdk:"attribute_string"`
 }
 
-const tfModelJSON = `
+const tfResponseJSON = `
 {
-	"bucket_name": "value_bucket",
-	"create_date": "value_date",
+	"attribute_string": "value_string",
+	"attribute_not_in_model": "val"
 }
 `

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -15,12 +15,20 @@ func TestUnmarshal(t *testing.T) {
 	assert.Equal(t, "value_string", model.AttributeString.ValueString())
 	assert.True(t, model.AttributeTrue.ValueBool())
 	assert.False(t, model.AttributeFalse.ValueBool())
+	assert.Equal(t, int64(123), model.AttributeInt.ValueInt64())
+	assert.Equal(t, int64(10), model.AttributeIntWithFloat.ValueInt64())
+	assert.Equal(t, float64(456.1), model.AttributeFloat.ValueFloat64())
+	assert.Equal(t, float64(13), model.AttributeFloatWithInt.ValueFloat64())
 }
 
 type tfModelTest struct {
-	AttributeString types.String `tfsdk:"attribute_string"`
-	AttributeTrue   types.Bool   `tfsdk:"attribute_true"`
-	AttributeFalse  types.Bool   `tfsdk:"attribute_false"`
+	AttributeString       types.String  `tfsdk:"attribute_string"`
+	AttributeTrue         types.Bool    `tfsdk:"attribute_true"`
+	AttributeFalse        types.Bool    `tfsdk:"attribute_false"`
+	AttributeInt          types.Int64   `tfsdk:"attribute_int"`
+	AttributeIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
+	AttributeFloat        types.Float64 `tfsdk:"attribute_float"`
+	AttributeFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
 }
 
 const tfResponseJSON = `
@@ -28,6 +36,10 @@ const tfResponseJSON = `
 	"attribute_string": "value_string",
 	"attribute_true": true,
 	"attribute_false": false,
+	"attribute_int": 123,
+	"attribute_int_with_float": 10.6,
+	"attribute_float": 456.1,
+	"attribute_float_with_int": 13,
 	"attribute_not_in_model": "val"
 }
 `

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -12,29 +12,17 @@ func TestUnmarshal(t *testing.T) {
 	var model tfModelTest
 	require.NoError(t, autogeneration.Unmarshal([]byte(tfModelJSON), &model))
 	require.Equal(t, "value_bucket", model.BucketName.ValueString())
-	require.Equal(t, "2023-10-01T00:00:00Z", model.CreateDate.ValueString())
-	require.Equal(t, "value_group", model.GroupId.ValueString())
-	require.Equal(t, "value_role", model.IamRoleId.ValueString())
-	require.Equal(t, "value_prefix", model.PrefixPath.ValueString())
-	require.Equal(t, "state", model.State.ValueString())
+	require.Equal(t, "value_date", model.CreateDate.ValueString())
 }
 
 type tfModelTest struct {
 	BucketName types.String `tfsdk:"bucket_name"`
 	CreateDate types.String `tfsdk:"create_date"`
-	GroupId    types.String `tfsdk:"group_id"`
-	IamRoleId  types.String `tfsdk:"iam_role_id"`
-	PrefixPath types.String `tfsdk:"prefix_path"`
-	State      types.String `tfsdk:"state"`
 }
 
 const tfModelJSON = `
 {
 	"bucket_name": "value_bucket",
-	"create_date": "2023-10-01T00:00:00Z",
-	"group_id": "value_group",
-	"iam_role_id": "value_role",
-	"prefix_path": "value_prefix",
-	"state": "state"
+	"create_date": "value_date",
 }
 `

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -9,37 +9,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnmarshal(t *testing.T) {
-	var model tfModelTest
+func TestUnmarshalBasic(t *testing.T) {
+	var model struct {
+		AttributeFloat        types.Float64 `tfsdk:"attribute_float"`
+		AttributeFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
+		AttributeString       types.String  `tfsdk:"attribute_string"`
+		AttributeInt          types.Int64   `tfsdk:"attribute_int"`
+		AttributeIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
+		AttributeTrue         types.Bool    `tfsdk:"attribute_true"`
+		AttributeFalse        types.Bool    `tfsdk:"attribute_false"`
+	}
+	const (
+		epsilon = 10e-15 // float tolerance
+		// attribute_not_in_model is ignored but not an error
+		tfResponseJSON = `
+			{
+				"attribute_string": "value_string",
+				"attribute_true": true,
+				"attribute_false": false,
+				"attribute_int": 123,
+				"attribute_int_with_float": 10.6,
+				"attribute_float": 456.1,
+				"attribute_float_with_int": 13,
+				"attribute_not_in_model": "val"
+			}
+		`
+	)
 	require.NoError(t, autogeneration.Unmarshal([]byte(tfResponseJSON), &model))
 	assert.Equal(t, "value_string", model.AttributeString.ValueString())
 	assert.True(t, model.AttributeTrue.ValueBool())
 	assert.False(t, model.AttributeFalse.ValueBool())
 	assert.Equal(t, int64(123), model.AttributeInt.ValueInt64())
 	assert.Equal(t, int64(10), model.AttributeIntWithFloat.ValueInt64())
-	assert.Equal(t, float64(456.1), model.AttributeFloat.ValueFloat64())
-	assert.Equal(t, float64(13), model.AttributeFloatWithInt.ValueFloat64())
+	assert.InEpsilon(t, float64(456.1), model.AttributeFloat.ValueFloat64(), epsilon)
+	assert.InEpsilon(t, float64(13), model.AttributeFloatWithInt.ValueFloat64(), epsilon)
 }
-
-type tfModelTest struct {
-	AttributeString       types.String  `tfsdk:"attribute_string"`
-	AttributeTrue         types.Bool    `tfsdk:"attribute_true"`
-	AttributeFalse        types.Bool    `tfsdk:"attribute_false"`
-	AttributeInt          types.Int64   `tfsdk:"attribute_int"`
-	AttributeIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
-	AttributeFloat        types.Float64 `tfsdk:"attribute_float"`
-	AttributeFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
-}
-
-const tfResponseJSON = `
-{
-	"attribute_string": "value_string",
-	"attribute_true": true,
-	"attribute_false": false,
-	"attribute_int": 123,
-	"attribute_int_with_float": 10.6,
-	"attribute_float": 456.1,
-	"attribute_float_with_int": 13,
-	"attribute_not_in_model": "val"
-}
-`

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -1,0 +1,40 @@
+package autogeneration_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshal(t *testing.T) {
+	var model tfModelTest
+	require.NoError(t, autogeneration.Unmarshal([]byte(tfModelJSON), &model))
+	require.Equal(t, "value_bucket", model.BucketName.ValueString())
+	require.Equal(t, "2023-10-01T00:00:00Z", model.CreateDate.ValueString())
+	require.Equal(t, "value_group", model.GroupId.ValueString())
+	require.Equal(t, "value_role", model.IamRoleId.ValueString())
+	require.Equal(t, "value_prefix", model.PrefixPath.ValueString())
+	require.Equal(t, "state", model.State.ValueString())
+}
+
+type tfModelTest struct {
+	BucketName types.String `tfsdk:"bucket_name"`
+	CreateDate types.String `tfsdk:"create_date"`
+	GroupId    types.String `tfsdk:"group_id"`
+	IamRoleId  types.String `tfsdk:"iam_role_id"`
+	PrefixPath types.String `tfsdk:"prefix_path"`
+	State      types.String `tfsdk:"state"`
+}
+
+const tfModelJSON = `
+{
+	"bucket_name": "value_bucket",
+	"create_date": "2023-10-01T00:00:00Z",
+	"group_id": "value_group",
+	"iam_role_id": "value_role",
+	"prefix_path": "value_prefix",
+	"state": "state"
+}
+`

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -132,11 +132,11 @@ func TestUnmarshalUnsupportedResponse(t *testing.T) {
 	}{
 		"JSON objects not support yet": {
 			responseJSON: `{"attr": {"key": "value"}}`,
-			errorStr:     "not supported yet type map[string]interface {} for field att",
+			errorStr:     "not supported yet type map[string]interface {} for field attr",
 		},
 		"JSON arrays not supported yet": {
 			responseJSON: `{"attr": [{"key": "value"}]}`,
-			errorStr:     "not supported yet type []interface {} for field att",
+			errorStr:     "not supported yet type []interface {} for field attr",
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
## Description

Define conversion function for setting API response values into TF Model (non-nested).
At the moment it's created in a new `autogeneration` package.

Link to any related issue(s): CLOUDP-309398

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
