### PR TITLE
fix: Realm Client Auth Token Overwritten by Transport Assignment

### DIFF
--- a/.changelog/3362.txt
+++ b/.changelog/3362.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fixes Realm Client authentication
+provider: Fixes Realm Client authentication
 ```

--- a/.changelog/3362.txt
+++ b/.changelog/3362.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixes Realm Client authentication
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -37,6 +37,9 @@ on:
       mongodb_atlas_base_url:
         type: string
         required: true
+      mongodb_realm_base_url:
+        type: string
+        required: true
       mongodb_atlas_project_owner_id:
         type: string
         required: true
@@ -199,6 +202,7 @@ env:
   # If the name (regex) of the test is set, only that test is run
   ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
+  MONGODB_REALM_BASE_URL: ${{ inputs.mongodb_realm_base_url }}
   MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
   MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
   MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -106,6 +106,7 @@ jobs:
       aws_region_federation: ${{ vars.AWS_REGION_FEDERATION }}
       mongodb_atlas_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA || vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
       mongodb_atlas_base_url: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_BASE_URL_QA || vars.MONGODB_ATLAS_BASE_URL }}
+      mongodb_realm_base_url: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_REALM_BASE_URL_QA || vars.MONGODB_REALM_BASE_URL }}
       mongodb_atlas_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_PROJECT_OWNER_ID }}
       mongodb_atlas_teams_ids: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_TEAMS_IDS_QA || vars.MONGODB_ATLAS_TEAMS_IDS }}
       azure_atlas_app_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AZURE_ATLAS_APP_ID_QA || vars.AZURE_ATLAS_APP_ID }}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -249,7 +249,6 @@ func (c *MongoDBClient) GetRealmClient(ctx context.Context) (*realm.Client, erro
 
 	clientRealm := realmAuth.NewClient(realmAuth.BasicTokenSource(token))
 
-	clientRealm.Transport = baseTransport
 	clientRealm.Transport = logging.NewTransport("MongoDB Realm", clientRealm.Transport)
 
 	// Initialize the MongoDB Realm API Client.

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -247,9 +247,12 @@ func (c *MongoDBClient) GetRealmClient(ctx context.Context) (*realm.Client, erro
 		return nil, err
 	}
 
-	clientRealm := realmAuth.NewClient(realmAuth.BasicTokenSource(token))
-
-	clientRealm.Transport = logging.NewTransport("MongoDB Realm", clientRealm.Transport)
+	clientRealm := &http.Client{
+		Transport: &realmAuth.Transport{
+			Source: realmAuth.BasicTokenSource(token),
+			Base:   logging.NewTransport("MongoDB Realm", baseTransport),
+		},
+	}
 
 	// Initialize the MongoDB Realm API Client.
 	realmClient, err := realm.New(clientRealm, optsRealm...)

--- a/internal/service/eventtrigger/data_source_event_triggers_test.go
+++ b/internal/service/eventtrigger/data_source_event_triggers_test.go
@@ -54,7 +54,7 @@ func TestAccEventTriggerDSPlural_basic(t *testing.T) {
 
 func TestAccEventTriggerDSPlural_realmClientWorks(t *testing.T) {
 	// This test is designed to run in CI and expects a 404 "app not found" error from the Realm API.
-	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	projectID := acc.ProjectIDExecution(t)
 	appID := "invalid-app-id" // known-bad app ID
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/eventtrigger/data_source_event_triggers_test.go
+++ b/internal/service/eventtrigger/data_source_event_triggers_test.go
@@ -3,6 +3,7 @@ package eventtrigger_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -51,6 +52,23 @@ func TestAccEventTriggerDSPlural_basic(t *testing.T) {
 	})
 }
 
+func TestAccEventTriggerDSPlural_realmClientWorks(t *testing.T) {
+	// This test is designed to run in CI and expects a 404 "app not found" error from the Realm API.
+	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	appID := "invalid-app-id" // known-bad app ID
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMongoDBAtlasEventTriggers404Config(projectID, appID),
+				ExpectError: regexp.MustCompile("app not found"),
+			},
+		},
+	})
+}
+
 func testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, operationTypes string, eventTrigger *realm.EventTriggerRequest) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_event_trigger" "test" {
@@ -75,4 +93,13 @@ func testAccMongoDBAtlasEventTriggersDataSourceConfig(projectID, appID, operatio
 `, projectID, appID, eventTrigger.Name, eventTrigger.Type, eventTrigger.FunctionID, *eventTrigger.Disabled, *eventTrigger.Config.Unordered, operationTypes,
 		eventTrigger.Config.Database, eventTrigger.Config.Collection,
 		eventTrigger.Config.ServiceID)
+}
+
+func testAccMongoDBAtlasEventTriggers404Config(projectID, appID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_event_triggers" "this" {
+			project_id = %q
+			app_id     = %q
+		}
+	`, projectID, appID)
 }


### PR DESCRIPTION
## Description

When using event triggers (which rely on the Realm client), the following error was encountered:
```
Error: error getting event triggers information: GET https://realm.mongodb.com/api/admin/v3.0/groups/<project-id>/apps/<app-id>/triggers: 401 (request "MissingSession") unauthorized
```
This was traced to the line:
```
clientRealm.Transport = baseTransport
```
Assigning baseTransport to clientRealm.Transport overwrites the authentication token transport required by the Realm client, resulting in unauthorized (401) errors.

### Solution
Removed the assignment of baseTransport to clientRealm.Transport for the Realm client.

Tested the fix with the following config:
```tf
data "mongodbatlas_event_triggers" "this" {
  project_id = var.project_id
  app_id     = var.app_id
}
```

```
data.mongodbatlas_event_triggers.this: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: error getting event triggers information: GET https://realm-dev.mongodb.com/api/admin/v3.0/groups/<project_id>/apps/<app_id>/triggers: 401 (request "MissingSession") unauthorized
│ 
│   with data.mongodbatlas_event_triggers.this,
│   on main.tf line 79, in data "mongodbatlas_event_triggers" "this":
│   79: data "mongodbatlas_event_triggers" "this" {
│ 
╵
➜  playground export TF_CLI_CONFIG_FILE=./dev.tfrc   --> use provider locally build with this fix                                                                                                                                                                                                               
➜  playground terraform plan                                                                                                                                                                                                                                        
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - mongodb/mongodbatlas in ../terraform-provider-mongodbatlas/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.mongodbatlas_event_triggers.this: Reading...
data.mongodbatlas_event_triggers.this: Read complete after 2s [id=terraform-20250529080544501200000001]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Link to any related issue(s): CLOUDP-320867 and https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3361

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
