### PR TITLE
chore: First iteration of option 3 modules with input abstraction for replication specs

### DIFF
--- a/examples/modules/direct-resource/multi-cloud.tf
+++ b/examples/modules/direct-resource/multi-cloud.tf
@@ -2,9 +2,9 @@
 # multi-cloud can also apply to multi-region multi geo, with sharding.
 
 resource "mongodbatlas_advanced_cluster" "multi_cloud" {
-  project_id = var.project_id
-  name = "multi-cloud"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "multi-cloud"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {
     region_configs {
@@ -16,8 +16,8 @@ resource "mongodbatlas_advanced_cluster" "multi_cloud" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -35,8 +35,8 @@ resource "mongodbatlas_advanced_cluster" "multi_cloud" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/direct-resource/multi-cloud.tf
+++ b/examples/modules/direct-resource/multi-cloud.tf
@@ -1,7 +1,7 @@
 # multiple providers, multi-region single geo
 # multi-cloud can also apply to multi-region multi geo, with sharding.
 
-resource "mongodbatlas_advanced_cluster" "multi-cloud" {
+resource "mongodbatlas_advanced_cluster" "multi_cloud" {
   project_id = var.project_id
   name = "multi-cloud"
   cluster_type = "REPLICASET"

--- a/examples/modules/direct-resource/multi-geo-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-sharded.tf
@@ -1,9 +1,9 @@
 # - multiple regions (different geographies) 
 # - with shards (single zone)
 
-resource "mongodbatlas_advanced_cluster" "multi-region-multi-geo-sharded" {
+resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
   project_id = var.project_id
-  name = "multi-region-multi-geo-sharded"
+  name = "multi_geo_sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)

--- a/examples/modules/direct-resource/multi-geo-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-sharded.tf
@@ -3,7 +3,7 @@
 
 resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
   project_id = var.project_id
-  name = "multi_geo_sharded"
+  name = "multi-geo-sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)

--- a/examples/modules/direct-resource/multi-geo-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-sharded.tf
@@ -2,9 +2,9 @@
 # - with shards (single zone)
 
 resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
-  project_id = var.project_id
-  name = "multi-geo-sharded"
-  cluster_type = "SHARDED"
+  project_id             = var.project_id
+  name                   = "multi-geo-sharded"
+  cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)
     region_configs {
@@ -16,8 +16,8 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
         node_count    = 3
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -31,8 +31,8 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -49,8 +49,8 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
         node_count    = 3
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -64,8 +64,8 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/direct-resource/multi-geo-zone-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-zone-sharded.tf
@@ -3,7 +3,7 @@
 
 resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
   project_id = var.project_id
-  name = "multi_geo_zone_sharded"
+  name = "multi-geo-zone-sharded"
   cluster_type = "GEOSHARDED"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/direct-resource/multi-geo-zone-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-zone-sharded.tf
@@ -1,9 +1,9 @@
 # - multiple regions (different geographies) 
 # - sharded zones
 
-resource "mongodbatlas_advanced_cluster" "multi-region-multi-geo-zone-sharded" {
+resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
   project_id = var.project_id
-  name = "multi-region-multi-geo-zone-sharded"
+  name = "multi_geo_zone_sharded"
   cluster_type = "GEOSHARDED"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/direct-resource/multi-geo-zone-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-zone-sharded.tf
@@ -2,9 +2,9 @@
 # - sharded zones
 
 resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
-  project_id = var.project_id
-  name = "multi-geo-zone-sharded"
-  cluster_type = "GEOSHARDED"
+  project_id             = var.project_id
+  name                   = "multi-geo-zone-sharded"
+  cluster_type           = "GEOSHARDED"
   mongo_db_major_version = "8.0"
 
   replication_specs { # shard 1 (US zone)
@@ -18,14 +18,14 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
         node_count    = 3
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
     }
   }
-  
+
   replication_specs { # shard 2 (EU zone)
     zone_name = "EU"
     region_configs {
@@ -37,8 +37,8 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
         node_count    = 3
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/direct-resource/multi-region-single-geo.tf
+++ b/examples/modules/direct-resource/multi-region-single-geo.tf
@@ -6,7 +6,7 @@
 
 resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
   project_id = var.project_id
-  name = "multi_region_single_geo_no_sharding"
+  name = "multi-region-single-geo-no-sharding"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {

--- a/examples/modules/direct-resource/multi-region-single-geo.tf
+++ b/examples/modules/direct-resource/multi-region-single-geo.tf
@@ -5,9 +5,9 @@
 # no sharding
 
 resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
-  project_id = var.project_id
-  name = "multi-region-single-geo-no-sharding"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "multi-region-single-geo-no-sharding"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {
     region_configs {
@@ -19,8 +19,8 @@ resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -38,8 +38,8 @@ resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
         node_count    = 2
       }
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/direct-resource/multi-region-single-geo.tf
+++ b/examples/modules/direct-resource/multi-region-single-geo.tf
@@ -4,9 +4,9 @@
 # - multiple regions (same geography)
 # no sharding
 
-resource "mongodbatlas_advanced_cluster" "multi-region-single-geo-no-sharding" {
+resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
   project_id = var.project_id
-  name = "multi-region-single-geo-no-sharding"
+  name = "multi_region_single_geo_no_sharding"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {

--- a/examples/modules/direct-resource/single-region-analytics-nodes.tf
+++ b/examples/modules/direct-resource/single-region-analytics-nodes.tf
@@ -3,21 +3,21 @@
 # - with analytics nodes defined
 
 resource "mongodbatlas_advanced_cluster" "single_region_analytics" {
-  project_id = var.project_id
-  name = "single-region-analytics"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "single-region-analytics"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {
     region_configs {
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
       analytics_auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M30"
         compute_min_instance_size = "M10"
       }

--- a/examples/modules/direct-resource/single-region-analytics-nodes.tf
+++ b/examples/modules/direct-resource/single-region-analytics-nodes.tf
@@ -1,0 +1,37 @@
+# - single region
+# - no sharding
+# - with analytics nodes defined
+
+resource "mongodbatlas_advanced_cluster" "single_region_analytics" {
+  project_id = var.project_id
+  name = "single-region-analytics"
+  cluster_type = "REPLICASET"
+  mongo_db_major_version = "8.0"
+  replication_specs {
+    region_configs {
+      auto_scaling {
+        disk_gb_enabled = true
+        compute_enabled = true
+        compute_max_instance_size = "M60"
+        compute_min_instance_size = "M30"
+      }
+      analytics_auto_scaling {
+        disk_gb_enabled = true
+        compute_enabled = true
+        compute_max_instance_size = "M30"
+        compute_min_instance_size = "M10"
+      }
+      electable_specs {
+        instance_size = "M30"
+        node_count    = 3
+      }
+      analytics_specs {
+        instance_size = "M10"
+        node_count    = 1
+      }
+      priority      = 7
+      provider_name = "AWS"
+      region_name   = "US_EAST_1"
+    }
+  }
+}

--- a/examples/modules/direct-resource/single-region-sharded.tf
+++ b/examples/modules/direct-resource/single-region-sharded.tf
@@ -1,9 +1,9 @@
 # - single region
 # - with shards (single zone)
 
-resource "mongodbatlas_advanced_cluster" "single-region-sharded" {
+resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
   project_id = var.project_id
-  name = "single-region-sharded"
+  name = "single_region_sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)

--- a/examples/modules/direct-resource/single-region-sharded.tf
+++ b/examples/modules/direct-resource/single-region-sharded.tf
@@ -2,15 +2,15 @@
 # - with shards (single zone)
 
 resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
-  project_id = var.project_id
-  name = "single-region-sharded"
-  cluster_type = "SHARDED"
+  project_id             = var.project_id
+  name                   = "single-region-sharded"
+  cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)
     region_configs {
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }
@@ -27,8 +27,8 @@ resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
   replication_specs { # shard 2 (single zone)
     region_configs {
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/direct-resource/single-region-sharded.tf
+++ b/examples/modules/direct-resource/single-region-sharded.tf
@@ -3,7 +3,7 @@
 
 resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
   project_id = var.project_id
-  name = "single_region_sharded"
+  name = "single-region-sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
   replication_specs { # shard 1 (single zone)
@@ -15,7 +15,7 @@ resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
         compute_min_instance_size = "M30"
       }
       electable_specs {
-        instance_size = "M30"
+        instance_size = "M40" # Independently scaled shard
         node_count    = 3
       }
       priority      = 7

--- a/examples/modules/direct-resource/single-region.tf
+++ b/examples/modules/direct-resource/single-region.tf
@@ -1,7 +1,7 @@
 # - single region
 # - no sharding
 
-resource "mongodbatlas_advanced_cluster" "single-region" {
+resource "mongodbatlas_advanced_cluster" "single_region" {
   project_id = var.project_id
   name = "single-region"
   cluster_type = "REPLICASET"

--- a/examples/modules/direct-resource/single-region.tf
+++ b/examples/modules/direct-resource/single-region.tf
@@ -2,15 +2,15 @@
 # - no sharding
 
 resource "mongodbatlas_advanced_cluster" "single_region" {
-  project_id = var.project_id
-  name = "single-region"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "single-region"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
   replication_specs {
     region_configs {
       auto_scaling {
-        disk_gb_enabled = true
-        compute_enabled = true
+        disk_gb_enabled           = true
+        compute_enabled           = true
         compute_max_instance_size = "M60"
         compute_min_instance_size = "M30"
       }

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/main.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/main.tf
@@ -5,11 +5,11 @@ locals {
   effective_replication_specs = (
     length(var.shards) > 0 ? [
       for shard in var.shards : {
-        zone_name      = shard.zone_name
+        zone_name = shard.zone_name
         region_configs = [for region in shard.region_configs : {
-          provider_name   = region.provider_name
-          region_name     = region.region_name
-          priority        = region.priority
+          provider_name = region.provider_name
+          region_name   = region.region_name
+          priority      = region.priority
           electable_specs = {
             instance_size   = region.instance_size
             node_count      = region.electable_node_count
@@ -26,7 +26,7 @@ locals {
               disk_iops       = try(region.disk_iops, null)
             } : null
           )
-          auto_scaling    = var.auto_scaling
+          auto_scaling           = var.auto_scaling
           analytics_auto_scaling = var.analytics_auto_scaling
           analytics_specs = (
             region.analytics_specs != null ? {
@@ -39,13 +39,13 @@ locals {
           )
         }]
       }
-    ] : [
+      ] : [
       {
-        zone_name      = null
+        zone_name = null
         region_configs = [for region in var.region_configs : {
-          provider_name   = region.provider_name
-          region_name     = region.region_name
-          priority        = region.priority
+          provider_name = region.provider_name
+          region_name   = region.region_name
+          priority      = region.priority
           electable_specs = {
             instance_size   = region.instance_size
             node_count      = region.electable_node_count
@@ -62,7 +62,7 @@ locals {
               disk_iops       = try(region.disk_iops, null)
             } : null
           )
-          auto_scaling    = var.auto_scaling # all autoscaling configs are the same cluster wide, this how API currently works
+          auto_scaling           = var.auto_scaling           # all autoscaling configs are the same cluster wide, this how API currently works
           analytics_auto_scaling = var.analytics_auto_scaling # all analytics autoscaling configs are the same cluster wide, this how API currently works
           analytics_specs = (
             region.analytics_specs != null ? {
@@ -98,21 +98,21 @@ resource "mongodbatlas_advanced_cluster" "this" {
           priority      = region_configs.value.priority
 
           electable_specs {
-            instance_size = region_configs.value.electable_specs.instance_size
-            node_count    = region_configs.value.electable_specs.node_count
+            instance_size   = region_configs.value.electable_specs.instance_size
+            node_count      = region_configs.value.electable_specs.node_count
             ebs_volume_type = region_configs.value.electable_specs.ebs_volume_type != null ? region_configs.value.electable_specs.ebs_volume_type : null
-            disk_size_gb    = region_configs.value.electable_specs.disk_size_gb    != null ? region_configs.value.electable_specs.disk_size_gb    : null
-            disk_iops       = region_configs.value.electable_specs.disk_iops       != null ? region_configs.value.electable_specs.disk_iops       : null
+            disk_size_gb    = region_configs.value.electable_specs.disk_size_gb != null ? region_configs.value.electable_specs.disk_size_gb : null
+            disk_iops       = region_configs.value.electable_specs.disk_iops != null ? region_configs.value.electable_specs.disk_iops : null
           }
 
           dynamic "read_only_specs" {
             for_each = region_configs.value.read_only_specs != null ? [region_configs.value.read_only_specs] : []
             content {
-              instance_size = read_only_specs.value.instance_size
-              node_count    = read_only_specs.value.node_count
+              instance_size   = read_only_specs.value.instance_size
+              node_count      = read_only_specs.value.node_count
               ebs_volume_type = read_only_specs.value.ebs_volume_type != null ? read_only_specs.value.ebs_volume_type : null
-              disk_size_gb    = read_only_specs.value.disk_size_gb    != null ? read_only_specs.value.disk_size_gb    : null
-              disk_iops       = read_only_specs.value.disk_iops       != null ? read_only_specs.value.disk_iops       : null
+              disk_size_gb    = read_only_specs.value.disk_size_gb != null ? read_only_specs.value.disk_size_gb : null
+              disk_iops       = read_only_specs.value.disk_iops != null ? read_only_specs.value.disk_iops : null
             }
           }
 
@@ -122,30 +122,30 @@ resource "mongodbatlas_advanced_cluster" "this" {
               instance_size   = analytics_specs.value.instance_size
               node_count      = analytics_specs.value.node_count
               ebs_volume_type = analytics_specs.value.ebs_volume_type != null ? analytics_specs.value.ebs_volume_type : null
-              disk_size_gb    = analytics_specs.value.disk_size_gb    != null ? analytics_specs.value.disk_size_gb    : null
-              disk_iops       = analytics_specs.value.disk_iops       != null ? analytics_specs.value.disk_iops       : null
+              disk_size_gb    = analytics_specs.value.disk_size_gb != null ? analytics_specs.value.disk_size_gb : null
+              disk_iops       = analytics_specs.value.disk_iops != null ? analytics_specs.value.disk_iops : null
             }
           }
 
           dynamic "auto_scaling" {
             for_each = region_configs.value.auto_scaling != null ? [region_configs.value.auto_scaling] : []
             content {
-              disk_gb_enabled           = region_configs.value.auto_scaling.disk_gb_enabled
-              compute_enabled           = region_configs.value.auto_scaling.compute_enabled
+              disk_gb_enabled            = region_configs.value.auto_scaling.disk_gb_enabled
+              compute_enabled            = region_configs.value.auto_scaling.compute_enabled
               compute_scale_down_enabled = region_configs.value.auto_scaling.compute_scale_down_enabled != null ? region_configs.value.auto_scaling.compute_scale_down_enabled : null
-              compute_min_instance_size = region_configs.value.auto_scaling.compute_min_instance_size != null ? region_configs.value.auto_scaling.compute_min_instance_size : null
-              compute_max_instance_size = region_configs.value.auto_scaling.compute_max_instance_size != null ? region_configs.value.auto_scaling.compute_max_instance_size : null
+              compute_min_instance_size  = region_configs.value.auto_scaling.compute_min_instance_size != null ? region_configs.value.auto_scaling.compute_min_instance_size : null
+              compute_max_instance_size  = region_configs.value.auto_scaling.compute_max_instance_size != null ? region_configs.value.auto_scaling.compute_max_instance_size : null
             }
           }
 
           dynamic "analytics_auto_scaling" {
             for_each = region_configs.value.analytics_auto_scaling != null ? [region_configs.value.analytics_auto_scaling] : []
             content {
-              disk_gb_enabled           = region_configs.value.analytics_auto_scaling.disk_gb_enabled
-              compute_enabled           = region_configs.value.analytics_auto_scaling.compute_enabled
+              disk_gb_enabled            = region_configs.value.analytics_auto_scaling.disk_gb_enabled
+              compute_enabled            = region_configs.value.analytics_auto_scaling.compute_enabled
               compute_scale_down_enabled = region_configs.value.analytics_auto_scaling.compute_scale_down_enabled != null ? region_configs.value.analytics_auto_scaling.compute_scale_down_enabled : null
-              compute_min_instance_size = region_configs.value.analytics_auto_scaling.compute_min_instance_size != null ? region_configs.value.analytics_auto_scaling.compute_min_instance_size : null
-              compute_max_instance_size = region_configs.value.analytics_auto_scaling.compute_max_instance_size != null ? region_configs.value.analytics_auto_scaling.compute_max_instance_size : null
+              compute_min_instance_size  = region_configs.value.analytics_auto_scaling.compute_min_instance_size != null ? region_configs.value.analytics_auto_scaling.compute_min_instance_size : null
+              compute_max_instance_size  = region_configs.value.analytics_auto_scaling.compute_max_instance_size != null ? region_configs.value.analytics_auto_scaling.compute_max_instance_size : null
             }
           }
         }

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/main.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/main.tf
@@ -1,0 +1,77 @@
+# Main resource logic for cluster-abstraction module
+
+locals {
+  # If single_region is set, build the specs from it; else, empty list
+  effective_replication_specs = (
+    var.single_region != null ? [
+      {
+        zone_name      = null
+        region_configs = [
+          {
+            provider_name   = var.single_region.provider_name
+            region_name     = var.single_region.region_name
+            priority        = 7
+            electable_specs = {
+              instance_size = var.single_region.instance_size
+              node_count    = var.single_region.node_count
+              ebs_volume_type = var.single_region.ebs_volume_type != null ? var.single_region.ebs_volume_type : null
+              disk_size_gb    = var.single_region.disk_size_gb    != null ? var.single_region.disk_size_gb    : null
+              disk_iops       = var.single_region.disk_iops       != null ? var.single_region.disk_iops       : null
+            }
+            read_only_specs = null
+            auto_scaling    = var.auto_scaling
+          }
+        ]
+      }
+    ] : []
+  )
+}
+
+resource "mongodbatlas_advanced_cluster" "this" {
+  project_id             = var.project_id
+  name                   = var.name
+  cluster_type           = var.cluster_type
+  mongo_db_major_version = var.mongo_db_major_version
+
+  dynamic "replication_specs" {
+    for_each = local.effective_replication_specs
+    content {
+      # zone_name is optional
+      zone_name = lookup(replication_specs.value, "zone_name", null)
+      dynamic "region_configs" {
+        for_each = replication_specs.value.region_configs
+        content {
+          provider_name = region_configs.value.provider_name
+          region_name   = region_configs.value.region_name
+          priority      = region_configs.value.priority
+
+          electable_specs {
+            instance_size = region_configs.value.electable_specs.instance_size
+            node_count    = region_configs.value.electable_specs.node_count
+            ebs_volume_type = region_configs.value.electable_specs.ebs_volume_type != null ? region_configs.value.electable_specs.ebs_volume_type : null
+            disk_size_gb    = region_configs.value.electable_specs.disk_size_gb    != null ? region_configs.value.electable_specs.disk_size_gb    : null
+            disk_iops       = region_configs.value.electable_specs.disk_iops       != null ? region_configs.value.electable_specs.disk_iops       : null
+          }
+
+          dynamic "read_only_specs" {
+            for_each = region_configs.value.read_only_specs != null ? [region_configs.value.read_only_specs] : []
+            content {
+              instance_size = read_only_specs.value.instance_size
+              node_count    = read_only_specs.value.node_count
+            }
+          }
+
+          dynamic "auto_scaling" {
+            for_each = region_configs.value.auto_scaling != null ? [region_configs.value.auto_scaling] : []
+            content {
+              disk_gb_enabled           = region_configs.value.auto_scaling.disk_gb_enabled
+              compute_enabled           = region_configs.value.auto_scaling.compute_enabled
+              compute_min_instance_size = region_configs.value.auto_scaling.compute_min_instance_size
+              compute_max_instance_size = region_configs.value.auto_scaling.compute_max_instance_size
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/outputs.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_id" {
+  description = "The ID of the created Atlas cluster."
+  value       = mongodbatlas_advanced_cluster.this.id
+}
+
+output "connection_strings" {
+  description = "Connection strings for the created cluster."
+  value       = mongodbatlas_advanced_cluster.this.connection_strings
+}

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -1,4 +1,4 @@
-variable "replica_set_regions" {
+variable "region_configs" {
   description = "List of region configurations for a replica set cluster. Each object defines a region."
   type = list(object({
     provider_name  = string
@@ -16,6 +16,32 @@ variable "replica_set_regions" {
       disk_size_gb    = optional(number)
       disk_iops       = optional(number)
       node_count      = number
+    }))
+  }))
+  default = []
+}
+
+variable "shards" {
+  description = "List of shard configurations for a sharded cluster. Each object defines a shard and its regions."
+  type = list(object({
+    zone_name = optional(string)
+    region_configs = list(object({
+      provider_name  = string
+      region_name    = string
+      instance_size  = string
+      priority       = optional(number, 7) # required if you have more than one region
+      ebs_volume_type = optional(string)
+      disk_size_gb = optional(number)
+      disk_iops = optional(number)
+      electable_node_count = number
+      read_only_node_count = optional(number, 0)
+      analytics_specs = optional(object({
+        instance_size   = string
+        ebs_volume_type = optional(string)
+        disk_size_gb    = optional(number)
+        disk_iops       = optional(number)
+        node_count      = number
+      }))
     }))
   }))
   default = []

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -1,0 +1,52 @@
+variable "single_region" {
+  description = "Configuration for a single-region cluster. If set, the module will use this for cluster creation."
+  type = object({
+    provider_name  = string
+    region_name    = string
+    instance_size  = string
+    ebs_volume_type = optional(string)
+    disk_size_gb = optional(number)
+    disk_iops = optional(number)
+    node_count     = number
+    read_only_node_count = optional(number, 0)
+  })
+  default = null
+}
+
+variable "auto_scaling" {
+  description = "Configuration for auto-scaling."
+  type = object({
+    disk_gb_enabled           = bool
+    compute_enabled           = bool
+    compute_max_instance_size = string
+    compute_min_instance_size = string
+  })
+  default = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+}
+
+variable "project_id" {
+  description = "The MongoDB Atlas project ID."
+  type        = string
+}
+
+variable "name" {
+  description = "The name of the cluster."
+  type        = string
+}
+
+variable "cluster_type" {
+  description = "Type of cluster (REPLICASET, SHARDED, GEOSHARDED)."
+  type        = string
+  default     = "REPLICASET"
+}
+
+variable "mongo_db_major_version" {
+  description = "The major MongoDB version."
+  type        = string
+  default     = "8.0"
+}

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -9,6 +9,13 @@ variable "single_region" {
     disk_iops = optional(number)
     node_count     = number
     read_only_node_count = optional(number, 0)
+    analytics_specs = optional(object({
+      instance_size   = string
+      ebs_volume_type = optional(string)
+      disk_size_gb    = optional(number)
+      disk_iops       = optional(number)
+      node_count      = number
+    }))
   })
   default = null
 }
@@ -24,7 +31,7 @@ variable "auto_scaling" {
   default = {
     disk_gb_enabled           = true
     compute_enabled           = true
-    compute_max_instance_size = "M60"
+    compute_max_instance_size = "M60" // TODO do we want to keep this as the default?
     compute_min_instance_size = "M30"
   }
 }

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -1,13 +1,13 @@
 variable "region_configs" {
   description = "List of region configurations for a replica set cluster. Each object defines a region."
   type = list(object({
-    provider_name  = string
-    region_name    = string
-    instance_size  = string
-    priority       = optional(number, 7) # required if you have more than one region
-    ebs_volume_type = optional(string)
-    disk_size_gb = optional(number)
-    disk_iops = optional(number)
+    provider_name        = string
+    region_name          = string
+    instance_size        = string
+    priority             = optional(number, 7) # required if you have more than one region
+    ebs_volume_type      = optional(string)
+    disk_size_gb         = optional(number)
+    disk_iops            = optional(number)
     electable_node_count = number
     read_only_node_count = optional(number, 0)
     analytics_specs = optional(object({
@@ -26,13 +26,13 @@ variable "shards" {
   type = list(object({
     zone_name = optional(string)
     region_configs = list(object({
-      provider_name  = string
-      region_name    = string
-      instance_size  = string
-      priority       = optional(number, 7) # required if you have more than one region
-      ebs_volume_type = optional(string)
-      disk_size_gb = optional(number)
-      disk_iops = optional(number)
+      provider_name        = string
+      region_name          = string
+      instance_size        = string
+      priority             = optional(number, 7) # required if you have more than one region
+      ebs_volume_type      = optional(string)
+      disk_size_gb         = optional(number)
+      disk_iops            = optional(number)
       electable_node_count = number
       read_only_node_count = optional(number, 0)
       analytics_specs = optional(object({
@@ -50,30 +50,30 @@ variable "shards" {
 variable "auto_scaling" {
   description = "Configuration for auto-scaling."
   type = object({
-    disk_gb_enabled           = bool
-    compute_enabled           = bool
+    disk_gb_enabled            = bool
+    compute_enabled            = bool
     compute_scale_down_enabled = optional(bool)
-    compute_max_instance_size = optional(string)
-    compute_min_instance_size = optional(string)
+    compute_max_instance_size  = optional(string)
+    compute_min_instance_size  = optional(string)
   })
   default = {
-    disk_gb_enabled           = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
-    compute_enabled           = false
+    disk_gb_enabled = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
+    compute_enabled = false
   }
 }
 
 variable "analytics_auto_scaling" {
   description = "Configuration for analytics auto-scaling."
   type = object({
-    disk_gb_enabled           = bool
-    compute_enabled           = bool
+    disk_gb_enabled            = bool
+    compute_enabled            = bool
     compute_scale_down_enabled = optional(bool)
-    compute_max_instance_size = optional(string)
-    compute_min_instance_size = optional(string)
+    compute_max_instance_size  = optional(string)
+    compute_min_instance_size  = optional(string)
   })
   default = {
-    disk_gb_enabled           = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
-    compute_enabled           = false
+    disk_gb_enabled = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
+    compute_enabled = false
   }
 }
 

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -52,14 +52,28 @@ variable "auto_scaling" {
   type = object({
     disk_gb_enabled           = bool
     compute_enabled           = bool
-    compute_max_instance_size = string
-    compute_min_instance_size = string
+    compute_scale_down_enabled = optional(bool)
+    compute_max_instance_size = optional(string)
+    compute_min_instance_size = optional(string)
   })
   default = {
-    disk_gb_enabled           = true
-    compute_enabled           = true
-    compute_max_instance_size = "M60" // TODO do we want to keep this as the default?
-    compute_min_instance_size = "M30"
+    disk_gb_enabled           = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
+    compute_enabled           = false
+  }
+}
+
+variable "analytics_auto_scaling" {
+  description = "Configuration for analytics auto-scaling."
+  type = object({
+    disk_gb_enabled           = bool
+    compute_enabled           = bool
+    compute_scale_down_enabled = optional(bool)
+    compute_max_instance_size = optional(string)
+    compute_min_instance_size = optional(string)
+  })
+  default = {
+    disk_gb_enabled           = false # defaults to false, default to true would imply being opinionated on a max_instance_size which can vary significantly
+    compute_enabled           = false
   }
 }
 

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/variables.tf
@@ -1,13 +1,14 @@
-variable "single_region" {
-  description = "Configuration for a single-region cluster. If set, the module will use this for cluster creation."
-  type = object({
+variable "replica_set_regions" {
+  description = "List of region configurations for a replica set cluster. Each object defines a region."
+  type = list(object({
     provider_name  = string
     region_name    = string
     instance_size  = string
+    priority       = optional(number, 7) # required if you have more than one region
     ebs_volume_type = optional(string)
     disk_size_gb = optional(number)
     disk_iops = optional(number)
-    node_count     = number
+    electable_node_count = number
     read_only_node_count = optional(number, 0)
     analytics_specs = optional(object({
       instance_size   = string
@@ -16,8 +17,8 @@ variable "single_region" {
       disk_iops       = optional(number)
       node_count      = number
     }))
-  })
-  default = null
+  }))
+  default = []
 }
 
 variable "auto_scaling" {

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/versions.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+}

--- a/examples/modules/option-3-input-abstractions/cluster-abstraction/versions.tf
+++ b/examples/modules/option-3-input-abstractions/cluster-abstraction/versions.tf
@@ -1,7 +1,9 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source = "mongodb/mongodbatlas"
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.0"
     }
   }
+  required_version = ">= 1.0" // TODO revisit versions
 }

--- a/examples/modules/option-3-input-abstractions/multi-cloud.tf
+++ b/examples/modules/option-3-input-abstractions/multi-cloud.tf
@@ -5,7 +5,7 @@ module "multi_cloud" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "multi_cloud"
+  name       = "multi-cloud"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/option-3-input-abstractions/multi-cloud.tf
+++ b/examples/modules/option-3-input-abstractions/multi-cloud.tf
@@ -1,20 +1,18 @@
-# 5-Node 2-Region Architecture
+# multiple providers, multi-region single geo
+# multi-cloud can also apply to multi-region multi geo, with sharding.
 
-# - multiple regions (same geography)
-# no sharding
-
-module "multi_region_single_geo_no_sharding" {
+module "multi_cloud" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "multi_region_single_geo_no_sharding"
+  name       = "multi_cloud"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
 
   region_configs = [
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_1"
+      provider_name  = "AZURE"
+      region_name    = "US_WEST_2"
       instance_size  = "M30"
       electable_node_count = 2
       priority       = 7

--- a/examples/modules/option-3-input-abstractions/multi-cloud.tf
+++ b/examples/modules/option-3-input-abstractions/multi-cloud.tf
@@ -4,26 +4,26 @@
 module "multi_cloud" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "multi-cloud"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "multi-cloud"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
 
   region_configs = [
     {
-      provider_name  = "AZURE"
-      region_name    = "US_WEST_2"
-      instance_size  = "M30"
+      provider_name        = "AZURE"
+      region_name          = "US_WEST_2"
+      instance_size        = "M30"
       electable_node_count = 2
-      priority       = 7
+      priority             = 7
     },
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_2"
-      instance_size  = "M30"
+      provider_name        = "AWS"
+      region_name          = "US_EAST_2"
+      instance_size        = "M30"
       electable_node_count = 1
       read_only_node_count = 2
-      priority       = 6
+      priority             = 6
     },
   ]
 

--- a/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
@@ -5,7 +5,7 @@ module "multi_geo_sharded" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "multi_geo_sharded"
+  name       = "multi-geo-sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
@@ -1,0 +1,57 @@
+# - multiple regions (different geographies) 
+# - with shards (single zone)
+
+module "multi_geo_sharded" {
+  source = "./cluster-abstraction"
+
+  project_id = var.project_id
+  name       = "multi_geo_sharded"
+  cluster_type = "SHARDED"
+  mongo_db_major_version = "8.0"
+
+  shards = [ 
+    { # shard 1 (single zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "US_EAST_1" # North America
+          instance_size  = "M30"
+          electable_node_count = 3
+          priority = 7
+        },
+        {
+          provider_name  = "AWS"
+          region_name    = "EU_WEST_1" # Europe
+          instance_size  = "M30"
+          electable_node_count = 2
+          priority = 6
+        }
+      ]
+    },
+    { # shard 2 (single zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "US_EAST_1" # North America
+          instance_size  = "M30"
+          electable_node_count = 3
+          priority = 7
+        },
+        {
+          provider_name  = "AWS"
+          region_name    = "EU_WEST_1" # Europe
+          instance_size  = "M30"
+          electable_node_count = 2
+          priority = 6
+        }
+      ]
+    }
+  ]
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+}

--- a/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-sharded.tf
@@ -4,45 +4,45 @@
 module "multi_geo_sharded" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "multi-geo-sharded"
-  cluster_type = "SHARDED"
+  project_id             = var.project_id
+  name                   = "multi-geo-sharded"
+  cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
 
-  shards = [ 
+  shards = [
     { # shard 1 (single zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "US_EAST_1" # North America
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "US_EAST_1" # North America
+          instance_size        = "M30"
           electable_node_count = 3
-          priority = 7
+          priority             = 7
         },
         {
-          provider_name  = "AWS"
-          region_name    = "EU_WEST_1" # Europe
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "EU_WEST_1" # Europe
+          instance_size        = "M30"
           electable_node_count = 2
-          priority = 6
+          priority             = 6
         }
       ]
     },
     { # shard 2 (single zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "US_EAST_1" # North America
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "US_EAST_1" # North America
+          instance_size        = "M30"
           electable_node_count = 3
-          priority = 7
+          priority             = 7
         },
         {
-          provider_name  = "AWS"
-          region_name    = "EU_WEST_1" # Europe
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "EU_WEST_1" # Europe
+          instance_size        = "M30"
           electable_node_count = 2
-          priority = 6
+          priority             = 6
         }
       ]
     }

--- a/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
@@ -1,0 +1,43 @@
+# - multiple regions (different geographies) 
+# - sharded zones
+
+module "multi_geo_zone_sharded" {
+  source = "./cluster-abstraction"
+
+  project_id = var.project_id
+  name       = "multi_geo_zone_sharded"
+  cluster_type = "GEOSHARDED"
+  mongo_db_major_version = "8.0"
+
+  shards = [ 
+    {
+      zone_name = "US" # shard 1 (US zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "US_EAST_1"
+          instance_size  = "M30"
+          electable_node_count = 3
+        }
+      ]
+    },
+    {
+      zone_name = "EU" # shard 2 (EU zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "EU_WEST_1"
+          instance_size  = "M30"
+          electable_node_count = 3
+        }
+      ]
+    }
+  ]
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+}

--- a/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
@@ -4,19 +4,19 @@
 module "multi_geo_zone_sharded" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "multi-geo-zone-sharded"
-  cluster_type = "GEOSHARDED"
+  project_id             = var.project_id
+  name                   = "multi-geo-zone-sharded"
+  cluster_type           = "GEOSHARDED"
   mongo_db_major_version = "8.0"
 
-  shards = [ 
+  shards = [
     {
       zone_name = "US" # shard 1 (US zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "US_EAST_1"
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "US_EAST_1"
+          instance_size        = "M30"
           electable_node_count = 3
         }
       ]
@@ -25,9 +25,9 @@ module "multi_geo_zone_sharded" {
       zone_name = "EU" # shard 2 (EU zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "EU_WEST_1"
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "EU_WEST_1"
+          instance_size        = "M30"
           electable_node_count = 3
         }
       ]

--- a/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/multi-geo-zone-sharded.tf
@@ -5,7 +5,7 @@ module "multi_geo_zone_sharded" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "multi_geo_zone_sharded"
+  name       = "multi-geo-zone-sharded"
   cluster_type = "GEOSHARDED"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
+++ b/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
@@ -1,0 +1,38 @@
+# 5-Node 2-Region Architecture
+
+# - multiple regions (same geography)
+# no sharding
+
+module "cluster_abstraction" {
+  source = "./cluster-abstraction"
+
+  project_id = var.project_id
+  name       = "multi-region-single-geo-no-sharding"
+  cluster_type = "REPLICASET"
+  mongo_db_major_version = "8.0"
+
+  replica_set_regions = [
+    {
+      provider_name  = "AWS"
+      region_name    = "US_EAST_1"
+      instance_size  = "M30"
+      electable_node_count = 2
+      priority       = 7
+    },
+    {
+      provider_name  = "AWS"
+      region_name    = "US_EAST_2"
+      instance_size  = "M30"
+      electable_node_count = 1
+      read_only_node_count = 2
+      priority       = 6
+    },
+  ]
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+}

--- a/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
+++ b/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
@@ -6,26 +6,26 @@
 module "multi_region_single_geo_no_sharding" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "multi-region-single-geo-no-sharding"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "multi-region-single-geo-no-sharding"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
 
   region_configs = [
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_1"
-      instance_size  = "M30"
+      provider_name        = "AWS"
+      region_name          = "US_EAST_1"
+      instance_size        = "M30"
       electable_node_count = 2
-      priority       = 7
+      priority             = 7
     },
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_2"
-      instance_size  = "M30"
+      provider_name        = "AWS"
+      region_name          = "US_EAST_2"
+      instance_size        = "M30"
       electable_node_count = 1
       read_only_node_count = 2
-      priority       = 6
+      priority             = 6
     },
   ]
 

--- a/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
+++ b/examples/modules/option-3-input-abstractions/multi-region-single-geo.tf
@@ -7,7 +7,7 @@ module "multi_region_single_geo_no_sharding" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "multi_region_single_geo_no_sharding"
+  name       = "multi-region-single-geo-no-sharding"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
 

--- a/examples/modules/option-3-input-abstractions/single-region-analytics-nodes.tf
+++ b/examples/modules/option-3-input-abstractions/single-region-analytics-nodes.tf
@@ -5,16 +5,16 @@
 module "single_region_analytics" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "single-region-analytics"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "single-region-analytics"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
 
   region_configs = [
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_1"
-      instance_size  = "M30"
+      provider_name        = "AWS"
+      region_name          = "US_EAST_1"
+      instance_size        = "M30"
       electable_node_count = 3
       analytics_specs = {
         instance_size = "M10"

--- a/examples/modules/option-3-input-abstractions/single-region-analytics-nodes.tf
+++ b/examples/modules/option-3-input-abstractions/single-region-analytics-nodes.tf
@@ -1,0 +1,38 @@
+# - single region
+# - no sharding
+# - with analytics nodes defined
+
+module "single_region_analytics" {
+  source = "./cluster-abstraction"
+
+  project_id = var.project_id
+  name       = "single-region-analytics"
+  cluster_type = "REPLICASET"
+  mongo_db_major_version = "8.0"
+
+  region_configs = [
+    {
+      provider_name  = "AWS"
+      region_name    = "US_EAST_1"
+      instance_size  = "M30"
+      electable_node_count = 3
+      analytics_specs = {
+        instance_size = "M10"
+        node_count    = 1
+      }
+    }
+  ]
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+  analytics_auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M30"
+    compute_min_instance_size = "M10"
+  }
+}

--- a/examples/modules/option-3-input-abstractions/single-region-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/single-region-sharded.tf
@@ -1,0 +1,41 @@
+# - single region
+# - with shards (single zone)
+
+module "single_region_sharded" {
+  source = "./cluster-abstraction"
+
+  project_id = var.project_id
+  name       = "single_region_sharded"
+  cluster_type = "SHARDED"
+  mongo_db_major_version = "8.0"
+
+  shards = [ 
+    { # shard 1 (single zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "US_EAST_1"
+          instance_size  = "M30"
+          electable_node_count = 3
+        }
+      ]
+    },
+    { # shard 2 (single zone)
+      region_configs = [
+        {
+          provider_name  = "AWS"
+          region_name    = "US_EAST_1"
+          instance_size  = "M30"
+          electable_node_count = 3
+        }
+      ]
+    }
+  ]
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M60"
+    compute_min_instance_size = "M30"
+  }
+}

--- a/examples/modules/option-3-input-abstractions/single-region-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/single-region-sharded.tf
@@ -4,18 +4,18 @@
 module "single_region_sharded" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "single-region-sharded"
-  cluster_type = "SHARDED"
+  project_id             = var.project_id
+  name                   = "single-region-sharded"
+  cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
 
-  shards = [ 
+  shards = [
     { # shard 1 (single zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "US_EAST_1"
-          instance_size  = "M40" # Independently scaled shard
+          provider_name        = "AWS"
+          region_name          = "US_EAST_1"
+          instance_size        = "M40" # Independently scaled shard
           electable_node_count = 3
         }
       ]
@@ -23,9 +23,9 @@ module "single_region_sharded" {
     { # shard 2 (single zone)
       region_configs = [
         {
-          provider_name  = "AWS"
-          region_name    = "US_EAST_1"
-          instance_size  = "M30"
+          provider_name        = "AWS"
+          region_name          = "US_EAST_1"
+          instance_size        = "M30"
           electable_node_count = 3
         }
       ]

--- a/examples/modules/option-3-input-abstractions/single-region-sharded.tf
+++ b/examples/modules/option-3-input-abstractions/single-region-sharded.tf
@@ -5,7 +5,7 @@ module "single_region_sharded" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "single_region_sharded"
+  name       = "single-region-sharded"
   cluster_type = "SHARDED"
   mongo_db_major_version = "8.0"
 
@@ -15,7 +15,7 @@ module "single_region_sharded" {
         {
           provider_name  = "AWS"
           region_name    = "US_EAST_1"
-          instance_size  = "M30"
+          instance_size  = "M40" # Independently scaled shard
           electable_node_count = 3
         }
       ]

--- a/examples/modules/option-3-input-abstractions/single-region.tf
+++ b/examples/modules/option-3-input-abstractions/single-region.tf
@@ -1,0 +1,33 @@
+# Example usage of the cluster-abstraction module for a single-region cluster
+
+module "cluster_abstraction" {
+  source = "./cluster-abstraction"
+
+  project_id = ""
+  name       = "example-single-region-cluster"
+  cluster_type = "REPLICASET"
+  mongo_db_major_version = "8.0"
+
+  single_region = {
+    provider_name  = "AWS"
+    region_name    = "US_EAST_1"
+    instance_size  = "M10"
+    node_count     = 3
+    read_only_node_count = 2
+  }
+
+  auto_scaling = {
+    disk_gb_enabled           = true
+    compute_enabled           = true
+    compute_max_instance_size = "M20"
+    compute_min_instance_size = "M10"
+  }
+}
+
+output "cluster_id" {
+  value = module.cluster_abstraction.cluster_id
+}
+
+output "connection_strings" {
+  value = module.cluster_abstraction.connection_strings
+}

--- a/examples/modules/option-3-input-abstractions/single-region.tf
+++ b/examples/modules/option-3-input-abstractions/single-region.tf
@@ -1,20 +1,22 @@
 # Example usage of the cluster-abstraction module for a single-region cluster
 
-module "cluster_abstraction" {
+module "single_region" {
   source = "./cluster-abstraction"
 
   project_id = var.project_id
-  name       = "example-single-region-cluster"
+  name       = "single-region"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
 
-  single_region = {
-    provider_name  = "AWS"
-    region_name    = "US_EAST_1"
-    instance_size  = "M10"
-    node_count     = 3
-    read_only_node_count = 2
-  }
+  replica_set_regions = [
+    {
+      provider_name  = "AWS"
+      region_name    = "US_EAST_1"
+      instance_size  = "M10"
+      electable_node_count = 3
+      read_only_node_count = 2
+    }
+  ]
 
   auto_scaling = {
     disk_gb_enabled           = true
@@ -25,9 +27,9 @@ module "cluster_abstraction" {
 }
 
 output "cluster_id" {
-  value = module.cluster_abstraction.cluster_id
+  value = module.single_region.cluster_id
 }
 
 output "connection_strings" {
-  value = module.cluster_abstraction.connection_strings
+  value = module.single_region.connection_strings
 }

--- a/examples/modules/option-3-input-abstractions/single-region.tf
+++ b/examples/modules/option-3-input-abstractions/single-region.tf
@@ -3,16 +3,16 @@
 module "single_region" {
   source = "./cluster-abstraction"
 
-  project_id = var.project_id
-  name       = "single-region"
-  cluster_type = "REPLICASET"
+  project_id             = var.project_id
+  name                   = "single-region"
+  cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
 
   region_configs = [
     {
-      provider_name  = "AWS"
-      region_name    = "US_EAST_1"
-      instance_size  = "M10"
+      provider_name        = "AWS"
+      region_name          = "US_EAST_1"
+      instance_size        = "M10"
       electable_node_count = 3
       read_only_node_count = 2
     }

--- a/examples/modules/option-3-input-abstractions/single-region.tf
+++ b/examples/modules/option-3-input-abstractions/single-region.tf
@@ -3,7 +3,7 @@
 module "cluster_abstraction" {
   source = "./cluster-abstraction"
 
-  project_id = ""
+  project_id = var.project_id
   name       = "example-single-region-cluster"
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"

--- a/examples/modules/option-3-input-abstractions/single-region.tf
+++ b/examples/modules/option-3-input-abstractions/single-region.tf
@@ -8,7 +8,7 @@ module "single_region" {
   cluster_type = "REPLICASET"
   mongo_db_major_version = "8.0"
 
-  replica_set_regions = [
+  region_configs = [
     {
       provider_name  = "AWS"
       region_name    = "US_EAST_1"
@@ -24,12 +24,4 @@ module "single_region" {
     compute_max_instance_size = "M20"
     compute_min_instance_size = "M10"
   }
-}
-
-output "cluster_id" {
-  value = module.single_region.cluster_id
-}
-
-output "connection_strings" {
-  value = module.single_region.connection_strings
 }

--- a/examples/modules/option-3-input-abstractions/variables.tf
+++ b/examples/modules/option-3-input-abstractions/variables.tf
@@ -6,8 +6,7 @@ variable "private_key" {
   description = "Private API key to authenticate to Atlas"
   type        = string
 }
-variable "cluster_name" {
-  description = "Atlas cluster name"
+variable "project_id" {
+  description = "Atlas project ID"
   type        = string
-  default     = "GlobalCluster"
 }

--- a/examples/modules/option-3-input-abstractions/variables.tf
+++ b/examples/modules/option-3-input-abstractions/variables.tf
@@ -1,0 +1,13 @@
+variable "public_key" {
+  description = "Public API key to authenticate to Atlas"
+  type        = string
+}
+variable "private_key" {
+  description = "Private API key to authenticate to Atlas"
+  type        = string
+}
+variable "cluster_name" {
+  description = "Atlas cluster name"
+  type        = string
+  default     = "GlobalCluster"
+}

--- a/examples/modules/option-3-input-abstractions/versions.tf
+++ b/examples/modules/option-3-input-abstractions/versions.tf
@@ -2,8 +2,10 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
+      version = "~> 1.0"
     }
   }
+  required_version = ">= 1.0"
 }
 
 provider "mongodbatlas" {

--- a/examples/modules/option-3-input-abstractions/versions.tf
+++ b/examples/modules/option-3-input-abstractions/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+    }
+  }
+}
+
+provider "mongodbatlas" {
+  public_key  = var.public_key
+  private_key = var.private_key
+}


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-331091

Initial PR which includes module definition of Option 3 with inputs associated to `replication_specs`. Follow up PRs will cover adding inputs for pending attributes (root level, advanced_configuration) and outputs.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
