### PR TITLE
chore: Sensitive data in auto-generation POC

### DIFF
--- a/internal/serviceapi/databaseuserapi/resource_schema.go
+++ b/internal/serviceapi/databaseuserapi/resource_schema.go
@@ -79,6 +79,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"password": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Alphanumeric string that authenticates this database user against the database specified in `databaseName`. To authenticate with SCRAM-SHA, you must specify this parameter. This parameter doesn't appear in this response.",
+				Sensitive:           true,
 			},
 			"roles": schema.ListNestedAttribute{
 				Optional:            true,

--- a/tools/codegen/codespec/api_spec_schema.go
+++ b/tools/codegen/codespec/api_spec_schema.go
@@ -48,12 +48,6 @@ func (s *APISpecSchema) GetDescription() *string {
 	return &s.Schema.Description
 }
 
-func (s *APISpecSchema) IsSensitive() *bool {
-	isSensitive := s.Schema.Format == OASFormatPassword
-
-	if !isSensitive {
-		return nil
-	}
-
-	return &isSensitive
+func (s *APISpecSchema) IsSensitive() bool {
+	return s.Schema.Format == OASFormatPassword
 }

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -100,6 +100,9 @@ func applyOverrides(attr *Attribute, attrPathName string, schemaOptions config.S
 		if override.Computability != nil {
 			attr.ComputedOptionalRequired = getComputabilityFromConfig(*override.Computability)
 		}
+		if override.Sensitive != nil {
+			attr.Sensitive = *override.Sensitive
+		}
 	}
 }
 

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -58,25 +58,25 @@ type Attributes []Attribute
 // Add this field to the Attribute struct
 // Usage AttributeUsage
 type Attribute struct {
-	Number                   *NumberAttribute
-	Int64                    *Int64Attribute
+	SetNested                *SetNestedAttribute
+	String                   *StringAttribute
 	Float64                  *Float64Attribute
-	Set                      *SetAttribute
+	List                     *ListAttribute
 	Bool                     *BoolAttribute
 	ListNested               *ListNestedAttribute
 	Map                      *MapAttribute
 	MapNested                *MapNestedAttribute
-	SetNested                *SetNestedAttribute
-	List                     *ListAttribute
-	String                   *StringAttribute
+	Int64                    *Int64Attribute
+	Number                   *NumberAttribute
+	Set                      *SetAttribute
 	SingleNested             *SingleNestedAttribute
 	Timeouts                 *TimeoutsAttribute
 	Description              *string
-	Name                     stringcase.SnakeCaseString
 	DeprecationMessage       *string
-	Sensitive                *bool
+	Name                     stringcase.SnakeCaseString
 	ComputedOptionalRequired ComputedOptionalRequired
 	ReqBodyUsage             AttributeReqBodyUsage
+	Sensitive                bool
 }
 
 type AttributeReqBodyUsage int

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -127,7 +127,9 @@ resources:
       aliases:
         resource_policy_id: id # path param name does not match the API response property
 
-  stream_instance_api: # no fully functional yet so it doesn't have acceptance tests yet
+  # No fully functional yet so it doesn't have acceptance tests yet.
+  # It has a sensitive attribute that has password format in OpenAPI spec.
+  stream_instance_api:
     read:
       path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}
       method: GET
@@ -144,7 +146,8 @@ resources:
       aliases:
         tenant_name: name # path param name does not match the API request property
 
-  cluster_api: # no fully functional yet so it doesn't have acceptance tests yet
+  # No fully functional yet so it doesn't have acceptance tests yet.
+  cluster_api:
     read:
       path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}
       method: GET

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -28,6 +28,10 @@ resources:
       path: /api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}
       method: DELETE
     version_header: application/vnd.atlas.2023-01-01+json
+    schema:
+      overrides:
+        password:
+          sensitive: true
 
   push_based_log_export_api:
     read:

--- a/tools/codegen/config/config_model.go
+++ b/tools/codegen/config/config_model.go
@@ -37,6 +37,7 @@ type SchemaOptions struct {
 
 type Override struct {
 	Computability *Computability `yaml:"computability,omitempty"`
+	Sensitive     *bool          `yaml:"sensitive"`
 	Description   string         `yaml:"description"`
 	PlanModifiers []PlanModifier `yaml:"plan_modifiers"`
 	Validators    []Validator    `yaml:"validators"`

--- a/tools/codegen/gofilegen/schema/schema_attribute.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute.go
@@ -138,7 +138,7 @@ func commonProperties(attr *codespec.Attribute) []string {
 	if attr.Description != nil {
 		result = append(result, fmt.Sprintf("MarkdownDescription: %q", *attr.Description))
 	}
-	if attr.Sensitive != nil && *attr.Sensitive {
+	if attr.Sensitive {
 		result = append(result, "Sensitive: true")
 	}
 	return result

--- a/tools/codegen/gofilegen/schema/schema_attribute_nested.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute_nested.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ListNestedAttrGenerator struct {
-	attr            codespec.Attribute
 	listNestedModel codespec.ListNestedAttribute
+	attr            codespec.Attribute
 }
 
 func (l *ListNestedAttrGenerator) AttributeCode() CodeStatement {
@@ -16,8 +16,8 @@ func (l *ListNestedAttrGenerator) AttributeCode() CodeStatement {
 }
 
 type SetNestedGenerator struct {
-	attr           codespec.Attribute
 	setNestedModel codespec.SetNestedAttribute
+	attr           codespec.Attribute
 }
 
 func (l *SetNestedGenerator) AttributeCode() CodeStatement {
@@ -25,8 +25,8 @@ func (l *SetNestedGenerator) AttributeCode() CodeStatement {
 }
 
 type MapNestedAttrGenerator struct {
-	attr           codespec.Attribute
 	mapNestedModel codespec.MapNestedAttribute
+	attr           codespec.Attribute
 }
 
 func (m *MapNestedAttrGenerator) AttributeCode() CodeStatement {
@@ -34,8 +34,8 @@ func (m *MapNestedAttrGenerator) AttributeCode() CodeStatement {
 }
 
 type SingleNestedAttrGenerator struct {
-	attr              codespec.Attribute
 	singleNestedModel codespec.SingleNestedAttribute
+	attr              codespec.Attribute
 }
 
 func (l *SingleNestedAttrGenerator) AttributeCode() CodeStatement {


### PR DESCRIPTION
## Description

Sensitive data in auto-generation POC. This is part of the spike: WRITING-29828.

- Allow overriding `Sensitive`.
- Change Sensitive from *bool to bool in autogen tool as false and nil are equivalent, we just need to know if the attribute is sensitive or not.

Link to any related issue(s): CLOUDP-320083

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
