### PR TITLE
chore: Adds empty values when auto_scaling is not defined

### DIFF
--- a/internal/common/conversion/path_helpers_test.go
+++ b/internal/common/conversion/path_helpers_test.go
@@ -42,7 +42,7 @@ func TestIndexMethods(t *testing.T) {
 	assert.Equal(t, "advanced_configuration.custom_openssl_cipher_config_tls12[-Value(\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\")]", conversion.AsRemovedIndex(setIndex))
 	setNoIndex, diags := conversion.AncestorPathNoIndex(setIndex, "custom_openssl_cipher_config_tls12")
 	assert.Empty(t, diags)
-	assert.Equal(t, "advanced_configuration.custom_openssl_cipher_config_tls12", setNoIndex)
+	assert.Equal(t, "advanced_configuration.custom_openssl_cipher_config_tls12", setNoIndex.String())
 	assert.Empty(t, conversion.AsRemovedIndex(path.Root("replication_specs")))
 }
 
@@ -65,7 +65,7 @@ func TestParentPathWithIndex_Found(t *testing.T) {
 	assert.Equal(t, parentPath.String(), parentPathActual.String())
 
 	basePathActual, diags := conversion.AncestorPathWithIndex(childPath, "resource")
-	assert.Equal(t, basePath.String(), basePathActual)
+	assert.Equal(t, basePath.String(), basePathActual.String())
 	assert.Empty(t, diags, "Diagnostics should not have errors")
 }
 
@@ -78,11 +78,11 @@ func TestParentPathWithIndex_FoundIncludesIndex(t *testing.T) {
 
 	parentPathActual, diags := conversion.AncestorPathWithIndex(childPath, "parent")
 	assert.Empty(t, diags)
-	assert.Equal(t, parentPath.AtListIndex(0).String(), parentPathActual)
+	assert.Equal(t, parentPath.AtListIndex(0).String(), parentPathActual.String())
 
 	basePathActual, diags := conversion.AncestorPathWithIndex(childPath, "resource")
 	assert.Empty(t, diags)
-	assert.Equal(t, basePath.AtListIndex(0).String(), basePathActual)
+	assert.Equal(t, basePath.AtListIndex(0).String(), basePathActual.String())
 	assert.Empty(t, diags, "Diagnostics should not have errors")
 }
 

--- a/internal/common/customplanmodifier/plan_modify_differ.go
+++ b/internal/common/customplanmodifier/plan_modify_differ.go
@@ -75,10 +75,12 @@ func (d *PlanModifyDiffer) Unknowns(ctx context.Context, diags *diag.Diagnostics
 	return unknowns
 }
 
+// ReadPlanStructValue reads a struct value from the plan, returns nil if the value is null or unknown, logs any error getting the attribute.
 func ReadPlanStructValue[T any](ctx context.Context, d *PlanModifyDiffer, p path.Path) *T {
 	return readSrcStructValue[T](ctx, d.plan, p)
 }
 
+// ReadStateStructValue reads a struct value from the state, returns nil if the value is null or unknown, logs any error getting the attribute.
 func ReadStateStructValue[T any](ctx context.Context, d *PlanModifyDiffer, p path.Path) *T {
 	return readSrcStructValue[T](ctx, d.state, p)
 }
@@ -95,6 +97,7 @@ func readSrcStructValue[T any](ctx context.Context, src conversion.TPFSrc, p pat
 	return conversion.TFModelObject[T](ctx, obj)
 }
 
+// ReadPlanStructValues reads a list of struct values from the plan, returns nil if conversion fails, logs any error getting the attribute.
 func ReadPlanStructValues[T any](ctx context.Context, d *PlanModifyDiffer, p path.Path) []T {
 	return readSrcStructValues[T](ctx, d.plan, p)
 }

--- a/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchema.yaml
+++ b/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchema.yaml
@@ -192,7 +192,7 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: PATCH
         version: '2023-02-01'
-        text: "{\n \"replicationSpecs\": [\n  {\n   \"numShards\": 2,\n   \"regionConfigs\": [\n    {\n     \"analyticsSpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M20\",\n      \"nodeCount\": 1\n     },\n     \"electableSpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 3\n     },\n     \"priority\": 7,\n     \"providerName\": \"AWS\",\n     \"readOnlySpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"EU_WEST_1\"\n    },\n    {\n     \"electableSpecs\": {\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 2\n     },\n     \"priority\": 6,\n     \"providerName\": \"AZURE\",\n     \"readOnlySpecs\": {\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"US_EAST_2\"\n    }\n   ],\n   \"zoneName\": \"ZoneName managed by Terraform\"\n  }\n ]\n}"
+        text: "{\n \"replicationSpecs\": [\n  {\n   \"numShards\": 2,\n   \"regionConfigs\": [\n    {\n     \"analyticsSpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M20\",\n      \"nodeCount\": 1\n     },\n     \"autoScaling\": {\n      \"compute\": {\n       \"enabled\": false,\n       \"scaleDownEnabled\": false\n      },\n      \"diskGB\": {\n       \"enabled\": false\n      }\n     },\n     \"electableSpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 3\n     },\n     \"priority\": 7,\n     \"providerName\": \"AWS\",\n     \"readOnlySpecs\": {\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"EU_WEST_1\"\n    },\n    {\n     \"autoScaling\": {\n      \"compute\": {\n       \"enabled\": false,\n       \"scaleDownEnabled\": false\n      },\n      \"diskGB\": {\n       \"enabled\": false\n      }\n     },\n     \"electableSpecs\": {\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 2\n     },\n     \"priority\": 6,\n     \"providerName\": \"AZURE\",\n     \"readOnlySpecs\": {\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"US_EAST_2\"\n    }\n   ],\n   \"zoneName\": \"ZoneName managed by Terraform\"\n  }\n ]\n}"
         responses:
           - response_index: 81
             status: 200
@@ -304,8 +304,7 @@ steps:
             status: 200
             duplicate_responses: 2
             text: "{\n \"links\": [\n  {\n   \"href\": \"https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/flexClusters?includeCount=true\\u0026pageNum=1\\u0026itemsPerPage=100\",\n   \"rel\": \"self\"\n  }\n ],\n \"results\": [],\n \"totalCount\": 0\n}"
-  - config: ""
-    diff_requests:
+  - diff_requests:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: DELETE
         version: '2023-02-01'

--- a/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchema/02_01_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
+++ b/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchema/02_01_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
@@ -9,6 +9,15 @@
       "instanceSize": "M20",
       "nodeCount": 1
      },
+     "autoScaling": {
+      "compute": {
+       "enabled": false,
+       "scaleDownEnabled": false
+      },
+      "diskGB": {
+       "enabled": false
+      }
+     },
      "electableSpecs": {
       "ebsVolumeType": "STANDARD",
       "instanceSize": "M10",
@@ -24,6 +33,15 @@
      "regionName": "EU_WEST_1"
     },
     {
+     "autoScaling": {
+      "compute": {
+       "enabled": false,
+       "scaleDownEnabled": false
+      },
+      "diskGB": {
+       "enabled": false
+      }
+     },
      "electableSpecs": {
       "instanceSize": "M10",
       "nodeCount": 2

--- a/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel.yaml
+++ b/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel.yaml
@@ -167,7 +167,7 @@ steps:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: PATCH
         version: '2023-02-01'
-        text: "{\n \"diskSizeGB\": 55,\n \"replicationSpecs\": [\n  {\n   \"numShards\": 2,\n   \"regionConfigs\": [\n    {\n     \"analyticsSpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"electableSpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 3\n     },\n     \"priority\": 7,\n     \"providerName\": \"AWS\",\n     \"readOnlySpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"US_EAST_1\"\n    }\n   ],\n   \"zoneName\": \"ZoneName managed by Terraform\"\n  }\n ]\n}"
+        text: "{\n \"diskSizeGB\": 55,\n \"replicationSpecs\": [\n  {\n   \"numShards\": 2,\n   \"regionConfigs\": [\n    {\n     \"analyticsSpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"autoScaling\": {\n      \"compute\": {\n       \"enabled\": false,\n       \"scaleDownEnabled\": false\n      },\n      \"diskGB\": {\n       \"enabled\": false\n      }\n     },\n     \"electableSpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 3\n     },\n     \"priority\": 7,\n     \"providerName\": \"AWS\",\n     \"readOnlySpecs\": {\n      \"diskIOPS\": 3000,\n      \"ebsVolumeType\": \"STANDARD\",\n      \"instanceSize\": \"M10\",\n      \"nodeCount\": 0\n     },\n     \"regionName\": \"US_EAST_1\"\n    }\n   ],\n   \"zoneName\": \"ZoneName managed by Terraform\"\n  }\n ]\n}"
         responses:
           - response_index: 69
             status: 200
@@ -254,8 +254,7 @@ steps:
             status: 200
             duplicate_responses: 2
             text: "{\n \"links\": [\n  {\n   \"href\": \"https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/flexClusters?includeCount=true\\u0026pageNum=1\\u0026itemsPerPage=100\",\n   \"rel\": \"self\"\n  }\n ],\n \"results\": [],\n \"totalCount\": 0\n}"
-  - config: ""
-    diff_requests:
+  - diff_requests:
       - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
         method: DELETE
         version: '2023-02-01'

--- a/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel/02_01_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
+++ b/internal/service/advancedcluster/testdata/TestAccMockableAdvancedCluster_symmetricShardedOldSchemaDiskSizeGBAtElectableLevel/02_01_PATCH__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
@@ -11,6 +11,15 @@
       "instanceSize": "M10",
       "nodeCount": 0
      },
+     "autoScaling": {
+      "compute": {
+       "enabled": false,
+       "scaleDownEnabled": false
+      },
+      "diskGB": {
+       "enabled": false
+      }
+     },
      "electableSpecs": {
       "diskIOPS": 3000,
       "ebsVolumeType": "STANDARD",

--- a/internal/service/advancedclustertpf/plan_modifier.go
+++ b/internal/service/advancedclustertpf/plan_modifier.go
@@ -79,7 +79,7 @@ func unknownReplacements(ctx context.Context, tfsdkState *tfsdk.State, tfsdkPlan
 	}
 	unknownReplacements.AddKeepUnknownsExtraCall(replicationSpecsKeepUnknownWhenChanged)
 	unknownReplacements.ApplyReplacements(ctx, diags)
-	if !computedUsed && !diskUsed {
+	if !diff.isUpdateOfFlex && !computedUsed && !diskUsed {
 		addEmptyAutoScaling(ctx, diags, tfsdkPlan, unknownReplacements.Differ)
 	}
 }

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling.tmpl.yaml
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling.tmpl.yaml
@@ -1,0 +1,94 @@
+variables:
+  clusterName: mocked-cluster
+  groupId: "111111111111111111111111"
+steps:
+  - config: |-
+      resource "mongodbatlas_advanced_cluster" "test" {
+        project_id   = "111111111111111111111111"
+        name         = "mocked-cluster"
+        cluster_type = "REPLICASET"
+
+        replication_specs = [{
+          region_configs = [{
+            electable_specs = {
+              instance_size = "M10"
+              node_count    = 3
+            }
+            priority      = 7
+            provider_name = "AWS"
+            region_name   = "US_EAST_1"
+          }]
+          zone_name = "Zone 1"
+        }]
+      }
+
+      data "mongodbatlas_advanced_cluster" "test" {
+        project_id                     = mongodbatlas_advanced_cluster.test.project_id
+        name                           = mongodbatlas_advanced_cluster.test.name
+        use_replication_spec_per_shard = true
+        depends_on                     = [mongodbatlas_advanced_cluster.test]
+      }
+
+      data "mongodbatlas_advanced_clusters" "test" {
+        use_replication_spec_per_shard = true
+        project_id                     = mongodbatlas_advanced_cluster.test.project_id
+        depends_on                     = [mongodbatlas_advanced_cluster.test]
+      }
+    diff_requests: []
+    request_responses:
+      - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
+        method: GET
+        version: '2024-08-05'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2024-08-05.json"
+      - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
+        method: GET
+        version: '2023-02-01'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json"
+      - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
+        method: GET
+        version: '2023-01-01'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2023-01-01.json"
+      - path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs
+        method: GET
+        version: '2024-08-05'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2024-08-05.json"
+      - path: /api/atlas/v2/groups/{groupId}/containers?providerName=AWS
+        method: GET
+        version: '2023-01-01'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_containers?providerName=AWS_2023-01-01.json"
+      - path: /api/atlas/v2/groups/{groupId}/clusters
+        method: GET
+        version: '2024-08-05'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_clusters_2024-08-05.json"
+      - path: /api/atlas/v2/groups/{groupId}/flexClusters
+        method: GET
+        version: '2024-11-13'
+        text: ""
+        responses:
+          - response_index: 0
+            status: 200
+            text: "import_GET__api_atlas_v2_groups_{groupId}_flexClusters_2024-11-13.json"

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_2024-08-05.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_2024-08-05.json
@@ -1,0 +1,105 @@
+{
+ "links": [
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters?includeCount=true\u0026includeDeletedWithRetainedBackups=false\u0026pageNum=1\u0026itemsPerPage=100",
+   "rel": "self"
+  }
+ ],
+ "results": [
+  {
+   "advancedConfiguration": {
+    "customOpensslCipherConfigTls12": [],
+    "minimumEnabledTlsProtocol": "TLS1_2",
+    "tlsCipherConfigMode": "DEFAULT"
+   },
+   "backupEnabled": false,
+   "biConnector": {
+    "enabled": false,
+    "readPreference": "secondary"
+   },
+   "clusterType": "REPLICASET",
+   "connectionStrings": {
+    "standard": "mongodb://ac-q72bhe5-shard-00-00.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-01.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-02.mgdq5wj.mongodb-dev.net:27017/?ssl=true\u0026authSource=admin\u0026replicaSet=atlas-rb3umh-shard-0",
+    "standardSrv": "mongodb+srv://test-acc-tf-c-381594904.mgdq5wj.mongodb-dev.net"
+   },
+   "createDate": "2025-03-27T17:59:08Z",
+   "encryptionAtRestProvider": "NONE",
+   "featureCompatibilityVersion": "8.0",
+   "globalClusterSelfManagedSharding": false,
+   "groupId": "{groupId}",
+   "id": "67e591ec71b0e316715fb2ec",
+   "labels": [],
+   "links": [
+    {
+     "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
+     "rel": "self"
+    },
+    {
+     "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs",
+     "rel": "https://cloud.mongodb.com/restoreJobs"
+    },
+    {
+     "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots",
+     "rel": "https://cloud.mongodb.com/snapshots"
+    }
+   ],
+   "mongoDBMajorVersion": "8.0",
+   "mongoDBVersion": "8.0.6",
+   "name": "{clusterName}",
+   "paused": false,
+   "pitEnabled": false,
+   "redactClientLogData": false,
+   "replicationSpecs": [
+    {
+     "id": "67e591ec71b0e316715fb2eb",
+     "regionConfigs": [
+      {
+       "analyticsSpecs": {
+        "diskIOPS": 3000,
+        "diskSizeGB": 10,
+        "ebsVolumeType": "STANDARD",
+        "instanceSize": "M10",
+        "nodeCount": 0
+       },
+       "autoScaling": {
+        "compute": {
+         "enabled": false,
+         "predictiveEnabled": false,
+         "scaleDownEnabled": false
+        },
+        "diskGB": {
+         "enabled": false
+        }
+       },
+       "electableSpecs": {
+        "diskIOPS": 3000,
+        "diskSizeGB": 10,
+        "ebsVolumeType": "STANDARD",
+        "instanceSize": "M10",
+        "nodeCount": 3
+       },
+       "priority": 7,
+       "providerName": "AWS",
+       "readOnlySpecs": {
+        "diskIOPS": 3000,
+        "diskSizeGB": 10,
+        "ebsVolumeType": "STANDARD",
+        "instanceSize": "M10",
+        "nodeCount": 0
+       },
+       "regionName": "US_EAST_1"
+      }
+     ],
+     "zoneId": "67e591ec71b0e316715fb2ea",
+     "zoneName": "Zone 1"
+    }
+   ],
+   "rootCertType": "ISRGROOTX1",
+   "stateName": "IDLE",
+   "tags": [],
+   "terminationProtectionEnabled": false,
+   "versionReleaseSystem": "LTS"
+  }
+ ],
+ "totalCount": 1
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2023-02-01.json
@@ -1,0 +1,91 @@
+{
+ "advancedConfiguration": {
+  "customOpensslCipherConfigTls12": [],
+  "minimumEnabledTlsProtocol": "TLS1_2",
+  "tlsCipherConfigMode": "DEFAULT"
+ },
+ "backupEnabled": false,
+ "biConnector": {
+  "enabled": false,
+  "readPreference": "secondary"
+ },
+ "clusterType": "REPLICASET",
+ "connectionStrings": {
+  "standard": "mongodb://ac-q72bhe5-shard-00-00.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-01.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-02.mgdq5wj.mongodb-dev.net:27017/?ssl=true\u0026authSource=admin\u0026replicaSet=atlas-rb3umh-shard-0",
+  "standardSrv": "mongodb+srv://test-acc-tf-c-381594904.mgdq5wj.mongodb-dev.net"
+ },
+ "createDate": "2025-03-27T17:59:08Z",
+ "diskSizeGB": 10,
+ "encryptionAtRestProvider": "NONE",
+ "globalClusterSelfManagedSharding": false,
+ "groupId": "{groupId}",
+ "id": "67e591ec71b0e316715fb2ec",
+ "labels": [],
+ "links": [
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
+   "rel": "self"
+  },
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs",
+   "rel": "https://cloud.mongodb.com/restoreJobs"
+  },
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots",
+   "rel": "https://cloud.mongodb.com/snapshots"
+  }
+ ],
+ "mongoDBMajorVersion": "8.0",
+ "mongoDBVersion": "8.0.6",
+ "name": "{clusterName}",
+ "paused": false,
+ "pitEnabled": false,
+ "replicationSpecs": [
+  {
+   "id": "67e591ec71b0e316715fb2e2",
+   "numShards": 1,
+   "regionConfigs": [
+    {
+     "analyticsSpecs": {
+      "diskIOPS": 3000,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 0
+     },
+     "autoScaling": {
+      "compute": {
+       "enabled": false,
+       "predictiveEnabled": false,
+       "scaleDownEnabled": false
+      },
+      "diskGB": {
+       "enabled": false
+      }
+     },
+     "electableSpecs": {
+      "diskIOPS": 3000,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 3
+     },
+     "priority": 7,
+     "providerName": "AWS",
+     "readOnlySpecs": {
+      "diskIOPS": 3000,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 0
+     },
+     "regionName": "US_EAST_1"
+    }
+   ],
+   "zoneId": "67e591ec71b0e316715fb2ea",
+   "zoneName": "Zone 1"
+  }
+ ],
+ "rootCertType": "ISRGROOTX1",
+ "stateName": "IDLE",
+ "tags": [],
+ "terminationProtectionEnabled": false,
+ "versionReleaseSystem": "LTS"
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2024-08-05.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_2024-08-05.json
@@ -1,0 +1,94 @@
+{
+ "advancedConfiguration": {
+  "customOpensslCipherConfigTls12": [],
+  "minimumEnabledTlsProtocol": "TLS1_2",
+  "tlsCipherConfigMode": "DEFAULT"
+ },
+ "backupEnabled": false,
+ "biConnector": {
+  "enabled": false,
+  "readPreference": "secondary"
+ },
+ "clusterType": "REPLICASET",
+ "connectionStrings": {
+  "standard": "mongodb://ac-q72bhe5-shard-00-00.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-01.mgdq5wj.mongodb-dev.net:27017,ac-q72bhe5-shard-00-02.mgdq5wj.mongodb-dev.net:27017/?ssl=true\u0026authSource=admin\u0026replicaSet=atlas-rb3umh-shard-0",
+  "standardSrv": "mongodb+srv://test-acc-tf-c-381594904.mgdq5wj.mongodb-dev.net"
+ },
+ "createDate": "2025-03-27T17:59:08Z",
+ "encryptionAtRestProvider": "NONE",
+ "featureCompatibilityVersion": "8.0",
+ "globalClusterSelfManagedSharding": false,
+ "groupId": "{groupId}",
+ "id": "67e591ec71b0e316715fb2ec",
+ "labels": [],
+ "links": [
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
+   "rel": "self"
+  },
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs",
+   "rel": "https://cloud.mongodb.com/restoreJobs"
+  },
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots",
+   "rel": "https://cloud.mongodb.com/snapshots"
+  }
+ ],
+ "mongoDBMajorVersion": "8.0",
+ "mongoDBVersion": "8.0.6",
+ "name": "{clusterName}",
+ "paused": false,
+ "pitEnabled": false,
+ "redactClientLogData": false,
+ "replicationSpecs": [
+  {
+   "id": "67e591ec71b0e316715fb2eb",
+   "regionConfigs": [
+    {
+     "analyticsSpecs": {
+      "diskIOPS": 3000,
+      "diskSizeGB": 10,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 0
+     },
+     "autoScaling": {
+      "compute": {
+       "enabled": false,
+       "predictiveEnabled": false,
+       "scaleDownEnabled": false
+      },
+      "diskGB": {
+       "enabled": false
+      }
+     },
+     "electableSpecs": {
+      "diskIOPS": 3000,
+      "diskSizeGB": 10,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 3
+     },
+     "priority": 7,
+     "providerName": "AWS",
+     "readOnlySpecs": {
+      "diskIOPS": 3000,
+      "diskSizeGB": 10,
+      "ebsVolumeType": "STANDARD",
+      "instanceSize": "M10",
+      "nodeCount": 0
+     },
+     "regionName": "US_EAST_1"
+    }
+   ],
+   "zoneId": "67e591ec71b0e316715fb2ea",
+   "zoneName": "Zone 1"
+  }
+ ],
+ "rootCertType": "ISRGROOTX1",
+ "stateName": "IDLE",
+ "tags": [],
+ "terminationProtectionEnabled": false,
+ "versionReleaseSystem": "LTS"
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2023-01-01.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2023-01-01.json
@@ -1,0 +1,19 @@
+{
+ "changeStreamOptionsPreAndPostImagesExpireAfterSeconds": null,
+ "chunkMigrationConcurrency": null,
+ "customOpensslCipherConfigTls12": [],
+ "defaultMaxTimeMS": null,
+ "defaultReadConcern": null,
+ "defaultWriteConcern": null,
+ "failIndexKeyTooLong": null,
+ "javascriptEnabled": true,
+ "minimumEnabledTlsProtocol": "TLS1_2",
+ "noTableScan": false,
+ "oplogMinRetentionHours": null,
+ "oplogSizeMB": null,
+ "queryStatsLogVerbosity": 1,
+ "sampleRefreshIntervalBIConnector": null,
+ "sampleSizeBIConnector": null,
+ "tlsCipherConfigMode": "DEFAULT",
+ "transactionLifetimeLimitSeconds": null
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2024-08-05.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_clusters_{clusterName}_processArgs_2024-08-05.json
@@ -1,0 +1,17 @@
+{
+ "changeStreamOptionsPreAndPostImagesExpireAfterSeconds": null,
+ "chunkMigrationConcurrency": null,
+ "customOpensslCipherConfigTls12": [],
+ "defaultMaxTimeMS": null,
+ "defaultWriteConcern": null,
+ "javascriptEnabled": true,
+ "minimumEnabledTlsProtocol": "TLS1_2",
+ "noTableScan": false,
+ "oplogMinRetentionHours": null,
+ "oplogSizeMB": null,
+ "queryStatsLogVerbosity": 1,
+ "sampleRefreshIntervalBIConnector": null,
+ "sampleSizeBIConnector": null,
+ "tlsCipherConfigMode": "DEFAULT",
+ "transactionLifetimeLimitSeconds": null
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_containers?providerName=AWS_2023-01-01.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_containers?providerName=AWS_2023-01-01.json
@@ -1,0 +1,19 @@
+{
+ "links": [
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/containers?includeCount=true\u0026providerName=AWS\u0026pageNum=1\u0026itemsPerPage=100",
+   "rel": "self"
+  }
+ ],
+ "results": [
+  {
+   "atlasCidrBlock": "192.168.248.0/21",
+   "id": "67e591ed71b0e316715fb2f1",
+   "providerName": "AWS",
+   "provisioned": true,
+   "regionName": "US_EAST_1",
+   "vpcId": "vpc-08d1b81c79940b015"
+  }
+ ],
+ "totalCount": 1
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_flexClusters_2024-11-13.json
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/import_GET__api_atlas_v2_groups_{groupId}_flexClusters_2024-11-13.json
@@ -1,0 +1,10 @@
+{
+ "links": [
+  {
+   "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/{groupId}/flexClusters?includeCount=true\u0026pageNum=1\u0026itemsPerPage=100",
+   "rel": "self"
+  }
+ ],
+ "results": [],
+ "totalCount": 0
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main.tf
@@ -1,0 +1,18 @@
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = "111111111111111111111111"
+  name         = "mocked-cluster"
+  cluster_type = "REPLICASET"
+
+  replication_specs = [{
+    region_configs = [{
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+    }]
+    zone_name = "Zone 1"
+  }]
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main_region_config_added.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main_region_config_added.tf
@@ -1,0 +1,27 @@
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = "111111111111111111111111"
+  name         = "mocked-cluster"
+  cluster_type = "REPLICASET"
+
+  replication_specs = [{
+    region_configs = [{
+        electable_specs = {
+          instance_size = "M10"
+          node_count    = 3
+        }
+        priority      = 7
+        provider_name = "AWS"
+        region_name   = "US_EAST_1"
+      },
+      {
+        electable_specs = {
+          instance_size = "M10"
+          node_count    = 2
+        }
+        priority      = 6
+        provider_name = "AWS"
+        region_name   = "US_EAST_2"
+      }]
+    zone_name = "Zone 1"
+  }]
+}

--- a/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main_replication_spec_added.tf
+++ b/internal/service/advancedclustertpf/testdata/ClusterReplicasetNoAutoScaling/main_replication_spec_added.tf
@@ -1,0 +1,30 @@
+resource "mongodbatlas_advanced_cluster" "test" {
+  project_id   = "111111111111111111111111"
+  name         = "mocked-cluster"
+  cluster_type = "SHARDED"
+
+  replication_specs = [{
+    region_configs = [{
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+    }]
+    zone_name = "Zone 1"
+  },
+  {
+    region_configs = [{
+      electable_specs = {
+        instance_size = "M10"
+        node_count    = 3
+      }
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+    }]
+    zone_name = "Zone 1"
+  }]
+}

--- a/internal/testutil/unit/http_mocker_plan_checks.go
+++ b/internal/testutil/unit/http_mocker_plan_checks.go
@@ -22,6 +22,7 @@ import (
 const (
 	ImportNameClusterTwoRepSpecsWithAutoScalingAndSpecs = "ClusterTwoRepSpecsWithAutoScalingAndSpecs"
 	ImportNameClusterReplicasetOneRegion                = "ClusterReplicasetOneRegion"
+	ImportNameClusterReplicasetNoAutoScaling            = "ClusterReplicasetNoAutoScaling"
 	ImportNameTwoRepSpecsMultipleRegions                = "TwoRepSpecsMultipleRegions"
 	MockedClusterName                                   = "mocked-cluster"
 	MockedProjectID                                     = "111111111111111111111111"
@@ -35,12 +36,14 @@ var (
 	importIDMapping = map[string]string{
 		ImportNameClusterTwoRepSpecsWithAutoScalingAndSpecs: clusterImportID,
 		ImportNameClusterReplicasetOneRegion:                clusterImportID,
+		ImportNameClusterReplicasetNoAutoScaling:            clusterImportID,
 		ImportNameTwoRepSpecsMultipleRegions:                clusterImportID,
 	}
 	// later this could be inferred when reading the src main.tf
 	importResourceNameMapping = map[string]string{
 		ImportNameClusterTwoRepSpecsWithAutoScalingAndSpecs: "mongodbatlas_advanced_cluster.test",
 		ImportNameClusterReplicasetOneRegion:                "mongodbatlas_advanced_cluster.test",
+		ImportNameClusterReplicasetNoAutoScaling:            "mongodbatlas_advanced_cluster.test",
 		ImportNameTwoRepSpecsMultipleRegions:                "mongodbatlas_advanced_cluster.test",
 	}
 )

--- a/internal/testutil/unit/http_mocker_plan_checks_test.go
+++ b/internal/testutil/unit/http_mocker_plan_checks_test.go
@@ -58,6 +58,13 @@ func TestConvertMockableTests(t *testing.T) {
 			SrcPackage:          pkgAdvancedCluster,
 			DestPackage:         pkgAdvancedClusterTPF,
 		},
+		unit.ImportNameClusterReplicasetNoAutoScaling: {
+			TestName:            "TestAccMockableAdvancedCluster_tenantUpgrade",
+			Step:                2,
+			VariableReplacments: clusterVariableReplacements,
+			SrcPackage:          pkgAdvancedCluster,
+			DestPackage:         pkgAdvancedClusterTPF,
+		},
 	} {
 		srcTestdata := path.Join(unit.PackagePath(config.SrcPackage), "testdata")
 		destTestdata := path.Join(unit.PackagePath(config.DestPackage), "testdata")


### PR DESCRIPTION
## Description

- Adds empty values when auto_scaling is not defined, to ensure we don't get the _auto_scaling must be present in every region config error_
- [x] [Full Test Run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/14195221291) Only `TestAccClusterFlexCluster_basic` failing, will re-run it
- [x] [Re-run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/14198637779) for TestAccClusterFlexCluster_basic 


Link to any related issue(s): CLOUDP-308783

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
