### PR TITLE
test: Adds sleep to reduce transient errors in advanced cluster creation tests

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1426,7 +1426,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateReplicaset(t *testing
 				Timeout:     60 * time.Second,
 				IsDelete:    true,
 			}, "waiting for cluster to be deleted after cleanup in create timeout", diags)
-			time.Sleep(time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
+			time.Sleep(1 * time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
 		}
 	)
 	resource.ParallelTest(t, *createCleanupTest(t, configCall, waitOnClusterDeleteDone, true))
@@ -1459,7 +1459,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 				Name:    clusterName,
 			}, acc.ConnV2().FlexClustersApi)
 			require.NoError(t, err)
-			time.Sleep(time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
+			time.Sleep(1 * time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
 		}
 	)
 	resource.ParallelTest(t, *createCleanupTest(t, configCall, waitOnClusterDeleteDone, false))

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1426,6 +1426,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateReplicaset(t *testing
 				Timeout:     60 * time.Second,
 				IsDelete:    true,
 			}, "waiting for cluster to be deleted after cleanup in create timeout", diags)
+			time.Sleep(time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
 		}
 	)
 	resource.ParallelTest(t, *createCleanupTest(t, configCall, waitOnClusterDeleteDone, true))
@@ -1458,6 +1459,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 				Name:    clusterName,
 			}, acc.ConnV2().FlexClustersApi)
 			require.NoError(t, err)
+			time.Sleep(time.Minute) // decrease the chance of `CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP`: "A transient error occurred. Please try again in a minute or use a different name"
 		}
 	)
 	resource.ParallelTest(t, *createCleanupTest(t, configCall, waitOnClusterDeleteDone, false))


### PR DESCRIPTION
## Description

test: Adds sleep to reduce transient errors in advanced cluster creation tests

failed run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/15199473124/job/42750906998#step:5:288 

```log
=== NAME  TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex
    resource_advanced_cluster_test.go:1463: Step 2/3 error: Error running apply: exit status 1
        
        Error: error creating flex cluster: https://cloud-dev.mongodb.com/api/atlas/v2/groups/682fc64f1fcba3225667d5ca/flexClusters POST: HTTP 400 Bad Request (Error code: "CONTAINER_WAITING_FOR_FAST_RECORD_CLEAN_UP") Detail: A transient error occurred. Please try again in a minute or use a different name. Reason: Bad Request. Params: [A transient error occurred. Please try again in a minute or use a different name.], BadRequestDetail: 
        
          with mongodbatlas_advanced_cluster.test,
          on terraform_plugin_test.tf line 12, in resource "mongodbatlas_advanced_cluster" "test":
          12: 			resource "mongodbatlas_advanced_cluster" "test" {
```

## Local OK
- `PASS: TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex (204.15s)`
- `PASS: TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateReplicaset (863.69s)`

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
