### PR TITLE
feat: Adds support for cluster_project_id field for stream_connection

### DIFF
--- a/.changelog/3424.txt
+++ b/.changelog/3424.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
+data-source/mongodbatlas_stream_connection Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_connection Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
 ```

--- a/.changelog/3424.txt
+++ b/.changelog/3424.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
+```

--- a/.changelog/3424.txt
+++ b/.changelog/3424.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-data-source/mongodbatlas_stream_connection Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
+data-source/mongodbatlas_stream_connection Adds `cluster_project_id` to allow connections to clusters in other projects within an organization
 ```
 
 ```release-note:enhancement
-resource/mongodbatlas_stream_connection Adds `cluster_project_id` field for stream_connection to allow connections to clusters in other projects within an organization
+resource/mongodbatlas_stream_connection Adds `cluster_project_id` to allow connections to clusters in other projects within an organization
 ```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -25,7 +25,7 @@ data "mongodbatlas_stream_connection" "example" {
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only defined if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
+* `cluster_project_id` - Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams instance. You must first enable the organization setting.
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -25,7 +25,7 @@ data "mongodbatlas_stream_connection" "example" {
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only defined if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -25,7 +25,7 @@ data "mongodbatlas_stream_connection" "example" {
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance.
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -25,6 +25,7 @@ data "mongodbatlas_stream_connection" "example" {
 If `type` is of value `Cluster` the following additional attributes are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance.
 
 If `type` is of value `Kafka` the following additional attributes are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -107,6 +107,7 @@ resource "mongodbatlas_stream_connection" "example-https" {
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance.
 
 If `type` is of value `Kafka` the following additional arguments are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -120,7 +120,7 @@ resource "mongodbatlas_stream_connection" "example-https" {
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only defined if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
+* `cluster_project_id` - Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams instance. You must first enable the organization setting.
 
 If `type` is of value `Kafka` the following additional arguments are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -107,7 +107,7 @@ resource "mongodbatlas_stream_connection" "example-https" {
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance.
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
 
 If `type` is of value `Kafka` the following additional arguments are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -19,6 +19,19 @@ resource "mongodbatlas_stream_connection" "test" {
 }
 ```
 
+### Example Cross Project Cluster Connection
+
+```terraform
+resource "mongodbatlas_stream_connection" "test" {
+    project_id         = var.project_id
+    instance_name      = "InstanceName"
+    connection_name    = "ConnectionName"
+    type               = "Cluster"
+    cluster_name       = "OtherCluster"
+    cluster_project_id = var.other_project_id
+}
+```
+
 ### Example Kafka SASL Plaintext Connection
 
 ```terraform
@@ -107,7 +120,7 @@ resource "mongodbatlas_stream_connection" "example-https" {
 If `type` is of value `Cluster` the following additional arguments are defined:
 * `cluster_name` - Name of the cluster configured for this connection.
 * `db_role_to_execute` - The name of a Built in or Custom DB Role to connect to an Atlas Cluster. See [DBRoleToExecute](#DBRoleToExecute).
-* `cluster_project_id` - The id of the project that contains the configured cluster. Only populated if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
+* `cluster_project_id` - The id of the project that contains the configured cluster. Only defined if the id does not match the project containing the streams instance. Requires the organization setting to be enabled first.
 
 If `type` is of value `Kafka` the following additional arguments are defined:
 * `authentication` - User credentials required to connect to a Kafka cluster. Includes the authentication type, as well as the parameters for that authentication mode. See [authentication](#authentication).

--- a/examples/mongodbatlas_stream_account_details/versions.tf
+++ b/examples/mongodbatlas_stream_account_details/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.35"
+      version = "~> 1.36"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_connection/README.md
+++ b/examples/mongodbatlas_stream_connection/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to create Atlas Stream Connections in Terraform. It also creates a stream instance, which is a prerequisite. Both Kafka and Cluster connections types are defined to showcase their usage.
 
-You must set the following variables:
+You must set the following variables depending on connection type:
 
 - `public_key`: Atlas public key
 - `private_key`: Atlas  private key
@@ -11,5 +11,6 @@ You must set the following variables:
 - `kafka_password`: Password used for connecting to your external Kafka Cluster.
 - `kafka_ssl_cert`: String value of public x509 certificate for connecting to Kafka over SSL.
 - `cluster_name`: Name of Cluster that will be used for creating a connection.
+- `cluster_project_id`: The project of the Cluster that will be used for creating a connection. Required if the project is different from the project of the stream instance.
 
 To learn more, see the [Stream Instance Connection Registry Documentation](https://www.mongodb.com/docs/atlas/atlas-sp/manage-processing-instance/#view-connections-in-the-connection-registry).

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -19,6 +19,19 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
   }
 }
 
+resource "mongodbatlas_stream_connection" "example-cross-project-cluster" {
+  project_id          = var.project_id
+  instance_name       = mongodbatlas_stream_instance.example.instance_name
+  connection_name     = "ClusterCrossProjectConnection"
+  type                = "Cluster"
+  cluster_name        = var.other_cluster
+  cluster_project_id  = var.other_project_id
+  db_role_to_execute  = {
+    role = "atlasAdmin"
+    type = "BUILT_IN"
+  }
+}
+
 resource "mongodbatlas_stream_connection" "example-kafka-plaintext" {
   project_id      = var.project_id
   instance_name   = mongodbatlas_stream_instance.example.instance_name

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -20,13 +20,13 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
 }
 
 resource "mongodbatlas_stream_connection" "example-cross-project-cluster" {
-  project_id          = var.project_id
-  instance_name       = mongodbatlas_stream_instance.example.instance_name
-  connection_name     = "ClusterCrossProjectConnection"
-  type                = "Cluster"
-  cluster_name        = var.other_cluster
-  cluster_project_id  = var.other_project_id
-  db_role_to_execute  = {
+  project_id         = var.project_id
+  instance_name      = mongodbatlas_stream_instance.example.instance_name
+  connection_name    = "ClusterCrossProjectConnection"
+  type               = "Cluster"
+  cluster_name       = var.other_cluster
+  cluster_project_id = var.other_project_id
+  db_role_to_execute = {
     role = "atlasAdmin"
     type = "BUILT_IN"
   }

--- a/examples/mongodbatlas_stream_connection/variables.tf
+++ b/examples/mongodbatlas_stream_connection/variables.tf
@@ -30,3 +30,13 @@ variable "cluster_name" {
   description = "Name of an existing cluster in your project that will be used to create a stream connection"
   type        = string
 }
+
+variable "other_project_id" {
+  description = "Unique 24-hexadecimal digit string that identifies another project with a cluster that can be connected"
+  type        = string
+}
+
+variable "other_cluster" {
+  description = "Name of an existing cluster in another project within an organization that will be used to create a stream connection"
+  type        = string
+}

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -125,6 +125,7 @@ func NewTFStreamConnection(ctx context.Context, projID, instanceName string, cur
 		ConnectionName:   types.StringPointerValue(apiResp.Name),
 		Type:             types.StringPointerValue(apiResp.Type),
 		ClusterName:      types.StringPointerValue(apiResp.ClusterName),
+		ClusterProjectID: types.StringPointerValue(apiResp.ClusterGroupId),
 		BootstrapServers: types.StringPointerValue(apiResp.BootstrapServers),
 		URL:              types.StringPointerValue(apiResp.Url),
 	}

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -17,6 +17,7 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 		Name:             plan.ConnectionName.ValueStringPointer(),
 		Type:             plan.Type.ValueStringPointer(),
 		ClusterName:      plan.ClusterName.ValueStringPointer(),
+		ClusterGroupId:   plan.ClusterProjectID.ValueStringPointer(),
 		BootstrapServers: plan.BootstrapServers.ValueStringPointer(),
 		Url:              plan.URL.ValueStringPointer(),
 	}

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -82,6 +82,37 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 			},
 		},
 		{
+			name: "Cluster cross project connection type SDK response",
+			SDKResp: &admin.StreamsConnection{
+				Name:           admin.PtrString(connectionName),
+				Type:           admin.PtrString("Cluster"),
+				ClusterName:    admin.PtrString(clusterName),
+				ClusterGroupId: admin.PtrString("foo"),
+				DbRoleToExecute: &admin.DBRoleToExecute{
+					Role: admin.PtrString(dbRole),
+					Type: admin.PtrString(dbRoleType),
+				},
+			},
+			providedProjID:       dummyProjectID,
+			providedInstanceName: instanceName,
+			providedAuthConfig:   nil,
+			expectedTFModel: &streamconnection.TFStreamConnectionModel{
+				ProjectID:        types.StringValue(dummyProjectID),
+				InstanceName:     types.StringValue(instanceName),
+				ConnectionName:   types.StringValue(connectionName),
+				Type:             types.StringValue("Cluster"),
+				ClusterName:      types.StringValue(clusterName),
+				ClusterProjectID: types.StringValue("foo"),
+				Authentication:   types.ObjectNull(streamconnection.ConnectionAuthenticationObjectType.AttrTypes),
+				Config:           types.MapNull(types.StringType),
+				Security:         types.ObjectNull(streamconnection.ConnectionSecurityObjectType.AttrTypes),
+				DBRoleToExecute:  tfDBRoleToExecuteObject(t, dbRole, dbRoleType),
+				Networking:       types.ObjectNull(streamconnection.NetworkingObjectType.AttrTypes),
+				AWS:              types.ObjectNull(streamconnection.AWSObjectType.AttrTypes),
+				Headers:          types.MapNull(types.StringType),
+			},
+		},
+		{
 			name: "Kafka connection type SDK response",
 			SDKResp: &admin.StreamsConnection{
 				Name: admin.PtrString(connectionName),

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -50,6 +50,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"cluster_name": schema.StringAttribute{
 				Optional: true,
 			},
+			"cluster_group_id": schema.StringAttribute{
+				Optional: true,
+			},
 			"db_role_to_execute": schema.SingleNestedAttribute{
 				Optional: true,
 				Attributes: map[string]schema.Attribute{

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -50,7 +50,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"cluster_name": schema.StringAttribute{
 				Optional: true,
 			},
-			"cluster_group_id": schema.StringAttribute{
+			"cluster_project_id": schema.StringAttribute{
 				Optional: true,
 			},
 			"db_role_to_execute": schema.SingleNestedAttribute{

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -40,6 +40,7 @@ type TFStreamConnectionModel struct {
 	ConnectionName   types.String `tfsdk:"connection_name"`
 	Type             types.String `tfsdk:"type"`
 	ClusterName      types.String `tfsdk:"cluster_name"`
+	ClusterProjectID types.String `tfsdk:"cluster_project_id"`
 	Authentication   types.Object `tfsdk:"authentication"`
 	BootstrapServers types.String `tfsdk:"bootstrap_servers"`
 	Config           types.Map    `tfsdk:"config"`


### PR DESCRIPTION
## Description

[CLOUDP-317399](https://jira.mongodb.org/browse/CLOUDP-317399)

Adds support for a new `cluster_project_id` in the stream_connection data source and resource. This field will allow users to create Cluster-Type Atlas Streams Connections that reference clusters in other projects within the same organization

Note: Since this field is just passed through to the downstream apis, there isn't an e2e test for this field as it would require setting up multiple projects, an api key with org owner permission, enabling a feature flag, and a private api call to enable an org setting. This is manually tested and the existing tests ensure that the field is not inappropriately populated.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
