### PR TITLE
fix: Fixes JSON comparison in `audit_filter` field in `mongodbatlas_auditing`

### DIFF
--- a/.changelog/3302.txt
+++ b/.changelog/3302.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_auditing: Fixed JSON comparison in `audit_filter` field
+```

--- a/.changelog/3302.txt
+++ b/.changelog/3302.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_auditing: Fixed JSON comparison in `audit_filter` field
+resource/mongodbatlas_auditing: Fixes JSON comparison in `audit_filter` field
 ```

--- a/internal/service/auditing/resource_auditing.go
+++ b/internal/service/auditing/resource_auditing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/schemafunc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"go.mongodb.org/atlas-sdk/v20250312002/admin"
@@ -40,9 +41,10 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"audit_filter": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: diffSuppressJSON,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -149,4 +151,8 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	d.SetId("")
 	return nil
+}
+
+func diffSuppressJSON(k, old, newStr string, d *schema.ResourceData) bool {
+	return schemafunc.EqualJSON(old, newStr, "audit_filter")
 }

--- a/internal/service/auditing/resource_auditing_migration_test.go
+++ b/internal/service/auditing/resource_auditing_migration_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestMigGenericAuditing_basic(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.34.0") // Version where JSON comparison in audit_filter field in mongodbatlas_auditing was fixed
 	var (
 		projectID   = acc.ProjectIDExecution(t)
 		auditFilter = "{ 'atype': 'authenticate', 'param': {   'user': 'auditAdmin',   'db': 'admin',   'mechanism': 'SCRAM-SHA-1' }}"

--- a/internal/service/auditing/resource_auditing_test.go
+++ b/internal/service/auditing/resource_auditing_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	resourceName   = "mongodbatlas_auditing.test"
-	dataSourceName = "data.mongodbatlas_auditing.test"
+	resourceName     = "mongodbatlas_auditing.test"
+	dataSourceName   = "data.mongodbatlas_auditing.test"
+	emptyAuditFilter = "{}"
 )
 
 func TestAccGenericAuditing_basic(t *testing.T) {
@@ -28,7 +29,6 @@ func TestAccGenericAuditing_basic(t *testing.T) {
 			},
 			"atype": "authenticate"
 		}`
-		emptyAuditFilter = `{}`
 	)
 
 	// Serial so it doesn't conflict with TestMigGenericAuditing_basic
@@ -104,7 +104,7 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 
 func configBasic(projectID, auditFilter string, auditAuth, enabled bool) string {
 	filterValue := fmt.Sprintf("%q", auditFilter)
-	if auditFilter != "{}" {
+	if auditFilter != emptyAuditFilter {
 		filterValue = fmt.Sprintf("<<EOF\n%s\nEOF", auditFilter)
 	}
 

--- a/internal/service/auditing/resource_auditing_test.go
+++ b/internal/service/auditing/resource_auditing_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -40,11 +39,6 @@ func TestAccGenericAuditing_basic(t *testing.T) {
 			{
 				Config: configBasic(projectID, auditFilter, true, true),
 				Check:  resource.ComposeAggregateTestCheckFunc(checks(auditFilter, true, true)...),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PostApplyPreRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 			},
 			{
 				Config: configBasic(projectID, emptyAuditFilter, false, false),


### PR DESCRIPTION
## Description

Fixes JSON comparison in `audit_filter` field in `mongodbatlas_auditing`

Link to any related issue(s): CLOUDP-315476 & HELP-74398

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
