### PR TITLE
chore: Docs team review improvements in dev branches

### DIFF
--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'skip-docs-notification')
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.changes.outputs.files }}

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -31,14 +31,19 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Checkout repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
-    - run: |
+    
+    - name: Config Git
+      run: |
         git config --local user.email svc-api-experience-integrations-escalation@mongodb.com
         git config --local user.name svc-apix-bot
     
-    - run: |
+    - name: Rebase branch with master
+      id: rebase-check
+      run: |
         echo "Updating branch: ${{ matrix.branch }}"
         
         if ! git ls-remote --heads origin ${{ matrix.branch }} | grep -q ${{ matrix.branch }}; then
@@ -78,9 +83,9 @@ jobs:
           echo "Changes detected between rebased branch and original remote branch. PR will introduce changes."
           echo "has-changes=true" >> "${GITHUB_OUTPUT}"
         fi
-      id: rebase-check
 
-    - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
       if: steps.rebase-check.outputs.has-changes == 'true'
       with:
         token: ${{ secrets.APIX_BOT_PAT }}
@@ -98,7 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52
+      - name: Send Slack notification on failure
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -50,6 +50,9 @@ jobs:
         git fetch origin ${{ matrix.branch }}        
         git checkout -B ${{ matrix.branch }} origin/${{ matrix.branch }}
         
+        # Store the original commit hash to compare later
+        original_commit=$(git rev-parse HEAD)
+        
         if git rebase origin/master; then
           echo "OK: Rebase completed successfully with no conflicts."
         else
@@ -69,8 +72,20 @@ jobs:
             exit 1
           fi
         fi
+        
+        # Check if there are any changes after rebase
+        new_commit=$(git rev-parse HEAD)
+        if [ "$original_commit" = "$new_commit" ]; then
+          echo "No changes detected after rebase. Branch is already up to date."
+          echo "has-changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "Changes detected after rebase."
+          echo "has-changes=true" >> $GITHUB_OUTPUT
+        fi
+      id: rebase-check
 
     - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+      if: steps.rebase-check.outputs.has-changes == 'true'
       with:
         token: ${{ secrets.APIX_BOT_PAT }}
         title: "chore: Update ${{ matrix.branch }} from master"

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -50,9 +50,6 @@ jobs:
         git fetch origin ${{ matrix.branch }}        
         git checkout -B ${{ matrix.branch }} origin/${{ matrix.branch }}
         
-        # Store the original commit hash to compare later
-        original_commit=$(git rev-parse HEAD)
-        
         if git rebase origin/master; then
           echo "OK: Rebase completed successfully with no conflicts."
         else
@@ -73,13 +70,12 @@ jobs:
           fi
         fi
         
-        # Check if there are any changes after rebase
-        new_commit=$(git rev-parse HEAD)
-        if [ "$original_commit" = "$new_commit" ]; then
-          echo "No changes detected after rebase. Branch is already up to date."
+        # Check if there are any changes between rebased branch and original remote branch
+        if git diff --quiet origin/${{ matrix.branch }} HEAD; then
+          echo "No changes detected between rebased branch and original remote branch. PR would not introduce any changes."
           echo "has-changes=false" >> $GITHUB_OUTPUT
         else
-          echo "Changes detected after rebase."
+          echo "Changes detected between rebased branch and original remote branch. PR will introduce changes."
           echo "has-changes=true" >> $GITHUB_OUTPUT
         fi
       id: rebase-check

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -78,7 +78,8 @@ jobs:
         delete-branch: true
         branch: update-${{ matrix.branch }}-from-master
         base: ${{ matrix.branch }}
-        body: "Automated update of ${{ matrix.branch }} branch with latest changes from master branch."
+        body: "Automated update of `${{ matrix.branch }}` branch with latest changes from master branch."
+        labels: "skip-docs-notification"
 
   slack-notification:
     needs: update-branches

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -73,10 +73,10 @@ jobs:
         # Check if there are any changes between rebased branch and original remote branch
         if git diff --quiet origin/${{ matrix.branch }} HEAD; then
           echo "No changes detected between rebased branch and original remote branch. PR would not introduce any changes."
-          echo "has-changes=false" >> $GITHUB_OUTPUT
+          echo "has-changes=false" >> "${GITHUB_OUTPUT}"
         else
           echo "Changes detected between rebased branch and original remote branch. PR will introduce changes."
-          echo "has-changes=true" >> $GITHUB_OUTPUT
+          echo "has-changes=true" >> "${GITHUB_OUTPUT}"
         fi
       id: rebase-check
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Use the navigation to the left to read about the available provider resources an
 You may want to consider pinning the [provider version](https://www.terraform.io/docs/configuration/providers.html#provider-versions) to ensure you have a chance to review and prepare for changes.
 Speaking of changes, see [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for current version information.  
 
-For the best experience, we recommend using the latest [HashiCorp Terraform Core Version](https://github.com/hashicorp/terraform).  For more details see [HashiCorp Terraform Version Compatibility Matrix](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#hashicorp-terraform-versionhttpswwwterraformiodownloadshtml-compatibility-matrix).
+For the best experience, we recommend using the latest [HashiCorp Terraform Core Version](https://github.com/hashicorp/terraform). For more details see [HashiCorp Terraform Version Compatibility Matrix](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#hashicorp-terraform-versionhttpswwwterraformiodownloadshtml-compatibility-matrix).
 
 ## Example Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Use the navigation to the left to read about the available provider resources an
 You may want to consider pinning the [provider version](https://www.terraform.io/docs/configuration/providers.html#provider-versions) to ensure you have a chance to review and prepare for changes.
 Speaking of changes, see [CHANGELOG](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CHANGELOG.md) for current version information.  
 
-For the best experience, we recommend using the latest [HashiCorp Terraform Core Version](https://github.com/hashicorp/terraform). For more details see [HashiCorp Terraform Version Compatibility Matrix](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#hashicorp-terraform-versionhttpswwwterraformiodownloadshtml-compatibility-matrix).
+For the best experience, we recommend using the latest [HashiCorp Terraform Core Version](https://github.com/hashicorp/terraform).  For more details see [HashiCorp Terraform Version Compatibility Matrix](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs#hashicorp-terraform-versionhttpswwwterraformiodownloadshtml-compatibility-matrix).
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

Docs team review improvements in dev branches

- Don't create the PR if no new changes have been introduced.
- Have a label skip-docs-notification to skip notifications to docs Team, only used from update dev branches GHA.
- Update update dev branches GHA to pass label skip-docs-notification
- Manual bypass is needed to merge branch to update dev branch from master if docs changes as docs team is an owner.
- Change owners file to always need an APIx Integration team reviewer even in docs. -> This is not possible, because: `/docs/ @mongodb/docs-cloud-team @mongodb/APIx-Integrations` means approval of EITHER of them, more info [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners):
```
# In this example, any change inside the `/scripts` directory
# will require approval from @doctocat or @octocat.
/scripts/ @doctocat @octocat
```

Link to any related issue(s): CLOUDP-329375

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
