### PR TITLE
test: Adds removal of encryption at rest private endpoints in project cleanup

### DIFF
--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -405,7 +405,7 @@ func removeFederatedDatabases(ctx context.Context, t *testing.T, dryRun bool, cl
 func removeEncryptionAtRestPrivateEndpoints(ctx context.Context, t *testing.T, dryRun bool, client *admin.APIClient, projectID string) int {
 	t.Helper()
 	endpointsCount := 0
-	for _, cloudProvider := range []string{"AWS", "AZURE"} {
+	for _, cloudProvider := range []string{constant.AWS, constant.AZURE} {
 		privateEndpoints, _, err := client.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRestPrivateEndpointsForCloudProvider(ctx, projectID, cloudProvider).Execute()
 		require.NoError(t, err)
 		endpoints := privateEndpoints.GetResults()
@@ -416,6 +416,7 @@ func removeEncryptionAtRestPrivateEndpoints(ctx context.Context, t *testing.T, d
 			if !dryRun {
 				_, err = client.EncryptionAtRestUsingCustomerKeyManagementApi.RequestEncryptionAtRestPrivateEndpointDeletion(ctx, projectID, cloudProvider, endpointID).Execute()
 				require.NoError(t, err)
+				time.Sleep(30 * time.Second)
 			}
 		}
 	}

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -210,6 +210,10 @@ func removeProjectResources(ctx context.Context, t *testing.T, dryRun bool, clie
 	if privateEndpointServicesRemoved > 0 {
 		changes = append(changes, fmt.Sprintf("removed %d private endpoint services", privateEndpointServicesRemoved))
 	}
+	encryptionAtRestPrivateEndpointsRemoved := removeEncryptionAtRestPrivateEndpoints(ctx, t, dryRun, client, projectID)
+	if encryptionAtRestPrivateEndpointsRemoved > 0 {
+		changes = append(changes, fmt.Sprintf("removed %d encryption at rest private endpoints", encryptionAtRestPrivateEndpointsRemoved))
+	}
 	return strings.Join(changes, ", ")
 }
 
@@ -396,4 +400,24 @@ func removeFederatedDatabases(ctx context.Context, t *testing.T, dryRun bool, cl
 		}
 	}
 	return len(federatedResults)
+}
+
+func removeEncryptionAtRestPrivateEndpoints(ctx context.Context, t *testing.T, dryRun bool, client *admin.APIClient, projectID string) int {
+	t.Helper()
+	endpointsCount := 0
+	for _, cloudProvider := range []string{"AWS", "AZURE"} {
+		privateEndpoints, _, err := client.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRestPrivateEndpointsForCloudProvider(ctx, projectID, cloudProvider).Execute()
+		require.NoError(t, err)
+		endpoints := privateEndpoints.GetResults()
+		endpointsCount += len(endpoints)
+		for _, endpoint := range endpoints {
+			endpointID := endpoint.GetId()
+			t.Logf("delete encryption at rest private endpoint %s", endpointID)
+			if !dryRun {
+				_, err = client.EncryptionAtRestUsingCustomerKeyManagementApi.RequestEncryptionAtRestPrivateEndpointDeletion(ctx, projectID, cloudProvider, endpointID).Execute()
+				require.NoError(t, err)
+			}
+		}
+	}
+	return endpointsCount
 }


### PR DESCRIPTION
## Description

- Adds removal of encryption at rest private endpoints in project cleanup
- Discovered we don't do this as project cleanup

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
