### PR TITLE
chore: Avoids flaky tests by sleeping 30s

### DIFF
--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -199,7 +199,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if err != nil || policy == nil {
 			return fmt.Errorf("backup compliance policy (%s) does not exist: %s", rs.Primary.ID, err)
 		}
-		time.Sleep(30 * time.Second) // Wait for the bcp to be fully applied, see more details in https://jira.mongodb.org/browse/CLOUDP-324378
+		time.Sleep(30 * time.Second) // Wait for the bcp to be fully applied, see more details in CLOUDP-324378.
 		return nil
 	}
 }

--- a/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
+++ b/internal/service/backupcompliancepolicy/resource_backup_compliance_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -198,6 +199,7 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		if err != nil || policy == nil {
 			return fmt.Errorf("backup compliance policy (%s) does not exist: %s", rs.Primary.ID, err)
 		}
+		time.Sleep(30 * time.Second) // Wait for the bcp to be fully applied, see more details in https://jira.mongodb.org/browse/CLOUDP-324378
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

Easy fix by adding a 30s to all checkExist. Avoids UPDATE/DELETE calls right after each other.
Can later investigate if any upstream changes have happened recently to pinpoint the problem.

Link to any related issue(s): CLOUDP-324378

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
