### PR TITLE
test: Lowering timeout value to ensure creation fails consistently in cluster test

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -1470,11 +1470,11 @@ func createCleanupTest(t *testing.T, configCall func(t *testing.T, timeoutSectio
 	var (
 		timeoutsStrShort = `
 			timeouts {
-				create = "10s"
+				create = "2s"
 			}
 			delete_on_create_timeout = true
 		`
-		timeoutsStrLong      = strings.ReplaceAll(timeoutsStrShort, "10s", "6000s")
+		timeoutsStrLong      = strings.ReplaceAll(timeoutsStrShort, "2s", "6000s")
 		timeoutsStrLongFalse = strings.ReplaceAll(timeoutsStrLong, "true", "false")
 	)
 	steps := []resource.TestStep{


### PR DESCRIPTION
## Description

Over past days we have seen a flaky test appear `TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex` (failed 4/5 days) in `advanced_cluster_tpf` group. 
Test fails with error: `resource_advanced_cluster_test.go:1465: Step 1/3, expected an error but got none.`. This means there is no error during creation, when the intention in this case it to see a failure due to custom configured timeout being reached.
Some additional observations:
- When run locally or [isolated](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/16026631254) it passes.
- Same test consistently passes in `advanced_cluster` test group.

**Fix:** Reduced the timeout value from 10s to 2s making it impossible for flex cluster creation to succeed under this period. When running locally the same config creations succeeds after 22s, which could indicate that under a particular execution context flex cluster creation improves and is made under the 10s timeout.


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
