### PR TITLE
fix: Increases update wait time in `mongodbatlas_private_endpoint_regional_mode`

### DIFF
--- a/.changelog/3320.txt
+++ b/.changelog/3320.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_private_endpoint_regional_mode: Increases update wait time so cluster connection strings are updated
+```

--- a/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
+++ b/internal/service/privateendpointregionalmode/resource_private_endpoint_regional_mode.go
@@ -116,8 +116,8 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Target:     []string{"IDLE", "DELETED"},
 		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, conn.ClustersApi),
 		Timeout:    d.Timeout(timeoutKey.(string)),
-		MinTimeout: 5 * time.Second,
-		Delay:      3 * time.Second,
+		MinTimeout: 15 * time.Second,
+		Delay:      30 * time.Second, // give time for cluster connection strings to be updated
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description

Increases update wait time in `mongodbatlas_private_endpoint_regional_mode` so cluster connection strings are updated.

It fixes: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3315
It is based on: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3316


Link to any related issue(s): CLOUDP-317448

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
