### PR TITLE
test: Adds value check of roles in `mongodbatlas_api_key_project_assignment` resource

### DIFF
--- a/internal/service/apikeyprojectassignment/resource_test.go
+++ b/internal/service/apikeyprojectassignment/resource_test.go
@@ -37,7 +37,7 @@ func TestAccApiKeyProjectAssignmentRS_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: apiKeyProjectAssignmentConfig(orgID, roleName, projectName),
-				Check:  apiKeyProjectAssignmentAttributeChecks(roleName),
+				Check:  apiKeyProjectAssignmentAttributeChecks(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue(
@@ -52,7 +52,7 @@ func TestAccApiKeyProjectAssignmentRS_basic(t *testing.T) {
 			},
 			{
 				Config: apiKeyProjectAssignmentConfig(orgID, roleNameUpdated, projectName),
-				Check:  apiKeyProjectAssignmentAttributeChecks(roleNameUpdated),
+				Check:  apiKeyProjectAssignmentAttributeChecks(),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue(
@@ -87,7 +87,7 @@ func importStateIDFunc(resourceName, attrNameProjectID, attrNameAPIKeyID string)
 	}
 }
 
-func apiKeyProjectAssignmentAttributeChecks(expectedRole string) resource.TestCheckFunc {
+func apiKeyProjectAssignmentAttributeChecks() resource.TestCheckFunc {
 	attrsMap := map[string]string{
 		"roles.#": "1",
 	}

--- a/internal/service/apikeyprojectassignment/resource_test.go
+++ b/internal/service/apikeyprojectassignment/resource_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -38,31 +38,27 @@ func TestAccApiKeyProjectAssignmentRS_basic(t *testing.T) {
 			{
 				Config: apiKeyProjectAssignmentConfig(orgID, roleName, projectName),
 				Check:  apiKeyProjectAssignmentAttributeChecks(),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(
-							resourceName,
-							tfjsonpath.New("roles"),
-							knownvalue.SetPartial([]knownvalue.Check{
-								knownvalue.StringExact(roleName),
-							}),
-						),
-					},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("roles"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(roleName),
+						}),
+					),
 				},
 			},
 			{
 				Config: apiKeyProjectAssignmentConfig(orgID, roleNameUpdated, projectName),
 				Check:  apiKeyProjectAssignmentAttributeChecks(),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(
-							resourceName,
-							tfjsonpath.New("roles"),
-							knownvalue.SetPartial([]knownvalue.Check{
-								knownvalue.StringExact(roleNameUpdated),
-							}),
-						),
-					},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						resourceName,
+						tfjsonpath.New("roles"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact(roleNameUpdated),
+						}),
+					),
 				},
 			},
 			{


### PR DESCRIPTION
## Description

Adds value check of roles in `mongodbatlas_api_key_project_assignment` resource after removing it in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3488


Link to any related issue(s): CLOUDP-330229

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
