### PR TITLE
chore: Fix `TestMigSearchDeployment_basic` by adjusting project setup

### DIFF
--- a/internal/service/searchdeployment/resource_migration_test.go
+++ b/internal/service/searchdeployment/resource_migration_test.go
@@ -1,7 +1,6 @@
 package searchdeployment_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,12 +10,11 @@ import (
 
 func TestMigSearchDeployment_basic(t *testing.T) {
 	var (
-		resourceName    = "mongodbatlas_search_deployment.test"
-		projectID       = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
-		clusterName     = acc.RandomClusterName()
-		instanceSize    = "S30_HIGHCPU_NVME"
-		searchNodeCount = 3
-		config          = configBasic(projectID, clusterName, instanceSize, searchNodeCount, false)
+		resourceName           = "mongodbatlas_search_deployment.test"
+		projectID, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)
+		instanceSize           = "S30_HIGHCPU_NVME"
+		searchNodeCount        = 3
+		config                 = configBasic(projectID, clusterName, instanceSize, searchNodeCount, false)
 	)
 	mig.SkipIfVersionBelow(t, "1.32.0") // enabled_for_search_nodes introduced in this version
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
## Description

This test has been failing for past 1+ week with error `failed to decode response body: undefined response type`. This is due to providing an empty string as project_id value, given that `MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID` is not configured in search_deployment test group. Created CLOUDP-313402 to improve this error message.

As there is no need for a fixed project in this test case, we simply do the same setup as in `TestAccSearchDeployment_basic` which is working correctly.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
