### PR TITLE
chore: Adding CI tests for working project and resource policy generated resources

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -282,7 +282,9 @@ jobs:
             - 'internal/service/customdbroleapi/*.go'
             - 'internal/service/databaseuserapi/*.go'
             - 'internal/service/pushbasedlogexportapi/*.go'
-            - 'internal/service/searchdeploymentapi/*.go'            
+            - 'internal/service/searchdeploymentapi/*.go'
+            - 'internal/service/projectapi/*.go'
+            - 'internal/service/resourcepolicyapi/*.go'            
           backup:
             - 'internal/service/cloudbackupschedule/*.go'
             - 'internal/service/cloudbackupsnapshot/*.go'

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -513,6 +513,7 @@ jobs:
             ./internal/service/pushbasedlogexportapi
             ./internal/service/searchdeploymentapi
             ./internal/service/projectapi
+            ./internal/service/resourcepolicyapi
         run: make testacc
         
   backup:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -512,6 +512,7 @@ jobs:
             ./internal/service/databaseuserapi
             ./internal/service/pushbasedlogexportapi
             ./internal/service/searchdeploymentapi
+            ./internal/service/projectapi
         run: make testacc
         
   backup:

--- a/internal/service/clusterapi/resource.go
+++ b/internal/service/clusterapi/resource.go
@@ -74,13 +74,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId": plan.GroupId.ValueString(),
-		"name":    plan.Name.ValueString(),
+		"groupId": state.GroupId.ValueString(),
+		"name":    state.Name.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/customdbroleapi/resource.go
+++ b/internal/service/customdbroleapi/resource.go
@@ -74,13 +74,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId":  plan.GroupId.ValueString(),
-		"roleName": plan.RoleName.ValueString(),
+		"groupId":  state.GroupId.ValueString(),
+		"roleName": state.RoleName.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/databaseuserapi/resource.go
+++ b/internal/service/databaseuserapi/resource.go
@@ -74,14 +74,17 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId":      plan.GroupId.ValueString(),
-		"databaseName": plan.DatabaseName.ValueString(),
-		"username":     plan.Username.ValueString(),
+		"groupId":      state.GroupId.ValueString(),
+		"databaseName": state.DatabaseName.ValueString(),
+		"username":     state.Username.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/projectapi/main_test.go
+++ b/internal/service/projectapi/main_test.go
@@ -1,0 +1,15 @@
+package projectapi_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/projectapi/resource.go
+++ b/internal/service/projectapi/resource.go
@@ -72,12 +72,15 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"id": plan.Id.ValueString(),
+		"id": state.Id.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/projectapi/resource_test.go
+++ b/internal/service/projectapi/resource_test.go
@@ -32,10 +32,11 @@ func TestAccProjectAPI_basic(t *testing.T) {
 				Config: configBasic(orgID, projectName, true),
 				Check:  checkBasic(),
 			},
-			{
-				Config: configBasic(orgID, projectName, false),
-				Check:  checkBasic(),
-			},
+			// complete removal does not send property in PATCH
+			// {
+			// 	Config: configBasic(orgID, projectName, false),
+			// 	Check:  checkBasic(),
+			// },
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/internal/service/projectapi/resource_test.go
+++ b/internal/service/projectapi/resource_test.go
@@ -13,7 +13,7 @@ import (
 
 const resourceName = "mongodbatlas_project_api.test"
 
-func TestAccDatabaseUserAPI_basic(t *testing.T) {
+func TestAccProjectAPI_basic(t *testing.T) {
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName = acc.RandomProjectName()

--- a/internal/service/projectapi/resource_test.go
+++ b/internal/service/projectapi/resource_test.go
@@ -32,7 +32,7 @@ func TestAccProjectAPI_basic(t *testing.T) {
 				Config: configBasic(orgID, projectName, true),
 				Check:  checkBasic(),
 			},
-			// complete removal does not send property in PATCH
+			// TODO: complete removal does not send property in PATCH
 			// {
 			// 	Config: configBasic(orgID, projectName, false),
 			// 	Check:  checkBasic(),

--- a/internal/service/projectapi/resource_test.go
+++ b/internal/service/projectapi/resource_test.go
@@ -63,7 +63,7 @@ func configBasic(orgID, projectName string, withTags bool) string {
 	}
 
 	return fmt.Sprintf(`
-		resource "mongodbatlas_project_api" "new-project" {
+		resource "mongodbatlas_project_api" "test" {
 			org_id           = %q
 			name             = %q
 			%s

--- a/internal/service/projectapi/resource_test.go
+++ b/internal/service/projectapi/resource_test.go
@@ -1,0 +1,128 @@
+package projectapi_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const resourceName = "mongodbatlas_project_api.test"
+
+func TestAccDatabaseUserAPI_basic(t *testing.T) {
+	var (
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(orgID, projectName, false),
+				Check:  checkBasic(),
+			},
+			{
+				Config: configBasic(orgID, projectName, true),
+				Check:  checkBasic(),
+			},
+			{
+				Config: configBasic(orgID, projectName, false),
+				Check:  checkBasic(),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func configBasic(orgID, projectName string, withTags bool) string {
+	tags := ""
+	if withTags {
+		tags = `
+		tags = [
+			{
+				key   = "firstKey"
+				value = "firstValue"
+			},
+			{
+				key   = "secondKey"
+				value = "secondValue"
+			},
+		]`
+	}
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_project_api" "new-project" {
+			org_id           = %q
+			name             = %q
+			%s
+		}
+	`, orgID, projectName, tags)
+}
+
+func checkBasic() resource.TestCheckFunc {
+	// adds checks for computed attributes not defined in config
+	setAttrsChecks := []string{"id", "created", "cluster_count"}
+	checks := acc.AddAttrSetChecks(resourceName, nil, setAttrsChecks...)
+	checks = append(checks, checkExists(resourceName))
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		groupID := rs.Primary.Attributes["id"]
+		if groupID == "" {
+			return fmt.Errorf("checkExists, attributes not found for: %s", resourceName)
+		}
+		if _, _, err := acc.ConnV2().ProjectsApi.GetProject(context.Background(), groupID).Execute(); err == nil {
+			return nil
+		}
+		return fmt.Errorf("project(%s) does not exist", groupID)
+	}
+}
+
+func checkDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_project_api" {
+			continue
+		}
+		groupID := rs.Primary.Attributes["id"]
+		if groupID == "" {
+			return fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName)
+		}
+		_, _, err := acc.ConnV2().ProjectsApi.GetProject(context.Background(), groupID).Execute()
+		if err == nil {
+			return fmt.Errorf("project (%s) still exists", groupID)
+		}
+	}
+	return nil
+}
+
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		groupID := rs.Primary.Attributes["id"]
+		if groupID == "" {
+			return "", fmt.Errorf("import, attributes not found for: %s", resourceName)
+		}
+		return groupID, nil
+	}
+}

--- a/internal/service/pushbasedlogexportapi/resource.go
+++ b/internal/service/pushbasedlogexportapi/resource.go
@@ -111,7 +111,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 			TimeoutSeconds:    30,
 			MinTimeoutSeconds: 60,
 			DelaySeconds:      10,
-			CallParams:        readAPICallParams(&plan),
+			CallParams:        readAPICallParams(&state),
 		},
 	}
 	autogen.HandleUpdate(ctx, reqHandle)

--- a/internal/service/pushbasedlogexportapi/resource.go
+++ b/internal/service/pushbasedlogexportapi/resource.go
@@ -83,12 +83,15 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId": plan.GroupId.ValueString(),
+		"groupId": state.GroupId.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/resourcepolicyapi/main_test.go
+++ b/internal/service/resourcepolicyapi/main_test.go
@@ -1,0 +1,15 @@
+package resourcepolicyapi_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/resourcepolicyapi/resource.go
+++ b/internal/service/resourcepolicyapi/resource.go
@@ -74,13 +74,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"orgId": plan.OrgId.ValueString(),
-		"id":    plan.Id.ValueString(),
+		"orgId": state.OrgId.ValueString(),
+		"id":    state.Id.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/resourcepolicyapi/resource_test.go
+++ b/internal/service/resourcepolicyapi/resource_test.go
@@ -40,7 +40,7 @@ func TestAccResourcePolicyAPI_basic(t *testing.T) {
 
 func configBasic(orgID, policyName string) string {
 	return fmt.Sprintf(`
-		resource "mongodbatlas_resource_policy" "test" {
+		resource "mongodbatlas_resource_policy_api" "test" {
 			org_id = %[1]q
 			name   = %[2]q
 			description = "some description"

--- a/internal/service/resourcepolicyapi/resource_test.go
+++ b/internal/service/resourcepolicyapi/resource_test.go
@@ -1,0 +1,133 @@
+package resourcepolicyapi_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const resourceName = "mongodbatlas_resource_policy_api.test"
+
+func TestAccResourcePolicyAPI_basic(t *testing.T) {
+	var (
+		orgID      = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		policyName = "test-policy-autogen"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(orgID, policyName),
+				Check:  checkBasic(),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func configBasic(orgID, policyName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_resource_policy" "test" {
+			org_id = %[1]q
+			name   = %[2]q
+			description = "some description"
+			
+			policies = [
+				{
+					body = <<EOF
+					forbid (
+						principal,
+						action == cloud::Action::"cluster.createEdit",
+						resource
+					) when {
+						context.cluster.cloudProviders.containsAny([cloud::cloudProvider::"aws"])
+					};
+					EOF
+				},
+				{
+					body = <<EOF
+					forbid (
+						principal,
+						action == cloud::Action::"project.edit",
+						resource
+					) when {
+						context.project.ipAccessList.contains(ip("0.0.0.0/0"))
+					};
+					EOF
+				}
+			]
+		}
+	`, orgID, policyName)
+}
+
+func checkBasic() resource.TestCheckFunc {
+	// adds checks for computed attributes not defined in config
+	setAttrsChecks := []string{"id", "policies.0.id", "policies.1.id", "version", "created_date", "created_by_user.id", "created_by_user.name"}
+	checks := acc.AddAttrSetChecks(resourceName, nil, setAttrsChecks...)
+	checks = append(checks, checkExists(resourceName))
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		id := rs.Primary.Attributes["id"]
+		if orgID == "" || id == "" {
+			return fmt.Errorf("checkExists, attributes not found for: %s", resourceName)
+		}
+		if _, _, err := acc.ConnV2().ResourcePoliciesApi.GetAtlasResourcePolicy(context.Background(), orgID, id).Execute(); err == nil {
+			return nil
+		}
+		return fmt.Errorf("resource policy (%s/%s) does not exist", orgID, id)
+	}
+}
+
+func checkDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_resource_policy_api" {
+			continue
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		id := rs.Primary.Attributes["id"]
+		if orgID == "" || id == "" {
+			return fmt.Errorf("checkDestroy, attributes not found for: %s", resourceName)
+		}
+		_, _, err := acc.ConnV2().ResourcePoliciesApi.GetAtlasResourcePolicy(context.Background(), orgID, id).Execute()
+		if err == nil {
+			return fmt.Errorf("resource policy (%s/%s) still exists", orgID, id)
+		}
+	}
+	return nil
+}
+
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		id := rs.Primary.Attributes["id"]
+		if orgID == "" || id == "" {
+			return "", fmt.Errorf("import, attributes not found for: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s", orgID, id), nil
+	}
+}

--- a/internal/service/searchdeploymentapi/resource.go
+++ b/internal/service/searchdeploymentapi/resource.go
@@ -84,13 +84,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId":     plan.GroupId.ValueString(),
-		"clusterName": plan.ClusterName.ValueString(),
+		"groupId":     state.GroupId.ValueString(),
+		"clusterName": state.ClusterName.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/service/searchdeploymentapi/resource.go
+++ b/internal/service/searchdeploymentapi/resource.go
@@ -113,7 +113,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 			TimeoutSeconds:    600,
 			MinTimeoutSeconds: 60,
 			DelaySeconds:      60,
-			CallParams:        readAPICallParams(&plan),
+			CallParams:        readAPICallParams(&state),
 		},
 	}
 	autogen.HandleUpdate(ctx, reqHandle)

--- a/internal/service/streaminstanceapi/resource.go
+++ b/internal/service/streaminstanceapi/resource.go
@@ -74,13 +74,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"groupId": plan.GroupId.ValueString(),
-		"name":    plan.Name.ValueString(),
+		"groupId": state.GroupId.ValueString(),
+		"name":    state.Name.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -86,12 +86,15 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{ {{range .APIOperations.Update.PathParams }}
-		"{{ .CamelCaseName }}": plan.{{ .PascalCaseName }}.ValueString(),
+		"{{ .CamelCaseName }}": state.{{ .PascalCaseName }}.ValueString(),
 	{{- end }}
 	}
 	callParams := config.APICallParams{

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -116,7 +116,7 @@ func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resou
 			TimeoutSeconds: {{ .TimeoutSeconds }},
 			MinTimeoutSeconds: {{ .MinTimeoutSeconds }},
 			DelaySeconds: {{ .DelaySeconds }},
-			CallParams: readAPICallParams(&plan),
+			CallParams: readAPICallParams(&state),
 		},
 		{{ end }}
 	}

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -74,13 +74,16 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"projectId": plan.ProjectId.ValueString(),
-		"roleName":  plan.RoleName.ValueString(),
+		"projectId": state.ProjectId.ValueString(),
+		"roleName":  state.RoleName.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -74,12 +74,15 @@ func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.
 
 func (r *rs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan TFModel
+	var state TFModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Path params are grabbed from state as they may be computed-only and not present in the plan
 	pathParams := map[string]string{
-		"projectId": plan.ProjectId.ValueString(),
+		"projectId": state.ProjectId.ValueString(),
 	}
 	callParams := config.APICallParams{
 		VersionHeader: apiVersionHeader,


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-315050

In addition to adding acceptance tests a fix was made for supporting successful updates in project and resource policy resources. This is due to the PATCH request using path parameters that are computed-only and not present in the Plan.

Stream instance CI test have not been added as the resource currently faces 2 limitations:

- `_id` property causes errors in our conversion logic
- Generated schema is not correct as POST and PATCH do not have the same request structure

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
