### PR TITLE
chore: Define conversion function for generating API request body from Resource Model in create (non-nested)

### DIFF
--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -11,87 +11,107 @@ import (
 )
 
 // Marshal gets Terraform model and marshals it into JSON (e.g. for an Atlas request).
-func Marshal(src any) ([]byte, error) {
-	valSrc := reflect.ValueOf(src)
-	if valSrc.Kind() != reflect.Ptr {
-		panic("src must be pointer")
+func Marshal(model any) ([]byte, error) {
+	valModel := reflect.ValueOf(model)
+	if valModel.Kind() != reflect.Ptr {
+		panic("Marshal expects a pointer")
 	}
-	valSrc = valSrc.Elem()
-	if valSrc.Kind() != reflect.Struct {
-		panic("src must be pointer to struct")
+	valModel = valModel.Elem()
+	if valModel.Kind() != reflect.Struct {
+		panic("Marshal expects a pointer to struct")
 	}
-	dest := make(map[string]any)
-	for i := 0; i < valSrc.NumField(); i++ {
-		nameAttr := xstrings.ToSnakeCase(valSrc.Type().Field(i).Name)
-		valAttr := valSrc.Field(i)
-		switch v := valAttr.Interface().(type) {
-		case types.String:
-			if v.IsNull() || v.IsUnknown() {
-				continue
-			}
-			dest[nameAttr] = v.ValueString()
-		default:
-			return nil, fmt.Errorf("marshal not supported yet for type %T for field %s", v, nameAttr)
+	objJSON, err := marshalAttrs(valModel)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(objJSON)
+}
+
+func marshalAttrs(valModel reflect.Value) (map[string]any, error) {
+	objJSON := make(map[string]any)
+	for i := 0; i < valModel.NumField(); i++ {
+		attrNameModel := valModel.Type().Field(i).Name
+		attrValModel := valModel.Field(i)
+		if err := marshalAttr(attrNameModel, attrValModel, objJSON); err != nil {
+			return nil, err
 		}
 	}
-	return json.Marshal(dest)
+	return objJSON, nil
+}
+
+func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[string]any) error {
+	attrNameJSON := xstrings.ToSnakeCase(attrNameModel)
+	if v, ok := attrValModel.Interface().(attr.Value); ok {
+		if v.IsNull() || v.IsUnknown() {
+			return nil // skip nil or unknown values
+		}
+	}
+	switch v := attrValModel.Interface().(type) {
+	case types.String:
+		objJSON[attrNameJSON] = v.ValueString()
+	case types.Int64:
+		objJSON[attrNameJSON] = v.ValueInt64()
+	default:
+		return fmt.Errorf("marshal not supported yet for type %T for field %s", v, attrNameJSON)
+	}
+	return nil
 }
 
 // Unmarshal gets a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
 // It supports the following Terraform model types: String, Bool, Int64, Float64.
-func Unmarshal(raw []byte, dest any) error {
-	var src map[string]any
-	if err := json.Unmarshal(raw, &src); err != nil {
+func Unmarshal(raw []byte, model any) error {
+	var objJSON map[string]any
+	if err := json.Unmarshal(raw, &objJSON); err != nil {
 		return err
 	}
-	return mapFields(src, dest)
+	return unmarshalAttrs(objJSON, model)
 }
 
-func mapFields(src map[string]any, dest any) error {
-	valDest := reflect.ValueOf(dest)
-	if valDest.Kind() != reflect.Ptr {
+func unmarshalAttrs(objJSON map[string]any, model any) error {
+	valModel := reflect.ValueOf(model)
+	if valModel.Kind() != reflect.Ptr {
 		panic("dest must be pointer")
 	}
-	valDest = valDest.Elem()
-	if valDest.Kind() != reflect.Struct {
+	valModel = valModel.Elem()
+	if valModel.Kind() != reflect.Struct {
 		panic("dest must be pointer to struct")
 	}
-	for nameAttrSrc, valueAttrSrc := range src {
-		if err := mapField(nameAttrSrc, valueAttrSrc, valDest); err != nil {
+	for attrNameJSON, attrObjJSON := range objJSON {
+		if err := unmarshalAttr(attrNameJSON, attrObjJSON, valModel); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func mapField(nameAttrSrc string, valueAttrSrc any, valDest reflect.Value) error {
-	nameDest := xstrings.ToPascalCase(nameAttrSrc)
-	fieldDest := valDest.FieldByName(nameDest)
-	if !fieldDest.CanSet() {
+func unmarshalAttr(attrNameJSON string, attrObjJSON any, valModel reflect.Value) error {
+	attrNameModel := xstrings.ToPascalCase(attrNameJSON)
+	fieldModel := valModel.FieldByName(attrNameModel)
+	if !fieldModel.CanSet() {
 		return nil // skip fields that cannot be set, are invalid or not found
 	}
-	switch v := valueAttrSrc.(type) {
+	switch v := attrObjJSON.(type) {
 	case string:
-		return assignField(nameDest, fieldDest, types.StringValue(v))
+		return setAttrModel(attrNameModel, fieldModel, types.StringValue(v))
 	case bool:
-		return assignField(nameDest, fieldDest, types.BoolValue(v))
+		return setAttrModel(attrNameModel, fieldModel, types.BoolValue(v))
 	case float64: // number: try int or float
-		if assignField(nameDest, fieldDest, types.Float64Value(v)) == nil {
+		if setAttrModel(attrNameModel, fieldModel, types.Float64Value(v)) == nil {
 			return nil
 		}
-		return assignField(nameDest, fieldDest, types.Int64Value(int64(v)))
+		return setAttrModel(attrNameModel, fieldModel, types.Int64Value(int64(v)))
 	case nil:
 		return nil // skip nil values, no need to set anything
 	default:
-		return fmt.Errorf("unmarshal not supported yet for type %T for field %s", v, nameAttrSrc)
+		return fmt.Errorf("unmarshal not supported yet for type %T for field %s", v, attrNameJSON)
 	}
 }
 
-func assignField(nameDest string, fieldDest reflect.Value, valueDest attr.Value) error {
-	valObj := reflect.ValueOf(valueDest)
-	if !fieldDest.Type().AssignableTo(valObj.Type()) {
-		return fmt.Errorf("unmarshal can't assign value to model field %s", nameDest)
+func setAttrModel(name string, field reflect.Value, val attr.Value) error {
+	obj := reflect.ValueOf(val)
+	if !field.Type().AssignableTo(obj.Type()) {
+		return fmt.Errorf("unmarshal can't assign value to model field %s", name)
 	}
-	fieldDest.Set(valObj)
+	field.Set(obj)
 	return nil
 }

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -10,6 +10,11 @@ import (
 	"github.com/huandu/xstrings"
 )
 
+// Marshal gets Terraform model and marshals it in JSON (e.g. for an Atlas request).
+func Marshal(src any) ([]byte, error) {
+	return nil, nil
+}
+
 // Unmarshal gets a JSON (e.g. from an Atlas response) and unmarshals it into a Terraform model.
 // It supports the following Terraform model types: String, Bool, Int64, Float64.
 func Unmarshal(raw []byte, dest any) error {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -74,7 +74,7 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 		panic("marshal expects only Terraform types in the model")
 	}
 	if obj.IsNull() || obj.IsUnknown() {
-		return nil // skip nil or unknown values
+		return nil // skip null or unknown values
 	}
 	switch v := attrValModel.Interface().(type) {
 	case types.String:

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -53,7 +53,7 @@ func marshalAttrs(valModel reflect.Value, isCreate bool) (map[string]any, error)
 			continue // skip fields with tag `omitjson`
 		}
 		if !isCreate && strings.Contains(tag, tagValCreateOnly) {
-			continue // skip fields with tag `createonly` if not createOnly
+			continue // skip fields with tag `createonly` if not in create
 		}
 		attrNameModel := attrTypeModel.Name
 		attrValModel := valModel.Field(i)

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -17,6 +17,10 @@ const (
 )
 
 // Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
+// It supports the following Terraform model types: String, Bool, Int64, Float64.
+// Attributes that are null or unknown are not marshaled.
+// Attributes with autogeneration tag `omitjson` are never marshaled.
+// Attributes with autogeneration tag `omitjsonupdate` are not marshaled if isUpdate is true.
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huandu/xstrings"
 )
 
-// Marshal gets Terraform model and marshals it into JSON (e.g. for an Atlas request).
+// Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
 func Marshal(model any) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -14,11 +14,11 @@ import (
 func Marshal(model any) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {
-		panic("Marshal expects a pointer")
+		panic("model must be pointer")
 	}
 	valModel = valModel.Elem()
 	if valModel.Kind() != reflect.Struct {
-		panic("Marshal expects a pointer to struct")
+		panic("model must be pointer to struct")
 	}
 	objJSON, err := marshalAttrs(valModel)
 	if err != nil {
@@ -53,7 +53,7 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 	attrNameJSON := xstrings.ToSnakeCase(attrNameModel)
 	obj, ok := attrValModel.Interface().(attr.Value)
 	if !ok {
-		panic("marshal expects only Terraform types")
+		panic("marshal expects only Terraform types in the model")
 	}
 	if obj.IsNull() || obj.IsUnknown() {
 		return nil // skip nil or unknown values
@@ -74,11 +74,11 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 func unmarshalAttrs(objJSON map[string]any, model any) error {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {
-		panic("dest must be pointer")
+		panic("model must be pointer")
 	}
 	valModel = valModel.Elem()
 	if valModel.Kind() != reflect.Struct {
-		panic("dest must be pointer to struct")
+		panic("model must be pointer to struct")
 	}
 	for attrNameJSON, attrObjJSON := range objJSON {
 		if err := unmarshalAttr(attrNameJSON, attrObjJSON, valModel); err != nil {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMarshalBasic(t *testing.T) {
+	model := struct {
+		AttributeString types.String `tfsdk:"attribute_string"`
+	}{
+		AttributeString: types.StringValue("hello"),
+	}
+	const (
+		expectedJSON = `
+			{
+				"attribute_string": "hello"
+			}
+		`
+	)
+	rawJSON, err := autogeneration.Marshal(&model)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(rawJSON))
+}
+
 func TestUnmarshalBasic(t *testing.T) {
 	var model struct {
 		AttributeFloat        types.Float64 `tfsdk:"attribute_float"`
@@ -132,11 +150,11 @@ func TestUnmarshalUnsupportedResponse(t *testing.T) {
 	}{
 		"JSON objects not support yet": {
 			responseJSON: `{"attr": {"key": "value"}}`,
-			errorStr:     "not supported yet type map[string]interface {} for field attr",
+			errorStr:     "unmarshal not supported yet for type map[string]interface {} for field attr",
 		},
 		"JSON arrays not supported yet": {
 			responseJSON: `{"attr": [{"key": "value"}]}`,
-			errorStr:     "not supported yet type []interface {} for field attr",
+			errorStr:     "unmarshal not supported yet for type []interface {} for field attr",
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -12,24 +12,26 @@ import (
 
 func TestMarshalBasic(t *testing.T) {
 	model := struct {
-		AttributeFloat  types.Float64 `tfsdk:"attribute_float"`
-		AttributeString types.String  `tfsdk:"attribute_string"`
-		AttributeUnkown types.String  `tfsdk:"attribute_unknown"`
-		AttributeNull   types.String  `tfsdk:"attribute_null"`
-		AttributeInt    types.Int64   `tfsdk:"attribute_int"`
+		AttrFloat  types.Float64 `tfsdk:"attribute_float"`
+		AttrString types.String  `tfsdk:"attribute_string"`
+		AttrOmit   types.String  `tfsdk:"attribute_omit" autogeneration:"omitjson"`
+		AttrUnkown types.String  `tfsdk:"attribute_unknown"`
+		AttrNull   types.String  `tfsdk:"attribute_null"`
+		AttrInt    types.Int64   `tfsdk:"attribute_int"`
 	}{
-		AttributeFloat:  types.Float64Value(1.234),
-		AttributeString: types.StringValue("hello"),
-		AttributeUnkown: types.StringUnknown(), // unknown values are not marshaled
-		AttributeNull:   types.StringNull(),    // null values are not marshaled
-		AttributeInt:    types.Int64Value(1),
+		AttrFloat:  types.Float64Value(1.234),
+		AttrString: types.StringValue("hello"),
+		AttrOmit:   types.StringValue("omit"), // values with tag `omitjson` are not marshaled
+		AttrUnkown: types.StringUnknown(),     // unknown values are not marshaled
+		AttrNull:   types.StringNull(),        // null values are not marshaled
+		AttrInt:    types.Int64Value(1),
 	}
 	const (
 		expectedJSON = `
 			{
-				"attribute_string": "hello",
-				"attribute_int": 1,
-				"attribute_float": 1.234
+				"attr_string": "hello",
+				"attr_int": 1,
+				"attr_float": 1.234
 			}
 		`
 	)
@@ -112,19 +114,18 @@ func TestMarshalPanic(t *testing.T) {
 			})
 		})
 	}
-
 }
 
 func TestUnmarshalBasic(t *testing.T) {
 	var model struct {
-		AttributeFloat        types.Float64 `tfsdk:"attribute_float"`
-		AttributeFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
-		AttributeString       types.String  `tfsdk:"attribute_string"`
-		AttributeNotInJSON    types.String  `tfsdk:"attribute_not_in_json"`
-		AttributeInt          types.Int64   `tfsdk:"attribute_int"`
-		AttributeIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
-		AttributeTrue         types.Bool    `tfsdk:"attribute_true"`
-		AttributeFalse        types.Bool    `tfsdk:"attribute_false"`
+		AttrFloat        types.Float64 `tfsdk:"attribute_float"`
+		AttrFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
+		AttrString       types.String  `tfsdk:"attribute_string"`
+		AttrNotInJSON    types.String  `tfsdk:"attribute_not_in_json"`
+		AttrInt          types.Int64   `tfsdk:"attribute_int"`
+		AttrIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
+		AttrTrue         types.Bool    `tfsdk:"attribute_true"`
+		AttrFalse        types.Bool    `tfsdk:"attribute_false"`
 	}
 	const (
 		epsilon = 10e-15 // float tolerance
@@ -132,27 +133,27 @@ func TestUnmarshalBasic(t *testing.T) {
 		// attribute_null is ignored because it is null, no error is thrown even if it is not in the model.
 		tfResponseJSON = `
 			{
-				"attribute_string": "value_string",
-				"attribute_true": true,
-				"attribute_false": false,
-				"attribute_int": 123,
-				"attribute_int_with_float": 10.6,
-				"attribute_float": 456.1,
-				"attribute_float_with_int": 13,
-				"attribute_not_in_model": "val",
-				"attribute_null": null
+				"attr_string": "value_string",
+				"attr_true": true,
+				"attr_false": false,
+				"attr_int": 123,
+				"attr_int_with_float": 10.6,
+				"attr_float": 456.1,
+				"attr_float_with_int": 13,
+				"attr_not_in_model": "val",
+				"attr_null": null
 			}
 		`
 	)
 	require.NoError(t, autogeneration.Unmarshal([]byte(tfResponseJSON), &model))
-	assert.Equal(t, "value_string", model.AttributeString.ValueString())
-	assert.True(t, model.AttributeTrue.ValueBool())
-	assert.False(t, model.AttributeFalse.ValueBool())
-	assert.Equal(t, int64(123), model.AttributeInt.ValueInt64())
-	assert.Equal(t, int64(10), model.AttributeIntWithFloat.ValueInt64()) // response floats stored in model ints have their decimals stripped.
-	assert.InEpsilon(t, float64(456.1), model.AttributeFloat.ValueFloat64(), epsilon)
-	assert.InEpsilon(t, float64(13), model.AttributeFloatWithInt.ValueFloat64(), epsilon)
-	assert.True(t, model.AttributeNotInJSON.IsNull()) // attributes not in JSON response are not changed, so null is kept.
+	assert.Equal(t, "value_string", model.AttrString.ValueString())
+	assert.True(t, model.AttrTrue.ValueBool())
+	assert.False(t, model.AttrFalse.ValueBool())
+	assert.Equal(t, int64(123), model.AttrInt.ValueInt64())
+	assert.Equal(t, int64(10), model.AttrIntWithFloat.ValueInt64()) // response floats stored in model ints have their decimals stripped.
+	assert.InEpsilon(t, float64(456.1), model.AttrFloat.ValueFloat64(), epsilon)
+	assert.InEpsilon(t, float64(13), model.AttrFloatWithInt.ValueFloat64(), epsilon)
+	assert.True(t, model.AttrNotInJSON.IsNull()) // attributes not in JSON response are not changed, so null is kept.
 }
 
 func TestUnmarshalErrors(t *testing.T) {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -12,13 +12,16 @@ import (
 func TestMarshalBasic(t *testing.T) {
 	model := struct {
 		AttributeString types.String `tfsdk:"attribute_string"`
+		AttributeInt    types.Int64  `tfsdk:"attribute_int"`
 	}{
 		AttributeString: types.StringValue("hello"),
+		AttributeInt:    types.Int64Value(1),
 	}
 	const (
 		expectedJSON = `
 			{
-				"attribute_string": "hello"
+				"attribute_string": "hello",
+				"attribute_int": 1
 			}
 		`
 	)

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -14,17 +14,20 @@ func TestMarshalBasic(t *testing.T) {
 	model := struct {
 		AttrFloat  types.Float64 `tfsdk:"attribute_float"`
 		AttrString types.String  `tfsdk:"attribute_string"`
-		AttrOmit   types.String  `tfsdk:"attribute_omit" autogeneration:"omitjson"`
-		AttrUnkown types.String  `tfsdk:"attribute_unknown"`
-		AttrNull   types.String  `tfsdk:"attribute_null"`
-		AttrInt    types.Int64   `tfsdk:"attribute_int"`
+		// values with tag `omitjson` are not marshaled, and they don't need to be Terraform types
+		AttrOmit            types.String `tfsdk:"attribute_omit" autogeneration:"omitjson"`
+		AttrOmitNoTerraform string       `autogeneration:"omitjson"`
+		AttrUnkown          types.String `tfsdk:"attribute_unknown"`
+		AttrNull            types.String `tfsdk:"attribute_null"`
+		AttrInt             types.Int64  `tfsdk:"attribute_int"`
 	}{
-		AttrFloat:  types.Float64Value(1.234),
-		AttrString: types.StringValue("hello"),
-		AttrOmit:   types.StringValue("omit"), // values with tag `omitjson` are not marshaled
-		AttrUnkown: types.StringUnknown(),     // unknown values are not marshaled
-		AttrNull:   types.StringNull(),        // null values are not marshaled
-		AttrInt:    types.Int64Value(1),
+		AttrFloat:           types.Float64Value(1.234),
+		AttrString:          types.StringValue("hello"),
+		AttrOmit:            types.StringValue("omit"),
+		AttrOmitNoTerraform: "omit",
+		AttrUnkown:          types.StringUnknown(), // unknown values are not marshaled
+		AttrNull:            types.StringNull(),    // null values are not marshaled
+		AttrInt:             types.Int64Value(1),
 	}
 	const (
 		expectedJSON = `

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -35,9 +35,9 @@ func TestMarshalBasic(t *testing.T) {
 			}
 		`
 	)
-	rawJSON, err := autogeneration.Marshal(&model)
+	raw, err := autogeneration.Marshal(&model)
 	require.NoError(t, err)
-	assert.JSONEq(t, expectedJSON, string(rawJSON))
+	assert.JSONEq(t, expectedJSON, string(raw))
 }
 
 func TestMarshalUnsupported(t *testing.T) {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -29,15 +29,7 @@ func TestMarshalBasic(t *testing.T) {
 		AttrNull:            types.StringNull(),    // null values are not marshaled
 		AttrInt:             types.Int64Value(1),
 	}
-	const (
-		expectedJSON = `
-			{
-				"attr_string": "hello",
-				"attr_int": 1,
-				"attr_float": 1.234
-			}
-		`
-	)
+	const expectedJSON = `{ "attr_string": "hello", "attr_int": 1, "attr_float": 1.234 }`
 	raw, err := autogeneration.Marshal(&model, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -35,27 +35,27 @@ func TestMarshalBasic(t *testing.T) {
 	assert.JSONEq(t, expectedJSON, string(raw))
 }
 
-func TestMarshalCreateOnly(t *testing.T) {
+func TestMarshalOmitJSONUpdate(t *testing.T) {
 	const (
-		expectedCreate   = `{ "attr": "val1", "attr_create_only": "val2" }`
-		expectedNoCreate = `{ "attr": "val1" }`
+		expectedCreate = `{ "attr": "val1", "attr_omit_update": "val2" }`
+		expectedUpdate = `{ "attr": "val1" }`
 	)
 	model := struct {
 		Attr           types.String `tfsdk:"attr"`
-		AttrCreateOnly types.String `tfsdk:"attr_create_only" autogeneration:"createonly"`
+		AttrOmitUpdate types.String `tfsdk:"attr_create_only" autogeneration:"omitjsonupdate"`
 		AttrOmit       types.String `tfsdk:"attr_omit" autogeneration:"omitjson"`
 	}{
 		Attr:           types.StringValue("val1"),
-		AttrCreateOnly: types.StringValue("val2"),
+		AttrOmitUpdate: types.StringValue("val2"),
 		AttrOmit:       types.StringValue("omit"),
 	}
-	noCreate, errNoCreate := autogeneration.Marshal(&model, false)
-	require.NoError(t, errNoCreate)
-	assert.JSONEq(t, expectedNoCreate, string(noCreate))
-
-	create, errCreate := autogeneration.Marshal(&model, true)
+	create, errCreate := autogeneration.Marshal(&model, false)
 	require.NoError(t, errCreate)
 	assert.JSONEq(t, expectedCreate, string(create))
+
+	update, errUpdate := autogeneration.Marshal(&model, true)
+	require.NoError(t, errUpdate)
+	assert.JSONEq(t, expectedUpdate, string(update))
 }
 
 func TestMarshalUnsupported(t *testing.T) {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestMarshalBasic(t *testing.T) {
 	model := struct {
-		AttrFloat  types.Float64 `tfsdk:"attribute_float"`
-		AttrString types.String  `tfsdk:"attribute_string"`
+		AttrFloat  types.Float64 `tfsdk:"attr_float"`
+		AttrString types.String  `tfsdk:"attr_string"`
 		// values with tag `omitjson` are not marshaled, and they don't need to be Terraform types
-		AttrOmit            types.String `tfsdk:"attribute_omit" autogeneration:"omitjson"`
+		AttrOmit            types.String `tfsdk:"attr_omit" autogeneration:"omitjson"`
 		AttrOmitNoTerraform string       `autogeneration:"omitjson"`
-		AttrUnkown          types.String `tfsdk:"attribute_unknown"`
-		AttrNull            types.String `tfsdk:"attribute_null"`
-		AttrInt             types.Int64  `tfsdk:"attribute_int"`
+		AttrUnkown          types.String `tfsdk:"attr_unknown"`
+		AttrNull            types.String `tfsdk:"attr_null"`
+		AttrInt             types.Int64  `tfsdk:"attr_int"`
 	}{
 		AttrFloat:           types.Float64Value(1.234),
 		AttrString:          types.StringValue("hello"),
@@ -42,7 +42,7 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 	)
 	model := struct {
 		Attr           types.String `tfsdk:"attr"`
-		AttrOmitUpdate types.String `tfsdk:"attr_create_only" autogeneration:"omitjsonupdate"`
+		AttrOmitUpdate types.String `tfsdk:"attr_omit_update" autogeneration:"omitjsonupdate"`
 		AttrOmit       types.String `tfsdk:"attr_omit" autogeneration:"omitjson"`
 	}{
 		Attr:           types.StringValue("val1"),
@@ -136,14 +136,14 @@ func TestMarshalPanic(t *testing.T) {
 
 func TestUnmarshalBasic(t *testing.T) {
 	var model struct {
-		AttrFloat        types.Float64 `tfsdk:"attribute_float"`
-		AttrFloatWithInt types.Float64 `tfsdk:"attribute_float_with_int"`
-		AttrString       types.String  `tfsdk:"attribute_string"`
-		AttrNotInJSON    types.String  `tfsdk:"attribute_not_in_json"`
-		AttrInt          types.Int64   `tfsdk:"attribute_int"`
-		AttrIntWithFloat types.Int64   `tfsdk:"attribute_int_with_float"`
-		AttrTrue         types.Bool    `tfsdk:"attribute_true"`
-		AttrFalse        types.Bool    `tfsdk:"attribute_false"`
+		AttrFloat        types.Float64 `tfsdk:"attr_float"`
+		AttrFloatWithInt types.Float64 `tfsdk:"attr_float_with_int"`
+		AttrString       types.String  `tfsdk:"attr_string"`
+		AttrNotInJSON    types.String  `tfsdk:"attr_not_in_json"`
+		AttrInt          types.Int64   `tfsdk:"attr_int"`
+		AttrIntWithFloat types.Int64   `tfsdk:"attr_int_with_float"`
+		AttrTrue         types.Bool    `tfsdk:"attr_true"`
+		AttrFalse        types.Bool    `tfsdk:"attr_false"`
 	}
 	const (
 		epsilon = 10e-15 // float tolerance


### PR DESCRIPTION
## Description

Define conversion function for generating API request body from Resource Model in create (non-nested).

`Marshal` is used to create the Atlas request from the Terraform plan model. It's called in operations that need to create an Atlas request payload, i.e. `Create` and `Update`. It's not used in `Read`, `Delete` or `Import`.

`Unmarshal` is used to update the Terraform model from the Atlas response. It's called in `Create`, `Update` and `Read`. It's not used in `Delete` or `Import`.

It supports an `autogeneration` tag in model struct fields that can have:
- `omitjson`:  Field will never be marshaled into JSON, useful for attributes not needed in Atlas requests like timeouts or computed values.
- `omitjsonupdate`: Field that is not marshaled into JSON when it's an update, this field is sent only when the resource is created.

Link to any related issue(s): CLOUDP-310079

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
