### PR TITLE
feat: Changes `hour_of_day` in `mongodbatlas_maintenance_window` to Required

### DIFF
--- a/.changelog/3499.txt
+++ b/.changelog/3499.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/mongodbatlas_maintenance_window: Changes `hour_of_day` to Required
+```
+
+```release-note:breaking-change
+resource/mongodbatlas_maintenance_window: Changes `start_asap` to Computed only
+```

--- a/docs/data-sources/maintenance_window.md
+++ b/docs/data-sources/maintenance_window.md
@@ -41,7 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
-* `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
+* `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If requested, this field returns true from the time the request was made until the time the maintenance event completes.
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -41,7 +41,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
-* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12 (Time zone is UTC). Defaults to 0.
+* `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12 (Time zone is UTC).
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `defer` - Defer the next scheduled maintenance for the given project for one week.
 * `auto_defer` - Defer any scheduled maintenance for the given project for one week.

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -42,13 +42,10 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12 (Time zone is UTC).
-* `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `defer` - Defer the next scheduled maintenance for the given project for one week.
 * `auto_defer` - Defer any scheduled maintenance for the given project for one week.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
-
--> **NOTE:** The `start_asap` attribute can't be used because of breaks the Terraform flow, but you can enable via API.
 
 ### Protected Hours
 * `start_hour_of_day` - Zero-based integer that represents the beginning hour of the day for the protected hours window.
@@ -60,6 +57,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 * `time_zone_id` - Identifier for the current time zone of the maintenance window. This can only be updated via the Project Settings UI.
+* `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If requested, this field returns true from the time the request was made until the time the maintenance event completes.
+
+-> **NOTE:** The `start_asap` attribute can only be enabled via API.
 
 ## Import
 

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -61,7 +61,6 @@ func Resource() *schema.Resource {
 			},
 			"start_asap": {
 				Type:     schema.TypeBool,
-				Optional: true,
 				Computed: true,
 			},
 			"number_of_deferrals": {

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -49,10 +49,8 @@ func Resource() *schema.Resource {
 				},
 			},
 			"hour_of_day": {
-				Type:          schema.TypeInt,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"start_asap"},
+				Type:     schema.TypeInt,
+				Required: true,
 				ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 					v := val.(int)
 					if v < 0 || v > 23 {
@@ -124,9 +122,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	params := new(admin.GroupMaintenanceWindow)
 
 	params.DayOfWeek = cast.ToInt(d.Get("day_of_week"))
-
-	hourOfDay := d.Get("hour_of_day")
-	params.HourOfDay = conversion.Pointer(cast.ToInt(hourOfDay)) // during creation of maintenance window hourOfDay needs to be set in PATCH to avoid errors, 0 value is sent when absent
+	params.HourOfDay = conversion.Pointer(cast.ToInt(d.Get("hour_of_day")))
 
 	if autoDeferOnceEnabled, ok := d.GetOk("auto_defer_once_enabled"); ok {
 		params.AutoDeferOnceEnabled = conversion.Pointer(autoDeferOnceEnabled.(bool))

--- a/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_migration_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 	"github.com/spf13/cast"
@@ -17,7 +16,7 @@ func TestMigConfigMaintenanceWindow_basic(t *testing.T) {
 		projectName = acc.RandomProjectName()
 		dayOfWeek   = 7
 		hourOfDay   = 3
-		config      = configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay), nil)
+		config      = configBasic(orgID, projectName, dayOfWeek, hourOfDay, nil)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/maintenancewindow/resource_maintenance_window_test.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window_test.go
@@ -45,20 +45,19 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				// testing hour_of_day set to 0 during creation phase does not return errors
-				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay), defaultProtectedHours),
+				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay, defaultProtectedHours),
 				Check:  checkBasic(dayOfWeek, hourOfDay, defaultProtectedHours),
 			},
 			{
-				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDayUpdated), updatedProtectedHours),
+				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDayUpdated, updatedProtectedHours),
 				Check:  checkBasic(dayOfWeek, hourOfDayUpdated, updatedProtectedHours),
 			},
 			{
-				Config: configBasic(orgID, projectName, dayOfWeekUpdated, conversion.Pointer(hourOfDay), nil),
+				Config: configBasic(orgID, projectName, dayOfWeekUpdated, hourOfDay, nil),
 				Check:  checkBasic(dayOfWeekUpdated, hourOfDay, nil),
 			},
 			{
-				Config: configBasic(orgID, projectName, dayOfWeek, conversion.Pointer(hourOfDay), defaultProtectedHours),
+				Config: configBasic(orgID, projectName, dayOfWeek, hourOfDay, defaultProtectedHours),
 				Check:  checkBasic(dayOfWeek, hourOfDay, defaultProtectedHours),
 			},
 			{
@@ -66,26 +65,6 @@ func TestAccConfigRSMaintenanceWindow_basic(t *testing.T) {
 				ImportStateIdFunc: importStateIDFunc(resourceName),
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccConfigRSMaintenanceWindow_emptyHourOfDay(t *testing.T) {
-	var (
-		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName = acc.RandomProjectName()
-		dayOfWeek   = 7
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configBasic(orgID, projectName, dayOfWeek, nil, defaultProtectedHours),
-				Check:  checkBasic(dayOfWeek, 0, defaultProtectedHours),
 			},
 		},
 	})
@@ -167,11 +146,7 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	}
 }
 
-func configBasic(orgID, projectName string, dayOfWeek int, hourOfDay *int, protectedHours *admin.ProtectedHours) string {
-	hourOfDayAttr := ""
-	if hourOfDay != nil {
-		hourOfDayAttr = fmt.Sprintf("hour_of_day = %d", *hourOfDay)
-	}
+func configBasic(orgID, projectName string, dayOfWeek, hourOfDay int, protectedHours *admin.ProtectedHours) string {
 	protectedHoursStr := ""
 	if protectedHours != nil {
 		protectedHoursStr = fmt.Sprintf(`
@@ -189,10 +164,10 @@ func configBasic(orgID, projectName string, dayOfWeek int, hourOfDay *int, prote
 		resource "mongodbatlas_maintenance_window" "test" {
 			project_id  = mongodbatlas_project.test.id
 			day_of_week = %[3]d
-			%[4]s
+			hour_of_day = %[4]d
 			%[5]s
 
-		}`, orgID, projectName, dayOfWeek, hourOfDayAttr, protectedHoursStr)
+		}`, orgID, projectName, dayOfWeek, hourOfDay, protectedHoursStr)
 }
 
 func configWithAutoDeferEnabled(orgID, projectName string, dayOfWeek, hourOfDay int) string {


### PR DESCRIPTION
## Description

- Changes `hour_of_day` in `mongodbatlas_maintenance_window` to Required
- Changes `start_asap` in `mongodbatlas_maintenance_window` to Computed only. This is technically a breaking change, but this field was not used in the Create or Update, so effectively it was already behaving as a Computed only attribute. This field was already changed to Computed only in https://github.com/mongodb/terraform-provider-mongodbatlas/commit/af8b57545492fb61588add48d5d99952ce5def1f because it broke Terraform, but then for some reason (I think by mistake), the Optional was added back in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1886 . The PR does not mention the change in any way, that is why I think it was a mistake. This amends that mistake.

Link to any related issue(s): CLOUDP-301793

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
