### PR TITLE
feat: Add azure attributes in federated database instance resource

### DIFF
--- a/.changelog/3484.txt
+++ b/.changelog/3484.txt
@@ -1,3 +1,11 @@
 ```release-note:enhancement
 resource/mongodbatlas_federated_database_instance: Adds `azure` attribute to allow the creation of federated databases with Azure cloud provider configuration
 ```
+
+```release-note:enhancement
+data-source/mongodbatlas_federated_database_instance: Adds `azure` attribute to support reading federated databases with Azure cloud provider configuration
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_federated_database_instances: Adds `azure` attribute to support reading federated databases with Azure cloud provider configuration
+```

--- a/.changelog/3484.txt
+++ b/.changelog/3484.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_federated_database_instance: Adds `azure` attribute to allow the creation of federated databases with Azure cloud provider configuration
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -768,6 +768,9 @@ jobs:
           MONGODB_ATLAS_FEDERATED_ISSUER_URI: ${{ inputs.mongodb_atlas_federated_issuer_uri }}
           MONGODB_ATLAS_FEDERATED_ORG_ID: ${{ inputs.mongodb_atlas_federated_org_id }}
           MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN: ${{ inputs.mongodb_atlas_federated_settings_associated_domain }}
+          AZURE_ATLAS_APP_ID: ${{ inputs.azure_atlas_app_id }}
+          AZURE_SERVICE_PRINCIPAL_ID: ${{ inputs.azure_service_principal_id }}
+          AZURE_TENANT_ID: ${{ inputs.azure_tenant_id }}
           AWS_S3_BUCKET: ${{ secrets.aws_s3_bucket_federation }}
           AWS_REGION: ${{ inputs.aws_region_federation }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}

--- a/internal/service/cloudprovideraccess/data_source_cloud_provider_access_setup.go
+++ b/internal/service/cloudprovideraccess/data_source_cloud_provider_access_setup.go
@@ -22,7 +22,7 @@ func DataSourceSetup() *schema.Resource {
 			"provider_name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"AWS"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"AWS", "AZURE"}, false),
 			},
 			"role_id": {
 				Type:     schema.TypeString,

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -26,13 +26,12 @@ func TestAccCloudProviderAccessSetupAzure_basic(t *testing.T) {
 		tenantID           = os.Getenv("AZURE_TENANT_ID")
 		projectID          = acc.ProjectIDExecution(t)
 	)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckCloudProviderAccessAzure(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: configSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID),
+				Config: acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
@@ -102,26 +101,6 @@ func configSetupAWS(projectID string) string {
 	 }
 
 	`, projectID)
-}
-
-func configSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID string) string {
-	return fmt.Sprintf(`
-	resource "mongodbatlas_cloud_provider_access_setup" "test" {
-		project_id = %[1]q
-		provider_name = "AZURE"
-		azure_config {
-			atlas_azure_app_id = %[2]q
-			service_principal_id = %[3]q
-			tenant_id = %[4]q
-		}
-	 }
-
-	 data "mongodbatlas_cloud_provider_access_setup" "test" {
-		project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
-		provider_name = "AWS"
-		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
-	 }
-	`, projectID, atlasAzureAppID, servicePrincipalID, tenantID)
 }
 
 func checkExists(resourceName string) resource.TestCheckFunc {

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -18,10 +18,10 @@ func TestAccCloudProviderAccessSetupAWS_basic(t *testing.T) {
 }
 
 const (
-	cloudProviderDataSource = `
+	cloudProviderAzureDataSource = `
 	     data "mongodbatlas_cloud_provider_access_setup" "test" {
         project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
-        provider_name = "AWS"
+        provider_name = "AZURE"
         role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
      }
 	`
@@ -41,7 +41,7 @@ func TestAccCloudProviderAccessSetupAzure_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID) + cloudProviderDataSource,
+				Config: acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID) + cloudProviderAzureDataSource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -17,6 +17,16 @@ func TestAccCloudProviderAccessSetupAWS_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicSetupTestCase(t))
 }
 
+const (
+	cloudProviderDataSource = `
+	     data "mongodbatlas_cloud_provider_access_setup" "test" {
+        project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
+        provider_name = "AWS"
+        role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
+     }
+	`
+)
+
 func TestAccCloudProviderAccessSetupAzure_basic(t *testing.T) {
 	var (
 		resourceName       = "mongodbatlas_cloud_provider_access_setup.test"
@@ -31,7 +41,7 @@ func TestAccCloudProviderAccessSetupAzure_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID),
+				Config: acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID) + cloudProviderDataSource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
@@ -332,7 +332,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstanceRead(ctx context.Context, d 
 		return diag.FromErr(fmt.Errorf("error setting `name` for data lakes (%s): %s", d.Id(), err))
 	}
 
-	if cloudProviderField := flattenCloudProviderConfig(dataFederationInstance.CloudProviderConfig); cloudProviderField != nil {
+	if cloudProviderField := flattenCloudProviderConfig(d, dataFederationInstance.CloudProviderConfig); cloudProviderField != nil {
 		if err = d.Set("cloud_provider_config", cloudProviderField); err != nil {
 			return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "cloud_provider_config", name, err))
 		}

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
@@ -332,7 +332,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstanceRead(ctx context.Context, d 
 		return diag.FromErr(fmt.Errorf("error setting `name` for data lakes (%s): %s", d.Id(), err))
 	}
 
-	if cloudProviderField := flattenCloudProviderConfig(d, dataFederationInstance.CloudProviderConfig); cloudProviderField != nil {
+	if cloudProviderField := flattenCloudProviderConfig(dataFederationInstance.CloudProviderConfig); cloudProviderField != nil {
 		if err = d.Set("cloud_provider_config", cloudProviderField); err != nil {
 			return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "cloud_provider_config", name, err))
 		}

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
@@ -71,6 +71,31 @@ func DataSource() *schema.Resource {
 								},
 							},
 						},
+						"azure": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"role_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"atlas_app_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"service_principal_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"tenant_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instance.go
@@ -33,72 +33,7 @@ func DataSource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"cloud_provider_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Computed: true,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"aws": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Computed: true,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"role_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"test_s3_bucket": {
-										Type:     schema.TypeString,
-										Computed: true,
-										Optional: true,
-									},
-									"iam_assumed_role_arn": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"iam_user_arn": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"external_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-						"azure": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"role_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"atlas_app_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"service_principal_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"tenant_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			"cloud_provider_config": cloudProviderConfig(true),
 			"data_process_region": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
@@ -45,47 +45,7 @@ func PluralDataSource() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"cloud_provider_config": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Computed: true,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"aws": {
-										Type:     schema.TypeList,
-										MaxItems: 1,
-										Computed: true,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"role_id": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"test_s3_bucket": {
-													Type:     schema.TypeString,
-													Computed: true,
-													Optional: true,
-												},
-												"iam_assumed_role_arn": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"iam_user_arn": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-												"external_id": {
-													Type:     schema.TypeString,
-													Computed: true,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
+						"cloud_provider_config": cloudProviderConfig(true),
 						"data_process_region": {
 							Type:     schema.TypeList,
 							Computed: true,

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
@@ -121,7 +121,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstancesRead(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("error getting MongoDB Atlas Federated Database Instances information: %s", err))
 	}
 
-	if results := flattenFederatedDatabaseInstances(d, projectID, federatedDatabaseInstances); results != nil {
+	if results := flattenFederatedDatabaseInstances(projectID, federatedDatabaseInstances); results != nil {
 		if err := d.Set("results", results); err != nil {
 			return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "results", projectID, err))
 		}
@@ -132,7 +132,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstancesRead(ctx context.Context, d
 	return nil
 }
 
-func flattenFederatedDatabaseInstances(d *schema.ResourceData, projectID string, federatedDatabaseInstances []admin.DataLakeTenant) []map[string]any {
+func flattenFederatedDatabaseInstances(projectID string, federatedDatabaseInstances []admin.DataLakeTenant) []map[string]any {
 	var federatedDatabaseInstancesMap []map[string]any
 
 	if len(federatedDatabaseInstances) > 0 {
@@ -144,7 +144,7 @@ func flattenFederatedDatabaseInstances(d *schema.ResourceData, projectID string,
 				"name":                  federatedDatabaseInstances[i].GetName(),
 				"state":                 federatedDatabaseInstances[i].GetState(),
 				"hostnames":             federatedDatabaseInstances[i].GetHostnames(),
-				"cloud_provider_config": flattenCloudProviderConfig(d, federatedDatabaseInstances[i].CloudProviderConfig),
+				"cloud_provider_config": flattenCloudProviderConfig(federatedDatabaseInstances[i].CloudProviderConfig),
 				"data_process_region":   flattenDataProcessRegion(federatedDatabaseInstances[i].DataProcessRegion),
 				"storage_databases":     flattenDataFederationDatabase(federatedDatabaseInstances[i].Storage.GetDatabases()),
 				"storage_stores":        flattenDataFederationStores(federatedDatabaseInstances[i].Storage.GetStores()),

--- a/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
+++ b/internal/service/federateddatabaseinstance/data_source_federated_database_instances.go
@@ -121,7 +121,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstancesRead(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("error getting MongoDB Atlas Federated Database Instances information: %s", err))
 	}
 
-	if results := flattenFederatedDatabaseInstances(projectID, federatedDatabaseInstances); results != nil {
+	if results := flattenFederatedDatabaseInstances(d, projectID, federatedDatabaseInstances); results != nil {
 		if err := d.Set("results", results); err != nil {
 			return diag.FromErr(fmt.Errorf(errorFederatedDatabaseInstanceSetting, "results", projectID, err))
 		}
@@ -132,7 +132,7 @@ func dataSourceMongoDBAtlasFederatedDatabaseInstancesRead(ctx context.Context, d
 	return nil
 }
 
-func flattenFederatedDatabaseInstances(projectID string, federatedDatabaseInstances []admin.DataLakeTenant) []map[string]any {
+func flattenFederatedDatabaseInstances(d *schema.ResourceData, projectID string, federatedDatabaseInstances []admin.DataLakeTenant) []map[string]any {
 	var federatedDatabaseInstancesMap []map[string]any
 
 	if len(federatedDatabaseInstances) > 0 {
@@ -144,7 +144,7 @@ func flattenFederatedDatabaseInstances(projectID string, federatedDatabaseInstan
 				"name":                  federatedDatabaseInstances[i].GetName(),
 				"state":                 federatedDatabaseInstances[i].GetState(),
 				"hostnames":             federatedDatabaseInstances[i].GetHostnames(),
-				"cloud_provider_config": flattenCloudProviderConfig(federatedDatabaseInstances[i].CloudProviderConfig),
+				"cloud_provider_config": flattenCloudProviderConfig(d, federatedDatabaseInstances[i].CloudProviderConfig),
 				"data_process_region":   flattenDataProcessRegion(federatedDatabaseInstances[i].DataProcessRegion),
 				"storage_databases":     flattenDataFederationDatabase(federatedDatabaseInstances[i].Storage.GetDatabases()),
 				"storage_stores":        flattenDataFederationStores(federatedDatabaseInstances[i].Storage.GetStores()),

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -777,10 +777,10 @@ func flattenCloudProviderConfig(cloudProviderConfig *admin.DataLakeCloudProvider
 
 	return []map[string]any{
 		{
-			"aws": flattenAWSCloudProviderConfig(cloudProviderConfig.Aws),
+			"aws":   flattenAWSCloudProviderConfig(cloudProviderConfig.Aws),
+			"azure": flattenAzureCloudProviderConfig(cloudProviderConfig.Azure),
 		},
 	}
-
 }
 
 func flattenAWSCloudProviderConfig(aws *admin.DataLakeAWSCloudProviderConfig) []map[string]any {
@@ -797,6 +797,21 @@ func flattenAWSCloudProviderConfig(aws *admin.DataLakeAWSCloudProviderConfig) []
 			"iam_assumed_role_arn": aws.GetIamAssumedRoleARN(),
 			"iam_user_arn":         aws.GetIamUserARN(),
 			"external_id":          aws.GetExternalId(),
+		},
+	}
+}
+
+func flattenAzureCloudProviderConfig(azure *admin.DataFederationAzureCloudProviderConfig) []map[string]any {
+	if azure == nil {
+		return nil
+	}
+
+	return []map[string]any{
+		{
+			"role_id":              azure.GetRoleId(),
+			"atlas_app_id":         azure.GetAtlasAppId(),
+			"service_principal_id": azure.GetServicePrincipalId(),
+			"tenant_id":            azure.GetTenantId(),
 		},
 	}
 }

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -54,71 +54,7 @@ func Resource() *schema.Resource {
 				},
 			},
 			// attribute not required in the create operation and not returned from the API when it is not set.
-			"cloud_provider_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Computed: true,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"aws": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							// Changing from required to optional to allow azure usage
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"role_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"test_s3_bucket": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"iam_assumed_role_arn": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"iam_user_arn": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"external_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-						"azure": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"role_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"atlas_app_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"service_principal_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"tenant_id": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			"cloud_provider_config": cloudProviderConfig(false),
 			"data_process_region": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -755,7 +755,6 @@ func newAzureConfig(cloudProvider []any) *admin.DataFederationAzureCloudProvider
 		azureSchema := azure[0].(map[string]any)
 		return admin.NewDataFederationAzureCloudProviderConfig(azureSchema["role_id"].(string))
 	}
-
 	return nil
 }
 

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -53,7 +53,7 @@ func Resource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			// attribute not required in the create operation and not returned from the API when it is not set.
+			// Optional-only behavior from the API, but keeping O+C to avoid behavior changes.
 			"cloud_provider_config": cloudProviderConfig(false),
 			"data_process_region": {
 				Type:     schema.TypeList,

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance.go
@@ -53,6 +53,7 @@ func Resource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			// attribute not required in the create operation and not returned from the API when it is not set.
 			"cloud_provider_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -63,6 +64,7 @@ func Resource() *schema.Resource {
 						"aws": {
 							Type:     schema.TypeList,
 							MaxItems: 1,
+							// Changing from required to optional to allow azure usage
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -137,47 +137,6 @@ func TestAccFederatedDatabaseInstance_azureCloudProviderConfig(t *testing.T) {
 	})
 }
 
-func configAzureCloudProvider(name, projectID, atlasAzureAppID, servicePrincipalID, tenantID string) string {
-	azureCloudProviderAccess := acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID)
-
-	return azureCloudProviderAccess + fmt.Sprintf(`
-
-resource "mongodbatlas_federated_database_instance" "test" {
-  project_id = %[2]q
-  name       = %[1]q
-
-  cloud_provider_config {
-    azure {
-		role_id         = mongodbatlas_cloud_provider_access_setup.test.role_id
-
-    }
-  }
-
-  storage_stores {
-    name         = "azure_store"
-    cluster_name = "azure_cluster"
-    project_id   = %[2]q
-    provider     = "atlas"
-    read_preference {
-      mode = "secondary"
-    }
-  }
-
-  storage_databases {
-    name = "VirtualDatabase0"
-    collections {
-      name = "VirtualCollection0"
-      data_sources {
-        collection = "listingsAndReviews"
-        database   = "sample_airbnb"
-        store_name = "azure_store"
-      }
-    }
-  }
-}
-`, name, projectID)
-}
-
 func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 	var (
 		specs = []acc.ReplicationSpecRequest{
@@ -471,6 +430,47 @@ resource "mongodbatlas_federated_database_instance" "test" {
    }
 }
 	`, name, testS3Bucket)
+}
+
+func configAzureCloudProvider(name, projectID, atlasAzureAppID, servicePrincipalID, tenantID string) string {
+	azureCloudProviderAccess := acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID)
+
+	return azureCloudProviderAccess + fmt.Sprintf(`
+
+resource "mongodbatlas_federated_database_instance" "test" {
+  project_id = %[2]q
+  name       = %[1]q
+
+  cloud_provider_config {
+    azure {
+		role_id         = mongodbatlas_cloud_provider_access_setup.test.role_id
+
+    }
+  }
+
+  storage_stores {
+    name         = "azure_store"
+    cluster_name = "azure_cluster"
+    project_id   = %[2]q
+    provider     = "atlas"
+    read_preference {
+      mode = "secondary"
+    }
+  }
+
+  storage_databases {
+    name = "VirtualDatabase0"
+    collections {
+      name = "VirtualCollection0"
+      data_sources {
+        collection = "listingsAndReviews"
+        database   = "sample_airbnb"
+        store_name = "azure_store"
+      }
+    }
+  }
+}
+`, name, projectID)
 }
 
 func configFirstSteps(federatedInstanceName, projectName, orgID string) string {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -438,8 +438,8 @@ func configAzureCloudProvider(name, projectID, atlasAzureAppID, servicePrincipal
 	return azureCloudProviderAccess + fmt.Sprintf(`
 
 resource "mongodbatlas_federated_database_instance" "test" {
-  project_id = %[2]q
   name       = %[1]q
+  project_id = %[2]q
 
   cloud_provider_config {
     azure {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -101,6 +101,83 @@ func TestAccFederatedDatabaseInstance_s3bucket(t *testing.T) {
 	})
 }
 
+func TestAccFederatedDatabaseInstance_azureCloudProviderConfig(t *testing.T) {
+	var (
+		resourceName       = "mongodbatlas_federated_database_instance.test"
+		projectID          = acc.ProjectIDExecution(t)
+		name               = acc.RandomName()
+		atlasAzureAppID    = os.Getenv("AZURE_ATLAS_APP_ID")
+		servicePrincipalID = os.Getenv("AZURE_SERVICE_PRINCIPAL_ID")
+		tenantID           = os.Getenv("AZURE_TENANT_ID")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckCloudProviderAccessAzure(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.CheckDestroyFederatedDatabaseInstance,
+		Steps: []resource.TestStep{
+			{
+				Config: configAzureCloudProvider(name, projectID, atlasAzureAppID, servicePrincipalID, tenantID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider_config.0.azure.0.role_id"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider_config.0.azure.0.atlas_app_id", atlasAzureAppID),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider_config.0.azure.0.service_principal_id", servicePrincipalID),
+					resource.TestCheckResourceAttr(resourceName, "cloud_provider_config.0.azure.0.tenant_id", tenantID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: importStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func configAzureCloudProvider(name, projectID, atlasAzureAppID, servicePrincipalID, tenantID string) string {
+	azureCloudProviderAccess := acc.ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID)
+
+	return azureCloudProviderAccess + fmt.Sprintf(`
+
+resource "mongodbatlas_federated_database_instance" "test" {
+  project_id = %[2]q
+  name       = %[1]q
+
+  cloud_provider_config {
+    azure {
+		role_id         = mongodbatlas_cloud_provider_access_setup.test.role_id
+
+    }
+  }
+
+  storage_stores {
+    name         = "azure_store"
+    cluster_name = "azure_cluster"
+    project_id   = %[2]q
+    provider     = "atlas"
+    read_preference {
+      mode = "secondary"
+    }
+  }
+
+  storage_databases {
+    name = "VirtualDatabase0"
+    collections {
+      name = "VirtualCollection0"
+      data_sources {
+        collection = "listingsAndReviews"
+        database   = "sample_airbnb"
+        store_name = "azure_store"
+      }
+    }
+  }
+}
+`, name, projectID)
+}
+
 func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 	var (
 		specs = []acc.ReplicationSpecRequest{

--- a/internal/service/federateddatabaseinstance/resource_schema.go
+++ b/internal/service/federateddatabaseinstance/resource_schema.go
@@ -1,0 +1,86 @@
+package federateddatabaseinstance
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func cloudProviderConfig(isDataSource bool) *schema.Schema {
+	var computed, optional, required bool
+	var maxItems int
+	if isDataSource {
+		computed = true
+		maxItems = 0
+	} else {
+		required = true
+		optional = true
+		maxItems = 1
+	}
+
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: maxItems,
+		Computed: true,
+		Optional: optional,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"aws": {
+					Type:     schema.TypeList,
+					MaxItems: maxItems,
+					Optional: optional,
+					Computed: computed,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"role_id": {
+								Type:     schema.TypeString,
+								Required: required,
+								Computed: computed,
+							},
+							"test_s3_bucket": {
+								Type:     schema.TypeString,
+								Required: required,
+								Computed: computed,
+							},
+							"iam_assumed_role_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"iam_user_arn": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"external_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"azure": {
+					Type:     schema.TypeList,
+					MaxItems: maxItems,
+					Optional: optional,
+					Computed: computed,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"role_id": {
+								Type:     schema.TypeString,
+								Required: required,
+								Computed: computed,
+							},
+							"atlas_app_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"service_principal_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"tenant_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/service/federateddatabaseinstance/resource_schema.go
+++ b/internal/service/federateddatabaseinstance/resource_schema.go
@@ -18,13 +18,13 @@ func cloudProviderConfig(isDataSource bool) *schema.Schema {
 		Type:     schema.TypeList,
 		MaxItems: maxItems,
 		Computed: true,
-		Optional: optional,
+		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"aws": {
 					Type:     schema.TypeList,
 					MaxItems: maxItems,
-					Optional: optional,
+					Optional: true,
 					Computed: computed,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -36,7 +36,7 @@ func cloudProviderConfig(isDataSource bool) *schema.Schema {
 							"test_s3_bucket": {
 								Type:     schema.TypeString,
 								Required: required,
-								Computed: computed,
+								Optional: isDataSource,
 							},
 							"iam_assumed_role_arn": {
 								Type:     schema.TypeString,

--- a/internal/testutil/acc/cloud_provider_access.go
+++ b/internal/testutil/acc/cloud_provider_access.go
@@ -1,0 +1,23 @@
+package acc
+
+import "fmt"
+
+func ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID string) string {
+	return fmt.Sprintf(`
+	resource "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = %[1]q
+		provider_name = "AZURE"
+		azure_config {
+			atlas_azure_app_id = %[2]q
+			service_principal_id = %[3]q
+			tenant_id = %[4]q
+		}
+	 }
+
+	 data "mongodbatlas_cloud_provider_access_setup" "test" {
+		project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
+		provider_name = "AWS"
+		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
+	 }
+	`, projectID, atlasAzureAppID, servicePrincipalID, tenantID)
+}

--- a/internal/testutil/acc/cloud_provider_access.go
+++ b/internal/testutil/acc/cloud_provider_access.go
@@ -13,11 +13,5 @@ func ConfigSetupAzure(projectID, atlasAzureAppID, servicePrincipalID, tenantID s
 			tenant_id = %[4]q
 		}
 	 }
-
-	 data "mongodbatlas_cloud_provider_access_setup" "test" {
-		project_id = mongodbatlas_cloud_provider_access_setup.test.project_id
-		provider_name = "AWS"
-		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
-	 }
 	`, projectID, atlasAzureAppID, servicePrincipalID, tenantID)
 }


### PR DESCRIPTION
## Description

- Adds azure to cloud-provider config in `federated_database_instance`
- Refactored out the cloud_provider_access setup for Azure to `acc.cloud_provider_access.go`
- There is already a migration test for empty CloudProvider config, so decided not to include an extra migration test.

Link to any related issue(s): CLOUDP-245406

## Follow up Work
1. Implement data source and refactor tests to run together with resource. 
2. Add documentation

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.