### PR TITLE
refactor: Updates replication_specs blocks to use latest schema version

### DIFF
--- a/examples/modules/direct-resource/multi-cloud.tf
+++ b/examples/modules/direct-resource/multi-cloud.tf
@@ -6,40 +6,44 @@ resource "mongodbatlas_advanced_cluster" "multi_cloud" {
   name                   = "multi-cloud"
   cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
-  replication_specs {
-    region_configs {
-      provider_name = "AZURE"
-      region_name   = "US_WEST_2"
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          provider_name = "AZURE"
+          region_name   = "US_WEST_2"
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        },
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_2"
+          priority      = 6
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 1
+          }
+          read_only_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
     }
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_2"
-      priority      = 6
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 1
-      }
-      read_only_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/multi-geo-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-sharded.tf
@@ -6,69 +6,74 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_sharded" {
   name                   = "multi-geo-sharded"
   cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
-  replication_specs { # shard 1 (single zone)
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_1" # North America
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
+  replication_specs = [
+    { # shard 1 (single zone)
+      region_configs = [
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_1" # North America
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        },
+        {
+          provider_name = "AWS"
+          region_name   = "EU_WEST_1" # Europe
+          priority      = 6
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
+    },
+    { # shard 2 (single zone)
+      region_configs = [
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_1" # North America
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        },
+        {
+          provider_name = "AWS"
+          region_name   = "EU_WEST_1" # Europe
+          priority      = 6
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
     }
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "EU_WEST_1" # Europe
-      priority      = 6
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-  }
-
-  replication_specs { # shard 2 (single zone)
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_1" # North America
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "EU_WEST_1" # Europe
-      priority      = 6
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/multi-geo-zone-sharded.tf
+++ b/examples/modules/direct-resource/multi-geo-zone-sharded.tf
@@ -6,42 +6,46 @@ resource "mongodbatlas_advanced_cluster" "multi_geo_zone_sharded" {
   name                   = "multi-geo-zone-sharded"
   cluster_type           = "GEOSHARDED"
   mongo_db_major_version = "8.0"
-
-  replication_specs { # shard 1 (US zone)
-    zone_name = "US"
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_1" # North America
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
+  replication_specs = [
+    { # shard 1 (US zone)
+      zone_name = "US"
+      region_configs = [
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_1" # North America
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
+    },
+    { # shard 2 (EU zone)
+      zone_name = "EU"
+      region_configs = [
+        {
+          provider_name = "AWS"
+          region_name   = "EU_WEST_1" # Europe
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
     }
-  }
-
-  replication_specs { # shard 2 (EU zone)
-    zone_name = "EU"
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "EU_WEST_1" # Europe
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/multi-region-single-geo.tf
+++ b/examples/modules/direct-resource/multi-region-single-geo.tf
@@ -9,40 +9,44 @@ resource "mongodbatlas_advanced_cluster" "multi_region_single_geo_no_sharding" {
   name                   = "multi-region-single-geo-no-sharding"
   cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
-  replication_specs {
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_1"
-      priority      = 7
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_1"
+          priority      = 7
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        },
+        {
+          provider_name = "AWS"
+          region_name   = "US_EAST_2"
+          priority      = 6
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 1
+          }
+          read_only_specs = {
+            instance_size = "M30"
+            node_count    = 2
+          }
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+        }
+      ]
     }
-    region_configs {
-      provider_name = "AWS"
-      region_name   = "US_EAST_2"
-      priority      = 6
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 1
-      }
-      read_only_specs {
-        instance_size = "M30"
-        node_count    = 2
-      }
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-    }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/single-region-analytics-nodes.tf
+++ b/examples/modules/direct-resource/single-region-analytics-nodes.tf
@@ -7,31 +7,35 @@ resource "mongodbatlas_advanced_cluster" "single_region_analytics" {
   name                   = "single-region-analytics"
   cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
-  replication_specs {
-    region_configs {
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-      analytics_auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M30"
-        compute_min_instance_size = "M10"
-      }
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      analytics_specs {
-        instance_size = "M10"
-        node_count    = 1
-      }
-      priority      = 7
-      provider_name = "AWS"
-      region_name   = "US_EAST_1"
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+          analytics_auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M30"
+            compute_min_instance_size = "M10"
+          }
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          analytics_specs = {
+            instance_size = "M10"
+            node_count    = 1
+          }
+          priority      = 7
+          provider_name = "AWS"
+          region_name   = "US_EAST_1"
+        }
+      ]
     }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/single-region-sharded.tf
+++ b/examples/modules/direct-resource/single-region-sharded.tf
@@ -6,39 +6,44 @@ resource "mongodbatlas_advanced_cluster" "single_region_sharded" {
   name                   = "single-region-sharded"
   cluster_type           = "SHARDED"
   mongo_db_major_version = "8.0"
-  replication_specs { # shard 1 (single zone)
-    region_configs {
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-      electable_specs {
-        instance_size = "M40" # Independently scaled shard
-        node_count    = 3
-      }
-      priority      = 7
-      provider_name = "AWS"
-      region_name   = "US_EAST_1"
+  replication_specs = [
+    { # shard 1 (single zone)
+      region_configs = [
+        {
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+          electable_specs = {
+            instance_size = "M40" # Independently scaled shard
+            node_count    = 3
+          }
+          priority      = 7
+          provider_name = "AWS"
+          region_name   = "US_EAST_1"
+        }
+      ]
+    },
+    { # shard 2 (single zone)
+      region_configs = [
+        {
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          priority      = 7
+          provider_name = "AWS"
+          region_name   = "US_EAST_1"
+        }
+      ]
     }
-  }
-
-  replication_specs { # shard 2 (single zone)
-    region_configs {
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      priority      = 7
-      provider_name = "AWS"
-      region_name   = "US_EAST_1"
-    }
-  }
+  ]
 }

--- a/examples/modules/direct-resource/single-region.tf
+++ b/examples/modules/direct-resource/single-region.tf
@@ -6,21 +6,25 @@ resource "mongodbatlas_advanced_cluster" "single_region" {
   name                   = "single-region"
   cluster_type           = "REPLICASET"
   mongo_db_major_version = "8.0"
-  replication_specs {
-    region_configs {
-      auto_scaling {
-        disk_gb_enabled           = true
-        compute_enabled           = true
-        compute_max_instance_size = "M60"
-        compute_min_instance_size = "M30"
-      }
-      electable_specs {
-        instance_size = "M30"
-        node_count    = 3
-      }
-      priority      = 7
-      provider_name = "AWS"
-      region_name   = "US_EAST_1"
+  replication_specs = [
+    {
+      region_configs = [
+        {
+          auto_scaling = {
+            disk_gb_enabled           = true
+            compute_enabled           = true
+            compute_max_instance_size = "M60"
+            compute_min_instance_size = "M30"
+          }
+          electable_specs = {
+            instance_size = "M30"
+            node_count    = 3
+          }
+          priority      = 7
+          provider_name = "AWS"
+          region_name   = "US_EAST_1"
+        }
+      ]
     }
-  }
+  ]
 }

--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -40,16 +40,16 @@ is_v2_dir() {
   local grand_parent_dir
   parent_dir=$(basename "$1")
   grand_parent_dir=$(basename "$(dirname "$1")")
-  local v2_parent_dirs=("cluster_with_schedule direct-resource")
+  local v2_parent_dirs=("cluster_with_schedule" "direct-resource")
   local v2_grand_parent_dirs=("module_maintainer" "module_user" "migrate_cluster_to_advanced_cluster" "mongodbatlas_backup_compliance_policy") # module_maintainer and module_user uses {PARENT_DIR}/vX/main.tf
   
   for dir in "${v2_parent_dirs[@]}"; do
-    if [[ $parent_dir =~ $dir ]]; then
+    if [[ $parent_dir == "$dir" ]]; then
       return 0  # True
     fi
   done
   for dir in "${v2_grand_parent_dirs[@]}"; do
-    if [[ $grand_parent_dir =~ $dir ]]; then
+    if [[ $grand_parent_dir == "$dir" ]]; then
       return 0  # True
     fi
   done

--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -40,7 +40,7 @@ is_v2_dir() {
   local grand_parent_dir
   parent_dir=$(basename "$1")
   grand_parent_dir=$(basename "$(dirname "$1")")
-  local v2_parent_dirs=("cluster_with_schedule")
+  local v2_parent_dirs=("cluster_with_schedule direct-resource")
   local v2_grand_parent_dirs=("module_maintainer" "module_user" "migrate_cluster_to_advanced_cluster" "mongodbatlas_backup_compliance_policy") # module_maintainer and module_user uses {PARENT_DIR}/vX/main.tf
   
   for dir in "${v2_parent_dirs[@]}"; do


### PR DESCRIPTION
## Description

Updates replication_specs blocks to use latest schema version

Link to any related issue(s): CLOUDP-331089

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
