### PR TITLE
chore: Remove `links` attributes in auto-generated resources

### DIFF
--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -201,22 +201,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
-			"links": schema.ListNestedAttribute{
-				Computed:            true,
-				MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"href": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-						"rel": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-					},
-				},
-			},
 			"mongo_dbemployee_access_grant": schema.SingleNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "MongoDB employee granted access level and expiration for a cluster.",
@@ -228,22 +212,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"grant_type": schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "Level of access to grant to MongoDB Employees.",
-					},
-					"links": schema.ListNestedAttribute{
-						Computed:            true,
-						MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"href": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-								"rel": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-							},
-						},
 					},
 				},
 			},
@@ -557,21 +525,20 @@ type TFModel struct {
 	Labels                                    types.List   `tfsdk:"labels"`
 	Tags                                      types.List   `tfsdk:"tags"`
 	ReplicationSpecs                          types.List   `tfsdk:"replication_specs"`
-	Links                                     types.List   `tfsdk:"links" autogen:"omitjson"`
-	CreateDate                                types.String `tfsdk:"create_date" autogen:"omitjson"`
+	GroupId                                   types.String `tfsdk:"group_id" autogen:"omitjson"`
 	BiConnector                               types.Object `tfsdk:"bi_connector"`
+	ConfigServerManagementMode                types.String `tfsdk:"config_server_management_mode"`
 	ConfigServerType                          types.String `tfsdk:"config_server_type" autogen:"omitjson"`
 	ConnectionStrings                         types.Object `tfsdk:"connection_strings" autogen:"omitjson"`
-	AcceptDataRisksAndForceReplicaSetReconfig types.String `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
+	CreateDate                                types.String `tfsdk:"create_date" autogen:"omitjson"`
 	DiskWarmingMode                           types.String `tfsdk:"disk_warming_mode"`
 	EncryptionAtRestProvider                  types.String `tfsdk:"encryption_at_rest_provider"`
 	FeatureCompatibilityVersion               types.String `tfsdk:"feature_compatibility_version" autogen:"omitjson"`
 	FeatureCompatibilityVersionExpirationDate types.String `tfsdk:"feature_compatibility_version_expiration_date" autogen:"omitjson"`
 	VersionReleaseSystem                      types.String `tfsdk:"version_release_system"`
-	GroupId                                   types.String `tfsdk:"group_id" autogen:"omitjson"`
+	AcceptDataRisksAndForceReplicaSetReconfig types.String `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
 	Id                                        types.String `tfsdk:"id" autogen:"omitjson"`
 	ClusterType                               types.String `tfsdk:"cluster_type"`
-	ConfigServerManagementMode                types.String `tfsdk:"config_server_management_mode"`
 	MongoDbemployeeAccessGrant                types.Object `tfsdk:"mongo_dbemployee_access_grant"`
 	MongoDbmajorVersion                       types.String `tfsdk:"mongo_dbmajor_version"`
 	MongoDbversion                            types.String `tfsdk:"mongo_dbversion" autogen:"omitjson"`
@@ -621,18 +588,9 @@ type TFLabelsModel struct {
 	Key   types.String `tfsdk:"key"`
 	Value types.String `tfsdk:"value"`
 }
-type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFMongoDbemployeeAccessGrantModel struct {
 	ExpirationTime types.String `tfsdk:"expiration_time"`
 	GrantType      types.String `tfsdk:"grant_type"`
-	Links          types.List   `tfsdk:"links" autogen:"omitjson"`
-}
-type TFMongoDbemployeeAccessGrantLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFReplicationSpecsModel struct {
 	Id            types.String `tfsdk:"id" autogen:"omitjson"`

--- a/internal/serviceapi/databaseuserapi/resource_schema.go
+++ b/internal/serviceapi/databaseuserapi/resource_schema.go
@@ -55,22 +55,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Part of the Lightweight Directory Access Protocol (LDAP) record that the database uses to authenticate this database user on the LDAP host.",
 			},
-			"links": schema.ListNestedAttribute{
-				Computed:            true,
-				MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"href": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-						"rel": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-					},
-				},
-			},
 			"oidc_auth_type": schema.StringAttribute{
 				Computed:            true,
 				Optional:            true,
@@ -138,7 +122,6 @@ type TFModel struct {
 	GroupId         types.String `tfsdk:"group_id"`
 	Labels          types.List   `tfsdk:"labels"`
 	LdapAuthType    types.String `tfsdk:"ldap_auth_type"`
-	Links           types.List   `tfsdk:"links" autogen:"omitjson"`
 	OidcAuthType    types.String `tfsdk:"oidc_auth_type"`
 	Password        types.String `tfsdk:"password"`
 	Roles           types.List   `tfsdk:"roles"`
@@ -149,10 +132,6 @@ type TFModel struct {
 type TFLabelsModel struct {
 	Key   types.String `tfsdk:"key"`
 	Value types.String `tfsdk:"value"`
-}
-type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFRolesModel struct {
 	CollectionName types.String `tfsdk:"collection_name"`

--- a/internal/serviceapi/projectapi/resource_schema.go
+++ b/internal/serviceapi/projectapi/resource_schema.go
@@ -24,22 +24,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the MongoDB Cloud project.",
 			},
-			"links": schema.ListNestedAttribute{
-				Computed:            true,
-				MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"href": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-						"rel": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-					},
-				},
-			},
 			"name": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Human-readable label that identifies the project included in the MongoDB Cloud organization.",
@@ -79,7 +63,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Links                     types.List   `tfsdk:"links" autogen:"omitjson"`
 	Tags                      types.List   `tfsdk:"tags"`
 	Created                   types.String `tfsdk:"created" autogen:"omitjson"`
 	Id                        types.String `tfsdk:"id" autogen:"omitjson"`
@@ -88,10 +71,6 @@ type TFModel struct {
 	RegionUsageRestrictions   types.String `tfsdk:"region_usage_restrictions" autogen:"omitjsonupdate"`
 	ClusterCount              types.Int64  `tfsdk:"cluster_count" autogen:"omitjson"`
 	WithDefaultAlertsSettings types.Bool   `tfsdk:"with_default_alerts_settings" autogen:"omitjsonupdate"`
-}
-type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFTagsModel struct {
 	Key   types.String `tfsdk:"key"`

--- a/internal/serviceapi/pushbasedlogexportapi/resource_schema.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource_schema.go
@@ -28,22 +28,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Required:            true,
 				MarkdownDescription: "ID of the AWS IAM role that will be used to write to the S3 bucket.",
 			},
-			"links": schema.ListNestedAttribute{
-				Computed:            true,
-				MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"href": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-						"rel": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-					},
-				},
-			},
 			"prefix_path": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "S3 directory in which vector will write to in order to store the logs. An empty string denotes the root directory.",
@@ -61,11 +45,6 @@ type TFModel struct {
 	CreateDate types.String `tfsdk:"create_date" autogen:"omitjson"`
 	GroupId    types.String `tfsdk:"group_id" autogen:"omitjson"`
 	IamRoleId  types.String `tfsdk:"iam_role_id"`
-	Links      types.List   `tfsdk:"links" autogen:"omitjson"`
 	PrefixPath types.String `tfsdk:"prefix_path"`
 	State      types.String `tfsdk:"state" autogen:"omitjson"`
-}
-type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }

--- a/internal/serviceapi/streaminstanceapi/resource_schema.go
+++ b/internal/serviceapi/streaminstanceapi/resource_schema.go
@@ -21,22 +21,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							MarkdownDescription: "User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
 							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
 								"mechanism": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: "Style of authentication. Can be one of PLAIN, SCRAM-256, or SCRAM-512.",
@@ -68,22 +52,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							MarkdownDescription: "AWS configurations for AWS-based connection types.",
 							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
 								"role_arn": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: "Amazon Resource Name (ARN) that identifies the Amazon Web Services (AWS) Identity and Access Management (IAM) role that MongoDB Cloud assumes when it accesses resources in your AWS account.",
@@ -115,22 +83,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							MarkdownDescription: "The name of a Built in or Custom DB Role to connect to an Atlas Cluster.",
 							Attributes: map[string]schema.Attribute{
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
 								"role": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: "The name of the role to use. Can be a built in role or a custom role.",
@@ -145,22 +97,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 							Computed:            true,
 							MarkdownDescription: "A map of key-value pairs that will be passed as headers for the request.",
 							ElementType:         types.StringType,
-						},
-						"links": schema.ListNestedAttribute{
-							Computed:            true,
-							MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: map[string]schema.Attribute{
-									"href": schema.StringAttribute{
-										Computed:            true,
-										MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-									},
-									"rel": schema.StringAttribute{
-										Computed:            true,
-										MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-									},
-								},
-							},
 						},
 						"name": schema.StringAttribute{
 							Computed:            true,
@@ -177,22 +113,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										"connection_id": schema.StringAttribute{
 											Computed:            true,
 											MarkdownDescription: "Reserved. Will be used by PRIVATE_LINK connection type.",
-										},
-										"links": schema.ListNestedAttribute{
-											Computed:            true,
-											MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-											NestedObject: schema.NestedAttributeObject{
-												Attributes: map[string]schema.Attribute{
-													"href": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-													},
-													"rel": schema.StringAttribute{
-														Computed:            true,
-														MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-													},
-												},
-											},
 										},
 										"name": schema.StringAttribute{
 											Computed:            true,
@@ -216,22 +136,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 										},
 									},
 								},
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
-								},
 							},
 						},
 						"security": schema.SingleNestedAttribute{
@@ -241,22 +145,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 								"broker_public_certificate": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: "A trusted, public x509 certificate for connecting to Kafka over SSL.",
-								},
-								"links": schema.ListNestedAttribute{
-									Computed:            true,
-									MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-									NestedObject: schema.NestedAttributeObject{
-										Attributes: map[string]schema.Attribute{
-											"href": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-											"rel": schema.StringAttribute{
-												Computed:            true,
-												MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-											},
-										},
-									},
 								},
 								"protocol": schema.StringAttribute{
 									Computed:            true,
@@ -283,22 +171,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						Required:            true,
 						MarkdownDescription: "Label that identifies the cloud service provider where MongoDB Cloud performs stream processing. Currently, this parameter only supports AWS and AZURE.",
 					},
-					"links": schema.ListNestedAttribute{
-						Computed:            true,
-						MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"href": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-								"rel": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-							},
-						},
-					},
 					"region": schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "Name of the cloud provider region hosting Atlas Stream Processing.",
@@ -314,22 +186,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "List that contains the hostnames assigned to the stream instance.",
 				ElementType:         types.StringType,
 			},
-			"links": schema.ListNestedAttribute{
-				Computed:            true,
-				MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"href": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-						"rel": schema.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-						},
-					},
-				},
-			},
 			"name": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
@@ -338,22 +194,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Sample connections to add to SPI.",
 				Attributes: map[string]schema.Attribute{
-					"links": schema.ListNestedAttribute{
-						Computed:            true,
-						MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"href": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-								"rel": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-							},
-						},
-					},
 					"solar": schema.BoolAttribute{
 						Computed:            true,
 						Optional:            true,
@@ -365,22 +205,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Configuration options for an Atlas Stream Processing Instance.",
 				Attributes: map[string]schema.Attribute{
-					"links": schema.ListNestedAttribute{
-						Computed:            true,
-						MarkdownDescription: "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"href": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-								"rel": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
-								},
-							},
-						},
-					},
 					"tier": schema.StringAttribute{
 						Optional:            true,
 						MarkdownDescription: "Selected tier for the Stream Instance. Configures Memory / VCPU allowances.",
@@ -396,7 +220,6 @@ type TFModel struct {
 	DataProcessRegion types.Object `tfsdk:"data_process_region" autogen:"omitjsonupdate"`
 	GroupId           types.String `tfsdk:"group_id" autogen:"omitjson"`
 	Hostnames         types.List   `tfsdk:"hostnames" autogen:"omitjson"`
-	Links             types.List   `tfsdk:"links" autogen:"omitjson"`
 	Name              types.String `tfsdk:"name" autogen:"omitjsonupdate"`
 	SampleConnections types.Object `tfsdk:"sample_connections" autogen:"omitjsonupdate"`
 	StreamConfig      types.Object `tfsdk:"stream_config" autogen:"omitjsonupdate"`
@@ -410,7 +233,6 @@ type TFConnectionsModel struct {
 	Config           types.Map    `tfsdk:"config" autogen:"omitjson"`
 	DbRoleToExecute  types.Object `tfsdk:"db_role_to_execute" autogen:"omitjson"`
 	Headers          types.Map    `tfsdk:"headers" autogen:"omitjson"`
-	Links            types.List   `tfsdk:"links" autogen:"omitjson"`
 	Name             types.String `tfsdk:"name" autogen:"omitjson"`
 	Networking       types.Object `tfsdk:"networking" autogen:"omitjson"`
 	Security         types.Object `tfsdk:"security" autogen:"omitjson"`
@@ -418,7 +240,6 @@ type TFConnectionsModel struct {
 	Url              types.String `tfsdk:"url" autogen:"omitjson"`
 }
 type TFConnectionsAuthenticationModel struct {
-	Links          types.List   `tfsdk:"links" autogen:"omitjson"`
 	Mechanism      types.String `tfsdk:"mechanism" autogen:"omitjson"`
 	Password       types.String `tfsdk:"password" autogen:"omitjson"`
 	SslCertificate types.String `tfsdk:"ssl_certificate" autogen:"omitjson"`
@@ -426,88 +247,36 @@ type TFConnectionsAuthenticationModel struct {
 	SslKeyPassword types.String `tfsdk:"ssl_key_password" autogen:"omitjson"`
 	Username       types.String `tfsdk:"username" autogen:"omitjson"`
 }
-type TFConnectionsAuthenticationLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFConnectionsAwsModel struct {
-	Links      types.List   `tfsdk:"links" autogen:"omitjson"`
 	RoleArn    types.String `tfsdk:"role_arn" autogen:"omitjson"`
 	TestBucket types.String `tfsdk:"test_bucket" autogen:"omitjson"`
 }
-type TFConnectionsAwsLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFConnectionsDbRoleToExecuteModel struct {
-	Links types.List   `tfsdk:"links" autogen:"omitjson"`
-	Role  types.String `tfsdk:"role" autogen:"omitjson"`
-	Type  types.String `tfsdk:"type" autogen:"omitjson"`
-}
-type TFConnectionsDbRoleToExecuteLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
+	Role types.String `tfsdk:"role" autogen:"omitjson"`
+	Type types.String `tfsdk:"type" autogen:"omitjson"`
 }
 type TFConnectionsNetworkingModel struct {
 	Access types.Object `tfsdk:"access" autogen:"omitjson"`
-	Links  types.List   `tfsdk:"links" autogen:"omitjson"`
 }
 type TFConnectionsNetworkingAccessModel struct {
 	ConnectionId types.String `tfsdk:"connection_id" autogen:"omitjson"`
-	Links        types.List   `tfsdk:"links" autogen:"omitjson"`
 	Name         types.String `tfsdk:"name" autogen:"omitjson"`
 	TgwId        types.String `tfsdk:"tgw_id" autogen:"omitjson"`
 	TgwRouteId   types.String `tfsdk:"tgw_route_id" autogen:"omitjson"`
 	Type         types.String `tfsdk:"type" autogen:"omitjson"`
 	VpcCidr      types.String `tfsdk:"vpc_cidr" autogen:"omitjson"`
 }
-type TFConnectionsNetworkingAccessLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFConnectionsNetworkingLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFConnectionsSecurityModel struct {
 	BrokerPublicCertificate types.String `tfsdk:"broker_public_certificate" autogen:"omitjson"`
-	Links                   types.List   `tfsdk:"links" autogen:"omitjson"`
 	Protocol                types.String `tfsdk:"protocol" autogen:"omitjson"`
-}
-type TFConnectionsSecurityLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
 }
 type TFDataProcessRegionModel struct {
 	CloudProvider types.String `tfsdk:"cloud_provider"`
-	Links         types.List   `tfsdk:"links" autogen:"omitjson"`
 	Region        types.String `tfsdk:"region"`
 }
-type TFDataProcessRegionLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
-type TFLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFSampleConnectionsModel struct {
-	Links types.List `tfsdk:"links" autogen:"omitjson"`
 	Solar types.Bool `tfsdk:"solar"`
 }
-type TFSampleConnectionsLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
-}
 type TFStreamConfigModel struct {
-	Links types.List   `tfsdk:"links" autogen:"omitjson"`
-	Tier  types.String `tfsdk:"tier"`
-}
-type TFStreamConfigLinksModel struct {
-	Href types.String `tfsdk:"href" autogen:"omitjson"`
-	Rel  types.String `tfsdk:"rel" autogen:"omitjson"`
+	Tier types.String `tfsdk:"tier"`
 }

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -338,7 +338,9 @@ resources:
       path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}
       method: DELETE
     schema:
-      ignores: [
+      # region and cloud_provider are incorrectly declared in PATCH as root attributes, _id can't be used in Terraform schema
+      ignores:
+        [
           "_id",
           "region",
           "cloud_provider",
@@ -353,7 +355,7 @@ resources:
           "data_process_region.links",
           "sample_connections.links",
           "stream_config.links",
-        ] # region and cloud_provider are incorrectly declared in PATCH as root attributes, _id can't be used in Terraform schema
+        ]
       aliases:
         tenant_name: name # path param name does not match the API request property
 

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -42,6 +42,7 @@ resources:
           ]
         target_states: ["DELETED"] # DELETED is a special state value when API returns 404 or empty object
     schema:
+      ignores: ["links", "mongo_dbemployee_access_grant.links"]
       aliases:
         cluster_name: name # path param name does not match the API request property
       # These attributes are optional but when not configured, Atlas returns a default value.
@@ -222,6 +223,7 @@ resources:
       method: DELETE
     version_header: application/vnd.atlas.2023-01-01+json
     schema:
+      ignores: ["links"]
       overrides:
         password:
           sensitive: true
@@ -242,6 +244,7 @@ resources:
       path: /api/atlas/v2/groups/{groupId}
       method: DELETE
     schema:
+      ignores: ["links"]
       aliases:
         group_id: id # path param name does not match the API response property
 
@@ -271,6 +274,8 @@ resources:
         pending_states: ["ACTIVE", "INITIATING", "BUCKET_VERIFIED"]
         target_states: ["UNCONFIGURED", "DELETED"] # DELETED is a special state value when API returns 404 or empty object
     version_header: application/vnd.atlas.2023-01-01+json
+    schema:
+      ignores: ["links"]
 
   resource_policy_api:
     read:
@@ -333,7 +338,22 @@ resources:
       path: /api/atlas/v2/groups/{groupId}/streams/{tenantName}
       method: DELETE
     schema:
-      ignores: ["_id", "region", "cloud_provider"] # region and cloud_provider are incorrectly declared in PATCH as root attributes, _id can't be used in Terraform schema
+      ignores: [
+          "_id",
+          "region",
+          "cloud_provider",
+          "links",
+          "connections.links",
+          "connections.authentication.links",
+          "connections.aws.links",
+          "connections.db_role_to_execute.links",
+          "connections.networking.links",
+          "connections.networking.access.links",
+          "connections.security.links",
+          "data_process_region.links",
+          "sample_connections.links",
+          "stream_config.links",
+        ] # region and cloud_provider are incorrectly declared in PATCH as root attributes, _id can't be used in Terraform schema
       aliases:
         tenant_name: name # path param name does not match the API request property
 


### PR DESCRIPTION
## Description

Remove `links` attributes in auto-generated resources. This makes a better user experience as they're not useful in Terraform.

Link to any related issue(s): CLOUDP-328662

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
