### PR TITLE
chore: Removes all usages of `MONGODB_ATLAS_ENABLE_PREVIEW`

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -94,9 +94,6 @@ on:
       mongodb_atlas_project_ear_pe_id:
         type: string
         required: true
-      mongodb_atlas_enable_preview:
-        type: string
-        required: true
       azure_private_endpoint_region:
         type: string
         required: true
@@ -661,7 +658,6 @@ jobs:
           AZURE_KEY_IDENTIFIER: ${{ secrets.azure_key_identifier }}
           AZURE_KEY_VAULT_NAME_UPDATED: ${{ secrets.azure_key_vault_name_updated }}
           AZURE_KEY_IDENTIFIER_UPDATED: ${{ secrets.azure_key_identifier_updated }}
-          MONGODB_ATLAS_ENABLE_PREVIEW: ${{ inputs.mongodb_atlas_enable_preview }}
           AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -125,7 +125,6 @@ jobs:
       mongodb_atlas_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_DEV }}
       mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
       aws_ear_role_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AWS_EAR_ROLE_ID_QA || vars.AWS_EAR_ROLE_ID_DEV }}
-      mongodb_atlas_enable_preview: ${{ vars.MONGODB_ATLAS_ENABLE_PREVIEW }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}
       confluent_cloud_network_id: ${{ vars.CONFLUENT_CLOUD_NETWORK_ID }} 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-west-2
-  MONGODB_ATLAS_ENABLE_PREVIEW: "true"
 
 jobs:
   tf-validate:

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ To use a released provider in your Terraform environment, run [`terraform init`]
 
 Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/).
 
-## Preview Features
-In order to use and/or test preview resources and datasources in this provider you'll need to set the environment variable `MONGODB_ATLAS_ENABLE_PREVIEW` to true.
-
-
-```bash
-export MONGODB_ATLAS_ENABLE_PREVIEW=true
-```
 ## Logs
 To help with issues, you can turn on Logs with `export TF_LOG=TRACE`. Note: this is very noisy. 
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -48,10 +47,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprivatelinkendpoint"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
-)
-
-var (
-	providerEnablePreview, _ = strconv.ParseBool(os.Getenv("MONGODB_ATLAS_ENABLE_PREVIEW"))
 )
 
 const (
@@ -462,10 +457,6 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 	if config.PreviewProviderV2AdvancedCluster() {
 		dataSources = append(dataSources, advancedclustertpf.DataSource, advancedclustertpf.PluralDataSource)
 	}
-	previewDataSources := []func() datasource.DataSource{} // Data sources not yet in GA
-	if providerEnablePreview {
-		dataSources = append(dataSources, previewDataSources...)
-	}
 	return dataSources
 }
 
@@ -489,10 +480,6 @@ func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resou
 	}
 	if config.PreviewProviderV2AdvancedCluster() {
 		resources = append(resources, advancedclustertpf.Resource)
-	}
-	previewResources := []func() resource.Resource{} // Resources not yet in GA
-	if providerEnablePreview {
-		resources = append(resources, previewResources...)
 	}
 	return resources
 }

--- a/internal/service/resourcepolicy/resource_migration_test.go
+++ b/internal/service/resourcepolicy/resource_migration_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestMigResourcePolicy_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.33.0") // this feature was GA (no need of MONGODB_ATLAS_ENABLE_PREVIEW env variable) in 1.33.0
-	mig.CreateAndRunTestNonParallel(t, basicTestCase(t, descriptionPtr))
+	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }

--- a/internal/service/resourcepolicy/resource_migration_test.go
+++ b/internal/service/resourcepolicy/resource_migration_test.go
@@ -7,12 +7,6 @@ import (
 )
 
 func TestMigResourcePolicy_basic(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.22.0") // this feature was introduced in provider version 1.21.0, plural data source schema was changed in 1.22.0
-
-	var description *string
-	if mig.IsProviderVersionAtLeast("1.32.0") {
-		description = descriptionPtr
-	}
-
-	mig.CreateAndRunTestNonParallel(t, basicTestCase(t, description))
+	mig.SkipIfVersionBelow(t, "1.33.0") // this feature was GA (no need of MONGODB_ATLAS_ENABLE_PREVIEW env variable) in 1.33.0
+	mig.CreateAndRunTestNonParallel(t, basicTestCase(t, descriptionPtr))
 }

--- a/internal/service/resourcepolicy/resource_test.go
+++ b/internal/service/resourcepolicy/resource_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
 
@@ -68,7 +67,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 		updatedName = "updated-policy"
 	)
 	updatedDescription := fmt.Sprintf("updated-%s", description)
-	
+
 	return &resource.TestCase{ // Need sequential execution for assertions to be deterministic (plural data source)
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,

--- a/internal/service/resourcepolicy/resource_test.go
+++ b/internal/service/resourcepolicy/resource_test.go
@@ -52,33 +52,31 @@ var (
 		when {
 		context.project.ipAccessList.contains(ip("0.0.0.0/0"))
 	};`
-	descriptionPtr = conversion.StringPtr("test-description")
+	description = "test-description"
 )
 
 func TestAccResourcePolicy_basic(t *testing.T) {
-	tc := basicTestCase(t, descriptionPtr)
+	tc := basicTestCase(t)
 	resource.Test(t, *tc)
 }
 
-func basicTestCase(t *testing.T, description *string) *resource.TestCase {
+func basicTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		policyName  = "test-policy"
 		updatedName = "updated-policy"
 	)
-	var updatedDescription string
-	if description != nil {
-		updatedDescription = fmt.Sprintf("updated-%s", *description)
-	}
+	updatedDescription := fmt.Sprintf("updated-%s", description)
+	
 	return &resource.TestCase{ // Need sequential execution for assertions to be deterministic (plural data source)
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(orgID, policyName, description),
-				Check:  checksResourcePolicy(orgID, policyName, description, 1),
+				Config: configBasic(orgID, policyName, &description),
+				Check:  checksResourcePolicy(orgID, policyName, &description, 1),
 			},
 			{
 				Config: configBasic(orgID, updatedName, nil),

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -74,14 +74,6 @@ func PreCheckCert(tb testing.TB) {
 	}
 }
 
-// PreCheckPreviewFlag is used for resources not yet in GA
-func PreCheckPreviewFlag(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_ENABLE_PREVIEW") == "" {
-		tb.Fatal("`MONGODB_ATLAS_ENABLE_PREVIEW` must be set for running this acceptance test")
-	}
-}
-
 func PreCheckCloudProviderAccessAzure(tb testing.TB) {
 	tb.Helper()
 	PreCheckBasic(tb)

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -67,9 +67,6 @@ if [ ! -f "${TEMPLATE_FOLDER_PATH}/data-sources/${resource_name}s.md.tmpl" ]; th
     printf "Skipping this check: We assume that the resource does not have a plural data source.\n\n"
 fi
 
-# ensure preview resource and data sources are also included during generation
-export MONGODB_ATLAS_ENABLE_PREVIEW="true" 
-
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
 tfplugindocs generate --tf-version "${TF_VERSION}" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out"

--- a/scripts/generate-docs-all.sh
+++ b/scripts/generate-docs-all.sh
@@ -29,9 +29,6 @@ set -euo pipefail
 TF_VERSION="${TF_VERSION:-"1.11.4"}" # TF version to use when running tfplugindocs. Default: 1.11.4
 TEMPLATE_FOLDER_PATH="${TEMPLATE_FOLDER_PATH:-"templates"}" # PATH to the templates folder. Default: templates
 
-# ensure preview resource and data sources are also included during generation
-export MONGODB_ATLAS_ENABLE_PREVIEW="true" 
-
 trap 'rm -R docs-out/' EXIT # temp dir cleanup when script exits
 
 tfplugindocs generate --tf-version "${TF_VERSION}" --website-source-dir "${TEMPLATE_FOLDER_PATH}"  --rendered-website-dir "docs-out" --provider-name "mongodbatlas"


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-282801

`MONGODB_ATLAS_ENABLE_PREVIEW` is no longer used after the GA of resource policies (https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3276).
Moving forwards preview features will be enabled with feature specific flags, as done with `MONGODB_ATLAS_PREVIEW_PROVIDER_V2_ADVANCED_CLUSTER`.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
