### PR TITLE
chore: Have enable-autogen generate all serviceapi resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 ifdef ACCTEST_PACKAGES
 		# remove newlines and blanks coming from GH Actions
     ACCTEST_PACKAGES := $(strip $(subst $(newline),, $(ACCTEST_PACKAGES)))
@@ -199,7 +198,10 @@ jira-release-version: ## Update Jira version in a release
 
 .PHONY: enable-autogen
 enable-autogen: ## Enable use of autogen resources in the provider
-	make add-lines filename=./internal/provider/provider.go find="project.Resource," add="customdbroleapi.Resource,databaseuserapi.Resource,pushbasedlogexportapi.Resource,searchdeploymentapi.Resource,projectapi.Resource,resourcepolicyapi.Resource,"
+	$(eval filename := ./internal/provider/provider.go)
+	$(eval resources := $(shell ls -d internal/serviceapi/*/ | xargs -n1 basename))
+	$(foreach resource,$(resources),make add-lines filename=${filename} find="project.Resource," add="$(resource).Resource,\n";)
+	goimports -w ${filename}
 
 .PHONY: delete-lines ${filename} ${delete}
 delete-lines:
@@ -211,16 +213,14 @@ delete-lines:
 .PHONY: add-lines ${filename} ${find} ${add}
 add-lines:
 	rm -f file.tmp
-	sed 's/${find}/${find}${add}/' "${filename}" > "file.tmp"
+	sed 's/${find}/${add}${find}/' "${filename}" > "file.tmp"
 	mv file.tmp ${filename}
-	goimports -w ${filename}
 
 .PHONY: change-lines ${filename} ${find} ${new}
 change-lines:
 	rm -f file.tmp
 	sed 's/${find}/${new}/' "${filename}" > "file.tmp"
 	mv file.tmp ${filename}
-	goimports -w ${filename}
 
 .PHONY: gen-purls
 gen-purls: # Generate purls on linux os


### PR DESCRIPTION
## Description

Have `enable-autogen` make goal generate all `serviceapi` resources, instead of having a hardcoded list. This is part of the spike: [WRITING-29828](https://jira.mongodb.org/browse/WRITING-29828).

Link to any related issue(s): CLOUDP-325279

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Example of changes in provider.go:
![provider](https://github.com/user-attachments/assets/864f0ee5-5ab4-4e0c-8750-fc9dbf1af848)
