### PR TITLE
feat: Adds `delete_on_create_timeout` flag to handle deletion on creation timeout to search_deployment

### DIFF
--- a/.changelog/3344.txt
+++ b/.changelog/3344.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_search_deployment: Adds `delete_on_create_timeout` a flag that indicates whether to delete the search deployment if the search deployment creation times out, default is false
+```

--- a/docs/resources/search_deployment.md
+++ b/docs/resources/search_deployment.md
@@ -68,6 +68,7 @@ output "mongodbatlas_search_deployment_encryption_at_rest_provider" {
 
 ### Optional
 
+- `delete_on_create_timeout` (Boolean) Flag that indicates whether to delete the search deployment if the creation times out, default is false.
 - `skip_wait_on_update` (Boolean) If true, the resource update is executed without waiting until the [state](#state_name-1) is `IDLE`, making the operation faster. This might cause update errors to go unnoticed and lead to non-empty plans at the next terraform execution.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/internal/common/cleanup/on_timeout.go
+++ b/internal/common/cleanup/on_timeout.go
@@ -42,9 +42,6 @@ const (
 func ReplaceContextDeadlineExceededDiags(diags *diag.Diagnostics, duration time.Duration) {
 	for i := range len(*diags) {
 		d := (*diags)[i]
-		if d.Severity() != diag.SeverityError {
-			continue
-		}
 		if strings.Contains(d.Detail(), contextDeadlineExceeded) {
 			(*diags)[i] = diag.NewErrorDiagnostic(
 				d.Summary(),

--- a/internal/common/cleanup/on_timeout.go
+++ b/internal/common/cleanup/on_timeout.go
@@ -9,6 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
+const (
+	CleanupWarning = "Failed to create resource. Will run cleanup due to the operation timing out"
+)
+
 // OnTimeout creates a new context with a timeout and a deferred function that will run `cleanup` when the context hit the timeout (no timeout=no-op).
 // Remember to always call the returned `deferCall` function: `defer deferCall()`.
 // `warningDetail` should have resource identifiable information, for example cluster name and project ID.
@@ -22,8 +26,7 @@ func OnTimeout(ctx context.Context, timeout time.Duration, warnDiags func(string
 		if !errors.Is(outCtx.Err(), context.DeadlineExceeded) {
 			return
 		}
-		cleanupWarning := "Failed to create resource, will run cleanup due to timeout reached"
-		warnDiags(cleanupWarning, warningDetail)
+		warnDiags(CleanupWarning, warningDetail)
 		newContext := context.Background() // Create a new context for cleanup as the old context is expired
 		if err := cleanup(newContext); err != nil {
 			warnDiags("Error during cleanup", warningDetail+" error="+err.Error())

--- a/internal/common/cleanup/on_timeout.go
+++ b/internal/common/cleanup/on_timeout.go
@@ -22,7 +22,7 @@ func OnTimeout(ctx context.Context, timeout time.Duration, warnDiags func(string
 		if !errors.Is(outCtx.Err(), context.DeadlineExceeded) {
 			return
 		}
-		cleanupWarning := "Failed to create a cluster, will run cleanup due to timeout reached"
+		cleanupWarning := "Failed to create resource, will run cleanup due to timeout reached"
 		warnDiags(cleanupWarning, warningDetail)
 		newContext := context.Background() // Create a new context for cleanup as the old context is expired
 		if err := cleanup(newContext); err != nil {

--- a/internal/common/cleanup/on_timeout_test.go
+++ b/internal/common/cleanup/on_timeout_test.go
@@ -45,7 +45,7 @@ func TestCleanupOnErrorCalledForATimeout(t *testing.T) {
 	assert.NotEqual(t, finalContext, ctx, "cleanup should be called with a new context")
 	require.NoError(t, finalContext.Err(), "cleanup should be called with a new context that hasn't been cancelled")
 	assert.Len(t, diags, 3) // diags entry 2 & 3 are added in the cleanup
-	assert.Equal(t, "Failed to create a cluster, will run cleanup due to timeout reached", diags[1].Summary())
+	assert.Equal(t, "Failed to create resource, will run cleanup due to timeout reached", diags[1].Summary())
 	assert.Equal(t, "warning detail", diags[1].Detail())
 
 	assert.Equal(t, "Error during cleanup", diags[2].Summary())

--- a/internal/common/cleanup/on_timeout_test.go
+++ b/internal/common/cleanup/on_timeout_test.go
@@ -82,8 +82,7 @@ func TestReplaceContextDeadlineExceededDiags(t *testing.T) {
 	duration := 2 * time.Minute
 	cleanup.ReplaceContextDeadlineExceededDiags(&diags, duration)
 
-	assert.Equal(t, 3, len(diags), "Expected same number of diagnostics")
-
+	assert.Len(t, diags, 3, "Expected same number of diagnostics")
 	for i, diag := range diags {
 		assert.Equal(t, expectedSummaries[i], diag.Summary(), "Summary at index %d should match", i)
 		assert.Equal(t, expectedDetails[i], diag.Detail(), "Detail at index %d should match", i)

--- a/internal/common/cleanup/on_timeout_test.go
+++ b/internal/common/cleanup/on_timeout_test.go
@@ -45,7 +45,7 @@ func TestCleanupOnErrorCalledForATimeout(t *testing.T) {
 	assert.NotEqual(t, finalContext, ctx, "cleanup should be called with a new context")
 	require.NoError(t, finalContext.Err(), "cleanup should be called with a new context that hasn't been cancelled")
 	assert.Len(t, diags, 3) // diags entry 2 & 3 are added in the cleanup
-	assert.Equal(t, "Failed to create resource, will run cleanup due to timeout reached", diags[1].Summary())
+	assert.Equal(t, cleanup.CleanupWarning, diags[1].Summary())
 	assert.Equal(t, "warning detail", diags[1].Detail())
 
 	assert.Equal(t, "Error during cleanup", diags[2].Summary())

--- a/internal/common/cleanup/on_timeout_test.go
+++ b/internal/common/cleanup/on_timeout_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	timeoutDuration = 1 * time.Millisecond
+	timeoutDuration = 10 * time.Millisecond
 )
 
 func TestCleanupOnErrorSkippedWhenNoTimeout(t *testing.T) {
@@ -76,7 +76,7 @@ func TestReplaceContextDeadlineExceededDiags(t *testing.T) {
 	expectedDetails := []string{
 		"Error waiting for state to be IDLE: Timeout reached after 2m0s",
 		"This is a different error",
-		"Warning with context deadline exceeded mentioned",
+		"Warning with Timeout reached after 2m0s mentioned",
 	}
 
 	duration := 2 * time.Minute

--- a/internal/service/searchdeployment/data_source.go
+++ b/internal/service/searchdeployment/data_source.go
@@ -29,7 +29,8 @@ func (d *searchDeploymentDS) Schema(ctx context.Context, req datasource.SchemaRe
 	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.DataSourceSchemaRequest{
 		RequiredFields: []string{"project_id", "cluster_name"},
 		OverridenFields: map[string]schema.Attribute{
-			"skip_wait_on_update": nil,
+			"skip_wait_on_update":      nil,
+			"delete_on_create_timeout": nil,
 		},
 	})
 }

--- a/internal/service/searchdeployment/data_source.go
+++ b/internal/service/searchdeployment/data_source.go
@@ -16,7 +16,7 @@ var _ datasource.DataSourceWithConfigure = &searchDeploymentDS{}
 func DataSource() datasource.DataSource {
 	return &searchDeploymentDS{
 		DSCommon: config.DSCommon{
-			DataSourceName: searchDeploymentName,
+			DataSourceName: resourceName,
 		},
 	}
 }

--- a/internal/service/searchdeployment/resource.go
+++ b/internal/service/searchdeployment/resource.go
@@ -96,6 +96,7 @@ func (r *searchDeploymentRS) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 	newSearchNodeModel.SkipWaitOnUpdate = plan.SkipWaitOnUpdate
+	newSearchNodeModel.DeleteOnCreateTimeout = plan.DeleteOnCreateTimeout
 	diags.Append(resp.State.Set(ctx, newSearchNodeModel)...)
 }
 
@@ -130,6 +131,7 @@ func (r *searchDeploymentRS) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	newSearchNodeModel.SkipWaitOnUpdate = searchDeploymentPlan.SkipWaitOnUpdate
+	newSearchNodeModel.DeleteOnCreateTimeout = searchDeploymentPlan.DeleteOnCreateTimeout
 	resp.Diagnostics.Append(resp.State.Set(ctx, newSearchNodeModel)...)
 }
 
@@ -170,6 +172,7 @@ func (r *searchDeploymentRS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	newSearchNodeModel.SkipWaitOnUpdate = searchDeploymentPlan.SkipWaitOnUpdate
+	newSearchNodeModel.DeleteOnCreateTimeout = searchDeploymentPlan.DeleteOnCreateTimeout
 	resp.Diagnostics.Append(resp.State.Set(ctx, newSearchNodeModel)...)
 }
 

--- a/internal/service/searchdeployment/resource_schema.go
+++ b/internal/service/searchdeployment/resource_schema.go
@@ -67,6 +67,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Description: "If true, the resource update is executed without waiting until the [state](#state_name-1) is `IDLE`, making the operation faster. This might cause update errors to go unnoticed and lead to non-empty plans at the next terraform execution.",
 				Optional:    true,
 			},
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Optional:            true,
+				MarkdownDescription: "Flag that indicates whether to delete the search deployment if the creation times out, default is false.",
+			},
 			"encryption_at_rest_provider": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Cloud service provider that manages your customer keys to provide an additional layer of Encryption At Rest for the cluster.",
@@ -84,6 +88,7 @@ type TFSearchDeploymentRSModel struct {
 	Timeouts                 timeouts.Value `tfsdk:"timeouts"`
 	EncryptionAtRestProvider types.String   `tfsdk:"encryption_at_rest_provider"`
 	SkipWaitOnUpdate         types.Bool     `tfsdk:"skip_wait_on_update"`
+	DeleteOnCreateTimeout    types.Bool     `tfsdk:"delete_on_create_timeout"`
 }
 
 type TFSearchNodeSpecModel struct {

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -53,7 +53,7 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 	})
 }
 
-const deleteTimeout = 60 * time.Second
+const deleteTimeout = 10 * time.Minute
 
 func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 	var (

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -22,9 +22,9 @@ const (
 	dataSourceID = "data.mongodbatlas_search_deployment.test"
 )
 
-func importStep(config string) resource.TestStep {
+func importStep(tfConfig string) resource.TestStep {
 	return resource.TestStep{
-		Config:            config,
+		Config:            tfConfig,
 		ResourceName:      resourceID,
 		ImportStateIdFunc: importStateIDFunc(resourceID),
 		ImportState:       true,

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -53,7 +53,7 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 	})
 }
 
-const deleteTimeout = 10 * time.Minute
+const deleteTimeout = 30 * time.Minute
 
 func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 	var (

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -16,6 +16,7 @@ import (
 	localHcl "github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/hcl"
 )
 
+// ConfigAddResourceStr is useful when you need to add one or more attributes to a resource block.
 func ConfigAddResourceStr(t *testing.T, hclConfig, resourceID, extraResourceStr string) string {
 	t.Helper()
 	resourceParts := strings.Split(resourceID, ".")

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -6,12 +6,32 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
+
+	localHcl "github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/hcl"
 )
+
+func ConfigAddResourceStr(t *testing.T, hclConfig, resourceID, extraResourceStr string) string {
+	t.Helper()
+	resourceParts := strings.Split(resourceID, ".")
+	if len(resourceParts) != 2 {
+		t.Fatalf("resourceID must be in the format <type>.<name>, got %s", resourceID)
+	}
+	resourceType := resourceParts[0]
+	resourceName := resourceParts[1]
+	resourceBlockDef := fmt.Sprintf("resource %q %q {", resourceType, resourceName)
+	if !strings.Contains(hclConfig, resourceBlockDef) {
+		t.Fatalf("resource block %q not found in config: %s", resourceBlockDef, hclConfig)
+	}
+	resourceBlockDefWithExtraResourceStr := fmt.Sprintf("%s\n%s\n", resourceBlockDef, extraResourceStr)
+	hclConfigModified := strings.Replace(hclConfig, resourceBlockDef, resourceBlockDefWithExtraResourceStr, 1)
+	return localHcl.PrettyHCL(t, hclConfigModified)
+}
 
 func FormatToHCLMap(m map[string]string, indent, varName string) string {
 	if m == nil {

--- a/internal/testutil/acc/config_formatter_test.go
+++ b/internal/testutil/acc/config_formatter_test.go
@@ -104,3 +104,39 @@ func TestFormatToHCLLifecycleIgnore(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigAddResourceStr(t *testing.T) {
+	testCases := map[string]struct {
+		hclConfig         string
+		resourceID        string
+		extraResourceStr  string
+		expectedHCLConfig string
+	}{
+		"add tags": {
+			hclConfig:        `resource "mongodbatlas_project" "test" {}`,
+			resourceID:       "mongodbatlas_project.test",
+			extraResourceStr: `tags = {}`,
+			expectedHCLConfig: `resource "mongodbatlas_project" "test" {
+  tags = {}
+}
+`},
+		"add timeout on create": {
+			hclConfig:  `resource "mongodbatlas_project" "test" {}`,
+			resourceID: "mongodbatlas_project.test",
+			extraResourceStr: `timeouts = { 
+			create = "1m" 
+		}`,
+			expectedHCLConfig: `resource "mongodbatlas_project" "test" {
+  timeouts = {
+    create = "1m"
+  }
+}
+`,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedHCLConfig, acc.ConfigAddResourceStr(t, tc.hclConfig, tc.resourceID, tc.extraResourceStr))
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Adds delete_on_create_timeout flag to handle deletion on creation timeout to search_deployment
- Introduces `ReplaceContextDeadlineExceededDiags` to refine diagnostic messages on timeout scenarios. See `Timeout reached after XXX` example [below](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3344#issuecomment-2901460257)
- Introduces `ConfigAddResourceStr` for adding extra attributes to acceptance test configs (`timeout` and `delete_on_create_timeout` in this PR)
- Removes `searchDeployment` prefix across CRUD operations and models 

Link to any related issue(s): CLOUDP-309389

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
