### PR TITLE
chore: Uses single version API spec instead of transformed API spec

### DIFF
--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -281,149 +281,13 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							MarkdownDescription: "Hardware specifications for nodes set for a given region. Each **regionConfigs** object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each **regionConfigs** object must have either an **analyticsSpecs** object, **electableSpecs** object, or **readOnlySpecs** object. Tenant clusters only require **electableSpecs. Dedicated** clusters can specify any of these specifications, but must have at least one **electableSpecs** object within a **replicationSpec**.\n\n**Example:**\n\nIf you set `\"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize\" : \"M30\"`, set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : `\"M30\"` if you have electable nodes and `\"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize\" : `\"M30\"` if you have read-only nodes.",
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
-									"analytics_auto_scaling": schema.SingleNestedAttribute{
-										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
-										Attributes: map[string]schema.Attribute{
-											"compute": schema.SingleNestedAttribute{
-												Optional:            true,
-												MarkdownDescription: "Options that determine how this cluster handles CPU scaling.",
-												Attributes: map[string]schema.Attribute{
-													"enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for **replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize**.\n- Set to `false` to disable instance size reactive auto-scaling.",
-													},
-													"max_instance_size": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Instance size boundary to which your cluster can automatically scale.",
-													},
-													"min_instance_size": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Instance size boundary to which your cluster can automatically scale.",
-													},
-													"predictive_enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether predictive instance size auto-scaling is enabled.\n\n- Set to `true` to enable predictive instance size auto-scaling. MongoDB Cloud requires **replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled** to be `true` in order to enable this feature.\n- Set to `false` to disable predictive instance size auto-scaling.",
-													},
-													"scale_down_enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if **replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled** is `true`. If you enable this option, specify a value for **replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize**.",
-													},
-												},
-											},
-											"disk_gb": schema.SingleNestedAttribute{
-												Optional:            true,
-												MarkdownDescription: "Setting that enables disk auto-scaling.",
-												Attributes: map[string]schema.Attribute{
-													"enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
-													},
-												},
-											},
-										},
-									},
-									"analytics_specs": schema.SingleNestedAttribute{
-										Optional:            true,
-										MarkdownDescription: "Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
-										Attributes: map[string]schema.Attribute{
-											"disk_iops": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
-											},
-											"disk_size_gb": schema.Float64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
-											},
-											"ebs_volume_type": schema.StringAttribute{
-												Computed:            true,
-												Optional:            true,
-												MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
-											},
-											"instance_size": schema.StringAttribute{
-												Optional:            true,
-												MarkdownDescription: "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
-											},
-											"node_count": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
-											},
-										},
-									},
-									"auto_scaling": schema.SingleNestedAttribute{
-										Optional:            true,
-										MarkdownDescription: "Options that determine how this cluster handles resource scaling.",
-										Attributes: map[string]schema.Attribute{
-											"compute": schema.SingleNestedAttribute{
-												Optional:            true,
-												MarkdownDescription: "Options that determine how this cluster handles CPU scaling.",
-												Attributes: map[string]schema.Attribute{
-													"enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for **replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize**.\n- Set to `false` to disable instance size reactive auto-scaling.",
-													},
-													"max_instance_size": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Instance size boundary to which your cluster can automatically scale.",
-													},
-													"min_instance_size": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Instance size boundary to which your cluster can automatically scale.",
-													},
-													"predictive_enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether predictive instance size auto-scaling is enabled.\n\n- Set to `true` to enable predictive instance size auto-scaling. MongoDB Cloud requires **replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled** to be `true` in order to enable this feature.\n- Set to `false` to disable predictive instance size auto-scaling.",
-													},
-													"scale_down_enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if **replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled** is `true`. If you enable this option, specify a value for **replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize**.",
-													},
-												},
-											},
-											"disk_gb": schema.SingleNestedAttribute{
-												Optional:            true,
-												MarkdownDescription: "Setting that enables disk auto-scaling.",
-												Attributes: map[string]schema.Attribute{
-													"enabled": schema.BoolAttribute{
-														Optional:            true,
-														MarkdownDescription: "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
-													},
-												},
-											},
-										},
-									},
-									"backing_provider_name": schema.StringAttribute{
-										Optional:            true,
-										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when **providerName** is `TENANT` and **electableSpecs.instanceSize** is `M0`, `M2` or `M5`. \n\nPlease note that  using an instanceSize of M2 or M5 will create a Flex cluster instead. Support for the instanceSize of M2 or M5 will be discontinued in January 2026. We recommend using the createFlexCluster API for such configurations moving forward.",
-									},
 									"electable_specs": schema.SingleNestedAttribute{
 										Optional:            true,
 										MarkdownDescription: "Hardware specifications for all electable nodes deployed in the region. Electable nodes can become the primary and can enable local reads. If you don't specify this option, MongoDB Cloud deploys no electable nodes to the region.",
 										Attributes: map[string]schema.Attribute{
-											"disk_iops": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
-											},
 											"disk_size_gb": schema.Float64Attribute{
 												Optional:            true,
 												MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
-											},
-											"ebs_volume_type": schema.StringAttribute{
-												Computed:            true,
-												Optional:            true,
-												MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
-											},
-											"effective_instance_size": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "The true tenant instance size. This is present to support backwards compatibility for deprecated provider types and/or instance sizes.",
-											},
-											"instance_size": schema.StringAttribute{
-												Optional:            true,
-												MarkdownDescription: "Hardware specification for the instances in this M0/M2/M5 tier cluster.",
-											},
-											"node_count": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
 											},
 										},
 									},
@@ -435,36 +299,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										Optional:            true,
 										MarkdownDescription: "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`.",
 									},
-									"read_only_specs": schema.SingleNestedAttribute{
-										Optional:            true,
-										MarkdownDescription: "Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads. If you don't specify this parameter, no read-only nodes are deployed to the region.",
-										Attributes: map[string]schema.Attribute{
-											"disk_iops": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `\"replicationSpecs[n].regionConfigs[m].providerName\" : \"Azure\"`.\n- set `\"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize\" : \"M40\"` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected **.instanceSize** and **.diskSizeGB**.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
-											},
-											"disk_size_gb": schema.Float64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set **replicationSpecs**.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
-											},
-											"ebs_volume_type": schema.StringAttribute{
-												Computed:            true,
-												Optional:            true,
-												MarkdownDescription: "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
-											},
-											"instance_size": schema.StringAttribute{
-												Optional:            true,
-												MarkdownDescription: "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
-											},
-											"node_count": schema.Int64Attribute{
-												Optional:            true,
-												MarkdownDescription: "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
-											},
-										},
-									},
-									"region_name": schema.StringAttribute{
+									"region_name": schema.SingleNestedAttribute{
 										Optional:            true,
 										MarkdownDescription: "Physical location of your MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. The region name is only returned in the response for single-region clusters. When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. It assigns the VPC a Classless Inter-Domain Routing (CIDR) block. To limit a new VPC peering connection to one Classless Inter-Domain Routing (CIDR) block and region, create the connection first. Deploy the cluster after the connection starts. GCP Clusters and Multi-region clusters require one VPC peering connection for each region. MongoDB nodes can use only the peering connection that resides in the same region as the nodes to communicate with the peered VPC.",
+										Attributes:          map[string]schema.Attribute{},
 									},
 								},
 							},
@@ -483,7 +321,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"root_cert_type": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
-				MarkdownDescription: "Root Certificate Authority that MongoDB Cloud cluster uses. MongoDB Cloud supports Internet Security Research Group.",
+				MarkdownDescription: "Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.",
 			},
 			"state_name": schema.StringAttribute{
 				Computed:            true,
@@ -607,65 +445,15 @@ type TFReplicationSpecsModel struct {
 	ZoneName      types.String `tfsdk:"zone_name"`
 }
 type TFReplicationSpecsRegionConfigsModel struct {
-	AnalyticsAutoScaling types.Object `tfsdk:"analytics_auto_scaling"`
-	AnalyticsSpecs       types.Object `tfsdk:"analytics_specs"`
-	AutoScaling          types.Object `tfsdk:"auto_scaling"`
-	BackingProviderName  types.String `tfsdk:"backing_provider_name"`
-	ElectableSpecs       types.Object `tfsdk:"electable_specs"`
-	Priority             types.Int64  `tfsdk:"priority"`
-	ProviderName         types.String `tfsdk:"provider_name"`
-	ReadOnlySpecs        types.Object `tfsdk:"read_only_specs"`
-	RegionName           types.String `tfsdk:"region_name"`
-}
-type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel struct {
-	Compute types.Object `tfsdk:"compute"`
-	DiskGb  types.Object `tfsdk:"disk_gb"`
-}
-type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel struct {
-	Enabled           types.Bool   `tfsdk:"enabled"`
-	MaxInstanceSize   types.String `tfsdk:"max_instance_size" autogen:"omitjson"`
-	MinInstanceSize   types.String `tfsdk:"min_instance_size" autogen:"omitjson"`
-	PredictiveEnabled types.Bool   `tfsdk:"predictive_enabled"`
-	ScaleDownEnabled  types.Bool   `tfsdk:"scale_down_enabled"`
-}
-type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGbModel struct {
-	Enabled types.Bool `tfsdk:"enabled"`
-}
-type TFReplicationSpecsRegionConfigsAnalyticsSpecsModel struct {
-	DiskIops      types.Int64   `tfsdk:"disk_iops"`
-	DiskSizeGb    types.Float64 `tfsdk:"disk_size_gb"`
-	EbsVolumeType types.String  `tfsdk:"ebs_volume_type"`
-	InstanceSize  types.String  `tfsdk:"instance_size"`
-	NodeCount     types.Int64   `tfsdk:"node_count"`
-}
-type TFReplicationSpecsRegionConfigsAutoScalingModel struct {
-	Compute types.Object `tfsdk:"compute"`
-	DiskGb  types.Object `tfsdk:"disk_gb"`
-}
-type TFReplicationSpecsRegionConfigsAutoScalingComputeModel struct {
-	Enabled           types.Bool   `tfsdk:"enabled"`
-	MaxInstanceSize   types.String `tfsdk:"max_instance_size" autogen:"omitjson"`
-	MinInstanceSize   types.String `tfsdk:"min_instance_size" autogen:"omitjson"`
-	PredictiveEnabled types.Bool   `tfsdk:"predictive_enabled"`
-	ScaleDownEnabled  types.Bool   `tfsdk:"scale_down_enabled"`
-}
-type TFReplicationSpecsRegionConfigsAutoScalingDiskGbModel struct {
-	Enabled types.Bool `tfsdk:"enabled"`
+	ElectableSpecs types.Object `tfsdk:"electable_specs"`
+	Priority       types.Int64  `tfsdk:"priority"`
+	ProviderName   types.String `tfsdk:"provider_name"`
+	RegionName     types.Object `tfsdk:"region_name"`
 }
 type TFReplicationSpecsRegionConfigsElectableSpecsModel struct {
-	DiskIops              types.Int64   `tfsdk:"disk_iops"`
-	DiskSizeGb            types.Float64 `tfsdk:"disk_size_gb"`
-	EbsVolumeType         types.String  `tfsdk:"ebs_volume_type"`
-	EffectiveInstanceSize types.String  `tfsdk:"effective_instance_size" autogen:"omitjson"`
-	InstanceSize          types.String  `tfsdk:"instance_size"`
-	NodeCount             types.Int64   `tfsdk:"node_count"`
+	DiskSizeGb types.Float64 `tfsdk:"disk_size_gb"`
 }
-type TFReplicationSpecsRegionConfigsReadOnlySpecsModel struct {
-	DiskIops      types.Int64   `tfsdk:"disk_iops"`
-	DiskSizeGb    types.Float64 `tfsdk:"disk_size_gb"`
-	EbsVolumeType types.String  `tfsdk:"ebs_volume_type"`
-	InstanceSize  types.String  `tfsdk:"instance_size"`
-	NodeCount     types.Int64   `tfsdk:"node_count"`
+type TFReplicationSpecsRegionConfigsRegionNameModel struct {
 }
 type TFTagsModel struct {
 	Key   types.String `tfsdk:"key"`

--- a/internal/serviceapi/streaminstanceapi/resource_schema.go
+++ b/internal/serviceapi/streaminstanceapi/resource_schema.go
@@ -25,131 +25,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "List of connections configured in the stream instance.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"authentication": schema.SingleNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
-							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
-								"mechanism": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Style of authentication. Can be one of PLAIN, SCRAM-256, or SCRAM-512.",
-								},
-								"password": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Password of the account to connect to the Kafka cluster.",
-									Sensitive:           true,
-								},
-								"ssl_certificate": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "SSL certificate for client authentication to Kafka.",
-								},
-								"ssl_key": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "SSL key for client authentication to Kafka.",
-								},
-								"ssl_key_password": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Password for the SSL key, if it is password protected.",
-								},
-								"username": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Username of the account to connect to the Kafka cluster.",
-								},
-							},
-						},
-						"aws": schema.SingleNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "AWS configurations for AWS-based connection types.",
-							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
-								"role_arn": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.",
-								},
-								"test_bucket": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "The name of an S3 bucket used to check authorization of the passed-in IAM role ARN.",
-								},
-							},
-						},
-						"bootstrap_servers": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Comma separated list of server addresses.",
-						},
-						"cluster_name": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Name of the cluster configured for this connection.",
-						},
-						"config": schema.MapAttribute{
-							Computed:            true,
-							MarkdownDescription: "A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
-							ElementType:         types.StringType,
-						},
-						"db_role_to_execute": schema.SingleNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
-							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
-								"role": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "The name of the role to use. Can be a built in role or a custom role.",
-								},
-								"type": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Type of the DB role. Can be either BuiltIn or Custom.",
-								},
-							},
-						},
-						"headers": schema.MapAttribute{
-							Computed:            true,
-							MarkdownDescription: "A map of key-value pairs that will be passed as headers for the request.",
-							ElementType:         types.StringType,
-						},
 						"links": schema.ListNestedAttribute{
 							Computed:            true,
 							MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
@@ -170,107 +45,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							MarkdownDescription: "Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.",
 						},
-						"networking": schema.SingleNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "Networking Access Type can either be 'PUBLIC' (default) or VPC. VPC type is in public preview, please file a support ticket to enable VPC Network Access.",
-							Attributes: map[string]schema.Attribute{
-								"access": schema.SingleNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "Information about the networking access.",
-									Attributes: map[string]schema.Attribute{
-										"connection_id": schema.StringAttribute{
-											Computed:            true,
-											MarkdownDescription: "Reserved. Will be used by PRIVATE_LINK connection type.",
-										},
-										"links": schema.ListNestedAttribute{
-											Computed:            true,
-											MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-											NestedObject: schema.NestedAttributeObject{
-												Attributes: map[string]schema.Attribute{
-													"href": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-													},
-													"rel": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-													},
-												},
-											},
-										},
-										"name": schema.StringAttribute{
-											Computed:            true,
-											MarkdownDescription: "Reserved. Will be used by PRIVATE_LINK connection type.",
-										},
-										"tgw_id": schema.StringAttribute{
-											Computed:            true,
-											MarkdownDescription: "Reserved. Will be used by TRANSIT_GATEWAY connection type.",
-										},
-										"type": schema.StringAttribute{
-											Computed:            true,
-											MarkdownDescription: "Selected networking type. Either PUBLIC, VPC, PRIVATE_LINK, or TRANSIT_GATEWAY. Defaults to PUBLIC. For VPC, ensure that VPC peering exists and connectivity has been established between Atlas VPC and the VPC where Kafka cluster is hosted for the connection to function properly. TRANSIT_GATEWAY support is coming soon.",
-										},
-										"vpc_cidr": schema.StringAttribute{
-											Computed:            true,
-											MarkdownDescription: "Reserved. Will be used by TRANSIT_GATEWAY connection type.",
-										},
-									},
-								},
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
-							},
-						},
-						"security": schema.SingleNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
-							Attributes: map[string]schema.Attribute{
-								"broker_public_certificate": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "A trusted, public x509 certificate for connecting to Kafka over SSL.",
-								},
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
-								"protocol": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Describes the transport type. Can be either SASL_PLAINTEXT, SASL_SSL, or SSL.",
-								},
-							},
-						},
 						"type": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Type of the connection.",
-						},
-						"url": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The url to be used for the request.",
 						},
 					},
 				},
@@ -299,9 +76,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							},
 						},
 					},
-					"region": schema.StringAttribute{
+					"region": schema.SingleNestedAttribute{
 						Required:            true,
 						MarkdownDescription: "Name of the cloud provider region hosting Atlas Stream Processing.",
+						Attributes:          map[string]schema.Attribute{},
 					},
 				},
 			},
@@ -334,9 +112,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
 			},
-			"region": schema.StringAttribute{
+			"region": schema.SingleNestedAttribute{
 				Required:            true,
 				MarkdownDescription: "Name of the cloud provider region hosting Atlas Stream Processing.",
+				Attributes:          map[string]schema.Attribute{},
 			},
 			"sample_connections": schema.SingleNestedAttribute{
 				Optional:            true,
@@ -404,101 +183,35 @@ type TFModel struct {
 	Hostnames         types.List   `tfsdk:"hostnames" autogen:"omitjson"`
 	Links             types.List   `tfsdk:"links" autogen:"omitjson"`
 	Name              types.String `tfsdk:"name" autogen:"omitjsonupdate"`
-	Region            types.String `tfsdk:"region"`
+	Region            types.Object `tfsdk:"region"`
 	SampleConnections types.Object `tfsdk:"sample_connections" autogen:"omitjsonupdate"`
 	StreamConfig      types.Object `tfsdk:"stream_config" autogen:"omitjsonupdate"`
 }
 type TFConnectionsModel struct {
-	Authentication   types.Object `tfsdk:"authentication" autogen:"omitjson"`
-	Aws              types.Object `tfsdk:"aws" autogen:"omitjson"`
-	BootstrapServers types.String `tfsdk:"bootstrap_servers" autogen:"omitjson"`
-	ClusterName      types.String `tfsdk:"cluster_name" autogen:"omitjson"`
-	Config           types.Map    `tfsdk:"config" autogen:"omitjson"`
-	DbRoleToExecute  types.Object `tfsdk:"db_role_to_execute" autogen:"omitjson"`
-	Headers          types.Map    `tfsdk:"headers" autogen:"omitjson"`
-	Links            types.List   `tfsdk:"links" autogen:"omitjson"`
-	Name             types.String `tfsdk:"name" autogen:"omitjson"`
-	Networking       types.Object `tfsdk:"networking" autogen:"omitjson"`
-	Security         types.Object `tfsdk:"security" autogen:"omitjson"`
-	Type             types.String `tfsdk:"type" autogen:"omitjson"`
-	Url              types.String `tfsdk:"url" autogen:"omitjson"`
-}
-type TFConnectionsAuthenticationModel struct {
-	Links          types.List   `tfsdk:"links" autogen:"omitjson"`
-	Mechanism      types.String `tfsdk:"mechanism" autogen:"omitjson"`
-	Password       types.String `tfsdk:"password" autogen:"omitjson"`
-	SslCertificate types.String `tfsdk:"ssl_certificate" autogen:"omitjson"`
-	SslKey         types.String `tfsdk:"ssl_key" autogen:"omitjson"`
-	SslKeyPassword types.String `tfsdk:"ssl_key_password" autogen:"omitjson"`
-	Username       types.String `tfsdk:"username" autogen:"omitjson"`
-}
-type TFConnectionsAuthenticationLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsAwsModel struct {
-	Links      types.List   `tfsdk:"links" autogen:"omitjson"`
-	RoleArn    types.String `tfsdk:"role_arn" autogen:"omitjson"`
-	TestBucket types.String `tfsdk:"test_bucket" autogen:"omitjson"`
-}
-type TFConnectionsAwsLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsDbRoleToExecuteModel struct {
 	Links types.List   `tfsdk:"links" autogen:"omitjson"`
-	Role  types.String `tfsdk:"role" autogen:"omitjson"`
+	Name  types.String `tfsdk:"name" autogen:"omitjson"`
 	Type  types.String `tfsdk:"type" autogen:"omitjson"`
 }
-type TFConnectionsDbRoleToExecuteLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFConnectionsLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsNetworkingModel struct {
-	Access types.Object `tfsdk:"access" autogen:"omitjson"`
-	Links  types.List   `tfsdk:"links" autogen:"omitjson"`
-}
-type TFConnectionsNetworkingAccessModel struct {
-	ConnectionId types.String `tfsdk:"connection_id" autogen:"omitjson"`
-	Links        types.List   `tfsdk:"links" autogen:"omitjson"`
-	Name         types.String `tfsdk:"name" autogen:"omitjson"`
-	TgwId        types.String `tfsdk:"tgw_id" autogen:"omitjson"`
-	Type         types.String `tfsdk:"type" autogen:"omitjson"`
-	VpcCidr      types.String `tfsdk:"vpc_cidr" autogen:"omitjson"`
-}
-type TFConnectionsNetworkingAccessLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsNetworkingLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsSecurityModel struct {
-	BrokerPublicCertificate types.String `tfsdk:"broker_public_certificate" autogen:"omitjson"`
-	Links                   types.List   `tfsdk:"links" autogen:"omitjson"`
-	Protocol                types.String `tfsdk:"protocol" autogen:"omitjson"`
-}
-type TFConnectionsSecurityLinksModel struct {
 	Href types.String `tfsdk:"href" autogen:"omitjson"`
 	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFDataProcessRegionModel struct {
 	CloudProvider types.String `tfsdk:"cloud_provider"`
 	Links         types.List   `tfsdk:"links" autogen:"omitjson"`
-	Region        types.String `tfsdk:"region"`
+	Region        types.Object `tfsdk:"region"`
 }
 type TFDataProcessRegionLinksModel struct {
 	Href types.String `tfsdk:"href" autogen:"omitjson"`
 	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
+type TFDataProcessRegionRegionModel struct {
+}
 type TFLinksModel struct {
 	Href types.String `tfsdk:"href" autogen:"omitjson"`
 	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
+}
+type TFRegionModel struct {
 }
 type TFSampleConnectionsModel struct {
 	Links types.List `tfsdk:"links" autogen:"omitjson"`

--- a/tools/codegen/gofilegen/schema/schema_attribute.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute.go
@@ -15,7 +15,10 @@ func GenerateSchemaAttributes(attrs codespec.Attributes) CodeStatement {
 		attrsCode = append(attrsCode, result.Code)
 		imports = append(imports, result.Imports...)
 	}
-	finalAttrs := strings.Join(attrsCode, ",\n") + ","
+	finalAttrs := strings.Join(attrsCode, ",\n")
+	if finalAttrs != "" {
+		finalAttrs += ","
+	}
 	return CodeStatement{
 		Code:    finalAttrs,
 		Imports: imports,

--- a/tools/codegen/main.go
+++ b/tools/codegen/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	atlasAdminAPISpecURL = "https://raw.githubusercontent.com/mongodb/atlas-sdk-go/main/openapi/atlas-api-transformed.yaml"
+	// atlasAdminAPISpecURL = "https://raw.githubusercontent.com/mongodb/atlas-sdk-go/main/openapi/atlas-api-transformed.yaml"
+	atlasAdminAPISpecURL = "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/main/openapi/v2/openapi-2025-03-12.yaml"
 	configPath           = "tools/codegen/config.yml"
 	specFilePath         = "tools/codegen/open-api-spec.yml"
 )


### PR DESCRIPTION
## Description

Uses single version API spec instead of transformed API spec


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
