### PR TITLE
chore: Update error message formatting in advanced cluster resource

### DIFF
--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -31,7 +31,7 @@ const (
 	resourceName                  = "advanced_cluster"
 	errorSchemaDowngrade          = "error operation not permitted, nums_shards from 1 -> > 1"
 	errorPatchPayload             = "error creating patch payload"
-	errorDetailDefault            = "cluster name %s. API error detail %s"
+	errorDetailDefault            = "cluster name: %s, API error details: %s"
 	errorSchemaUpgradeReadIDs     = "error reading IDs from API when upgrading schema"
 	errorReadResource             = "error reading advanced cluster"
 	errorAdvancedConfRead         = "error reading Advanced Configuration"


### PR DESCRIPTION
## Description

Update error message formatting in advanced cluster resource.

Once it includes the Atlas Go SDK with this [PR](https://github.com/mongodb/atlas-sdk-go/pull/604), it will improve errors when empty path parameters, e.g.:

Current error:
![cur_error](https://github.com/user-attachments/assets/294dd18c-51d5-4395-914c-104d568bcbe9)

New error:
![new_error](https://github.com/user-attachments/assets/48e59105-b5ef-49b6-b90a-81deb1aba95d)


Link to any related issue(s): CLOUDP-313402

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
