### PR TITLE
doc: Removes reference to private_key from api_key datasource

### DIFF
--- a/docs/data-sources/api_key.md
+++ b/docs/data-sources/api_key.md
@@ -34,7 +34,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `description` - Description of this Organization API key.
 * `public_key` - Public key for this Organization API key.
-* `private_key` - Private key for this Organization API key.
 * `role_names` - Name of the role. This resource returns all the roles the user has in Atlas.
 The following are valid roles:
   * `ORG_OWNER`


### PR DESCRIPTION
## Description

Removes reference to `private_key` from api_key datasource. This value is not (and cannot, as the api only returns a partial value) returned by this datasource.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

