### PR TITLE
chore: Adjust provider version for `organization` examples

### DIFF
--- a/examples/mongodbatlas_organization/README.md
+++ b/examples/mongodbatlas_organization/README.md
@@ -13,7 +13,7 @@ This project provides examples for both creating new MongoDB Atlas Organizations
 
 * Terraform v0.15 or greater
 * A MongoDB Atlas account 
-* provider.mongodbatlas: version = "~> 1.10.0" for creating an organization, 1.38.0 for importing an existing organization.
+* provider.mongodbatlas: version = "~> 1.10" for creating an organization, 1.38 for importing an existing organization.
 * [Cross-organization billing](https://www.mongodb.com/docs/atlas/billing/#cross-organization-billing) enabled and the requesting API Key's organization must be a paying organization. 
 * Some users (see [here](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1083)) have reported issues deploying this starter example with Mac M1 CPU. you encounter this issue, try deploying instead on x86 linux if possible. See list of supported binaries [here](https://github.com/mongodb/terraform-provider-mongodbatlas/releases/tag/v1.8.1)  
 

--- a/examples/mongodbatlas_organization/organization-import/README.md
+++ b/examples/mongodbatlas_organization/organization-import/README.md
@@ -11,7 +11,7 @@ Don't include `org_owner_id`, `description`, `role_names` or `federation_setting
 ## Dependencies
 
 - Terraform v0.15 or greater
-- provider.mongodbatlas: version = "~> 1.38.0"
+- provider.mongodbatlas: version = "~> 1.38"
 - MongoDB Atlas account with an existing organization
 - API key with Organization Owner permissions for the organization you want to import
 - Organization ID of the existing organization

--- a/examples/mongodbatlas_organization/organization-import/versions.tf
+++ b/examples/mongodbatlas_organization/organization-import/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      version = "~> 1.38"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_organization/organization-step-1/Readme.md
+++ b/examples/mongodbatlas_organization/organization-step-1/Readme.md
@@ -11,7 +11,7 @@ This project aims to provide a very straight-forward example of setting up a Mon
 
 * Terraform v0.15 or greater
 * A MongoDB Atlas account 
-* provider.mongodbatlas: version = "~> 1.10.0"
+* provider.mongodbatlas: version = "~> 1.10"
 * [Cross-organization billing](https://www.mongodb.com/docs/atlas/billing/#cross-organization-billing) enabled and the requesting API Key's organization must be a paying organization. 
 * Some users (see [here](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1083)) have reported issues deploying this starter example with Mac M1 CPU. you encounter this issue, try deploying instead on x86 linux if possible. See list of supported binaries [here](https://github.com/mongodb/terraform-provider-mongodbatlas/releases/tag/v1.8.1)  
 

--- a/examples/mongodbatlas_organization/organization-step-1/versions.tf
+++ b/examples/mongodbatlas_organization/organization-step-1/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      version = "~> 1.10"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_organization/organization-step-2/Readme.md
+++ b/examples/mongodbatlas_organization/organization-step-2/Readme.md
@@ -8,7 +8,7 @@ This project aims to provide a very straight-forward example of setting up Terra
 
 * Terraform v0.15 or greater
 * A MongoDB Atlas account 
-* provider.mongodbatlas: version = "~> 1.10.0"
+* provider.mongodbatlas: version = "~> 1.10"
 * Some users (see [here](https://github.com/mongodb/terraform-provider-mongodbatlas/issues/1083)) have reported issues deploying this starter example with Mac M1 CPU. you encounter this issue, try deploying instead on x86 linux if possible. See list of supported binaries [here](https://github.com/mongodb/terraform-provider-mongodbatlas/releases/tag/v1.8.1)  
 
 ## Usage

--- a/examples/mongodbatlas_organization/organization-step-2/versions.tf
+++ b/examples/mongodbatlas_organization/organization-step-2/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      version = "~> 1.10"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
## Description

Adjust provider version for `organization` examples. This has to be done after provider version 1.38.0 was released.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
