### PR TITLE
feat: add a data source for current IP

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/myip"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -22,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/myip"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/myip"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -429,6 +430,7 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 		alertconfiguration.DataSource,
 		alertconfiguration.PluralDataSource,
 		projectipaccesslist.DataSource,
+		myip.DataSource,
 		atlasuser.DataSource,
 		atlasuser.PluralDataSource,
 		searchdeployment.DataSource,

--- a/internal/service/myip/data_source_my_ip.go
+++ b/internal/service/myip/data_source_my_ip.go
@@ -1,0 +1,68 @@
+package myip
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+const (
+	myIP = "my_ip"
+)
+
+type ds struct {
+	config.DSCommon
+}
+
+func DataSource() datasource.DataSource {
+	return &ds{
+		DSCommon: config.DSCommon{
+			DataSourceName: myIP,
+		},
+	}
+}
+
+var _ datasource.DataSource = &ds{}
+var _ datasource.DataSourceWithConfigure = &ds{}
+
+type Model struct {
+	IPAddress types.String `tfsdk:"ip_address"`
+}
+
+func (d *ds) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "My IP",
+		Attributes: map[string]schema.Attribute{
+			"ip_address": schema.StringAttribute{
+				MarkdownDescription: "The IP.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var databaseDSUserConfig *Model
+	var err error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &databaseDSUserConfig)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	info, _, err := d.Client.Atlas.IPInfo.Get(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("error getting access list entry", err.Error())
+		return
+	}
+
+	accessListEntry := &Model{
+		IPAddress: types.StringValue(info.CurrentIPv4Address),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &accessListEntry)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}


### PR DESCRIPTION
## Description

Going to leave this here for discussion. Feel free to close or improve on it

This change adds a data source to get my current IP (as seen by atlas)

This was handy for me while doing some demos and since the code is done I wanted to share it a let the team discuss if worth adding or not 


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
