### PR TITLE
chore: Remove plural checks in upgrade tests to avoid failure of 1 test impacting another

### DIFF
--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -124,7 +124,8 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 
 func testAccAdvancedClusterFlexUpgrade(t *testing.T, instanceSize string, includeDedicated bool) resource.TestCase {
 	t.Helper()
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 1)
+	projectID := acc.ProjectIDExecution(t)
+	clusterName := acc.RandomClusterName()
 	defaultZoneName := "Zone 1" // Uses backend default as in existing tests
 
 	steps := []resource.TestStep{

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -127,7 +127,7 @@ func testAccAdvancedClusterFlexUpgrade(t *testing.T, instanceSize string, includ
 	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 1)
 	defaultZoneName := "Zone 1" // Uses backend default as in existing tests
 
-	// avoid checking plural data source to reduce risk of being impacted from failure in other test using same project, test is focused on upgrade
+	// avoid checking plural data source to reduce risk of being impacted from failure in other test using same project, allows running in parallel
 	steps := []resource.TestStep{
 		{
 			Config: configTenant(t, true, projectID, clusterName, defaultZoneName, instanceSize),
@@ -154,11 +154,11 @@ func testAccAdvancedClusterFlexUpgrade(t *testing.T, instanceSize string, includ
 }
 
 func TestAccAdvancedCluster_basicTenant_flexUpgrade_dedicatedUpgrade(t *testing.T) {
-	resource.Test(t, testAccAdvancedClusterFlexUpgrade(t, freeInstanceSize, true))
+	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, freeInstanceSize, true))
 }
 
 func TestAccAdvancedCluster_sharedTier_flexUpgrade(t *testing.T) {
-	resource.Test(t, testAccAdvancedClusterFlexUpgrade(t, sharedInstanceSize, false))
+	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, sharedInstanceSize, false))
 }
 func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	var (

--- a/internal/service/advancedcluster/resource_advanced_cluster_test.go
+++ b/internal/service/advancedcluster/resource_advanced_cluster_test.go
@@ -124,8 +124,7 @@ func TestGetReplicationSpecAttributesFromOldAPI(t *testing.T) {
 
 func testAccAdvancedClusterFlexUpgrade(t *testing.T, instanceSize string, includeDedicated bool) resource.TestCase {
 	t.Helper()
-	projectID := acc.ProjectIDExecution(t)
-	clusterName := acc.RandomClusterName()
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 1)
 	defaultZoneName := "Zone 1" // Uses backend default as in existing tests
 
 	steps := []resource.TestStep{


### PR DESCRIPTION
## Description

**Issue:** `TestAccAdvancedCluster_sharedTier_flexUpgrade` has been facing flaky errors during the past weeks: [74% pass rate](https://espenalbert.github.io/schedule-test/ci-tests/site/2025-07-30_error-only/). It fails consistently when there is a failure in `TestAccAdvancedCluster_basicTenant_flexUpgrade_dedicatedUpgrade`.

Test is currently creating a project which can be shared with other cluster creations, however `checkFlexClusterConfig` is making assertions in the plural data sources and uses a fixed index of 0. ~Following `TestAccClusterFlexCluster_basic` this PR adjusts upgrade test to have a single project for its execution~.

(Edit): I later noticed that upgrade test are **not** run in parallel, which limits risk of being impacted by other tests. It has however been failing consistently due to failures in a different test `TestAccAdvancedCluster_basicTenant_flexUpgrade_dedicatedUpgrade`. This is because even though they run sequentially they share the same project, so if first test fails due to an error and does not delete the cluster the other test is impacted.

**Solution:** To avoid this coupling of one failing test impacting the other, I have removed plural checks in these tests as they are still being validated in other tests and are not significant for testing successful upgrades. This also allows them to run in parallel.

**Additional considerations**
Ideally `acc.PluralResultCheck` can be used to make assertions in the plural data source independent of the amount of resources, however this requires a significant refactor in `CheckRSAndDSPreviewProviderV2` to support creating StateChecks. This new logic supporting preview v2 with state checks would be deleted in v2 release.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
