### PR TITLE
chore: Fixes update-dev-branches Github action

### DIFF
--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -27,6 +27,8 @@ jobs:
       pull-requests: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        fetch-depth: 0
     - run: |
         git config --local user.email svc-api-experience-integrations-escalation@mongodb.com
         git config --local user.name svc-apix-bot


### PR DESCRIPTION
## Description

Fixes update-dev-branches Github action.

Retrieve the full git history to avoid error:
```
branch 'CLOUDP-320243-dev-2.0.0' set up to track 'origin/CLOUDP-320243-dev-2.0.0'.
fatal: refusing to merge unrelated histories
fatal: There is no merge to abort (MERGE_HEAD missing).
```

Example of PR generated: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3399

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
