### PR TITLE
feat: add support for datadog metrics in `third_party_integration`

### DIFF
--- a/docs/data-sources/third_party_integration.md
+++ b/docs/data-sources/third_party_integration.md
@@ -46,6 +46,8 @@ Additional values based on Type
 * `DATADOG`
   * `api_key` - Your API Key.
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getThirdPartyIntegration) for more details. Datadog will use "US" by default.
+  * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection namesand latency metrics on reads, writes, commands, and transactions.
+  * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getThirdPartyIntegration) for more details. Opsgenie will use US by default.

--- a/docs/data-sources/third_party_integrations.md
+++ b/docs/data-sources/third_party_integrations.md
@@ -60,6 +60,8 @@ Additional values based on Type
 * `DATADOG`
   * `api_key` - Your API Key.
   * `region` - Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getThirdPartyIntegration) for more details. Datadog will use "US" by default.
+  * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection namesand latency metrics on reads, writes, commands, and transactions.
+  * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` -  Two-letter code that indicates which API URL to use. See the `region` response field of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/getThirdPartyIntegration) for more details. Opsgenie will use US by default.

--- a/docs/resources/third_party_integration.md
+++ b/docs/resources/third_party_integration.md
@@ -43,6 +43,8 @@ resource "mongodbatlas_third_party_integration" "test_datadog" {
 * `DATADOG`
   * `api_key` - Your API Key.
   * `region` (Required) - Two-letter code that indicates which API URL to use. See the `region` request parameter of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/createThirdPartyIntegration) for more details. Datadog will use "US" by default.
+  * `send_collection_latency_metrics` - Toggle sending collection latency metrics that includes database names and collection namesand latency metrics on reads, writes, commands, and transactions. Default: `false`.
+  * `send_database_metrics` - Toggle sending database metrics that includes database names and metrics on the number of collections, storage size, and index size. Default: `false`.
 * `OPS_GENIE`
   * `api_key` - Your API Key.
   * `region` (Required) - Two-letter code that indicates which API URL to use. See the `region` request parameter of [MongoDB API Third-Party Service Integration documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Third-Party-Integrations/operation/createThirdPartyIntegration) for more details. OpsGenie will use "US" by default.

--- a/examples/mongodbatlas_third_party_integration/datadog/integration.tf
+++ b/examples/mongodbatlas_third_party_integration/datadog/integration.tf
@@ -3,4 +3,7 @@ resource "mongodbatlas_third_party_integration" "test-datadog" {
   type       = "DATADOG"
   api_key    = var.datadog_api_key
   region     = var.datadog_region
+
+  send_collection_latency_metrics = var.send_collection_latency_metrics
+  send_database_metrics           = var.send_database_metrics
 }

--- a/examples/mongodbatlas_third_party_integration/datadog/variables.tf
+++ b/examples/mongodbatlas_third_party_integration/datadog/variables.tf
@@ -24,3 +24,15 @@ variable "cluster_name" {
   default     = "datadog-test-cluster"
   type        = string
 }
+
+variable "send_collection_latency_metrics" {
+  description = "Send collection latency metrics"
+  default     = false
+  type        = bool
+}
+
+variable "send_database_metrics" {
+  description = "Send database metrics"
+  default     = false
+  type        = bool
+}

--- a/internal/service/thirdpartyintegration/data_source_third_party_integration.go
+++ b/internal/service/thirdpartyintegration/data_source_third_party_integration.go
@@ -101,6 +101,14 @@ func thirdPartyIntegrationSchema() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"send_collection_latency_metrics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"send_database_metrics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }

--- a/internal/service/thirdpartyintegration/data_source_third_party_integrations.go
+++ b/internal/service/thirdpartyintegration/data_source_third_party_integrations.go
@@ -89,28 +89,36 @@ func integrationToSchema(d *schema.ResourceData, integration *admin.ThirdPartyIn
 	if integrationSchema.Url == nil {
 		integrationSchema.Url = integration.Url
 	}
+	if integrationSchema.SendCollectionLatencyMetrics == nil {
+		integrationSchema.SendCollectionLatencyMetrics = integration.SendCollectionLatencyMetrics
+	}
+	if integrationSchema.SendDatabaseMetrics == nil {
+		integrationSchema.SendDatabaseMetrics = integration.SendDatabaseMetrics
+	}
 
 	out := map[string]any{
-		"id":                          integration.Id,
-		"type":                        integration.Type,
-		"api_key":                     integrationSchema.ApiKey,
-		"region":                      integration.Region,
-		"service_key":                 integrationSchema.ServiceKey,
-		"team_name":                   integration.TeamName,
-		"channel_name":                integration.ChannelName,
-		"routing_key":                 integration.RoutingKey,
-		"url":                         integrationSchema.Url,
-		"secret":                      integrationSchema.Secret,
-		"microsoft_teams_webhook_url": integrationSchema.MicrosoftTeamsWebhookUrl,
-		"user_name":                   integration.Username,
-		"password":                    integrationSchema.Password,
-		"service_discovery":           integration.ServiceDiscovery,
-		"enabled":                     integration.Enabled,
+		"id":                              integration.Id,
+		"type":                            integration.Type,
+		"api_key":                         integrationSchema.ApiKey,
+		"region":                          integration.Region,
+		"service_key":                     integrationSchema.ServiceKey,
+		"team_name":                       integration.TeamName,
+		"channel_name":                    integration.ChannelName,
+		"routing_key":                     integration.RoutingKey,
+		"url":                             integrationSchema.Url,
+		"secret":                          integrationSchema.Secret,
+		"microsoft_teams_webhook_url":     integrationSchema.MicrosoftTeamsWebhookUrl,
+		"user_name":                       integration.Username,
+		"password":                        integrationSchema.Password,
+		"service_discovery":               integration.ServiceDiscovery,
+		"enabled":                         integration.Enabled,
+		"send_collection_latency_metrics": integration.SendCollectionLatencyMetrics,
+		"send_database_metrics":           integration.SendDatabaseMetrics,
 	}
 
 	// removing optional empty values, terraform complains about unexpected values even though they're empty
 	optionals := []string{"api_key", "region", "service_key",
-		"team_name", "channel_name", "url", "secret", "password"}
+		"team_name", "channel_name", "url", "secret", "password", "send_collection_latency_metrics", "send_database_metrics"}
 
 	for _, attr := range optionals {
 		if val, ok := out[attr]; ok {
@@ -183,6 +191,14 @@ func schemaToIntegration(in *schema.ResourceData) (out *admin.ThirdPartyIntegrat
 		out.Enabled = admin.PtrBool(enabled.(bool))
 	}
 
+	if sendCollectionLatencyMetrics, ok := in.GetOk("send_collection_latency_metrics"); ok {
+		out.SendCollectionLatencyMetrics = admin.PtrBool(sendCollectionLatencyMetrics.(bool))
+	}
+
+	if sendDatabaseMetrics, ok := in.GetOk("send_database_metrics"); ok {
+		out.SendDatabaseMetrics = admin.PtrBool(sendDatabaseMetrics.(bool))
+	}
+
 	return out
 }
 
@@ -235,5 +251,13 @@ func updateIntegrationFromSchema(d *schema.ResourceData, integration *admin.Thir
 
 	if d.HasChange("enabled") {
 		integration.Enabled = admin.PtrBool(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("send_collection_latency_metrics") {
+		integration.SendCollectionLatencyMetrics = admin.PtrBool(d.Get("send_collection_latency_metrics").(bool))
+	}
+
+	if d.HasChange("send_database_metrics") {
+		integration.SendDatabaseMetrics = admin.PtrBool(d.Get("send_database_metrics").(bool))
 	}
 }

--- a/internal/service/thirdpartyintegration/resource_third_party_integration.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration.go
@@ -24,7 +24,7 @@ var integrationTypes = []string{
 
 var requiredPerType = map[string][]string{
 	"PAGER_DUTY":      {"service_key"},
-	"DATADOG":         {"api_key", "region"},
+	"DATADOG":         {"api_key", "region", "send_collection_latency_metrics", "send_database_metrics"},
 	"OPS_GENIE":       {"api_key", "region"},
 	"VICTOR_OPS":      {"api_key"},
 	"WEBHOOK":         {"url"},
@@ -125,6 +125,16 @@ func Resource() *schema.Resource {
 				Sensitive: true,
 			},
 			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
+			"send_collection_latency_metrics": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
+			"send_database_metrics": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,

--- a/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
+++ b/internal/service/thirdpartyintegration/resource_third_party_integration_test.go
@@ -178,23 +178,42 @@ func datadogTest(tb testing.TB) *resource.TestCase {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configDatadog(projectID, apiKey, "US"),
+				Config: configDatadog(projectID, apiKey, "US", false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
 					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "type", intType),
 					resource.TestCheckResourceAttr(dataSourceName, "region", region),
+					resource.TestCheckResourceAttr(dataSourceName, "send_collection_latency_metrics", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_database_metrics", "false"),
 				),
 			},
 			{
-				Config: configDatadog(projectID, updatedAPIKey, "US"),
+				Config: configDatadog(projectID, updatedAPIKey, "US", false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "type", intType),
 					resource.TestCheckResourceAttr(resourceName, "api_key", updatedAPIKey),
 					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "false"),
+				),
+			},
+			{
+				Config: configDatadog(projectID, updatedAPIKey, "US", true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", intType),
+					resource.TestCheckResourceAttr(resourceName, "api_key", updatedAPIKey),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttr(resourceName, "send_collection_latency_metrics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "send_database_metrics", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_collection_latency_metrics", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "send_database_metrics", "true"),
 				),
 			},
 			importStep(resourceName),
@@ -424,19 +443,23 @@ func configVictorOps(projectID, apiKey string) string {
 	) + singularDataStr
 }
 
-func configDatadog(projectID, apiKey, region string) string {
+func configDatadog(projectID, apiKey, region string, sendCollectionLatencyMetrics, sendDatabaseMetrics bool) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_third_party_integration" "test" {
 		project_id = "%[1]s"
 		type = "%[2]s"
 		api_key = "%[3]s"
 		region  ="%[4]s"
+		send_collection_latency_metrics = %[5]t
+		send_database_metrics = %[6]t
 	}
 	`,
 		projectID,
 		"DATADOG",
 		apiKey,
 		region,
+		sendCollectionLatencyMetrics,
+		sendDatabaseMetrics,
 	) + singularDataStr
 }
 


### PR DESCRIPTION
## Description

Adds support for `sendCollectionLatencyMetrics` and `sendDatabaseMetrics` in the Datadog `third_party_integration` resource and data sources as they are supported by the atlas API

Updates documentation and example configurations to reflect these new options.

Link to any related issue(s):

https://feedback.mongodb.com/forums/924145-atlas/suggestions/49619627-add-sendcollectionlatencymetrics-and-senddatabasem

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
