### PR TITLE
refactor: Supports cleaning resources for static projects with `test-acc-tf-p-keep` prefix

### DIFF
--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -84,7 +84,7 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	projects := readAllProjects(t.Context(), t, client)
 	projectsBefore := len(projects)
 	t.Logf("found %d projects (DRY_RUN=%t)", projectsBefore, dryRun)
-	projectsToDelete := map[string]string{}
+	projectsToClean := map[string]string{}
 	projectInfos := []string{}
 	for _, p := range projects {
 		skipReason := projectSkipReason(&p, skipProjectsAfter, onlyZeroClusters)
@@ -95,14 +95,14 @@ func TestCleanProjectAndClusters(t *testing.T) {
 			continue
 		}
 		projectInfos = append(projectInfos, fmt.Sprintf("Project created at %s name %s (%s)", p.GetCreated().Format(time.RFC3339), projectName, p.GetId()))
-		projectsToDelete[projectName] = projectID
+		projectsToClean[projectName] = projectID
 	}
-	t.Logf("will try to delete %d projects:", len(projectsToDelete))
+	t.Logf("deleting project resources and optionally delete projects for %d projects", len(projectsToClean))
 	slices.Sort(projectInfos)
 	t.Log(strings.Join(projectInfos, "\n"))
 	var deleteErrors int
 	var emptyProjectCount int
-	for name, projectID := range projectsToDelete {
+	for name, projectID := range projectsToClean {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			changes := removeProjectResources(t.Context(), t, dryRun, client, projectID)

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -109,8 +109,8 @@ func TestCleanProjectAndClusters(t *testing.T) {
 			if changes != "" {
 				t.Logf("project %s %s", name, changes)
 			}
-			if skipReason := projectNoDeleteReason(name); skipReason != "" {
-				t.Logf("keep project empty, but no delete %s (%s), reason: %s", name, projectID, skipReason)
+			if skipProjectDelete(name) {
+				t.Logf("keep project empty, but no delete %s (%s)", name, projectID)
 				emptyProjectCount++
 				return
 			}
@@ -230,13 +230,13 @@ func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bo
 	return ""
 }
 
-func projectNoDeleteReason(name string) string {
+func skipProjectDelete(name string) bool {
 	for _, keepPrefix := range keptPrefixes {
 		if strings.HasPrefix(name, keepPrefix) {
-			return "keep project but not resources"
+			return true
 		}
 	}
-	return ""
+	return false
 }
 
 func removeClusters(ctx context.Context, t *testing.T, dryRun bool, client *admin.APIClient, projectID string) int {

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -34,7 +34,7 @@ var (
 		"cfn-test-bot-",
 		"test-acc-tf-p-",
 	}
-	// These are projects gets their resources removed but the project itself is kept
+	// keptPrefixes has the prefix of the projects that we want to delete their resources but keep the projects themselves.
 	// Useful when a feature flag or cloud provider is configured outside of the test
 	keptPrefixes = []string{
 		"test-acc-tf-p-keep",

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -37,6 +37,9 @@ var (
 	keptPrefixes = []string{
 		"test-acc-tf-p-keep",
 	}
+	keepProjectEmptyPrefixes = []string{
+		"test-acc-tf-p-empty",
+	}
 	projectRetryDeleteErrors = []string{
 		"CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS",
 		"CANNOT_CLOSE_GROUP_ACTIVE_PEERING_CONNECTIONS",
@@ -87,24 +90,31 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	for _, p := range projects {
 		skipReason := projectSkipReason(&p, skipProjectsAfter, onlyZeroClusters)
 		projectName := p.GetName()
+		projectID := p.GetId()
 		if skipReason != "" {
-			t.Logf("skip project %s, reason: %s", projectName, skipReason)
+			t.Logf("skip project %s (%s), reason: %s", projectName, projectID, skipReason)
 			continue
 		}
 		projectInfos = append(projectInfos, fmt.Sprintf("Project created at %s name %s (%s)", p.GetCreated().Format(time.RFC3339), projectName, p.GetId()))
-		projectID := p.GetId()
 		projectsToDelete[projectName] = projectID
 	}
 	t.Logf("will try to delete %d projects:", len(projectsToDelete))
 	slices.Sort(projectInfos)
 	t.Log(strings.Join(projectInfos, "\n"))
 	var deleteErrors int
+	var emptyProjectCount int
 	for name, projectID := range projectsToDelete {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			changes := removeProjectResources(t.Context(), t, dryRun, client, projectID)
 			if changes != "" {
 				t.Logf("project %s %s", name, changes)
+			}
+			skipReason := projectNoDeleteReason(name)
+			if skipReason != "" {
+				t.Logf("keep project empty, but no delete %s (%s), reason: %s", name, projectID, skipReason)
+				emptyProjectCount++
+				return
 			}
 			var err error
 			for i := range runRetries {
@@ -133,7 +143,7 @@ func TestCleanProjectAndClusters(t *testing.T) {
 	t.Cleanup(func() {
 		//nolint:usetesting // reason: using context.Background() here intentionally because t.Context() is canceled at cleanup
 		projectsAfter := readAllProjects(context.Background(), t, client)
-		t.Logf("SUMMARY\nProjects changed from %d to %d\ndelete_errors=%d\nDRY_RUN=%t", projectsBefore, len(projectsAfter), deleteErrors, dryRun)
+		t.Logf("SUMMARY\nProjects changed from %d to %d\ndelete_errors=%d\nempty_project_count=%d\nDRY_RUN=%t", projectsBefore, len(projectsAfter), deleteErrors, emptyProjectCount, dryRun)
 	})
 }
 
@@ -224,6 +234,15 @@ func projectSkipReason(p *admin.Group, skipProjectsAfter time.Time, onlyEmpty bo
 	}
 	if onlyEmpty && p.GetClusterCount() > 0 {
 		return "has clusters"
+	}
+	return ""
+}
+
+func projectNoDeleteReason(name string) string {
+	for _, keepPrefix := range keepProjectEmptyPrefixes {
+		if strings.HasPrefix(name, keepPrefix) {
+			return "keep project but not resources"
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Description

Related issue: https://jira.mongodb.org/browse/CLOUDP-314965

Supports cleaning projects with `"test-acc-tf-p-keep"` prefix, that shouldn't be deleted but have resources removed when running the cleanup (the project should be empty after tests).

We have various tests that depend on using specific projects with feature flags enabled.
However, these projects risk having extra resources that are not cleaned.

The only resources found for deletion:
```
test-acc-tf-p-keep-ear-AWS-private-endpoint (6790e57a9b41416f5c216fee) # 3 stream instances
test-acc-tf-p-keep-ear-private-endpoint (66d83bcc1fe1835125c52422) # no resources
test-acc-tf-p-keep-encryption-at-rest (67810c93a7dcf40b5f0db4c2) # no resources
```

## Sweeper Alternative considered
tl;dr: Uses the same mechanism as `go test` but with a `-sweep={regionName}` flag. I consider our current cleanup test to be easier to adapt than adding custom sweepers and a new CI workflow. 

- Docs: https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests/sweepers
- AWS Example [invoke](https://github.com/hashicorp/terraform-provider-aws/blob/main/GNUmakefile#L585) and [code](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/accessanalyzer/sweep.go#L24)
- Advantage over `CheckDestroy`: If a test panics or the process terminates unexpectedly, checkDestroy never runs.
- CI Integration: Sweepers are designed to be run in CI pipelines on schedules, independent of test runs.
- The sweeper function must accept a region string parameter and return an error

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
