### PR TITLE
chore: Updates changelog generation script to rebase after commit

### DIFF
--- a/.github/workflows/run-script-and-commit.yml
+++ b/.github/workflows/run-script-and-commit.yml
@@ -52,12 +52,12 @@ jobs:
       - name: Commit changes
         run: |
           if [[ $(git status --porcelain) ]]; then
-            git pull
             git config --local user.email svc-api-experience-integrations-escalation@mongodb.com
             git config --local user.name svc-apix-bot
-            git remote set-url origin ${{ secrets.remote }}
             git add ${{ inputs.file_to_commit }}
             git commit -m "${{ inputs.commit_message }}"
+            git remote set-url origin ${{ secrets.remote }}
+            git pull --rebase
             git push
           else
             echo "No changes to commit."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ ENHANCEMENTS:
 
 * data-source/mongodbatlas_organization: Adds `security_contact` attribute ([#3263](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3263))
 * data-source/mongodbatlas_organizations: Adds `security_contact` attribute ([#3263](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3263))
+* data-source/mongodbatlas_third_party_integration: Adds support for `send_collection_latency_metrics` and `send_database_metrics` for Datadog integrations ([#3259](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3259))
+* data-source/mongodbatlas_third_party_integrations: Adds support for `send_collection_latency_metrics` and `send_database_metrics` for Datadog integrations ([#3259](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3259))
 * resource/mongodbatlas_organization: Adds `security_contact` attribute ([#3263](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3263))
+* resource/mongodbatlas_third_party_integration: Adds support for `send_collection_latency_metrics` and `send_database_metrics` for Datadog integrations ([#3259](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3259))
 
 ## 1.32.0 (April 09, 2025)
 


### PR DESCRIPTION
## Description

Changelog generation failing in the workflow https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/14401131031/job/40387494791 , updated script to rebase after commit.

Test run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/14401478512 -> this run updated this PR with changelog changes (which will be removed before merging the PR)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
