### PR TITLE
chore: Notify to Docs team only if PR is to master

### DIFF
--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   check:
-    if: github.event.pull_request.draft == false
+    # Docs team review only for PRs to master branch
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master' }}
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.changes.outputs.files }}


### PR DESCRIPTION
## Description

Notify to Docs team only if PR is to master.

In this way they don't have to review the same content twice, e.g. when merging master content to `CLOUDP-320243-dev-2.0.0 branch`.

Note that you can always ask manually Docs team to review your changes if you need some specific PR review in a development branch.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
