### PR TITLE
chore: Support list nested attributes in conversion logic for generating API request from Resource Model

### DIFF
--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -83,11 +83,11 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 	return nil
 }
 
-func getAttr(obj attr.Value) (any, error) {
-	if obj.IsNull() || obj.IsUnknown() {
+func getAttr(val attr.Value) (any, error) {
+	if val.IsNull() || val.IsUnknown() {
 		return nil, nil // skip null or unknown values
 	}
-	switch v := obj.(type) {
+	switch v := val.(type) {
 	case types.String:
 		return v.ValueString(), nil
 	case types.Int64:
@@ -95,26 +95,26 @@ func getAttr(obj attr.Value) (any, error) {
 	case types.Float64:
 		return v.ValueFloat64(), nil
 	case types.Object:
-		objJSON := make(map[string]any)
+		obj := make(map[string]any)
 		for name, attr := range v.Attributes() {
-			val, err := getAttr(attr)
+			valChild, err := getAttr(attr)
 			if err != nil {
 				return nil, err
 			}
-			if val != nil {
-				objJSON[name] = val
+			if valChild != nil {
+				obj[name] = valChild
 			}
 		}
-		return objJSON, nil
+		return obj, nil
 	case types.List:
 		arr := make([]any, 0)
-		for _, elem := range v.Elements() {
-			val, err := getAttr(elem)
+		for _, attr := range v.Elements() {
+			valChild, err := getAttr(attr)
 			if err != nil {
 				return nil, err
 			}
-			if val != nil {
-				arr = append(arr, val)
+			if valChild != nil {
+				arr = append(arr, valChild)
 			}
 		}
 		return arr, nil

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -118,6 +118,18 @@ func getAttr(val attr.Value) (any, error) {
 			}
 		}
 		return arr, nil
+	case types.Set:
+		arr := make([]any, 0)
+		for _, attr := range v.Elements() {
+			valChild, err := getAttr(attr)
+			if err != nil {
+				return nil, err
+			}
+			if valChild != nil {
+				arr = append(arr, valChild)
+			}
+		}
+		return arr, nil
 	default:
 		return nil, fmt.Errorf("unmarshal not supported yet for type %T", v)
 	}

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -94,6 +94,18 @@ func getAttr(obj attr.Value) (any, error) {
 		return v.ValueInt64(), nil
 	case types.Float64:
 		return v.ValueFloat64(), nil
+	case types.Object:
+		objJSON := make(map[string]any)
+		for name, attr := range v.Attributes() {
+			val, err := getAttr(attr)
+			if err != nil {
+				return nil, err
+			}
+			if val != nil {
+				objJSON[name] = val
+			}
+		}
+		return objJSON, nil
 	case types.List:
 		arr := make([]any, 0)
 		for _, elem := range v.Elements() {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -95,56 +95,44 @@ func getAttr(val attr.Value) (any, error) {
 	case types.Float64:
 		return v.ValueFloat64(), nil
 	case types.Object:
-		obj := make(map[string]any)
-		for name, attr := range v.Attributes() {
-			valChild, err := getAttr(attr)
-			if err != nil {
-				return nil, err
-			}
-			if valChild != nil {
-				obj[name] = valChild
-			}
-		}
-		return obj, nil
+		return getMapAttr(v.Attributes())
 	case types.Map:
-		obj := make(map[string]any)
-		for name, attr := range v.Elements() {
-			valChild, err := getAttr(attr)
-			if err != nil {
-				return nil, err
-			}
-			if valChild != nil {
-				obj[name] = valChild
-			}
-		}
-		return obj, nil
+		return getMapAttr(v.Elements())
 	case types.List:
-		arr := make([]any, 0)
-		for _, attr := range v.Elements() {
-			valChild, err := getAttr(attr)
-			if err != nil {
-				return nil, err
-			}
-			if valChild != nil {
-				arr = append(arr, valChild)
-			}
-		}
-		return arr, nil
+		return getListAttr(v.Elements())
 	case types.Set:
-		arr := make([]any, 0)
-		for _, attr := range v.Elements() {
-			valChild, err := getAttr(attr)
-			if err != nil {
-				return nil, err
-			}
-			if valChild != nil {
-				arr = append(arr, valChild)
-			}
-		}
-		return arr, nil
+		return getListAttr(v.Elements())
 	default:
 		return nil, fmt.Errorf("unmarshal not supported yet for type %T", v)
 	}
+}
+
+func getListAttr(elms []attr.Value) (any, error) {
+	arr := make([]any, 0)
+	for _, attr := range elms {
+		valChild, err := getAttr(attr)
+		if err != nil {
+			return nil, err
+		}
+		if valChild != nil {
+			arr = append(arr, valChild)
+		}
+	}
+	return arr, nil
+}
+
+func getMapAttr(elms map[string]attr.Value) (any, error) {
+	obj := make(map[string]any)
+	for name, attr := range elms {
+		valChild, err := getAttr(attr)
+		if err != nil {
+			return nil, err
+		}
+		if valChild != nil {
+			obj[name] = valChild
+		}
+	}
+	return obj, nil
 }
 
 func unmarshalAttrs(objJSON map[string]any, model any) error {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -95,9 +95,9 @@ func getAttr(val attr.Value) (any, error) {
 	case types.Float64:
 		return v.ValueFloat64(), nil
 	case types.Object:
-		return getMapAttr(v.Attributes())
+		return getMapAttr(v.Attributes(), false)
 	case types.Map:
-		return getMapAttr(v.Elements())
+		return getMapAttr(v.Elements(), true)
 	case types.List:
 		return getListAttr(v.Elements())
 	case types.Set:
@@ -121,7 +121,7 @@ func getListAttr(elms []attr.Value) (any, error) {
 	return arr, nil
 }
 
-func getMapAttr(elms map[string]attr.Value) (any, error) {
+func getMapAttr(elms map[string]attr.Value, keepKeyCase bool) (any, error) {
 	obj := make(map[string]any)
 	for name, attr := range elms {
 		valChild, err := getAttr(attr)
@@ -129,7 +129,11 @@ func getMapAttr(elms map[string]attr.Value) (any, error) {
 			return nil, err
 		}
 		if valChild != nil {
-			obj[name] = valChild
+			nameJSON := xstrings.ToCamelCase(name)
+			if keepKeyCase {
+				nameJSON = name
+			}
+			obj[nameJSON] = valChild
 		}
 	}
 	return obj, nil

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -17,10 +17,10 @@ const (
 )
 
 // Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
-// It supports the following Terraform model types: String, Bool, Int64, Float64.
+// It supports the following Terraform model types: String, Bool, Int64, Float64, Object, Map, List, Set.
 // Attributes that are null or unknown are not marshaled.
-// Attributes with autogeneration tag `omitjson` are never marshaled.
-// Attributes with autogeneration tag `omitjsonupdate` are not marshaled if isUpdate is true.
+// Attributes with autogeneration tag `omitjson` are never marshaled, this only applies to the root model.
+// Attributes with autogeneration tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {

--- a/internal/common/autogeneration/marshal.go
+++ b/internal/common/autogeneration/marshal.go
@@ -106,6 +106,18 @@ func getAttr(val attr.Value) (any, error) {
 			}
 		}
 		return obj, nil
+	case types.Map:
+		obj := make(map[string]any)
+		for name, attr := range v.Elements() {
+			valChild, err := getAttr(attr)
+			if err != nil {
+				return nil, err
+			}
+			if valChild != nil {
+				obj[name] = valChild
+			}
+		}
+		return obj, nil
 	case types.List:
 		arr := make([]any, 0)
 		for _, attr := range v.Elements() {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 type TFTestModel struct {
-	Attr1 types.String `tfsdk:"attr1"`
-	Attr2 types.Int64  `tfsdk:"attr2"`
+	AttrString types.String `tfsdk:"attr_string"`
+	AttrInt    types.Int64  `tfsdk:"attr_int"`
 }
 
 var TestObjType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"attr1": types.StringType,
-	"attr2": types.Int64Type,
+	"attr_string": types.StringType,
+	"attr_int":    types.Int64Type,
 }}
 
 func TestMarshalBasic(t *testing.T) {
@@ -48,12 +48,12 @@ func TestMarshalBasic(t *testing.T) {
 func TestMarshalList(t *testing.T) {
 	attrListObj, diags := types.ListValueFrom(t.Context(), TestObjType, []TFTestModel{
 		{
-			Attr1: types.StringValue("val1"),
-			Attr2: types.Int64Value(2),
+			AttrString: types.StringValue("str1"),
+			AttrInt:    types.Int64Value(1),
 		},
 		{
-			Attr1: types.StringValue("val11"),
-			Attr2: types.Int64Value(22),
+			AttrString: types.StringValue("str2"),
+			AttrInt:    types.Int64Value(2),
 		},
 	})
 	assert.False(t, diags.HasError())
@@ -71,8 +71,8 @@ func TestMarshalList(t *testing.T) {
 			"attrString": "val", 
 			"attrListSimple": ["val1", "val2"],
 			"attrListObj": [
-				{ "attr1": "val1", "attr2": 2 },
-				{ "attr1": "val11", "attr2": 22 }
+				{ "attr_string": "str1", "attr_int": 1 },
+				{ "attr_string": "str2", "attr_int": 2 }
 			]
 		}
 	`

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -35,6 +35,20 @@ func TestMarshalBasic(t *testing.T) {
 	assert.JSONEq(t, expectedJSON, string(raw))
 }
 
+func TestMarshalList(t *testing.T) {
+	model := struct {
+		AttrString types.String `tfsdk:"attr_string"`
+		AttrList   types.List   `tfsdk:"attr_list"`
+	}{
+		AttrString: types.StringValue("val"),
+		AttrList:   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("val1"), types.StringValue("val2")}),
+	}
+	const expectedJSON = `{ "attrString": "val", "attrList": ["val1", "val2"] }`
+	raw, err := autogeneration.Marshal(&model, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(raw))
+}
+
 func TestMarshalOmitJSONUpdate(t *testing.T) {
 	const (
 		expectedCreate = `{ "attr": "val1", "attrOmitUpdate": "val2" }`
@@ -67,13 +81,6 @@ func TestMarshalUnsupported(t *testing.T) {
 				"key": types.StringType,
 			}, map[string]attr.Value{
 				"key": types.StringValue("value"),
-			}),
-		},
-		"List not supported yet, only no-nested types": &struct {
-			Attr types.List
-		}{
-			Attr: types.ListValueMust(types.StringType, []attr.Value{
-				types.StringValue("value"),
 			}),
 		},
 		"Map not supported yet, only no-nested types": &struct {

--- a/internal/common/autogeneration/marshal_test.go
+++ b/internal/common/autogeneration/marshal_test.go
@@ -69,11 +69,11 @@ func TestMarshalNested(t *testing.T) {
 	})
 	assert.False(t, diags.HasError())
 	attrMapObj, diags := types.MapValueFrom(t.Context(), TestObjType, map[string]TFTestModel{
-		"key1": {
+		"keyOne": {
 			AttrString: types.StringValue("str1"),
 			AttrInt:    types.Int64Value(1),
 		},
-		"key2": {
+		"KeyTwo": { // don't change the key case when it's a map
 			AttrString: types.StringValue("str2"),
 			AttrInt:    types.Int64Value(2),
 		},
@@ -94,8 +94,8 @@ func TestMarshalNested(t *testing.T) {
 		AttrSetSimple:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("val11"), types.StringValue("val22")}),
 		AttrSetObj:     attrSetObj,
 		AttrMapSimple: types.MapValueMust(types.StringType, map[string]attr.Value{
-			"key1": types.StringValue("val1"),
-			"key2": types.StringValue("val2"),
+			"keyOne": types.StringValue("val1"),
+			"KeyTwo": types.StringValue("val2"), // don't change the key case when it's a map
 		}),
 		AttrMapObj: attrMapObj,
 	}
@@ -104,21 +104,21 @@ func TestMarshalNested(t *testing.T) {
 			"attrString": "val", 
 			"attrListSimple": ["val1", "val2"],
 			"attrListObj": [
-				{ "attr_string": "str1", "attr_int": 1 },
-				{ "attr_string": "str2", "attr_int": 2 }
+				{ "attrString": "str1", "attrInt": 1 },
+				{ "attrString": "str2", "attrInt": 2 }
 			],
 			"attrSetSimple": ["val11", "val22"],
 			"attrSetObj": [
-				{ "attr_string": "str11", "attr_int": 11 },
-				{ "attr_string": "str22", "attr_int": 22 }
+				{ "attrString": "str11", "attrInt": 11 },
+				{ "attrString": "str22", "attrInt": 22 }
 			],
 			"attrMapSimple": {
-				"key1": "val1",
-				"key2": "val2"
+				"keyOne": "val1",
+				"KeyTwo": "val2"
 			},
 			"attrMapObj": {
-				"key1": { "attr_string": "str1", "attr_int": 1 },
-				"key2": { "attr_string": "str2", "attr_int": 2 }
+				"keyOne": { "attrString": "str1", "attrInt": 1 },
+				"KeyTwo": { "attrString": "str2", "attrInt": 2 }
 			}
 		}
 	`


### PR DESCRIPTION
## Description

Support list nested attributes in conversion logic for generating API request from Resource Model. It includes ListNest, SetNested, SingleNested and MapNested.

**NOTE**: autogeneration struct field tag is only supported in the main Terraform model. If for instance one of its children is a types.Object, tags in its Terraform model won't be considered.

Link to any related issue(s): CLOUDP-311377

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
