### PR TITLE
feat: Changes `export` and `auto_export_enabled` to Optional only in `mongodbatlas_cloud_backup_schedule` resource

### DIFF
--- a/.changelog/3500.txt
+++ b/.changelog/3500.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/mongodbatlas_cloud_backup_schedule: Changes `export` and `auto_export_enabled` to Optional only
+```

--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -228,7 +228,7 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `policy_item_weekly` - (Optional) Weekly policy item. See [below](#policy_item_weekly)
 * `policy_item_monthly` - (Optional) Monthly policy item. See [below](#policy_item_monthly)
 * `policy_item_yearly` - (Optional) Yearly policy item. See [below](#policy_item_yearly)
-* `auto_export_enabled` - Flag that indicates whether MongoDB Cloud automatically exports Cloud Backup Snapshots to the Export Bucket. Value can be one of the following:
+* `auto_export_enabled` - (Optional) Flag that indicates whether MongoDB Cloud automatically exports Cloud Backup Snapshots to the Export Bucket. Value can be one of the following:
 	* true - Enables automatic export of cloud backup snapshots to the Export Bucket.
  	* false - Disables automatic export of cloud backup snapshots to the Export Bucket. (default)
 * `use_org_and_group_names_in_export_prefix` - Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your bucket after it finishes exporting the snapshots. To learn more about the metadata files that Atlas uploads, see [Export Cloud Backup Snapshot](https://www.mongodb.com/docs/atlas/backup/cloud-backup/export/#std-label-cloud-provider-snapshot-export).

--- a/docs/resources/cloud_backup_schedule.md
+++ b/docs/resources/cloud_backup_schedule.md
@@ -228,12 +228,12 @@ resource "mongodbatlas_cloud_backup_schedule" "test" {
 * `policy_item_weekly` - (Optional) Weekly policy item. See [below](#policy_item_weekly)
 * `policy_item_monthly` - (Optional) Monthly policy item. See [below](#policy_item_monthly)
 * `policy_item_yearly` - (Optional) Yearly policy item. See [below](#policy_item_yearly)
-* `auto_export_enabled` - Flag that indicates whether MongoDB Cloud automatically exports Cloud Backup Snapshots to the Export Bucket. Once enabled, it must be disabled by explicitly setting the value to `false`. Value can be one of the following:
+* `auto_export_enabled` - Flag that indicates whether MongoDB Cloud automatically exports Cloud Backup Snapshots to the Export Bucket. Value can be one of the following:
 	* true - Enables automatic export of cloud backup snapshots to the Export Bucket.
  	* false - Disables automatic export of cloud backup snapshots to the Export Bucket. (default)
 * `use_org_and_group_names_in_export_prefix` - Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your bucket after it finishes exporting the snapshots. To learn more about the metadata files that Atlas uploads, see [Export Cloud Backup Snapshot](https://www.mongodb.com/docs/atlas/backup/cloud-backup/export/#std-label-cloud-provider-snapshot-export).
 * `copy_settings` - List that contains a document for each copy setting item in the desired backup policy. See [below](#copy_settings)
-* `export` - Policy for automatically exporting Cloud Backup Snapshots. `auto_export_enabled` must be set to true when defining this attribute. See [below](#export)
+* `export` - Policy for automatically exporting Cloud Backup Snapshots. See [below](#export)
 ### export
 * `export_bucket_id` - Unique identifier of the mongodbatlas_cloud_backup_snapshot_export_bucket export_bucket_id value.
 * `frequency_type` - Frequency associated with the export snapshot item: `weekly`, `monthly`, `yearly`, `daily` (requires reaching out to Customer Support)

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -143,13 +143,12 @@ func TestMigBackupRSCloudBackupSchedule_export(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          mig.PreCheckBasicSleep(t),
-		ExternalProviders: acc.ExternalProvidersOnlyAWS(),
-		CheckDestroy:      checkDestroy,
+		PreCheck:     mig.PreCheckBasicSleep(t),
+		CheckDestroy: checkDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: Apply config with export and auto_export_enabled (old provider)
 			{
-				ExternalProviders: mig.ExternalProviders(),
+				ExternalProviders: mig.ExternalProvidersWithAWS(),
 				Config:            configWithExport,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkExists(resourceName),
@@ -160,7 +159,7 @@ func TestMigBackupRSCloudBackupSchedule_export(t *testing.T) {
 			},
 			// Step 2: Remove export and auto_export_enabled, expect empty plan (old provider)
 			{
-				ExternalProviders: mig.ExternalProviders(),
+				ExternalProviders: mig.ExternalProvidersWithAWS(),
 				Config:            configWithExport,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -143,8 +143,9 @@ func TestMigBackupRSCloudBackupSchedule_export(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     mig.PreCheckBasicSleep(t),
-		CheckDestroy: checkDestroy,
+		PreCheck:          mig.PreCheckBasicSleep(t),
+		ExternalProviders: acc.ExternalProvidersOnlyAWS(),
+		CheckDestroy:      checkDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: Apply config with export and auto_export_enabled (old provider)
 			{

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
@@ -124,6 +125,59 @@ func TestMigBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 				Check:                    resource.ComposeAggregateTestCheckFunc(checksUpdateWithZoneID...),
 			},
 			mig.TestStepCheckEmptyPlan(copySettingsConfigWithZoneID),
+		},
+	})
+}
+
+func TestMigBackupRSCloudBackupSchedule_export(t *testing.T) {
+	// TODO: uncomment before merging this, this is temporary to make sure the test is working
+	// mig.SkipIfVersionBelow(t, "2.0.0")
+	var (
+		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
+		policyName  = acc.RandomName()
+		roleName    = acc.RandomIAMRole()
+		bucketName  = acc.RandomS3BucketName()
+
+		configWithExport    = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, true, true)
+		configWithoutExport = configExportPolicies(&clusterInfo, policyName, roleName, bucketName, false, false)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     mig.PreCheckBasicSleep(t),
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Apply config with export and auto_export_enabled (old provider)
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configWithExport,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
+					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "1"),
+				),
+			},
+			// Step 2: Remove export and auto_export_enabled, expect empty plan (old provider)
+			{
+				ExternalProviders: mig.ExternalProviders(),
+				Config:            configWithExport,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			// Step 3: Apply config without export and auto_export_enabled (new provider)
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   configWithoutExport,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterInfo.Name),
+					resource.TestCheckResourceAttr(resourceName, "auto_export_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "export.#", "0"),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -130,8 +130,7 @@ func TestMigBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
 }
 
 func TestMigBackupRSCloudBackupSchedule_export(t *testing.T) {
-	// TODO: uncomment before merging this, this is temporary to make sure the test is working
-	// mig.SkipIfVersionBelow(t, "2.0.0")
+	mig.SkipIfVersionBelow(t, "2.0.0") // in 2.0.0 we made auto_export_enabled and export fields optional only
 	var (
 		clusterInfo = acc.GetClusterInfo(t, &acc.ClusterRequest{CloudBackup: true, ResourceDependencyName: "mongodbatlas_cloud_backup_snapshot_export_bucket.test"})
 		policyName  = acc.RandomName()


### PR DESCRIPTION
## Description

Changes `export` and `auto_export_enabled` to Optional only in `mongodbatlas_cloud_backup_schedule` resource.

We are considering this a breaking change because of the following scenario:
- using current version attributes export/auto_export_enabled (with enabled true) is removed -> no plan changes generated, still present in state
- updating to new version that is optional-only -> user receives a non-empty plan

Link to any related issue(s): CLOUDP-301129

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
