### PR TITLE
chore: Use SP10 instead of default SP30 for stream_instance acceptance tests

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -427,6 +427,9 @@ func configureCluster(projectID, instanceName, clusterName string) string {
 				region = "VIRGINIA_USA"
 				cloud_provider = "AWS"
 			}
+			stream_config = {
+				tier = "SP10"
+			}
 		}
 		
 		resource "mongodbatlas_stream_connection" "test" {
@@ -451,6 +454,9 @@ func configureHTTPS(projectID, instanceName, url, headers string) string {
 			data_process_region = {
 				region = "VIRGINIA_USA"
 				cloud_provider = "AWS"
+			}
+			stream_config = {
+				tier = "SP10"
 			}
 		}
 			

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -456,6 +456,9 @@ func configToUpdateStreamProcessor(projectID, instanceName, processorName, state
 				region         = "VIRGINIA_USA"
 				cloud_provider = "AWS"
 			}
+			stream_config = {
+				tier = "SP10"
+			}
 		}
 
 		resource "mongodbatlas_stream_connection" "sample" {
@@ -574,6 +577,9 @@ func config(t *testing.T, projectID, instanceName, processorName, state string, 
 			data_process_region = {
 				region         = "VIRGINIA_USA"
 				cloud_provider = "AWS"
+			}
+			stream_config = {
+				tier = "SP10"
 			}
 		}
 

--- a/internal/testutil/unit/http_mocker_round_tripper.go
+++ b/internal/testutil/unit/http_mocker_round_tripper.go
@@ -131,7 +131,6 @@ func (r *MockRoundTripper) nextDiffResponseIndex() {
 	step := r.currentStep()
 	if step == nil {
 		r.t.Fatal("no more steps, in testCase")
-		return
 	}
 	for index, req := range step.DiffRequests {
 		if _, ok := r.foundsDiffs[index]; !ok {

--- a/internal/testutil/unit/http_mocker_round_tripper.go
+++ b/internal/testutil/unit/http_mocker_round_tripper.go
@@ -131,6 +131,7 @@ func (r *MockRoundTripper) nextDiffResponseIndex() {
 	step := r.currentStep()
 	if step == nil {
 		r.t.Fatal("no more steps, in testCase")
+		return
 	}
 	for index, req := range step.DiffRequests {
 		if _, ok := r.foundsDiffs[index]; !ok {


### PR DESCRIPTION
## Description

Use SP10 instead of default SP30 for stream_instance acceptance tests to reduce resource usage.

Link to any related issue(s): CLOUDP-328093

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
