### PR TITLE
feat: Adds `users` attribute to `mongodbatlas_team` singular data source.

### DIFF
--- a/.changelog/3483.txt
+++ b/.changelog/3483.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/mongodbatlas_team: Adds `users` attribute
+```

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -55,7 +55,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ### Users
 * `id` - Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.
-* `org_membership_status` - String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or they are already active in the organization.
+* `org_membership_status` - String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or are already active in the organization.
 * `roles` - Organization and project-level roles assigned to one MongoDB Cloud user within one organization.
 * `team_ids` - List of unique 24-hexadecimal digit strings that identifies the teams to which this MongoDB Cloud user belongs.
 * `username` - Email address that represents the username of the MongoDB Cloud user.

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -56,7 +56,7 @@ In addition to all arguments above, the following attributes are exported:
 ### Users
 * `id` - Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.
 * `org_membership_status` - String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or they are already active in the organization.
-* `roles` - Organization- and project-level roles assigned to one MongoDB Cloud user within one organization.
+* `roles` - Organization and project-level roles assigned to one MongoDB Cloud user within one organization.
 * `team_ids` - List of unique 24-hexadecimal digit strings that identifies the teams to which this MongoDB Cloud user belongs.
 * `username` - Email address that represents the username of the MongoDB Cloud user.
 * `country` - Two-character alphabetical string that identifies the MongoDB Cloud user's geographic location. This parameter uses the ISO 3166-1a2 code format.

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -50,8 +50,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Terraform's unique identifier used internally for state management.
 * `team_id` -  The unique identifier for the team.
 * `name` -  The name of the team you want to create.
-* `usernames` - The users who are part of the organization.
-* `users`- Returns a list of all pending and active MongoDB Cloud users associated with the specified organization.
+* `usernames` - The users who are part of the team.
+* `users`- Returns a list of all pending and active MongoDB Cloud users associated with the specified team.
 
 ### Users
 * `id` - Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -70,7 +70,7 @@ In addition to all arguments above, the following attributes are exported:
 * `mobile_number` - Mobile phone number that belongs to the MongoDB Cloud user.
 
 
-~> **NOTE:** - Users with pending invitations created using [`mongodbatlas_project_invitation`](../resources/project_invitation.md) resource or via the deprecated [Invite One MongoDB Cloud User to Join One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createprojectinvitation) endpoint are excluded (or cannot be managed) with this resource. See  [MongoDB Atlas API]<link-to-resource-API> for details. 
+~> **NOTE:** - Users with pending invitations created using [`mongodbatlas_project_invitation`](../resources/project_invitation.md) resource or via the deprecated [Invite One MongoDB Cloud User to Join One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createprojectinvitation) endpoint are excluded (or cannot be managed) with this resource. See  [MongoDB Atlas API](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/group/endpoint-mongodb-cloud-users) for details. 
 To manage these users with this resource/data source, refer to our [migration guide]<link-to-migration-guide>.
 
 See detailed information for arguments and attributes: [MongoDB API Teams](https://docs.atlas.mongodb.com/reference/api/teams-create-one/)

--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -51,5 +51,26 @@ In addition to all arguments above, the following attributes are exported:
 * `team_id` -  The unique identifier for the team.
 * `name` -  The name of the team you want to create.
 * `usernames` - The users who are part of the organization.
+* `users`- Returns a list of all pending and active MongoDB Cloud users associated with the specified organization.
+
+### Users
+* `id` - Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.
+* `org_membership_status` - String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or they are already active in the organization.
+* `roles` - Organization- and project-level roles assigned to one MongoDB Cloud user within one organization.
+* `team_ids` - List of unique 24-hexadecimal digit strings that identifies the teams to which this MongoDB Cloud user belongs.
+* `username` - Email address that represents the username of the MongoDB Cloud user.
+* `country` - Two-character alphabetical string that identifies the MongoDB Cloud user's geographic location. This parameter uses the ISO 3166-1a2 code format.
+* `invitation_created_at` - Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+* `invitation_expires_at` - Date and time when the invitation from MongoDB Cloud expires. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+* `inviter_username` - Username of the MongoDB Cloud user who sent the invitation to join the organization.
+* `created_at` - Date and time when MongoDB Cloud created the current account. This value is in the ISO 8601 timestamp format in UTC.
+* `first_name` - First or given name that belongs to the MongoDB Cloud user.
+* `last_auth` - Date and time when the current account last authenticated. This value is in the ISO 8601 timestamp format in UTC.
+* `last_name` - Last name, family name, or surname that belongs to the MongoDB Cloud user.
+* `mobile_number` - Mobile phone number that belongs to the MongoDB Cloud user.
+
+
+~> **NOTE:** - Users with pending invitations created using [`mongodbatlas_project_invitation`](../resources/project_invitation.md) resource or via the deprecated [Invite One MongoDB Cloud User to Join One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createprojectinvitation) endpoint are excluded (or cannot be managed) with this resource. See  [MongoDB Atlas API]<link-to-resource-API> for details. 
+To manage these users with this resource/data source, refer to our [migration guide]<link-to-migration-guide>.
 
 See detailed information for arguments and attributes: [MongoDB API Teams](https://docs.atlas.mongodb.com/reference/api/teams-create-one/)

--- a/internal/common/conversion/flatten_expand.go
+++ b/internal/common/conversion/flatten_expand.go
@@ -1,6 +1,8 @@
 package conversion
 
 import (
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"go.mongodb.org/atlas-sdk/v20250312005/admin"
@@ -24,6 +26,57 @@ func FlattenTags(tags []admin.ResourceTag) []map[string]string {
 			"key":   tag.GetKey(),
 			"value": tag.GetValue(),
 		}
+	}
+	return ret
+}
+
+func FlattenUsers(users []admin.OrgUserResponse) []map[string]any {
+	ret := make([]map[string]any, len(users))
+	for i := range users {
+		user := &users[i]
+		ret[i] = map[string]any{
+			"id":                    user.GetId(),
+			"org_membership_status": user.GetOrgMembershipStatus(),
+			"roles":                 flattenUserRoles(user.GetRoles()),
+			"team_ids":              user.GetTeamIds(),
+			"username":              user.GetUsername(),
+			"invitation_created_at": user.GetInvitationCreatedAt().Format(time.RFC3339),
+			"invitation_expires_at": user.GetInvitationExpiresAt().Format(time.RFC3339),
+			"inviter_username":      user.GetInviterUsername(),
+			"country":               user.GetCountry(),
+			"created_at":            user.GetCreatedAt().Format(time.RFC3339),
+			"first_name":            user.GetFirstName(),
+			"last_auth":             user.GetLastAuth().Format(time.RFC3339),
+			"last_name":             user.GetLastName(),
+			"mobile_number":         user.GetMobileNumber(),
+		}
+	}
+	return ret
+}
+
+func flattenUserRoles(roles admin.OrgUserRolesResponse) []map[string]any {
+	ret := make([]map[string]any, 0)
+	roleMap := map[string]any{
+		"org_roles":                 []string{},
+		"project_roles_assignments": []map[string]any{},
+	}
+	if roles.HasOrgRoles() {
+		roleMap["org_roles"] = roles.GetOrgRoles()
+	}
+	if roles.HasGroupRoleAssignments() {
+		roleMap["project_roles_assignments"] = flattenProjectRolesAssignments(roles.GetGroupRoleAssignments())
+	}
+	ret = append(ret, roleMap)
+	return ret
+}
+
+func flattenProjectRolesAssignments(assignments []admin.GroupRoleAssignment) []map[string]any {
+	ret := make([]map[string]any, 0, len(assignments))
+	for _, assignment := range assignments {
+		ret = append(ret, map[string]any{
+			"project_id":    assignment.GetGroupId(),
+			"project_roles": assignment.GetGroupRoles(),
+		})
 	}
 	return ret
 }

--- a/internal/common/dsschema/users_schema.go
+++ b/internal/common/dsschema/users_schema.go
@@ -1,0 +1,153 @@
+package dsschema
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"go.mongodb.org/atlas-sdk/v20250312005/admin"
+)
+
+var (
+	DSOrgUsersSchema = schema.Schema{
+		Type:     schema.TypeSet,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"org_membership_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"roles": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"org_roles": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"project_roles_assignments": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"project_id": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"project_roles": {
+											Type:     schema.TypeSet,
+											Computed: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"team_ids": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"username": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"invitation_created_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"invitation_expires_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"inviter_username": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"country": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"created_at": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"first_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"last_auth": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"last_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"mobile_number": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+)
+
+func FlattenUsers(users []admin.OrgUserResponse) []map[string]any {
+	ret := make([]map[string]any, len(users))
+	for i := range users {
+		user := &users[i]
+		ret[i] = map[string]any{
+			"id":                    user.GetId(),
+			"org_membership_status": user.GetOrgMembershipStatus(),
+			"roles":                 FlattenUserRoles(user.GetRoles()),
+			"team_ids":              user.GetTeamIds(),
+			"username":              user.GetUsername(),
+			"invitation_created_at": user.GetInvitationCreatedAt().Format(time.RFC3339),
+			"invitation_expires_at": user.GetInvitationExpiresAt().Format(time.RFC3339),
+			"inviter_username":      user.GetInviterUsername(),
+			"country":               user.GetCountry(),
+			"created_at":            user.GetCreatedAt().Format(time.RFC3339),
+			"first_name":            user.GetFirstName(),
+			"last_auth":             user.GetLastAuth().Format(time.RFC3339),
+			"last_name":             user.GetLastName(),
+			"mobile_number":         user.GetMobileNumber(),
+		}
+	}
+	return ret
+}
+
+func FlattenUserRoles(roles admin.OrgUserRolesResponse) []map[string]any {
+	ret := make([]map[string]any, 0)
+	roleMap := map[string]any{
+		"org_roles":                 []string{},
+		"project_roles_assignments": []map[string]any{},
+	}
+	if roles.HasOrgRoles() {
+		roleMap["org_roles"] = roles.GetOrgRoles()
+	}
+	if roles.HasGroupRoleAssignments() {
+		roleMap["project_roles_assignments"] = FlattenProjectRolesAssignments(roles.GetGroupRoleAssignments())
+	}
+	ret = append(ret, roleMap)
+	return ret
+}
+
+func FlattenProjectRolesAssignments(assignments []admin.GroupRoleAssignment) []map[string]any {
+	ret := make([]map[string]any, 0, len(assignments))
+	for _, assignment := range assignments {
+		ret = append(ret, map[string]any{
+			"project_id":    assignment.GetGroupId(),
+			"project_roles": assignment.GetGroupRoles(),
+		})
+	}
+	return ret
+}

--- a/internal/common/dsschema/users_schema.go
+++ b/internal/common/dsschema/users_schema.go
@@ -1,14 +1,11 @@
 package dsschema
 
 import (
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"go.mongodb.org/atlas-sdk/v20250312005/admin"
 )
 
-var (
-	DSOrgUsersSchema = schema.Schema{
+func DSOrgUsersSchema() *schema.Schema {
+	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Computed: true,
 		Elem: &schema.Resource{
@@ -99,55 +96,4 @@ var (
 			},
 		},
 	}
-)
-
-func FlattenUsers(users []admin.OrgUserResponse) []map[string]any {
-	ret := make([]map[string]any, len(users))
-	for i := range users {
-		user := &users[i]
-		ret[i] = map[string]any{
-			"id":                    user.GetId(),
-			"org_membership_status": user.GetOrgMembershipStatus(),
-			"roles":                 FlattenUserRoles(user.GetRoles()),
-			"team_ids":              user.GetTeamIds(),
-			"username":              user.GetUsername(),
-			"invitation_created_at": user.GetInvitationCreatedAt().Format(time.RFC3339),
-			"invitation_expires_at": user.GetInvitationExpiresAt().Format(time.RFC3339),
-			"inviter_username":      user.GetInviterUsername(),
-			"country":               user.GetCountry(),
-			"created_at":            user.GetCreatedAt().Format(time.RFC3339),
-			"first_name":            user.GetFirstName(),
-			"last_auth":             user.GetLastAuth().Format(time.RFC3339),
-			"last_name":             user.GetLastName(),
-			"mobile_number":         user.GetMobileNumber(),
-		}
-	}
-	return ret
-}
-
-func FlattenUserRoles(roles admin.OrgUserRolesResponse) []map[string]any {
-	ret := make([]map[string]any, 0)
-	roleMap := map[string]any{
-		"org_roles":                 []string{},
-		"project_roles_assignments": []map[string]any{},
-	}
-	if roles.HasOrgRoles() {
-		roleMap["org_roles"] = roles.GetOrgRoles()
-	}
-	if roles.HasGroupRoleAssignments() {
-		roleMap["project_roles_assignments"] = FlattenProjectRolesAssignments(roles.GetGroupRoleAssignments())
-	}
-	ret = append(ret, roleMap)
-	return ret
-}
-
-func FlattenProjectRolesAssignments(assignments []admin.GroupRoleAssignment) []map[string]any {
-	ret := make([]map[string]any, 0, len(assignments))
-	for _, assignment := range assignments {
-		ret = append(ret, map[string]any{
-			"project_id":    assignment.GetGroupId(),
-			"project_roles": assignment.GetGroupRoles(),
-		})
-	}
-	return ret
 }

--- a/internal/service/organization/data_source_organization.go
+++ b/internal/service/organization/data_source_organization.go
@@ -46,7 +46,7 @@ func DataSource() *schema.Resource {
 					},
 				},
 			},
-			"users": &dsschema.DSOrgUsersSchema,
+			"users": dsschema.DSOrgUsersSchema(),
 			"api_access_list_required": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -105,7 +105,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting organization users: %s", err))
 	}
-	if err := d.Set("users", dsschema.FlattenUsers(users)); err != nil {
+	if err := d.Set("users", conversion.FlattenUsers(users)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `users`: %s", err))
 	}
 

--- a/internal/service/organization/data_source_organization.go
+++ b/internal/service/organization/data_source_organization.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,100 +12,6 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-)
-
-var (
-	DSOrgUsersSchema = schema.Schema{
-		Type:     schema.TypeSet,
-		Computed: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"id": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"org_membership_status": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"roles": {
-					Type:     schema.TypeList,
-					Computed: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"org_roles": {
-								Type:     schema.TypeSet,
-								Computed: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-							},
-							"project_roles_assignments": {
-								Type:     schema.TypeSet,
-								Computed: true,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"project_id": {
-											Type:     schema.TypeString,
-											Computed: true,
-										},
-										"project_roles": {
-											Type:     schema.TypeSet,
-											Computed: true,
-											Elem:     &schema.Schema{Type: schema.TypeString},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				"team_ids": {
-					Type:     schema.TypeList,
-					Computed: true,
-					Elem:     &schema.Schema{Type: schema.TypeString},
-				},
-				"username": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"invitation_created_at": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"invitation_expires_at": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"inviter_username": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"country": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"created_at": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"first_name": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"last_auth": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"last_name": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"mobile_number": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-			},
-		},
-	}
 )
 
 func DataSource() *schema.Resource {
@@ -141,7 +46,7 @@ func DataSource() *schema.Resource {
 					},
 				},
 			},
-			"users": &DSOrgUsersSchema,
+			"users": &dsschema.DSOrgUsersSchema,
 			"api_access_list_required": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -168,57 +73,6 @@ func DataSource() *schema.Resource {
 			},
 		},
 	}
-}
-
-func flattenUsers(users []admin.OrgUserResponse) []map[string]any {
-	ret := make([]map[string]any, len(users))
-	for i := range users {
-		user := &users[i]
-		ret[i] = map[string]any{
-			"id":                    user.GetId(),
-			"org_membership_status": user.GetOrgMembershipStatus(),
-			"roles":                 flattenUserRoles(user.GetRoles()),
-			"team_ids":              user.GetTeamIds(),
-			"username":              user.GetUsername(),
-			"invitation_created_at": user.GetInvitationCreatedAt().Format(time.RFC3339),
-			"invitation_expires_at": user.GetInvitationExpiresAt().Format(time.RFC3339),
-			"inviter_username":      user.GetInviterUsername(),
-			"country":               user.GetCountry(),
-			"created_at":            user.GetCreatedAt().Format(time.RFC3339),
-			"first_name":            user.GetFirstName(),
-			"last_auth":             user.GetLastAuth().Format(time.RFC3339),
-			"last_name":             user.GetLastName(),
-			"mobile_number":         user.GetMobileNumber(),
-		}
-	}
-	return ret
-}
-
-func flattenUserRoles(roles admin.OrgUserRolesResponse) []map[string]any {
-	ret := make([]map[string]any, 0)
-	roleMap := map[string]any{
-		"org_roles":                 []string{},
-		"project_roles_assignments": []map[string]any{},
-	}
-	if roles.HasOrgRoles() {
-		roleMap["org_roles"] = roles.GetOrgRoles()
-	}
-	if roles.HasGroupRoleAssignments() {
-		roleMap["project_roles_assignments"] = flattenProjectRolesAssignments(roles.GetGroupRoleAssignments())
-	}
-	ret = append(ret, roleMap)
-	return ret
-}
-
-func flattenProjectRolesAssignments(assignments []admin.GroupRoleAssignment) []map[string]any {
-	ret := make([]map[string]any, 0, len(assignments))
-	for _, assignment := range assignments {
-		ret = append(ret, map[string]any{
-			"project_id":    assignment.GetGroupId(),
-			"project_roles": assignment.GetGroupRoles(),
-		})
-	}
-	return ret
 }
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -251,7 +105,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting organization users: %s", err))
 	}
-	if err := d.Set("users", flattenUsers(users)); err != nil {
+	if err := d.Set("users", dsschema.FlattenUsers(users)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `users`: %s", err))
 	}
 

--- a/internal/service/organization/data_source_organizations.go
+++ b/internal/service/organization/data_source_organizations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
@@ -63,7 +64,7 @@ func PluralDataSource() *schema.Resource {
 								},
 							},
 						},
-						"users": &DSOrgUsersSchema,
+						"users": &dsschema.DSOrgUsersSchema,
 						"api_access_list_required": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -153,7 +154,7 @@ func flattenOrganizations(ctx context.Context, conn *admin.APIClient, organizati
 			"skip_default_alerts_settings": organization.SkipDefaultAlertsSettings,
 			"is_deleted":                   organization.IsDeleted,
 			"links":                        conversion.FlattenLinks(organization.GetLinks()),
-			"users":                        flattenUsers(users),
+			"users":                        dsschema.FlattenUsers(users),
 			"api_access_list_required":     settings.ApiAccessListRequired,
 			"multi_factor_auth_required":   settings.MultiFactorAuthRequired,
 			"restrict_employee_access":     settings.RestrictEmployeeAccess,

--- a/internal/service/organization/data_source_organizations.go
+++ b/internal/service/organization/data_source_organizations.go
@@ -64,7 +64,7 @@ func PluralDataSource() *schema.Resource {
 								},
 							},
 						},
-						"users": &dsschema.DSOrgUsersSchema,
+						"users": dsschema.DSOrgUsersSchema(),
 						"api_access_list_required": {
 							Type:     schema.TypeBool,
 							Computed: true,
@@ -154,7 +154,7 @@ func flattenOrganizations(ctx context.Context, conn *admin.APIClient, organizati
 			"skip_default_alerts_settings": organization.SkipDefaultAlertsSettings,
 			"is_deleted":                   organization.IsDeleted,
 			"links":                        conversion.FlattenLinks(organization.GetLinks()),
-			"users":                        dsschema.FlattenUsers(users),
+			"users":                        conversion.FlattenUsers(users),
 			"api_access_list_required":     settings.ApiAccessListRequired,
 			"multi_factor_auth_required":   settings.MultiFactorAuthRequired,
 			"restrict_employee_access":     settings.RestrictEmployeeAccess,

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -207,16 +207,16 @@ func TestAccConfigDSOrganization_users(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "users.0.id"),
 					resource.TestCheckResourceAttrSet(datasourceName, "users.0.roles.0.org_roles.#"),
 					resource.TestCheckResourceAttrSet(datasourceName, "users.0.roles.0.project_roles_assignments.#"),
-					resource.TestMatchResourceAttr(datasourceName, "users.0.username", regexp.MustCompile(`.*@mongodb\.com$`)),
-					resource.TestMatchResourceAttr(datasourceName, "users.0.last_auth", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)), // Follows RFC3339 timestamp
+					resource.TestCheckResourceAttrWith(datasourceName, "users.0.username", acc.IsUsername()),
+					resource.TestCheckResourceAttrWith(datasourceName, "users.0.last_auth", acc.IsTimestamp()),
+					resource.TestCheckResourceAttrWith(datasourceName, "users.0.created_at", acc.IsTimestamp()),
 
 					resource.TestCheckResourceAttrWith(pluralDSName, "results.0.users.#", acc.IntGreatThan(0)),
 					resource.TestCheckResourceAttrSet(pluralDSName, "results.0.users.0.id"),
 					resource.TestCheckResourceAttrSet(pluralDSName, "results.0.users.0.roles.0.org_roles.#"),
 					resource.TestCheckResourceAttrSet(pluralDSName, "results.0.users.0.roles.0.project_roles_assignments.#"),
-					resource.TestMatchResourceAttr(pluralDSName, "results.0.users.0.username", regexp.MustCompile(`.*@mongodb\.com$`)),
-					resource.TestMatchResourceAttr(pluralDSName, "results.0.users.0.last_auth", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)), // Follows RFC3339 timestamp
-
+					resource.TestCheckResourceAttrWith(pluralDSName, "results.0.users.0.username", acc.IsUsername()),
+					resource.TestCheckResourceAttrWith(pluralDSName, "results.0.users.0.last_auth", acc.IsTimestamp()),
 				),
 			},
 		},

--- a/internal/service/team/data_source_team.go
+++ b/internal/service/team/data_source_team.go
@@ -45,7 +45,7 @@ func DataSource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"users": &dsschema.DSOrgUsersSchema,
+			"users": dsschema.DSOrgUsersSchema(),
 		},
 	}
 }
@@ -58,6 +58,10 @@ func LegacyTeamsDataSource() *schema.Resource {
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var (
+		/* Note: We continue using the legacy API for usernames endpoint due to behavioral differences
+		 	between API versions. The newer SDK returns both pending & active users.
+			The legacy API returns only active.*/
+
 		connV220241113   = meta.(*config.MongoDBClient).AtlasV220241113
 		connV2           = meta.(*config.MongoDBClient).AtlasV2
 		orgID            = d.Get("org_id").(string)
@@ -110,7 +114,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diag.FromErr(fmt.Errorf(errorTeamRead, err))
 	}
 
-	if err := d.Set("users", dsschema.FlattenUsers(users)); err != nil {
+	if err := d.Set("users", conversion.FlattenUsers(users)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `users`: %s", err))
 	}
 

--- a/internal/service/team/data_source_team_test.go
+++ b/internal/service/team/data_source_team_test.go
@@ -3,6 +3,7 @@ package team_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -29,6 +30,11 @@ func TestAccConfigDSTeam_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.team_ids.0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.roles.0.project_roles_assignments.#"),
+					resource.TestMatchResourceAttr(dataSourceName, "users.0.username", regexp.MustCompile(`.*@mongodb\.com$`)),
+					resource.TestMatchResourceAttr(dataSourceName, "users.0.last_auth", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)),  // Follows RFC3339 timestamp
+					resource.TestMatchResourceAttr(dataSourceName, "users.0.created_at", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)), // Follows RFC3339 timestamp
 				),
 			},
 		},
@@ -55,6 +61,32 @@ func TestAccConfigDSTeamByName_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", name),
 					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccConfigDSTeam_NoUsers(t *testing.T) {
+	var (
+		dataSourceName = "data.mongodbatlas_team.test3"
+		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name           = acc.RandomName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckAtlasUsername(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyTeam,
+		Steps: []resource.TestStep{
+			{
+				Config: dataSourceConfigNoUsers(orgID, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "org_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "team_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "users.#", "0"),
 				),
 			},
 		},
@@ -90,4 +122,20 @@ func dataSourceConfigBasicByName(orgID, name, username string) string {
 			name    = mongodbatlas_team.test.name
 		}
 	`, orgID, name, username)
+}
+
+func dataSourceConfigNoUsers(orgID, name string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_team" "test" {
+			org_id     = "%s"
+			name       = "%s"
+			usernames  = []
+		}
+
+		data "mongodbatlas_team" "test3" {
+			org_id     = mongodbatlas_team.test.org_id
+			team_id    = mongodbatlas_team.test.team_id
+		}
+
+	`, orgID, name)
 }

--- a/internal/service/team/data_source_team_test.go
+++ b/internal/service/team/data_source_team_test.go
@@ -3,7 +3,6 @@ package team_test
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,9 +31,9 @@ func TestAccConfigDSTeam_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "usernames.#", "1"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.team_ids.0"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.roles.0.project_roles_assignments.#"),
-					resource.TestMatchResourceAttr(dataSourceName, "users.0.username", regexp.MustCompile(`.*@mongodb\.com$`)),
-					resource.TestMatchResourceAttr(dataSourceName, "users.0.last_auth", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)),  // Follows RFC3339 timestamp
-					resource.TestMatchResourceAttr(dataSourceName, "users.0.created_at", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)), // Follows RFC3339 timestamp
+					resource.TestCheckResourceAttrWith(dataSourceName, "users.0.username", acc.IsUsername()),
+					resource.TestCheckResourceAttrWith(dataSourceName, "users.0.last_auth", acc.IsTimestamp()),
+					resource.TestCheckResourceAttrWith(dataSourceName, "users.0.created_at", acc.IsTimestamp()),
 				),
 			},
 		},
@@ -96,9 +95,9 @@ func TestAccConfigDSTeam_NoUsers(t *testing.T) {
 func dataSourceConfigBasic(orgID, name, username string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_team" "test" {
-			org_id     = "%s"
-			name       = "%s"
-			usernames  = ["%s"]
+			org_id     = %[1]q
+			name       = %[2]q
+			usernames  = [%[3]q]
 		}
 
 		data "mongodbatlas_team" "test" {
@@ -112,9 +111,9 @@ func dataSourceConfigBasic(orgID, name, username string) string {
 func dataSourceConfigBasicByName(orgID, name, username string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_team" "test" {
-			org_id     = "%s"
-			name       = "%s"
-			usernames  = ["%s"]
+			org_id     = %[1]q
+			name       = %[2]q
+			usernames  = [%[3]q]
 		}
 
 		data "mongodbatlas_team" "test2" {
@@ -127,8 +126,8 @@ func dataSourceConfigBasicByName(orgID, name, username string) string {
 func dataSourceConfigNoUsers(orgID, name string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_team" "test" {
-			org_id     = "%s"
-			name       = "%s"
+			org_id     = %[1]q
+			name       = %[2]q
 			usernames  = []
 		}
 

--- a/internal/testutil/acc/attribute_checks.go
+++ b/internal/testutil/acc/attribute_checks.go
@@ -14,6 +14,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+var (
+	matchTimestamp = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$`)
+	matchUsername  = regexp.MustCompile(`.*@mongodb\.com$`)
+)
+
 func MatchesExpression(expr string) resource.CheckResourceAttrWithFunc {
 	return func(value string) error {
 		matched, err := regexp.MatchString(expr, value)
@@ -22,6 +27,33 @@ func MatchesExpression(expr string) resource.CheckResourceAttrWithFunc {
 		}
 		if !matched {
 			return fmt.Errorf("%s did not match expression %s", value, expr)
+		}
+		return nil
+	}
+}
+
+// IsTimestamp checks if the value is a valid timestamp in RFC3339 format.
+func IsTimestamp() resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		matched, err := regexp.MatchString(matchTimestamp.String(), value)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return fmt.Errorf("expected a timestamp, got %s", value)
+		}
+		return nil
+	}
+}
+
+func IsUsername() resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		matched, err := regexp.MatchString(matchUsername.String(), value)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return fmt.Errorf("expected a username, got %s", value)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

Adds `users` attribute to `mongodbatlas_team` singular data source.

Link to any related issue(s): [CLOUDP-328757](https://jira.mongodb.org/browse/CLOUDP-328757)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
**Mixed SDK Usage**: This PR intentionally uses a mixture of old and new MongoDB Atlas Admin API SDK versions to maintain existing functionality while adding new functionality. I'm planning to investigate and open a ticket to standardize all calls to the new API version, if feasible.
