### PR TITLE
doc: Adds `retain_backups_enabled`  details on error

### DIFF
--- a/docs/resources/advanced_cluster (preview provider 2.0.0).md
+++ b/docs/resources/advanced_cluster (preview provider 2.0.0).md
@@ -602,7 +602,7 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-  If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups. This parameter defaults to false.
+  If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups.
 
 - `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 

--- a/docs/resources/advanced_cluster (preview provider 2.0.0).md
+++ b/docs/resources/advanced_cluster (preview provider 2.0.0).md
@@ -602,11 +602,9 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups.
+  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups. This parameter defaults to false.
 
-This parameter defaults to false.
-
-* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only.
+- `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 
 **NOTE** Prior version of provider had parameter as `bi_connector` state will migrate it to new value you only need to update parameter in your terraform file
 

--- a/docs/resources/advanced_cluster (preview provider 2.0.0).md
+++ b/docs/resources/advanced_cluster (preview provider 2.0.0).md
@@ -602,7 +602,7 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups. This parameter defaults to false.
+  If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups. This parameter defaults to false.
 
 - `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 

--- a/docs/resources/advanced_cluster (preview provider 2.0.0).md
+++ b/docs/resources/advanced_cluster (preview provider 2.0.0).md
@@ -604,7 +604,7 @@ Refer to the following for full privatelink endpoint connection string examples:
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
   If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups.
 
-- `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
+* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 
 **NOTE** Prior version of provider had parameter as `bi_connector` state will migrate it to new value you only need to update parameter in your terraform file
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -429,7 +429,7 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups. This parameter defaults to false.
+    If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups.
 
 * `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -429,7 +429,7 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-    If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups.
+  If "`backup_enabled`"  is `false` (default), the cluster doesn't use Atlas backups.
 
 * `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 

--- a/docs/resources/advanced_cluster.md
+++ b/docs/resources/advanced_cluster.md
@@ -429,11 +429,9 @@ Refer to the following for full privatelink endpoint connection string examples:
   Backup uses:
   [Cloud Backups](https://docs.atlas.mongodb.com/backup/cloud-backup/overview/#std-label-backup-cloud-provider) for dedicated clusters.
   [Flex Cluster Backups](https://www.mongodb.com/docs/atlas/backup/cloud-backup/flex-cluster-backup/) for flex clusters.
-  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups.
+  If "`backup_enabled`" : `false`, the cluster doesn't use Atlas backups. This parameter defaults to false.
 
-This parameter defaults to false.
-
-* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only.
+* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 
 **NOTE** Prior version of provider had parameter as `bi_connector` state will migrate it to new value you only need to update parameter in your terraform file
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -303,9 +303,9 @@ But in order to explicitly change `provider_instance_size_name` comment the `lif
     backup_enabled = "false"
     cloud_backup = "true"
     ```
-    * The default value is false.  M10 and above only.
+  * The default value is false. M10 and above only.
 
-* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. 
+* `retain_backups_enabled` - (Optional) Set to true to retain backup snapshots for the deleted cluster. M10 and above only. This only applies to the `Delete` operation. If you see the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code, set it to explicit `true`.
 * `bi_connector_config` - (Optional) Specifies BI Connector for Atlas configuration on this cluster. BI Connector for Atlas is only available for M10+ clusters. See [BI Connector](#bi-connector) below for more details.
 * `cluster_type` - (Required) Specifies the type of the cluster that you want to modify. You cannot convert a sharded cluster deployment to a replica set deployment.
 


### PR DESCRIPTION
## Description

Updates the documentation for the `advanced_cluster` and `cluster` resources, specifically related to the `retain_backups_enabled` parameter. 
The `retain_backups_enabled` parameter now includes additional guidance for handling the `CANNOT_DELETE_SNAPSHOT_WITH_BACKUP_COMPLIANCE_POLICY` error code by setting it to true when necessary. This ensures users can delete clusters when backup snapshots compliance policy is used.

Link to any related issue(s): CLOUDP-315346

## Type of change

- [x] Documentation fix/enhancement

## Required Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
