### PR TITLE
chore: Fix PATCH in auto-generated resources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,7 @@ linters:
           - gocritic
         text: "^hugeParam: req is heavy"
       - path: schema\.go # exclude rules for schema files as it's auto-genereated from OpenAPI spec
-        text: fieldalignment|hugeParam|var-naming|ST1003|S1007|exceeds the maximum|too long|regexpSimplify|nolint
+        text: var-naming|exceeds the maximum|regexpSimplify
       - path: (.+)\.go$
         text: declaration of ".*" shadows declaration at line .*
 formatters:

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -21,6 +21,7 @@ const (
 // Attributes that are null or unknown are not marshaled.
 // Attributes with autogen tag `omitjson` are never marshaled, this only applies to the root model.
 // Attributes with autogen tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
+// Null list or set root elements are sent as empty arrays if isUpdate is true.
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
 	if valModel.Kind() != reflect.Ptr {
@@ -50,14 +51,14 @@ func marshalAttrs(valModel reflect.Value, isUpdate bool) (map[string]any, error)
 		}
 		attrNameModel := attrTypeModel.Name
 		attrValModel := valModel.Field(i)
-		if err := marshalAttr(attrNameModel, attrValModel, objJSON); err != nil {
+		if err := marshalAttr(attrNameModel, attrValModel, objJSON, isUpdate); err != nil {
 			return nil, err
 		}
 	}
 	return objJSON, nil
 }
 
-func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[string]any) error {
+func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[string]any, isUpdate bool) error {
 	attrNameJSON := xstrings.ToCamelCase(attrNameModel)
 	obj, ok := attrValModel.Interface().(attr.Value)
 	if !ok {
@@ -67,6 +68,15 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 	if err != nil {
 		return err
 	}
+
+	// What to send in update request body if the root field is null, nothing is sent by default
+	if val == nil && isUpdate {
+		switch obj.(type) {
+		case types.List, types.Set:
+			val = []any{} // Send an empty array if it's a list or set
+		}
+	}
+
 	if val != nil {
 		objJSON[attrNameJSON] = val
 	}

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	tagKey               = "autogen"
-	tagValOmitJSON       = "omitjson"
-	tagValOmitJSONUpdate = "omitjsonupdate"
+	tagKey                  = "autogen"
+	tagValOmitJSON          = "omitjson"
+	tagValOmitJSONUpdate    = "omitjsonupdate"
+	tagValIncludeJSONUpdate = "includejsonupdate"
 )
 
 // Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
@@ -21,6 +22,7 @@ const (
 // Attributes that are null or unknown are not marshaled.
 // Attributes with autogen tag `omitjson` are never marshaled, this only applies to the root model.
 // Attributes with autogen tag `omitjsonupdate` are not marshaled if isUpdate is true, this only applies to the root model.
+// Attributes with autogen tag `includejsonupdate` are marshaled if isUpdate is true (even if null), this only applies to the root model.
 // Null list or set root elements are sent as empty arrays if isUpdate is true.
 func Marshal(model any, isUpdate bool) ([]byte, error) {
 	valModel := reflect.ValueOf(model)
@@ -51,14 +53,14 @@ func marshalAttrs(valModel reflect.Value, isUpdate bool) (map[string]any, error)
 		}
 		attrNameModel := attrTypeModel.Name
 		attrValModel := valModel.Field(i)
-		if err := marshalAttr(attrNameModel, attrValModel, objJSON, isUpdate); err != nil {
+		if err := marshalAttr(attrNameModel, attrValModel, objJSON, isUpdate, tag == tagValIncludeJSONUpdate); err != nil {
 			return nil, err
 		}
 	}
 	return objJSON, nil
 }
 
-func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[string]any, isUpdate bool) error {
+func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[string]any, isUpdate, includeUpdate bool) error {
 	attrNameJSON := xstrings.ToCamelCase(attrNameModel)
 	obj, ok := attrValModel.Interface().(attr.Value)
 	if !ok {
@@ -69,15 +71,14 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 		return err
 	}
 
-	// What to send in update request body if the root field is null, nothing is sent by default
 	if val == nil && isUpdate {
 		switch obj.(type) {
 		case types.List, types.Set:
-			val = []any{} // Send an empty array if it's a list or set
+			val = []any{} // Send an empty array if it's a null root list or set
 		}
 	}
 
-	if val != nil {
+	if val != nil || (isUpdate && includeUpdate) {
 		objJSON[attrNameJSON] = val
 	}
 	return nil

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -240,6 +240,30 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 	assert.JSONEq(t, expectedUpdate, string(update))
 }
 
+func TestMarshalUpdateNull(t *testing.T) {
+	model := struct {
+		AttrList   types.List   `tfsdk:"attr_list"`
+		AttrSet    types.Set    `tfsdk:"attr_set"`
+		AttrString types.String `tfsdk:"attr_string"`
+		AttrObj    types.Object `tfsdk:"attr_obj"`
+	}{
+		AttrList:   types.ListNull(types.StringType),
+		AttrSet:    types.SetNull(types.StringType),
+		AttrString: types.StringNull(),
+		AttrObj:    types.ObjectNull(objTypeTest.AttrTypes),
+	}
+	// null list and set root elements are sent as empty arrays in update.
+	const expectedJSON = `
+		{
+			"attrList": [],
+			"attrSet": []
+		}
+	`
+	raw, err := autogen.Marshal(&model, true)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(raw))
+}
+
 func TestMarshalUnsupported(t *testing.T) {
 	testCases := map[string]any{
 		"Int32 not supported yet as it's not being used in any model": &struct {

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -242,26 +242,42 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 
 func TestMarshalUpdateNull(t *testing.T) {
 	model := struct {
-		AttrList   types.List   `tfsdk:"attr_list"`
-		AttrSet    types.Set    `tfsdk:"attr_set"`
-		AttrString types.String `tfsdk:"attr_string"`
-		AttrObj    types.Object `tfsdk:"attr_obj"`
+		AttrList          types.List   `tfsdk:"attr_list"`
+		AttrSet           types.Set    `tfsdk:"attr_set"`
+		AttrString        types.String `tfsdk:"attr_string"`
+		AttrObj           types.Object `tfsdk:"attr_obj"`
+		AttrIncludeString types.String `tfsdk:"attr_include_update" autogen:"includejsonupdate"`
+		AttrIncludeObj    types.Object `tfsdk:"attr_include_obj" autogen:"includejsonupdate"`
 	}{
-		AttrList:   types.ListNull(types.StringType),
-		AttrSet:    types.SetNull(types.StringType),
-		AttrString: types.StringNull(),
-		AttrObj:    types.ObjectNull(objTypeTest.AttrTypes),
+		AttrList:          types.ListNull(types.StringType),
+		AttrSet:           types.SetNull(types.StringType),
+		AttrString:        types.StringNull(),
+		AttrObj:           types.ObjectNull(objTypeTest.AttrTypes),
+		AttrIncludeString: types.StringNull(),
+		AttrIncludeObj:    types.ObjectNull(objTypeTest.AttrTypes),
 	}
 	// null list and set root elements are sent as empty arrays in update.
+	// fields with includejsonupdate tag are included even when null during updates.
 	const expectedJSON = `
 		{
 			"attrList": [],
-			"attrSet": []
+			"attrSet": [],
+			"attrIncludeString": null,
+			"attrIncludeObj": null
 		}
 	`
 	raw, err := autogen.Marshal(&model, true)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedJSON, string(raw))
+
+	// Test that includejsonupdate fields are NOT included when isUpdate is false
+	rawCreate, errCreate := autogen.Marshal(&model, false)
+	require.NoError(t, errCreate)
+	const expectedJSONCreate = `
+		{
+		}
+	`
+	assert.JSONEq(t, expectedJSONCreate, string(rawCreate))
 }
 
 func TestMarshalUnsupported(t *testing.T) {

--- a/internal/service/encryptionatrest/data_source_schema.go
+++ b/internal/service/encryptionatrest/data_source_schema.go
@@ -30,7 +30,7 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 					},
 					"region": schema.StringAttribute{
 						Computed:            true,
-						MarkdownDescription: "Physical location where MongoDB Atlas deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. When MongoDB Atlas deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Atlas creates them as part of the deployment. MongoDB Atlas assigns the VPC a CIDR block. To limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.", //nolint:lll // reason: auto-generated from Open API spec.
+						MarkdownDescription: "Physical location where MongoDB Atlas deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. When MongoDB Atlas deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Atlas creates them as part of the deployment. MongoDB Atlas assigns the VPC a CIDR block. To limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.",
 					},
 					"role_id": schema.StringAttribute{
 						Computed:            true,

--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -554,38 +554,38 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	AcceptDataRisksAndForceReplicaSetReconfig types.String `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
-	AdvancedConfiguration                     types.Object `tfsdk:"advanced_configuration"`
-	BackupEnabled                             types.Bool   `tfsdk:"backup_enabled"`
+	Labels                                    types.List   `tfsdk:"labels"`
+	Tags                                      types.List   `tfsdk:"tags"`
+	ReplicationSpecs                          types.List   `tfsdk:"replication_specs"`
+	Links                                     types.List   `tfsdk:"links" autogen:"omitjson"`
+	CreateDate                                types.String `tfsdk:"create_date" autogen:"omitjson"`
 	BiConnector                               types.Object `tfsdk:"bi_connector"`
-	ClusterType                               types.String `tfsdk:"cluster_type"`
-	ConfigServerManagementMode                types.String `tfsdk:"config_server_management_mode"`
 	ConfigServerType                          types.String `tfsdk:"config_server_type" autogen:"omitjson"`
 	ConnectionStrings                         types.Object `tfsdk:"connection_strings" autogen:"omitjson"`
-	CreateDate                                types.String `tfsdk:"create_date" autogen:"omitjson"`
+	AcceptDataRisksAndForceReplicaSetReconfig types.String `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
 	DiskWarmingMode                           types.String `tfsdk:"disk_warming_mode"`
 	EncryptionAtRestProvider                  types.String `tfsdk:"encryption_at_rest_provider"`
 	FeatureCompatibilityVersion               types.String `tfsdk:"feature_compatibility_version" autogen:"omitjson"`
 	FeatureCompatibilityVersionExpirationDate types.String `tfsdk:"feature_compatibility_version_expiration_date" autogen:"omitjson"`
-	GlobalClusterSelfManagedSharding          types.Bool   `tfsdk:"global_cluster_self_managed_sharding"`
+	VersionReleaseSystem                      types.String `tfsdk:"version_release_system"`
 	GroupId                                   types.String `tfsdk:"group_id" autogen:"omitjson"`
 	Id                                        types.String `tfsdk:"id" autogen:"omitjson"`
-	Labels                                    types.List   `tfsdk:"labels"`
-	Links                                     types.List   `tfsdk:"links" autogen:"omitjson"`
+	ClusterType                               types.String `tfsdk:"cluster_type"`
+	ConfigServerManagementMode                types.String `tfsdk:"config_server_management_mode"`
 	MongoDbemployeeAccessGrant                types.Object `tfsdk:"mongo_dbemployee_access_grant"`
 	MongoDbmajorVersion                       types.String `tfsdk:"mongo_dbmajor_version"`
 	MongoDbversion                            types.String `tfsdk:"mongo_dbversion" autogen:"omitjson"`
 	Name                                      types.String `tfsdk:"name"`
-	Paused                                    types.Bool   `tfsdk:"paused"`
-	PitEnabled                                types.Bool   `tfsdk:"pit_enabled"`
-	RedactClientLogData                       types.Bool   `tfsdk:"redact_client_log_data"`
-	ReplicaSetScalingStrategy                 types.String `tfsdk:"replica_set_scaling_strategy"`
-	ReplicationSpecs                          types.List   `tfsdk:"replication_specs"`
-	RootCertType                              types.String `tfsdk:"root_cert_type"`
+	AdvancedConfiguration                     types.Object `tfsdk:"advanced_configuration"`
 	StateName                                 types.String `tfsdk:"state_name" autogen:"omitjson"`
-	Tags                                      types.List   `tfsdk:"tags"`
+	RootCertType                              types.String `tfsdk:"root_cert_type"`
+	ReplicaSetScalingStrategy                 types.String `tfsdk:"replica_set_scaling_strategy"`
+	BackupEnabled                             types.Bool   `tfsdk:"backup_enabled"`
+	RedactClientLogData                       types.Bool   `tfsdk:"redact_client_log_data"`
+	PitEnabled                                types.Bool   `tfsdk:"pit_enabled"`
+	Paused                                    types.Bool   `tfsdk:"paused"`
 	TerminationProtectionEnabled              types.Bool   `tfsdk:"termination_protection_enabled"`
-	VersionReleaseSystem                      types.String `tfsdk:"version_release_system"`
+	GlobalClusterSelfManagedSharding          types.Bool   `tfsdk:"global_cluster_self_managed_sharding"`
 }
 type TFAdvancedConfigurationModel struct {
 	CustomOpensslCipherConfigTls12 types.List   `tfsdk:"custom_openssl_cipher_config_tls12"`
@@ -593,8 +593,8 @@ type TFAdvancedConfigurationModel struct {
 	TlsCipherConfigMode            types.String `tfsdk:"tls_cipher_config_mode"`
 }
 type TFBiConnectorModel struct {
-	Enabled        types.Bool   `tfsdk:"enabled"`
 	ReadPreference types.String `tfsdk:"read_preference"`
+	Enabled        types.Bool   `tfsdk:"enabled"`
 }
 type TFConnectionStringsModel struct {
 	AwsPrivateLink    types.Map    `tfsdk:"aws_private_link" autogen:"omitjson"`
@@ -646,19 +646,19 @@ type TFReplicationSpecsRegionConfigsModel struct {
 	AutoScaling          types.Object `tfsdk:"auto_scaling"`
 	BackingProviderName  types.String `tfsdk:"backing_provider_name"`
 	ElectableSpecs       types.Object `tfsdk:"electable_specs"`
-	Priority             types.Int64  `tfsdk:"priority"`
 	ProviderName         types.String `tfsdk:"provider_name"`
 	ReadOnlySpecs        types.Object `tfsdk:"read_only_specs"`
 	RegionName           types.String `tfsdk:"region_name"`
+	Priority             types.Int64  `tfsdk:"priority"`
 }
 type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel struct {
 	Compute types.Object `tfsdk:"compute"`
 	DiskGb  types.Object `tfsdk:"disk_gb"`
 }
 type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel struct {
-	Enabled           types.Bool   `tfsdk:"enabled"`
 	MaxInstanceSize   types.String `tfsdk:"max_instance_size" autogen:"omitjson"`
 	MinInstanceSize   types.String `tfsdk:"min_instance_size" autogen:"omitjson"`
+	Enabled           types.Bool   `tfsdk:"enabled"`
 	PredictiveEnabled types.Bool   `tfsdk:"predictive_enabled"`
 	ScaleDownEnabled  types.Bool   `tfsdk:"scale_down_enabled"`
 }
@@ -666,10 +666,10 @@ type TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGbModel struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 }
 type TFReplicationSpecsRegionConfigsAnalyticsSpecsModel struct {
-	DiskIops      types.Int64   `tfsdk:"disk_iops"`
 	DiskSizeGb    types.Float64 `tfsdk:"disk_size_gb"`
 	EbsVolumeType types.String  `tfsdk:"ebs_volume_type"`
 	InstanceSize  types.String  `tfsdk:"instance_size"`
+	DiskIops      types.Int64   `tfsdk:"disk_iops"`
 	NodeCount     types.Int64   `tfsdk:"node_count"`
 }
 type TFReplicationSpecsRegionConfigsAutoScalingModel struct {
@@ -677,9 +677,9 @@ type TFReplicationSpecsRegionConfigsAutoScalingModel struct {
 	DiskGb  types.Object `tfsdk:"disk_gb"`
 }
 type TFReplicationSpecsRegionConfigsAutoScalingComputeModel struct {
-	Enabled           types.Bool   `tfsdk:"enabled"`
 	MaxInstanceSize   types.String `tfsdk:"max_instance_size" autogen:"omitjson"`
 	MinInstanceSize   types.String `tfsdk:"min_instance_size" autogen:"omitjson"`
+	Enabled           types.Bool   `tfsdk:"enabled"`
 	PredictiveEnabled types.Bool   `tfsdk:"predictive_enabled"`
 	ScaleDownEnabled  types.Bool   `tfsdk:"scale_down_enabled"`
 }
@@ -687,18 +687,18 @@ type TFReplicationSpecsRegionConfigsAutoScalingDiskGbModel struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 }
 type TFReplicationSpecsRegionConfigsElectableSpecsModel struct {
-	DiskIops              types.Int64   `tfsdk:"disk_iops"`
 	DiskSizeGb            types.Float64 `tfsdk:"disk_size_gb"`
 	EbsVolumeType         types.String  `tfsdk:"ebs_volume_type"`
 	EffectiveInstanceSize types.String  `tfsdk:"effective_instance_size" autogen:"omitjson"`
 	InstanceSize          types.String  `tfsdk:"instance_size"`
+	DiskIops              types.Int64   `tfsdk:"disk_iops"`
 	NodeCount             types.Int64   `tfsdk:"node_count"`
 }
 type TFReplicationSpecsRegionConfigsReadOnlySpecsModel struct {
-	DiskIops      types.Int64   `tfsdk:"disk_iops"`
 	DiskSizeGb    types.Float64 `tfsdk:"disk_size_gb"`
 	EbsVolumeType types.String  `tfsdk:"ebs_volume_type"`
 	InstanceSize  types.String  `tfsdk:"instance_size"`
+	DiskIops      types.Int64   `tfsdk:"disk_iops"`
 	NodeCount     types.Int64   `tfsdk:"node_count"`
 }
 type TFTagsModel struct {

--- a/internal/serviceapi/clusterapi/resource_test.go
+++ b/internal/serviceapi/clusterapi/resource_test.go
@@ -24,11 +24,15 @@ func TestAccClusterAPI_basic(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configBasic(groupID, clusterName, "M10"),
+				Config: configBasic(groupID, clusterName, "M10", false),
 				Check:  checkBasic(groupID, clusterName, "M10"),
 			},
 			{
-				Config: configBasic(groupID, clusterName, "M30"),
+				Config: configBasic(groupID, clusterName, "M30", true),
+				Check:  checkBasic(groupID, clusterName, "M30"),
+			},
+			{
+				Config: configBasic(groupID, clusterName, "M30", false),
 				Check:  checkBasic(groupID, clusterName, "M30"),
 			},
 			{
@@ -48,7 +52,29 @@ func TestAccClusterAPI_basic(t *testing.T) {
 	})
 }
 
-func configBasic(groupID, clusterName, instanceSize string) string {
+func configBasic(groupID, clusterName, instanceSize string, withTagsAndLabels bool) string {
+	tagsAndLabels := ""
+	if withTagsAndLabels {
+		tagsAndLabels = `
+			tags = [
+				{
+					key   = "tagKey"
+					value = "tagValue"
+				},
+				{
+					key   = "tagKey2"
+					value = "tagValue2"
+				},
+			]
+			labels = [
+				{
+					key   = "labelKey"
+					value = "labelValue"
+				},
+			]
+		`
+	}
+
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cluster_api" "test" {
 			group_id     = %[1]q
@@ -65,8 +91,9 @@ func configBasic(groupID, clusterName, instanceSize string) string {
 					}
 				}]
 			}]
+			%[4]s
 		}
-	`, groupID, clusterName, instanceSize)
+	`, groupID, clusterName, instanceSize, tagsAndLabels)
 }
 
 func checkBasic(groupID, clusterName, instanceSize string) resource.TestCheckFunc {

--- a/internal/serviceapi/customdbroleapi/resource_schema.go
+++ b/internal/serviceapi/customdbroleapi/resource_schema.go
@@ -83,9 +83,9 @@ type TFActionsModel struct {
 	Resources types.List   `tfsdk:"resources"`
 }
 type TFActionsResourcesModel struct {
-	Cluster    types.Bool   `tfsdk:"cluster"`
 	Collection types.String `tfsdk:"collection"`
 	Db         types.String `tfsdk:"db"`
+	Cluster    types.Bool   `tfsdk:"cluster"`
 }
 type TFInheritedRolesModel struct {
 	Db   types.String `tfsdk:"db"`

--- a/internal/serviceapi/databaseuserapi/resource_schema.go
+++ b/internal/serviceapi/databaseuserapi/resource_schema.go
@@ -134,7 +134,7 @@ type TFModel struct {
 	AwsIamtype      types.String `tfsdk:"aws_iamtype"`
 	DatabaseName    types.String `tfsdk:"database_name"`
 	DeleteAfterDate types.String `tfsdk:"delete_after_date"`
-	Description     types.String `tfsdk:"description"`
+	Description     types.String `tfsdk:"description" autogen:"includejsonupdate"`
 	GroupId         types.String `tfsdk:"group_id"`
 	Labels          types.List   `tfsdk:"labels"`
 	LdapAuthType    types.String `tfsdk:"ldap_auth_type"`

--- a/internal/serviceapi/projectapi/resource_schema.go
+++ b/internal/serviceapi/projectapi/resource_schema.go
@@ -79,14 +79,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	ClusterCount              types.Int64  `tfsdk:"cluster_count" autogen:"omitjson"`
+	Links                     types.List   `tfsdk:"links" autogen:"omitjson"`
+	Tags                      types.List   `tfsdk:"tags"`
 	Created                   types.String `tfsdk:"created" autogen:"omitjson"`
 	Id                        types.String `tfsdk:"id" autogen:"omitjson"`
-	Links                     types.List   `tfsdk:"links" autogen:"omitjson"`
 	Name                      types.String `tfsdk:"name"`
 	OrgId                     types.String `tfsdk:"org_id" autogen:"omitjsonupdate"`
 	RegionUsageRestrictions   types.String `tfsdk:"region_usage_restrictions" autogen:"omitjsonupdate"`
-	Tags                      types.List   `tfsdk:"tags"`
+	ClusterCount              types.Int64  `tfsdk:"cluster_count" autogen:"omitjson"`
 	WithDefaultAlertsSettings types.Bool   `tfsdk:"with_default_alerts_settings" autogen:"omitjsonupdate"`
 }
 type TFLinksModel struct {

--- a/internal/serviceapi/projectapi/resource_test.go
+++ b/internal/serviceapi/projectapi/resource_test.go
@@ -32,11 +32,10 @@ func TestAccProjectAPI_basic(t *testing.T) {
 				Config: configBasic(orgID, projectName, true),
 				Check:  checkBasic(),
 			},
-			// TODO: complete removal does not send property in PATCH
-			// {
-			// 	Config: configBasic(orgID, projectName, false),
-			// 	Check:  checkBasic(),
-			// },
+			{
+				Config: configBasic(orgID, projectName, false),
+				Check:  checkBasic(),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportStateIdFunc: importStateIDFunc(resourceName),

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -381,6 +381,13 @@ func TestConvertToProviderSpec_nested_schemaOverrides(t *testing.T) {
 							Description:              conversion.StringPtr("Optional string that has config override to optional/computed"),
 						},
 						{
+							Name:                     "attr_always_in_updates",
+							ComputedOptionalRequired: codespec.Computed,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Always in updates"),
+							ReqBodyUsage:             codespec.IncludeInUpdateBody,
+						},
+						{
 							Name:                     "outer_object",
 							ComputedOptionalRequired: codespec.Computed,
 							ReqBodyUsage:             codespec.OmitAlways,

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -131,6 +131,12 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 					Description: conversion.StringPtr(testResourceDesc),
 					Attributes: codespec.Attributes{
 						{
+							Name:                     "attr_always_in_updates",
+							ComputedOptionalRequired: codespec.Optional,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Always in updates"),
+						},
+						{
 							Name:                     "cluster_name",
 							ComputedOptionalRequired: codespec.Required,
 							String:                   &codespec.StringAttribute{},
@@ -323,8 +329,7 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 					},
 					VersionHeader: "application/vnd.atlas.2024-05-30+json",
 				},
-			},
-			},
+			}},
 		},
 	}
 	runTestCase(t, tc)
@@ -341,6 +346,13 @@ func TestConvertToProviderSpec_nested_schemaOverrides(t *testing.T) {
 				Schema: &codespec.Schema{
 					Description: conversion.StringPtr(testResourceDesc),
 					Attributes: codespec.Attributes{
+						{
+							Name:                     "attr_always_in_updates",
+							ComputedOptionalRequired: codespec.Optional,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr("Always in updates"),
+							ReqBodyUsage:             codespec.IncludeInUpdateBody,
+						},
 						{
 							Name:                     "project_id",
 							ComputedOptionalRequired: codespec.Required,
@@ -379,13 +391,6 @@ func TestConvertToProviderSpec_nested_schemaOverrides(t *testing.T) {
 							ComputedOptionalRequired: codespec.ComputedOptional,
 							String:                   &codespec.StringAttribute{},
 							Description:              conversion.StringPtr("Optional string that has config override to optional/computed"),
-						},
-						{
-							Name:                     "attr_always_in_updates",
-							ComputedOptionalRequired: codespec.Computed,
-							String:                   &codespec.StringAttribute{},
-							Description:              conversion.StringPtr("Always in updates"),
-							ReqBodyUsage:             codespec.IncludeInUpdateBody,
 						},
 						{
 							Name:                     "outer_object",

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -103,6 +103,9 @@ func applyOverrides(attr *Attribute, attrPathName string, schemaOptions config.S
 		if override.Sensitive != nil {
 			attr.Sensitive = *override.Sensitive
 		}
+		if override.IncludeJSONUpdate != nil && *override.IncludeJSONUpdate {
+			attr.ReqBodyUsage = IncludeInUpdateBody
+		}
 	}
 }
 

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -84,7 +84,8 @@ type AttributeReqBodyUsage int
 const (
 	AllRequestBodies = iota // by default attribute is sent in request bodies
 	OmitInUpdateBody
-	OmitAlways // this covers computed-only attributes and attributes which are only used for path/query params
+	IncludeInUpdateBody // attributes that always must be sent in update request body even if null
+	OmitAlways          // this covers computed-only attributes and attributes which are only used for path/query params
 )
 
 type BoolAttribute struct {

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -474,6 +474,9 @@ components:
         optional_string_attr:
           type: string
           description: Optional string
+        attrAlwaysInUpdates:
+          type: string
+          description: Always in updates
     SingleNestedAttrWithNestedMaps:
       type: object
       description: Test field description
@@ -534,6 +537,9 @@ components:
         optional_string_attr:
           type: string
           description: Optional string
+        attrAlwaysInUpdates:
+          type: string
+          description: Always in updates
       required:
         - nestedListArrayAttr
     SimpleStringRefObject:

--- a/tools/codegen/codespec/testdata/config-nested-schema-overrides.yml
+++ b/tools/codegen/codespec/testdata/config-nested-schema-overrides.yml
@@ -31,4 +31,6 @@ resources:
             optional: true
             computed: true
           description: "Optional string that has config override to optional/computed"
+        attr_always_in_updates:
+          include_json_update: true
       timeouts: ["create", "read", "update", "delete"]

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -12,7 +12,7 @@ resources:
     delete:
       path: /api/atlas/v2/groups/{groupId}/testResource
       method: DELETE
-  
+
   test_resource_with_nested_attr:
     read:
       path: /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/nestedTestResource

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -32,6 +32,8 @@ resources:
       overrides:
         password:
           sensitive: true
+        description:
+          include_json_update: true
 
   push_based_log_export_api:
     read:

--- a/tools/codegen/config/config_model.go
+++ b/tools/codegen/config/config_model.go
@@ -36,11 +36,12 @@ type SchemaOptions struct {
 }
 
 type Override struct {
-	Computability *Computability `yaml:"computability,omitempty"`
-	Sensitive     *bool          `yaml:"sensitive"`
-	Description   string         `yaml:"description"`
-	PlanModifiers []PlanModifier `yaml:"plan_modifiers"`
-	Validators    []Validator    `yaml:"validators"`
+	Computability     *Computability `yaml:"computability,omitempty"`
+	Sensitive         *bool          `yaml:"sensitive"`
+	IncludeJSONUpdate *bool          `yaml:"include_json_update"`
+	Description       string         `yaml:"description"`
+	PlanModifiers     []PlanModifier `yaml:"plan_modifiers"`
+	Validators        []Validator    `yaml:"validators"`
 }
 
 type PlanModifier struct {

--- a/tools/codegen/gofilegen/schema/typed_model.go
+++ b/tools/codegen/gofilegen/schema/typed_model.go
@@ -91,6 +91,8 @@ func typedModelProperty(attr *codespec.Attribute) string {
 		autogenTag = ` autogen:"omitjson"`
 	case codespec.OmitInUpdateBody:
 		autogenTag = ` autogen:"omitjsonupdate"`
+	case codespec.IncludeInUpdateBody:
+		autogenTag = ` autogen:"includejsonupdate"`
 	}
 	return fmt.Sprintf("%s %s", namePascalCase, propType) + " `" + fmt.Sprintf("tfsdk:%q", attr.Name.SnakeCase()) + autogenTag + "`"
 }


### PR DESCRIPTION
## Description

Fix PATCH in auto-generated resources. This is part of the spike: WRITING-29828.

- Lists and sets are always sent in PATCH requests, empty array is sent if they are null.
- Add support for tag `includejsonupdate` for attributes that always must go in PATH requests, e.g. `description` in `database_user_api`. Will be further explained in the spike.
- Call `fieldalignment` for the generated schema files so they follow Go linter rules.

Link to any related issue(s): CLOUDP-326339

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
