### PR TITLE
chore: Supporting unknown map type that is not returned by API

### DIFF
--- a/internal/common/autogen/unknown.go
+++ b/internal/common/autogen/unknown.go
@@ -113,6 +113,9 @@ func getNullAttr(attrType attr.Type) (attr.Value, error) {
 		if setType, ok := attrType.(types.SetType); ok {
 			return types.SetNull(setType.ElemType), nil
 		}
+		if mapType, ok := attrType.(types.MapType); ok {
+			return types.MapNull(mapType.ElemType), nil
+		}
 		return nil, fmt.Errorf("unmarshal to get null value not supported yet for type %T", attrType)
 	}
 }

--- a/internal/common/autogen/unknown_test.go
+++ b/internal/common/autogen/unknown_test.go
@@ -19,6 +19,7 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrListString    types.List   `tfsdk:"attr_list_string"`
 		AttrSetString     types.Set    `tfsdk:"attr_set_string"`
 		AttrListObjObj    types.List   `tfsdk:"attr_list_obj_obj"`
+		AttrMapUnknown    types.Map    `tfsdk:"attr_map_unknown"`
 	}
 	model := modelst{
 		AttrStringUnknown: types.StringUnknown(),
@@ -63,6 +64,7 @@ func TestResolveUnknowns(t *testing.T) {
 			}),
 			types.ObjectUnknown(objTypeParentTest.AttributeTypes()),
 		}),
+		AttrMapUnknown: types.MapUnknown(types.StringType),
 	}
 	modelExpected := modelst{
 		AttrStringUnknown: types.StringNull(),
@@ -107,6 +109,7 @@ func TestResolveUnknowns(t *testing.T) {
 			}),
 			types.ObjectNull(objTypeParentTest.AttributeTypes()),
 		}),
+		AttrMapUnknown: types.MapNull(types.StringType),
 	}
 	require.NoError(t, autogen.ResolveUnknowns(&model))
 	assert.Equal(t, modelExpected, model)


### PR DESCRIPTION
## Description

Small fix in unmarshall logic to support empty value in a computed-only map type attribute. This fixes error when running cluster auto-generated resource.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
