### PR TITLE
test: Fixes streams connection kafka update tests

### DIFF
--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -127,7 +127,7 @@ func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T)
 			},
 			{
 				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
-				ExpectError: regexp.MustCompile("Stream networking access type cannot be modified"),
+				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 		},
 	})
@@ -147,7 +147,7 @@ func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T)
 			},
 			{
 				Config:      networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
-				ExpectError: regexp.MustCompile("Stream networking access type cannot be modified"),
+				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 		},
 	})

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -93,8 +93,9 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
+			// cannot change networking access type once set
 			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config:      configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
 				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 			{

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -94,40 +94,15 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
+				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
+			},
+			{
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       checkStreamConnectionImportStateIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"authentication.password"},
-			},
-		},
-	})
-}
-
-func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T) {
-	var (
-		projectID            = acc.ProjectIDExecution(t)
-		instanceName         = acc.RandomName()
-		vpcID                = os.Getenv("AWS_VPC_ID")
-		vpcCIDRBlock         = os.Getenv("AWS_VPC_CIDR_BLOCK")
-		awsAccountID         = os.Getenv("AWS_ACCOUNT_ID")
-		containerRegion      = os.Getenv("AWS_REGION")
-		peerRegion           = conversion.MongoDBRegionToAWSRegion(containerRegion)
-		providerName         = "AWS"
-		networkPeeringConfig = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAWS(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             CheckDestroyStreamConnection,
-		Steps: []resource.TestStep{
-			{
-				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
-				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, true, true),
-			},
-			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
-				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 		},
 	})

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -93,11 +93,6 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
-			// cannot change networking access type once set
-			{
-				Config:      configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
-				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
-			},
 			{
 				ResourceName:            resourceName,
 				ImportStateIdFunc:       checkStreamConnectionImportStateIDFunc(resourceName),
@@ -111,8 +106,15 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 
 func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 	var (
-		projectID    = acc.ProjectIDExecution(t)
-		instanceName = acc.RandomName()
+		projectID            = acc.ProjectIDExecution(t)
+		instanceName         = acc.RandomName()
+		vpcID                = os.Getenv("AWS_VPC_ID")
+		vpcCIDRBlock         = os.Getenv("AWS_VPC_CIDR_BLOCK")
+		awsAccountID         = os.Getenv("AWS_ACCOUNT_ID")
+		containerRegion      = os.Getenv("AWS_REGION")
+		peerRegion           = conversion.MongoDBRegionToAWSRegion(containerRegion)
+		providerName         = "AWS"
+		networkPeeringConfig = configNetworkPeeringAWS(projectID, providerName, vpcID, awsAccountID, vpcCIDRBlock, containerRegion, peerRegion)
 	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
@@ -122,6 +124,11 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 			{
 				Config: configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
 				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, true, true),
+			},
+			// cannot change networking access type once set
+			{
+				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 			{
 				ResourceName:            resourceName,

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -131,26 +131,6 @@ func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T)
 			},
 		},
 	})
-
-	// // Test the reverse direction: VPC to Public
-	var (
-		instanceName2 = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckPeeringEnvAWS(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             CheckDestroyStreamConnection,
-		Steps: []resource.TestStep{
-			{
-				Config: networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
-				Check:  checkKafkaAttributes(resourceName, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
-			},
-			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
-				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
-			},
-		},
-	})
 }
 
 func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -122,11 +122,11 @@ func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T)
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, false),
-				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, false, true),
+				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
+				Check:  checkKafkaAttributes(resourceName, instanceName, "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, true, true),
 			},
 			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, false),
+				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ExpectError: regexp.MustCompile("Stream networking access type cannot be modified"),
 			},
 		},
@@ -142,11 +142,11 @@ func TestAccStreamRSStreamConnection_invalidKafkaNetworkingUpdates(t *testing.T)
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, false),
-				Check:  checkKafkaAttributes(resourceName, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, false, true),
+				Config: networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Check:  checkKafkaAttributes(resourceName, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, false),
+				Config:      networkPeeringConfig + configureKafka(projectID, instanceName2, "user", "rawpassword", "localhost:9092", "earliest", kafkaNetworkingPublic, true),
 				ExpectError: regexp.MustCompile("Stream networking access type cannot be modified"),
 			},
 		},


### PR DESCRIPTION
## Description

The test for the kafka connection with VPC has a step where it is changing from a public networking type to a VPC type which is invalid and was fixed in our API with the following [PR](https://github.com/10gen/mms/pull/133418). This change updates the test to directly test the POST kafka connection with VPC. I also added a test to show the invalid updates on the networking type for the kafka connection.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
