### PR TITLE
bump private_endpoint_regional_mode state change delay from 3s to 15s

### DIFF
--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
@@ -117,7 +117,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, conn.ClustersApi),
 		Timeout:    d.Timeout(timeoutKey.(string)),
 		MinTimeout: 5 * time.Second,
-		Delay:      3 * time.Second,
+		Delay:      15 * time.Second,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

Wait 15s instead of 3s before polling clusters for connection string updates, this should be enough time to allow the regional-mode change to propagate from the project to the clusters.

Issue described @ https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3315

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
