### PR TITLE
deprecate: Deprecates & updates `resource.mongodbatlas_team.usernames` attribute to be Optional & Computed

### DIFF
--- a/.changelog/3494.txt
+++ b/.changelog/3494.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/mongodbatlas_team: Deprecates `usernames` attribute & makes it Optional & Computed in favour of `mongodbatlas_cloud_user_team_assignment` resource
+```
+
+```release-note:note
+data-source/mongodbatlas_team: Deprecates `usernames` attribute in favour of `data.mongodbatlas_team.users` attribute
+```

--- a/internal/common/constant/deprecation.go
+++ b/internal/common/constant/deprecation.go
@@ -13,4 +13,5 @@ const (
 	DeprecationParamByDateWithExternalLink      = "This parameter is deprecated and will be removed in %s. For more details see %s."
 	DeprecationSharedTier                       = "Shared-tier instance sizes are deprecated and will reach End of Life in %s. For more details see %s"
 	ServerlessSharedEOLDate                     = "January 2026"
+	DeprecationNextMajorWithReplacementGuide    = "This %s is deprecated and will be removed in the next major release. Please transition to `%s`. For more details, see %s."
 )

--- a/internal/service/team/data_source_team.go
+++ b/internal/service/team/data_source_team.go
@@ -39,8 +39,9 @@ func DataSource() *schema.Resource {
 				ConflictsWith: []string{"team_id"},
 			},
 			"usernames": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationNextMajorWithReplacementGuide, "parameter", "data.mongodbatlas_team.users", "<link-to-migration-guide>"),
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/service/team/resource_team.go
+++ b/internal/service/team/resource_team.go
@@ -56,7 +56,8 @@ func Resource() *schema.Resource {
 			},
 			"usernames": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/internal/service/team/resource_team.go
+++ b/internal/service/team/resource_team.go
@@ -55,9 +55,10 @@ func Resource() *schema.Resource {
 				Required: true,
 			},
 			"usernames": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: fmt.Sprintf(constant.DeprecationNextMajorWithReplacementGuide, "parameter", "mongodbatlas_cloud_user_team_assignment", "<link-to-migration-guide>"),
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -77,11 +78,15 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	orgID := d.Get("org_id").(string)
 
 	usernames := conversion.ExpandStringListFromSetSchema(d.Get("usernames").(*schema.Set))
-	teamsResp, _, err := connV2.TeamsApi.CreateTeam(ctx, orgID,
-		&admin20241113.Team{
-			Name:      d.Get("name").(string),
-			Usernames: usernames,
-		}).Execute()
+	createTeamReq := &admin20241113.Team{
+		Name: d.Get("name").(string),
+	}
+
+	if len(usernames) > 0 {
+		createTeamReq.Usernames = usernames
+	}
+
+	teamsResp, _, err := connV2.TeamsApi.CreateTeam(ctx, orgID, createTeamReq).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorTeamCreate, err))
 	}

--- a/internal/service/team/resource_team_migration_test.go
+++ b/internal/service/team/resource_team_migration_test.go
@@ -63,8 +63,10 @@ func TestMigConfigTeams_usernamesDeprecation(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", username),
 				),
 			},
+			mig.TestStepCheckEmptyPlan(configBasic(orgID, name, &usernames)),
 			{
-				Config: configBasic(orgID, name, nil),
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configBasic(orgID, name, nil),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
@@ -74,6 +76,7 @@ func TestMigConfigTeams_usernamesDeprecation(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", username),
 				),
 			},
+			mig.TestStepCheckEmptyPlan(configBasic(orgID, name, nil)),
 		},
 	})
 }

--- a/internal/service/team/resource_team_migration_test.go
+++ b/internal/service/team/resource_team_migration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
@@ -15,7 +16,8 @@ func TestMigConfigTeams_basic(t *testing.T) {
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		username     = os.Getenv("MONGODB_ATLAS_USERNAME")
 		name         = acc.RandomName()
-		config       = configBasic(orgID, name, []string{username})
+		usernames    = []string{username}
+		config       = configBasic(orgID, name, &usernames)
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -33,6 +35,45 @@ func TestMigConfigTeams_basic(t *testing.T) {
 				),
 			},
 			mig.TestStepCheckEmptyPlan(config),
+		},
+	})
+}
+
+func TestMigConfigTeams_usernamesDeprecation(t *testing.T) {
+	var (
+		resourceName = "mongodbatlas_team.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		username     = os.Getenv("MONGODB_ATLAS_USERNAME")
+		name         = acc.RandomName()
+		usernames    = []string{username}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckAtlasUsername(t) },
+		CheckDestroy: acc.CheckDestroyTeam,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configBasic(orgID, name, &usernames),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", username),
+				),
+			},
+			{
+				Config: configBasic(orgID, name, nil),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					// usernames should still be present in state (computed) but not in config
+					resource.TestCheckResourceAttr(resourceName, "usernames.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "usernames.*", username),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

Updates `resource.mongodbatlas_team.usernames` attribute to be Optional & Computed

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-329988

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
