### PR TITLE
test: Add data source acceptance tests for azure cloud provider on Federated Database Instance into same file where resource test is located

### DIFF
--- a/examples/mongodbatlas_federated_database_instance/azure/versions.tf
+++ b/examples/mongodbatlas_federated_database_instance/azure/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.38.0"
+      version = "~> 1.39.0"
     }
   }
   required_version = ">= 1.0"

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -20,9 +20,9 @@ const (
 
 func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 	var (
-		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
-		projectName    = acc.RandomProjectName()
-		name           = acc.RandomName()
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+		name        = acc.RandomName()
 	)
 
 	valueChecks := map[string]string{

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -496,8 +495,7 @@ func checkAttrs(projectID, name string, extraAttrs map[string]string, extra ...r
 
 	maps.Copy(attrsMap, extraAttrs)
 	check := acc.CheckRSAndDS(resourceName, conversion.Pointer(dataSourceName), nil, nil, attrsMap, extra...)
-	checks := slices.Concat(extra, []resource.TestCheckFunc{check})
-	return resource.ComposeAggregateTestCheckFunc(checks...)
+	return check
 }
 
 func configFirstSteps(federatedInstanceName, projectName, orgID string) string {

--- a/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
+++ b/internal/service/federateddatabaseinstance/resource_federated_database_instance_test.go
@@ -20,8 +20,6 @@ const (
 
 func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 	var (
-		resourceName   = "mongodbatlas_federated_database_instance.test"
-		dataSourceName = "data.mongodbatlas_federated_database_instance.test"
 		orgID          = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName    = acc.RandomProjectName()
 		name           = acc.RandomName()
@@ -75,7 +73,6 @@ func TestAccFederatedDatabaseInstance_basic(t *testing.T) {
 
 func TestAccFederatedDatabaseInstance_s3bucket(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_federated_database_instance.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName()
 		name         = acc.RandomName()
@@ -158,7 +155,6 @@ func TestAccFederatedDatabaseInstance_atlasCluster(t *testing.T) {
 		clusterRequest = acc.ClusterRequest{
 			ReplicationSpecs: specs,
 		}
-		resourceName    = "mongodbatlas_federated_database_instance.test"
 		name            = acc.RandomName()
 		clusterInfo     = acc.GetClusterInfo(t, &clusterRequest)
 		projectID       = clusterInfo.ProjectID


### PR DESCRIPTION
## Description

This is an improvement related to acceptance tests for federated database instance - Azure provider. 

It adds data source tests to same file where resource tests are to avoid duplication into difference files for `federated_database_instance` where cloud provider config is `azure`.

Link to any related issue(s): This is a follow-up of [CLOUDP-245406](https://jira.mongodb.org/browse/CLOUDP-245406)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.
