### PR TITLE
chore: Rename autogeneration to autogen

### DIFF
--- a/internal/common/autogen/import.go
+++ b/internal/common/autogen/import.go
@@ -1,4 +1,4 @@
-package autogeneration
+package autogen
 
 import (
 	"context"

--- a/internal/common/autogen/import_test.go
+++ b/internal/common/autogen/import_test.go
@@ -1,10 +1,10 @@
-package autogeneration_test
+package autogen_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,13 +40,13 @@ func TestGenericImportOperation(t *testing.T) {
 			name:          "Error: Wrong number of attributes",
 			importID:      "5c9d0a239ccf643e6a35ddasdf/myCluster",
 			idAttributes:  []string{"project_id", "cluster_name", "region"},
-			expectedError: conversion.StringPtr(fmt.Sprintf(autogeneration.ExpectedErrorMsg, "project_id/cluster_name/region")),
+			expectedError: conversion.StringPtr(fmt.Sprintf(autogen.ExpectedErrorMsg, "project_id/cluster_name/region")),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attrValues, err := autogeneration.ProcessImportID(tc.importID, tc.idAttributes)
+			attrValues, err := autogen.ProcessImportID(tc.importID, tc.idAttributes)
 
 			if tc.expectedError != nil {
 				require.Error(t, err)

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -1,4 +1,4 @@
-package autogeneration
+package autogen
 
 import (
 	"encoding/json"

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	tagKey               = "autogeneration"
+	tagKey               = "autogen"
 	tagValOmitJSON       = "omitjson"
 	tagValOmitJSONUpdate = "omitjsonupdate"
 )
@@ -19,8 +19,8 @@ const (
 // Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
 // It supports the following Terraform model types: String, Bool, Int64, Float64, Object, Map, List, Set.
 // Attributes that are null or unknown are not marshaled.
-// Attributes with autogeneration tag `omitjson` are never marshaled, this only applies to the root model.
-// Attributes with autogeneration tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
+// Attributes with autogen tag `omitjson` are never marshaled, this only applies to the root model.
+// Attributes with autogen tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -1,11 +1,11 @@
-package autogeneration_test
+package autogen_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,7 +66,7 @@ func TestMarshalBasic(t *testing.T) {
 		AttrBoolNull:        types.BoolNull(), // null values are not marshaled
 	}
 	const expectedJSON = `{ "attrString": "hello", "attrInt": 1, "attrFloat": 1.234, "attrBoolTrue": true, "attrBoolFalse": false }`
-	raw, err := autogeneration.Marshal(&model, false)
+	raw, err := autogen.Marshal(&model, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))
 }
@@ -148,7 +148,7 @@ func TestMarshalNestedAllTypes(t *testing.T) {
 			}
 		}
 	`
-	raw, err := autogeneration.Marshal(&model, false)
+	raw, err := autogen.Marshal(&model, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))
 }
@@ -212,7 +212,7 @@ func TestMarshalNestedMultiLevel(t *testing.T) {
 			]
 		}
 	`
-	raw, err := autogeneration.Marshal(&model, false)
+	raw, err := autogen.Marshal(&model, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))
 }
@@ -231,11 +231,11 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 		AttrOmitUpdate: types.StringValue("val2"),
 		AttrOmit:       types.StringValue("omit"),
 	}
-	create, errCreate := autogeneration.Marshal(&model, false)
+	create, errCreate := autogen.Marshal(&model, false)
 	require.NoError(t, errCreate)
 	assert.JSONEq(t, expectedCreate, string(create))
 
-	update, errUpdate := autogeneration.Marshal(&model, true)
+	update, errUpdate := autogen.Marshal(&model, true)
 	require.NoError(t, errUpdate)
 	assert.JSONEq(t, expectedUpdate, string(update))
 }
@@ -255,7 +255,7 @@ func TestMarshalUnsupported(t *testing.T) {
 	}
 	for name, model := range testCases {
 		t.Run(name, func(t *testing.T) {
-			raw, err := autogeneration.Marshal(model, false)
+			raw, err := autogen.Marshal(model, false)
 			require.Error(t, err)
 			assert.Nil(t, raw)
 		})
@@ -280,7 +280,7 @@ func TestMarshalPanic(t *testing.T) {
 	for name, model := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert.Panics(t, func() {
-				_, _ = autogeneration.Marshal(model, false)
+				_, _ = autogen.Marshal(model, false)
 			})
 		})
 	}

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -45,8 +45,8 @@ func TestMarshalBasic(t *testing.T) {
 		AttrFloat  types.Float64 `tfsdk:"attr_float"`
 		AttrString types.String  `tfsdk:"attr_string"`
 		// values with tag `omitjson` are not marshaled, and they don't need to be Terraform types
-		AttrOmit            types.String `tfsdk:"attr_omit" autogeneration:"omitjson"`
-		AttrOmitNoTerraform string       `autogeneration:"omitjson"`
+		AttrOmit            types.String `tfsdk:"attr_omit" autogen:"omitjson"`
+		AttrOmitNoTerraform string       `autogen:"omitjson"`
 		AttrUnkown          types.String `tfsdk:"attr_unknown"`
 		AttrNull            types.String `tfsdk:"attr_null"`
 		AttrInt             types.Int64  `tfsdk:"attr_int"`
@@ -224,8 +224,8 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 	)
 	model := struct {
 		Attr           types.String `tfsdk:"attr"`
-		AttrOmitUpdate types.String `tfsdk:"attr_omit_update" autogeneration:"omitjsonupdate"`
-		AttrOmit       types.String `tfsdk:"attr_omit" autogeneration:"omitjson"`
+		AttrOmitUpdate types.String `tfsdk:"attr_omit_update" autogen:"omitjsonupdate"`
+		AttrOmit       types.String `tfsdk:"attr_omit" autogen:"omitjson"`
 	}{
 		Attr:           types.StringValue("val1"),
 		AttrOmitUpdate: types.StringValue("val2"),

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -1,4 +1,4 @@
-package autogeneration
+package autogen
 
 import (
 	"context"

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -1,11 +1,11 @@
-package autogeneration_test
+package autogen_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +38,7 @@ func TestUnmarshalBasic(t *testing.T) {
 			}
 		`
 	)
-	require.NoError(t, autogeneration.Unmarshal([]byte(jsonResp), &model))
+	require.NoError(t, autogen.Unmarshal([]byte(jsonResp), &model))
 	assert.Equal(t, "value_string", model.AttrString.ValueString())
 	assert.True(t, model.AttrTrue.ValueBool())
 	assert.False(t, model.AttrFalse.ValueBool())
@@ -299,7 +299,7 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 			}),
 		}),
 	}
-	require.NoError(t, autogeneration.Unmarshal([]byte(jsonResp), &model))
+	require.NoError(t, autogen.Unmarshal([]byte(jsonResp), &model))
 	assert.Equal(t, modelExpected, model)
 }
 
@@ -383,7 +383,7 @@ func TestUnmarshalErrors(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			assert.ErrorContains(t, autogeneration.Unmarshal([]byte(tc.responseJSON), tc.model), tc.errorStr)
+			assert.ErrorContains(t, autogen.Unmarshal([]byte(tc.responseJSON), tc.model), tc.errorStr)
 		})
 	}
 }
@@ -410,7 +410,7 @@ func TestUnmarshalUnsupportedModel(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			assert.Error(t, autogeneration.Unmarshal([]byte(tc.responseJSON), tc.model))
+			assert.Error(t, autogen.Unmarshal([]byte(tc.responseJSON), tc.model))
 		})
 	}
 }
@@ -433,7 +433,7 @@ func TestUnmarshalUnsupportedResponse(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			assert.ErrorContains(t, autogeneration.Unmarshal([]byte(tc.responseJSON), tc.model), tc.errorStr)
+			assert.ErrorContains(t, autogen.Unmarshal([]byte(tc.responseJSON), tc.model), tc.errorStr)
 		})
 	}
 }

--- a/internal/service/customdbroleapi/resource.go
+++ b/internal/service/customdbroleapi/resource.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -77,7 +77,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -119,7 +119,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -133,7 +133,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -164,7 +164,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -195,5 +195,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "role_name"}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/internal/service/customdbroleapi/resource_schema.go
+++ b/internal/service/customdbroleapi/resource_schema.go
@@ -74,9 +74,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 
 type TFModel struct {
 	Actions        types.List   `tfsdk:"actions"`
-	GroupId        types.String `tfsdk:"group_id" autogeneration:"omitjson"`
+	GroupId        types.String `tfsdk:"group_id" autogen:"omitjson"`
 	InheritedRoles types.Set    `tfsdk:"inherited_roles"`
-	RoleName       types.String `tfsdk:"role_name" autogeneration:"omitjsonupdate"`
+	RoleName       types.String `tfsdk:"role_name" autogen:"omitjsonupdate"`
 }
 type TFActionsModel struct {
 	Action    types.String `tfsdk:"action"`

--- a/internal/service/databaseuserapi/resource.go
+++ b/internal/service/databaseuserapi/resource.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -77,7 +77,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -120,7 +120,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -134,7 +134,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -166,7 +166,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -198,5 +198,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id", "database_name", "username"}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/internal/service/databaseuserapi/resource_schema.go
+++ b/internal/service/databaseuserapi/resource_schema.go
@@ -137,7 +137,7 @@ type TFModel struct {
 	GroupId         types.String `tfsdk:"group_id"`
 	Labels          types.List   `tfsdk:"labels"`
 	LdapAuthType    types.String `tfsdk:"ldap_auth_type"`
-	Links           types.List   `tfsdk:"links" autogeneration:"omitjson"`
+	Links           types.List   `tfsdk:"links" autogen:"omitjson"`
 	OidcAuthType    types.String `tfsdk:"oidc_auth_type"`
 	Password        types.String `tfsdk:"password"`
 	Roles           types.List   `tfsdk:"roles"`
@@ -150,8 +150,8 @@ type TFLabelsModel struct {
 	Value types.String `tfsdk:"value"`
 }
 type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogeneration:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogeneration:"omitjson"`
+	Href types.String `tfsdk:"href" autogen:"omitjson"`
+	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFRolesModel struct {
 	CollectionName types.String `tfsdk:"collection_name"`

--- a/internal/service/pushbasedlogexportapi/resource.go
+++ b/internal/service/pushbasedlogexportapi/resource.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -77,7 +77,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -118,7 +118,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -132,7 +132,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -162,7 +162,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -192,5 +192,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"group_id"}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/internal/service/pushbasedlogexportapi/resource_schema.go
+++ b/internal/service/pushbasedlogexportapi/resource_schema.go
@@ -58,14 +58,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 
 type TFModel struct {
 	BucketName types.String `tfsdk:"bucket_name"`
-	CreateDate types.String `tfsdk:"create_date" autogeneration:"omitjson"`
-	GroupId    types.String `tfsdk:"group_id" autogeneration:"omitjson"`
+	CreateDate types.String `tfsdk:"create_date" autogen:"omitjson"`
+	GroupId    types.String `tfsdk:"group_id" autogen:"omitjson"`
 	IamRoleId  types.String `tfsdk:"iam_role_id"`
-	Links      types.List   `tfsdk:"links" autogeneration:"omitjson"`
+	Links      types.List   `tfsdk:"links" autogen:"omitjson"`
 	PrefixPath types.String `tfsdk:"prefix_path"`
-	State      types.String `tfsdk:"state" autogeneration:"omitjson"`
+	State      types.String `tfsdk:"state" autogen:"omitjson"`
 }
 type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogeneration:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogeneration:"omitjson"`
+	Href types.String `tfsdk:"href" autogen:"omitjson"`
+	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"io"
 	
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -78,7 +78,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -120,7 +120,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -134,7 +134,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -165,7 +165,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -196,5 +196,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{ {{range .ImportIDAttributes }}"{{ . }}", {{- end }}}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -77,7 +77,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -119,7 +119,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -133,7 +133,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -164,7 +164,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -195,5 +195,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id", "role_name"}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogeneration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -47,7 +47,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, false)
+	reqBody, err := autogen.Marshal(&plan, false)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -77,7 +77,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -118,7 +118,7 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 	}
 
 	// Use the current state as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &state); err != nil {
+	if err := autogen.Unmarshal(respBody, &state); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -132,7 +132,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 		return
 	}
 
-	reqBody, err := autogeneration.Marshal(&plan, true)
+	reqBody, err := autogen.Marshal(&plan, true)
 	if err != nil {
 		resp.Diagnostics.AddError(errorBuildingAPIRequest, err.Error())
 		return
@@ -162,7 +162,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 	}
 
 	// Use the plan as the base model to set the response state
-	if err := autogeneration.Unmarshal(respBody, &plan); err != nil {
+	if err := autogen.Unmarshal(respBody, &plan); err != nil {
 		resp.Diagnostics.AddError(errorProcessingAPIResponse, err.Error())
 	}
 
@@ -192,5 +192,5 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idAttributes := []string{"project_id"}
-	autogeneration.GenericImportOperation(ctx, idAttributes, req, resp)
+	autogen.GenericImportOperation(ctx, idAttributes, req, resp)
 }

--- a/tools/codegen/gofilegen/schema/testdata/nested-attributes.golden.go
+++ b/tools/codegen/gofilegen/schema/testdata/nested-attributes.golden.go
@@ -106,7 +106,7 @@ type TFModel struct {
 type TFNestedSingleAttrModel struct {
 	StringAttr                 types.String `tfsdk:"string_attr"`
 	IntAttr                    types.Int64  `tfsdk:"int_attr"`
-	AttrNotIncludedInReqBodies types.String `tfsdk:"attr_not_included_in_req_bodies" autogeneration:"omitjson"`
+	AttrNotIncludedInReqBodies types.String `tfsdk:"attr_not_included_in_req_bodies" autogen:"omitjson"`
 }
 
 var NestedSingleAttrObjType = types.ObjectType{AttrTypes: map[string]attr.Type{

--- a/tools/codegen/gofilegen/schema/testdata/primitive-attributes.golden.go
+++ b/tools/codegen/gofilegen/schema/testdata/primitive-attributes.golden.go
@@ -69,6 +69,6 @@ type TFModel struct {
 	SimpleListAttr             types.List    `tfsdk:"simple_list_attr"`
 	SimpleSetAttr              types.Set     `tfsdk:"simple_set_attr"`
 	SimpleMapAttr              types.Map     `tfsdk:"simple_map_attr"`
-	AttrNotIncludedInReqBodies types.String  `tfsdk:"attr_not_included_in_req_bodies" autogeneration:"omitjson"`
-	AttrOnlyInPostReqBodies    types.String  `tfsdk:"attr_only_in_post_req_bodies" autogeneration:"omitjsonupdate"`
+	AttrNotIncludedInReqBodies types.String  `tfsdk:"attr_not_included_in_req_bodies" autogen:"omitjson"`
+	AttrOnlyInPostReqBodies    types.String  `tfsdk:"attr_only_in_post_req_bodies" autogen:"omitjsonupdate"`
 }

--- a/tools/codegen/gofilegen/schema/testdata/timeouts.golden.go
+++ b/tools/codegen/gofilegen/schema/testdata/timeouts.golden.go
@@ -28,5 +28,5 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 
 type TFModel struct {
 	StringAttr types.String   `tfsdk:"string_attr"`
-	Timeouts   timeouts.Value `tfsdk:"timeouts" autogeneration:"omitjson"`
+	Timeouts   timeouts.Value `tfsdk:"timeouts" autogen:"omitjson"`
 }

--- a/tools/codegen/gofilegen/schema/typed_model.go
+++ b/tools/codegen/gofilegen/schema/typed_model.go
@@ -82,16 +82,16 @@ func generateStructOfTypedModel(attributes codespec.Attributes, name string) Cod
 
 func typedModelProperty(attr *codespec.Attribute) string {
 	var (
-		namePascalCase    = attr.Name.PascalCase()
-		propType          = attrModelType(attr)
-		autogenerationTag string
+		namePascalCase = attr.Name.PascalCase()
+		propType       = attrModelType(attr)
+		autogenTag     string
 	)
 	if attr.ReqBodyUsage == codespec.OmitAlways {
-		autogenerationTag = ` autogeneration:"omitjson"`
+		autogenTag = ` autogen:"omitjson"`
 	} else if attr.ReqBodyUsage == codespec.OmitInUpdateBody {
-		autogenerationTag = ` autogeneration:"omitjsonupdate"`
+		autogenTag = ` autogen:"omitjsonupdate"`
 	}
-	return fmt.Sprintf("%s %s", namePascalCase, propType) + " `" + fmt.Sprintf("tfsdk:%q", attr.Name.SnakeCase()) + autogenerationTag + "`"
+	return fmt.Sprintf("%s %s", namePascalCase, propType) + " `" + fmt.Sprintf("tfsdk:%q", attr.Name.SnakeCase()) + autogenTag + "`"
 }
 
 func attrModelType(attr *codespec.Attribute) string {


### PR DESCRIPTION
## Description

Rename autogeneration to autogen

Link to any related issue(s): CLOUDP-312836

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
