### PR TITLE
fix: Avoids 0 itemsPerPage and pageNum when the args are missing in plural data sources

### DIFF
--- a/.changelog/3459.txt
+++ b/.changelog/3459.txt
@@ -1,19 +1,23 @@
 ```release-note:bug
-data-source/mongodbatlas_cloud_backup_snapshots: Fix pagination when `items_per_page` and `page_num` are not set
+data-source/mongodbatlas_cloud_backup_snapshots: Fix pagination when `items_per_page` or `page_num` are not set
 ```
 
 ```release-note:bug
-data-source/mongodbatlas_cloud_backup_snapshot_export_buckets: Fix pagination when `items_per_page` and `page_num` are not set
+data-source/mongodbatlas_cloud_backup_snapshot_export_buckets: Fix pagination when `items_per_page` or `page_num` are not set
 ```
 
 ```release-note:bug
-data-source/mongodbatlas_cloud_backup_snapshot_restore_jobs: Fix pagination when `items_per_page` and `page_num` are not set
+data-source/mongodbatlas_cloud_backup_snapshot_restore_jobs: Fix pagination when `items_per_page` or `page_num` are not set
 ```
 
 ```release-note:bug
-data-source/mongodbatlas_federated_settings_org_configs: Fix pagination when `items_per_page` and `page_num` are not set
+data-source/mongodbatlas_federated_settings_org_configs: Fix pagination when `items_per_page` or `page_num` are not set
 ```
 
 ```release-note:bug
-data-source/mongodbatlas_organizations: Fix pagination when `items_per_page` and `page_num` are not set
+data-source/mongodbatlas_organizations: Fix pagination when `items_per_page` or `page_num` are not set
+```
+
+```release-note:bug
+data-source/mongodbatlas_cloud_backup_snapshot_export_jobs: Fix pagination when `items_per_page` or `page_num` are not set
 ```

--- a/.changelog/3459.txt
+++ b/.changelog/3459.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+data-source/mongodbatlas_cloud_backup_snapshots: Fix pagination when `items_per_page` and `page_num` are not set
+```
+
+```release-note:bug
+data-source/mongodbatlas_cloud_backup_snapshot_export_buckets: Fix pagination when `items_per_page` and `page_num` are not set
+```
+
+```release-note:bug
+data-source/mongodbatlas_cloud_backup_snapshot_restore_jobs: Fix pagination when `items_per_page` and `page_num` are not set
+```
+
+```release-note:bug
+data-source/mongodbatlas_federated_settings_org_configs: Fix pagination when `items_per_page` and `page_num` are not set
+```
+
+```release-note:bug
+data-source/mongodbatlas_organizations: Fix pagination when `items_per_page` and `page_num` are not set
+```

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 .DS_Store
 .idea
 .vscode
+.windsurf
 *.env
 *.bak
 *.log

--- a/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
+++ b/internal/service/cloudbackupsnapshot/data_source_cloud_backup_snapshots.go
@@ -129,8 +129,8 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 	params := &admin.ListReplicaSetBackupsApiParams{
 		GroupId:      d.Get("project_id").(string),
 		ClusterName:  d.Get("cluster_name").(string),
-		PageNum:      conversion.Pointer(d.Get("page_num").(int)),
-		ItemsPerPage: conversion.Pointer(d.Get("items_per_page").(int)),
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
 	}
 
 	snapshots, _, err := connV2.CloudBackupsApi.ListReplicaSetBackupsWithParams(ctx, params).Execute()

--- a/internal/service/cloudbackupsnapshotexportbucket/data_source_cloud_backup_snapshot_export_buckets.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/data_source_cloud_backup_snapshot_export_buckets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -78,10 +79,13 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	projectID := d.Get("project_id").(string)
-	itemsPerPage := d.Get("items_per_page").(int)
-	pageNum := d.Get("page_num").(int)
+	request := admin.ListExportBucketsApiParams{
+		GroupId:      projectID,
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+	}
 
-	buckets, _, err := conn.CloudBackupsApi.ListExportBuckets(ctx, projectID).ItemsPerPage(itemsPerPage).PageNum(pageNum).Execute()
+	buckets, _, err := conn.CloudBackupsApi.ListExportBucketsWithParams(ctx, &request).Execute()
 	if err != nil {
 		return diag.Errorf("error getting CloudProviderSnapshotExportBuckets information: %s", err)
 	}

--- a/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_jobs.go
+++ b/internal/service/cloudbackupsnapshotexportjob/data_source_cloud_backup_snapshot_export_jobs.go
@@ -119,10 +119,14 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
-	pageNum := d.Get("page_num").(int)
-	itemsPerPage := d.Get("items_per_page").(int)
+	request := admin.ListBackupExportJobsApiParams{
+		GroupId:      projectID,
+		ClusterName:  clusterName,
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+	}
 
-	jobs, _, err := connV2.CloudBackupsApi.ListBackupExportJobs(ctx, projectID, clusterName).PageNum(pageNum).ItemsPerPage(itemsPerPage).Execute()
+	jobs, _, err := connV2.CloudBackupsApi.ListBackupExportJobsWithParams(ctx, &request).Execute()
 	if err != nil {
 		return diag.Errorf("error getting CloudProviderSnapshotExportJobs information: %s", err)
 	}

--- a/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
+++ b/internal/service/cloudbackupsnapshotrestorejob/data_source_cloud_backup_snapshot_restore_jobs.go
@@ -116,10 +116,13 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 	projectID := d.Get("project_id").(string)
 	clusterName := d.Get("cluster_name").(string)
-	pageNum := d.Get("page_num").(int)
-	itermsPerPage := d.Get("items_per_page").(int)
-
-	cloudProviderSnapshotRestoreJobs, _, err := conn.CloudBackupsApi.ListBackupRestoreJobs(ctx, projectID, clusterName).PageNum(pageNum).ItemsPerPage(itermsPerPage).Execute()
+	params := &admin.ListBackupRestoreJobsApiParams{
+		GroupId:      projectID,
+		ClusterName:  clusterName,
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
+	}
+	cloudProviderSnapshotRestoreJobs, _, err := conn.CloudBackupsApi.ListBackupRestoreJobsWithParams(ctx, params).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting cloudProviderSnapshotRestoreJobs information: %s", err))
 	}

--- a/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs.go
+++ b/internal/service/federatedsettingsorgconfig/data_source_federated_settings_connected_orgs.go
@@ -123,8 +123,8 @@ func dataSourcePluralRead(ctx context.Context, d *schema.ResourceData, meta any)
 
 	params := &admin.ListConnectedOrgConfigsApiParams{
 		FederationSettingsId: federationSettingsID.(string),
-		PageNum:              conversion.Pointer(d.Get("page_num").(int)),
-		ItemsPerPage:         conversion.Pointer(d.Get("items_per_page").(int)),
+		PageNum:              conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage:         conversion.IntPtr(d.Get("items_per_page").(int)),
 	}
 
 	federatedSettingsConnectedOrganizations, _, err := conn.FederatedAuthenticationApi.ListConnectedOrgConfigsWithParams(ctx, params).Execute()

--- a/internal/service/organization/data_source_organizations.go
+++ b/internal/service/organization/data_source_organizations.go
@@ -102,8 +102,8 @@ func pluralDataSourceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	conn := meta.(*config.MongoDBClient).AtlasV2
 
 	organizationOptions := &admin.ListOrganizationsApiParams{
-		PageNum:      conversion.Pointer(d.Get("page_num").(int)),
-		ItemsPerPage: conversion.Pointer(d.Get("items_per_page").(int)),
+		PageNum:      conversion.IntPtr(d.Get("page_num").(int)),
+		ItemsPerPage: conversion.IntPtr(d.Get("items_per_page").(int)),
 		Name:         conversion.Pointer(d.Get("name").(string)),
 	}
 


### PR DESCRIPTION
## Description

- Avoids 0 itemsPerPage and pageNum when the args are missing in plural data sources
- How: Standardizes API params with WithParams pattern and IntPtr conversion (returns nil instead of 0)

Link to any related issue(s): CLOUDP-325392

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
