### PR TITLE
fix: Sets org_id on import of `mongodbatlas_organization` resource

### DIFF
--- a/.changelog/3513.txt
+++ b/.changelog/3513.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_organization: Sets org_id on import
+```

--- a/internal/service/organization/resource_organization.go
+++ b/internal/service/organization/resource_organization.go
@@ -139,9 +139,6 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		d.SetId("")
 		return diag.FromErr(fmt.Errorf("an error occurred when updating Organization settings: %s", err))
 	}
-	if err := d.Set("org_id", orgID); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `org_id`: %s", err))
-	}
 	d.SetId(conversion.EncodeStateID(map[string]string{
 		"org_id": orgID,
 	}))
@@ -168,6 +165,9 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	}
 	if err := d.Set("skip_default_alerts_settings", organization.SkipDefaultAlertsSettings); err != nil {
 		return diag.Errorf("error setting `skip_default_alerts_settings` for organization (%s): %s", orgID, err)
+	}
+	if err := d.Set("org_id", orgID); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting `org_id`: %s", err))
 	}
 
 	settings, _, err := conn.OrganizationsApi.GetOrganizationSettings(ctx, orgID).Execute()

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -220,10 +220,11 @@ func TestAccConfigRSOrganization_import(t *testing.T) {
 				Config: configImportSet(orgID, orgName), // Use import so a new organization is not created, the resource must exist in a step before import state is verified.
 			},
 			{
-				ResourceName:      resourceName,
-				ImportStateId:     orgID,
-				ImportState:       true, // Do the import check.
-				ImportStateVerify: true,
+				ResourceName:                         resourceName,
+				ImportStateId:                        orgID,
+				ImportState:                          true, // Do the import check.
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "org_id",
 			},
 			{
 				// Use removed block so the organization is not deleted.


### PR DESCRIPTION
## Description

Sets org_id on import of `mongodbatlas_organization` resource

Link to any related issue(s): CLOUDP-332689

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
