### PR TITLE
doc: Fixing inconsistent docs in `federated_settings_org_role_mapping` associated to required attributes

### DIFF
--- a/docs/data-sources/federated_settings_org_role_mapping.md
+++ b/docs/data-sources/federated_settings_org_role_mapping.md
@@ -46,7 +46,7 @@ data "mongodbatlas_federated_settings_org_role_mapping" "role_mapping" {
 In addition to all arguments above, the following attributes are exported:
 ### FederatedSettingsOrgRoleMappings
 
-* `external_group_name` - Unique human-readable label that identifies the identity provider group to which this role mapping applies.
+* `external_group_name` - Unique label that identifies the identity provider group to which this role mapping applies.
 * `id` - Unique 24-hexadecimal digit string that identifies this role mapping.
 * `role_assignments` - Atlas roles and the unique identifiers of the groups and organizations associated with each role.
 * `group_id` - Unique identifier of the project to which you want the role mapping to apply.

--- a/docs/data-sources/federated_settings_org_role_mapping.md
+++ b/docs/data-sources/federated_settings_org_role_mapping.md
@@ -38,7 +38,8 @@ data "mongodbatlas_federated_settings_org_role_mapping" "role_mapping" {
 ## Argument Reference
 
 * `federation_settings_id` - (Required) Unique 24-hexadecimal digit string that identifies the federated authentication configuration.
-* `org_id` - Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+* `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+* `role_mapping_id` - (Required) Unique 24-hexadecimal digit string that identifies this role mapping.
 
 ## Attributes Reference
 

--- a/docs/data-sources/federated_settings_org_role_mappings.md
+++ b/docs/data-sources/federated_settings_org_role_mappings.md
@@ -39,7 +39,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### FederatedSettingsOrgRoleMappings
 
-* `external_group_name` - Unique human-readable label that identifies the identity provider group to which this role mapping applies.
+* `external_group_name` - Unique label that identifies the identity provider group to which this role mapping applies.
 * `id` - Unique 24-hexadecimal digit string that identifies this role mapping.
 * `role_assignments` - Atlas roles and the unique identifiers of the groups and organizations associated with each role.
 * `group_id` - Unique identifier of the project to which you want the role mapping to apply.

--- a/docs/data-sources/federated_settings_org_role_mappings.md
+++ b/docs/data-sources/federated_settings_org_role_mappings.md
@@ -26,7 +26,7 @@ data "mongodbatlas_federated_settings_org_role_mappings" "role_mappings" {
 ## Argument Reference
 
 * `federation_settings_id` - (Required) Unique 24-hexadecimal digit string that identifies the federated authentication configuration.
-* `org_id` - Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+* `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
 * `page_num` - (Optional)  	The page to return. Defaults to `1`.
 * `items_per_page` - (Optional) Number of items to return per page, up to a maximum of 500. Defaults to `100`.
 

--- a/docs/resources/federated_settings_org_role_mapping.md
+++ b/docs/resources/federated_settings_org_role_mapping.md
@@ -30,9 +30,9 @@ resource "mongodbatlas_federated_settings_org_role_mapping" "org_group_role_mapp
 ## Argument Reference
 
 * `federation_settings_id` - (Required) Unique 24-hexadecimal digit string that identifies the federated authentication configuration.
-* `org_id` - Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
-* `external_group_name` - Unique human-readable label that identifies the identity provider group to which this role mapping applies.
-* `role_assignments` - Atlas roles and the unique identifiers of the groups and organizations associated with each role.
+* `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
+* `external_group_name` - (Required) Unique human-readable label that identifies the identity provider group to which this role mapping applies.
+* `role_assignments` - (Required) Atlas roles and the unique identifiers of the groups and organizations associated with each role.
     * `group_id` - Unique identifier of the project to which you want the role mapping to apply.
     * `roles` - Specifies the Roles that are attached to the Role Mapping. Available role IDs can be found on [the User Roles
   Reference](https://www.mongodb.com/docs/atlas/reference/user-roles/).

--- a/docs/resources/federated_settings_org_role_mapping.md
+++ b/docs/resources/federated_settings_org_role_mapping.md
@@ -31,7 +31,7 @@ resource "mongodbatlas_federated_settings_org_role_mapping" "org_group_role_mapp
 
 * `federation_settings_id` - (Required) Unique 24-hexadecimal digit string that identifies the federated authentication configuration.
 * `org_id` - (Required) Unique 24-hexadecimal digit string that identifies the organization that contains your projects.
-* `external_group_name` - (Required) Unique human-readable label that identifies the identity provider group to which this role mapping applies.
+* `external_group_name` - (Required) Unique label that identifies the identity provider group to which this role mapping applies.
 * `role_assignments` - (Required) Atlas roles and the unique identifiers of the groups and organizations associated with each role.
     * `group_id` - Unique identifier of the project to which you want the role mapping to apply.
     * `roles` - Specifies the Roles that are attached to the Role Mapping. Available role IDs can be found on [the User Roles


### PR DESCRIPTION
## Description

Inconsistency was brought up by TSE.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
