### PR TITLE
chore: Enhances User-Agent with additional metadata support 

### DIFF
--- a/internal/config/transport.go
+++ b/internal/config/transport.go
@@ -98,11 +98,12 @@ func AddUserAgentExtra(ctx context.Context, extra UserAgentExtra) context.Contex
 	return context.WithValue(ctx, UserAgentExtraKey, newExtra)
 }
 
-type TFSrcUserAgentAdder struct {
+// UserAgentTransport wraps an http.RoundTripper to add User-Agent header with additional metadata.
+type UserAgentTransport struct {
 	Transport http.RoundTripper
 }
 
-func (t *TFSrcUserAgentAdder) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	extra := ReadUserAgentExtra(req.Context())
 	if extra != nil {
 		userAgent := req.Header.Get(UserAgentHeader)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -506,7 +506,7 @@ func MuxProviderFactory() func() tfprotov6.ProviderServer {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return muxServer.ProviderServer
+	return NewWrappedProviderServer(muxServer.ProviderServer)
 }
 
 func MultiEnvDefaultFunc(ks []string, def any) any {

--- a/internal/provider/wrapper_provider_server.go
+++ b/internal/provider/wrapper_provider_server.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+func NewWrappedProviderServer(old func() tfprotov6.ProviderServer) func() tfprotov6.ProviderServer {
+	return func() tfprotov6.ProviderServer {
+		return &WrappedProviderServer{
+			OldServer: old(),
+		}
+	}
+}
+
+type WrappedProviderServer struct {
+	OldServer tfprotov6.ProviderServer
+}
+
+func (s *WrappedProviderServer) GetMetadata(ctx context.Context, req *tfprotov6.GetMetadataRequest) (*tfprotov6.GetMetadataResponse, error) {
+	return s.OldServer.GetMetadata(ctx, req)
+}
+
+func (s *WrappedProviderServer) GetProviderSchema(ctx context.Context, req *tfprotov6.GetProviderSchemaRequest) (*tfprotov6.GetProviderSchemaResponse, error) {
+	return s.OldServer.GetProviderSchema(ctx, req)
+}
+
+func (s *WrappedProviderServer) GetResourceIdentitySchemas(ctx context.Context, req *tfprotov6.GetResourceIdentitySchemasRequest) (*tfprotov6.GetResourceIdentitySchemasResponse, error) {
+	return s.OldServer.GetResourceIdentitySchemas(ctx, req)
+}
+
+func (s *WrappedProviderServer) ValidateProviderConfig(ctx context.Context, req *tfprotov6.ValidateProviderConfigRequest) (*tfprotov6.ValidateProviderConfigResponse, error) {
+	return s.OldServer.ValidateProviderConfig(ctx, req)
+}
+
+func (s *WrappedProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov6.ConfigureProviderRequest) (*tfprotov6.ConfigureProviderResponse, error) {
+	return s.OldServer.ConfigureProvider(ctx, req)
+}
+
+func (s *WrappedProviderServer) StopProvider(ctx context.Context, req *tfprotov6.StopProviderRequest) (*tfprotov6.StopProviderResponse, error) {
+	return s.OldServer.StopProvider(ctx, req)
+}
+
+func (s *WrappedProviderServer) ValidateResourceConfig(ctx context.Context, req *tfprotov6.ValidateResourceConfigRequest) (*tfprotov6.ValidateResourceConfigResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.ValidateResourceConfig(ctx, req)
+}
+
+func (s *WrappedProviderServer) UpgradeResourceState(ctx context.Context, req *tfprotov6.UpgradeResourceStateRequest) (*tfprotov6.UpgradeResourceStateResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "upgrade."+req.TypeName)
+	return s.OldServer.UpgradeResourceState(ctx, req)
+}
+
+func (s *WrappedProviderServer) ReadResource(ctx context.Context, req *tfprotov6.ReadResourceRequest) (*tfprotov6.ReadResourceResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.ReadResource(ctx, req)
+}
+
+func (s *WrappedProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanResourceChangeRequest) (*tfprotov6.PlanResourceChangeResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.PlanResourceChange(ctx, req)
+}
+
+func (s *WrappedProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest) (*tfprotov6.ApplyResourceChangeResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.ApplyResourceChange(ctx, req)
+}
+
+func (s *WrappedProviderServer) ImportResourceState(ctx context.Context, req *tfprotov6.ImportResourceStateRequest) (*tfprotov6.ImportResourceStateResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "import."+req.TypeName)
+	return s.OldServer.ImportResourceState(ctx, req)
+}
+
+func (s *WrappedProviderServer) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "move."+req.TargetTypeName)
+	return s.OldServer.MoveResourceState(ctx, req)
+}
+
+func (s *WrappedProviderServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov6.UpgradeResourceIdentityRequest) (*tfprotov6.UpgradeResourceIdentityResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.UpgradeResourceIdentity(ctx, req)
+}
+
+func (s *WrappedProviderServer) ValidateDataResourceConfig(ctx context.Context, req *tfprotov6.ValidateDataResourceConfigRequest) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "data."+req.TypeName)
+	return s.OldServer.ValidateDataResourceConfig(ctx, req)
+}
+
+func (s *WrappedProviderServer) ReadDataSource(ctx context.Context, req *tfprotov6.ReadDataSourceRequest) (*tfprotov6.ReadDataSourceResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "data."+req.TypeName)
+	return s.OldServer.ReadDataSource(ctx, req)
+}
+
+func (s *WrappedProviderServer) CallFunction(ctx context.Context, req *tfprotov6.CallFunctionRequest) (*tfprotov6.CallFunctionResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "func."+req.Name)
+	return s.OldServer.CallFunction(ctx, req)
+}
+
+func (s *WrappedProviderServer) GetFunctions(ctx context.Context, req *tfprotov6.GetFunctionsRequest) (*tfprotov6.GetFunctionsResponse, error) {
+	return s.OldServer.GetFunctions(ctx, req)
+}
+
+func (s *WrappedProviderServer) ValidateEphemeralResourceConfig(ctx context.Context, req *tfprotov6.ValidateEphemeralResourceConfigRequest) (*tfprotov6.ValidateEphemeralResourceConfigResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.ValidateEphemeralResourceConfig(ctx, req)
+}
+
+func (s *WrappedProviderServer) OpenEphemeralResource(ctx context.Context, req *tfprotov6.OpenEphemeralResourceRequest) (*tfprotov6.OpenEphemeralResourceResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.OpenEphemeralResource(ctx, req)
+}
+
+func (s *WrappedProviderServer) RenewEphemeralResource(ctx context.Context, req *tfprotov6.RenewEphemeralResourceRequest) (*tfprotov6.RenewEphemeralResourceResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.RenewEphemeralResource(ctx, req)
+}
+
+func (s *WrappedProviderServer) CloseEphemeralResource(ctx context.Context, req *tfprotov6.CloseEphemeralResourceRequest) (*tfprotov6.CloseEphemeralResourceResponse, error) {
+	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	return s.OldServer.CloseEphemeralResource(ctx, req)
+}

--- a/internal/provider/wrapper_provider_server.go
+++ b/internal/provider/wrapper_provider_server.go
@@ -7,6 +7,8 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
+// NewWrappedProviderServer returns a new ProviderServer that wraps the old one.
+// This is used to add additional metadata to the User-Agent header and context.
 func NewWrappedProviderServer(old func() tfprotov6.ProviderServer) func() tfprotov6.ProviderServer {
 	return func() tfprotov6.ProviderServer {
 		return &WrappedProviderServer{
@@ -44,57 +46,101 @@ func (s *WrappedProviderServer) StopProvider(ctx context.Context, req *tfprotov6
 }
 
 func (s *WrappedProviderServer) ValidateResourceConfig(ctx context.Context, req *tfprotov6.ValidateResourceConfigRequest) (*tfprotov6.ValidateResourceConfigResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "ValidateResourceConfig",
+	})
 	return s.OldServer.ValidateResourceConfig(ctx, req)
 }
 
 func (s *WrappedProviderServer) UpgradeResourceState(ctx context.Context, req *tfprotov6.UpgradeResourceStateRequest) (*tfprotov6.UpgradeResourceStateResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "upgrade."+req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "UpgradeResourceState",
+	})
 	return s.OldServer.UpgradeResourceState(ctx, req)
 }
 
 func (s *WrappedProviderServer) ReadResource(ctx context.Context, req *tfprotov6.ReadResourceRequest) (*tfprotov6.ReadResourceResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "ReadResource",
+	})
 	return s.OldServer.ReadResource(ctx, req)
 }
 
 func (s *WrappedProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanResourceChangeRequest) (*tfprotov6.PlanResourceChangeResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "PlanResourceChange",
+	})
 	return s.OldServer.PlanResourceChange(ctx, req)
 }
 
 func (s *WrappedProviderServer) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest) (*tfprotov6.ApplyResourceChangeResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "ApplyResourceChange",
+	})
 	return s.OldServer.ApplyResourceChange(ctx, req)
 }
 
 func (s *WrappedProviderServer) ImportResourceState(ctx context.Context, req *tfprotov6.ImportResourceStateRequest) (*tfprotov6.ImportResourceStateResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "import."+req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "ImportResourceState",
+	})
 	return s.OldServer.ImportResourceState(ctx, req)
 }
 
 func (s *WrappedProviderServer) MoveResourceState(ctx context.Context, req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "move."+req.TargetTypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TargetTypeName,
+		Operation: "MoveResourceState",
+	})
 	return s.OldServer.MoveResourceState(ctx, req)
 }
 
 func (s *WrappedProviderServer) UpgradeResourceIdentity(ctx context.Context, req *tfprotov6.UpgradeResourceIdentityRequest) (*tfprotov6.UpgradeResourceIdentityResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Resource",
+		Name:      req.TypeName,
+		Operation: "UpgradeResourceIdentity",
+	})
 	return s.OldServer.UpgradeResourceIdentity(ctx, req)
 }
 
 func (s *WrappedProviderServer) ValidateDataResourceConfig(ctx context.Context, req *tfprotov6.ValidateDataResourceConfigRequest) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "data."+req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Datasource",
+		Name:      req.TypeName,
+		Operation: "ValidateDataResourceConfig",
+	})
 	return s.OldServer.ValidateDataResourceConfig(ctx, req)
 }
 
 func (s *WrappedProviderServer) ReadDataSource(ctx context.Context, req *tfprotov6.ReadDataSourceRequest) (*tfprotov6.ReadDataSourceResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "data."+req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Datasource",
+		Name:      req.TypeName,
+		Operation: "ReadDataSource",
+	})
 	return s.OldServer.ReadDataSource(ctx, req)
 }
 
 func (s *WrappedProviderServer) CallFunction(ctx context.Context, req *tfprotov6.CallFunctionRequest) (*tfprotov6.CallFunctionResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, "func."+req.Name)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Function",
+		Name:      req.Name,
+		Operation: "CallFunction",
+	})
 	return s.OldServer.CallFunction(ctx, req)
 }
 
@@ -103,21 +149,37 @@ func (s *WrappedProviderServer) GetFunctions(ctx context.Context, req *tfprotov6
 }
 
 func (s *WrappedProviderServer) ValidateEphemeralResourceConfig(ctx context.Context, req *tfprotov6.ValidateEphemeralResourceConfigRequest) (*tfprotov6.ValidateEphemeralResourceConfigResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Ephemeral",
+		Name:      req.TypeName,
+		Operation: "ValidateEphemeralResourceConfig",
+	})
 	return s.OldServer.ValidateEphemeralResourceConfig(ctx, req)
 }
 
 func (s *WrappedProviderServer) OpenEphemeralResource(ctx context.Context, req *tfprotov6.OpenEphemeralResourceRequest) (*tfprotov6.OpenEphemeralResourceResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Ephemeral",
+		Name:      req.TypeName,
+		Operation: "OpenEphemeralResource",
+	})
 	return s.OldServer.OpenEphemeralResource(ctx, req)
 }
 
 func (s *WrappedProviderServer) RenewEphemeralResource(ctx context.Context, req *tfprotov6.RenewEphemeralResourceRequest) (*tfprotov6.RenewEphemeralResourceResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Ephemeral",
+		Name:      req.TypeName,
+		Operation: "RenewEphemeralResource",
+	})
 	return s.OldServer.RenewEphemeralResource(ctx, req)
 }
 
 func (s *WrappedProviderServer) CloseEphemeralResource(ctx context.Context, req *tfprotov6.CloseEphemeralResourceRequest) (*tfprotov6.CloseEphemeralResourceResponse, error) {
-	ctx = context.WithValue(ctx, config.ContextKeyTFSrc, req.TypeName)
+	ctx = config.AddUserAgentExtra(ctx, config.UserAgentExtra{
+		Type:      "Ephemeral",
+		Name:      req.TypeName,
+		Operation: "CloseEphemeralResource",
+	})
 	return s.OldServer.CloseEphemeralResource(ctx, req)
 }


### PR DESCRIPTION
## Description

This PR introduces enhanced user agent context propagation and analytics metadata for all resource, data source, and function operations. The changes include:

- Addition of the `UserAgentExtra` to `internal/config/transport.go` struct and related helpers to capture operation type, name, and action for every provider call.
- Addition of the `WrappedProviderServer` in `internal/provider/wrapper_provider_server.go`. A new file that wraps the provider server to inject detailed operation metadata into the context for every gRPC entrypoint. This wrapper ensures that all resource, data source, and function operations are enriched with type, name, and operation metadata, enabling improved observability, analytics, and debugging. The wrapper works by intercepting each call and using `AddUserAgentExtra`.
- New `UserAgentTransport` HTTP middleware that reads the `UserAgentExtra` and updates the request header.

These changes improve observability, analytics, and debugging capabilities by making operation context available for logging and downstream systems.

Link to any related issue(s):  CLOUDP-329015

## Sequence diagram

```mermaid
sequenceDiagram
    autonumber
    participant Terraform as Terraform CLI/Cloud
    participant Wrapped as WrappedProviderServer
    participant Old as OldProviderServer
    participant Logic as Resource/Data Logic
    participant HTTP as HTTP RoundTripper/API

    Terraform->>Wrapped: gRPC Request (e.g., ReadResource)
    Wrapped->>Wrapped: AddUserAgentExtra(ctx, type, name, operation)
    Wrapped->>Old: Call OldProviderServer.ReadResource(ctx, req)
    Old->>Logic: Resource/Data Logic (uses ctx)
    Logic->>HTTP: HTTP Request with context    
    HTTP->>HTTP: UserAgentTransport:<br/>Read UserAgentExtra from ctx<br/>Modify User-Agent header
    HTTP->>HTTP: TerraformLoggingTransport:<br/>Log request with final User-Agent
    HTTP->>HTTP: DigestTransport:<br/>Prepare for digest auth
    HTTP->>HTTP: Rest of the chain
    HTTP-->>Logic: API Response
    Logic-->>Old: Resource/Data Response
    Old-->>Wrapped: Response
    Wrapped-->>Terraform: Response
```

1. Terraform CLI initiates the grpc call  
2. gRPC request is received by the WrappedProviderServer.{FuncName} (internal/provider/wrapper\_provider\_server.go) which adds AddUserAgentExtra (internal/config/transport.go)  
   * The type of operation (Resource, Datasource, Function, Ephemeral)  
   * The name of the resource/data/function (from the request)  
   * The operation (the gRPC method name, e.g., ReadResource internal/provider/wrapper\_provider\_server.go)  
3. It then calls the OldProviderServer.{FuncName}(updated\_ctx, req) (the new context has the extra metadata)  
4. Any Resource/Data source is called as before.  
   Any logic, logging, or HTTP requests made further down the stack (including SDK calls) can now read this metadata from the context.  
5. For any API Call the Transport chain processes the API Calls.  
6. UserAgentTransport reads the ctx and updates the user agent  
7. Processing as before

## Type of change:

- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
