### PR TITLE
feat: Long-running operation improvements for `mongodbatlas_stream_processor` resource

### DIFF
--- a/.changelog/3571.txt
+++ b/.changelog/3571.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_processor: Adds `delete_on_create_timeout` attribute to indicate whether to delete the resource if its creation times out
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_processor: Adds `timeouts` attribute for create operation
+```

--- a/docs/guides/2.0.0-upgrade-guide.md
+++ b/docs/guides/2.0.0-upgrade-guide.md
@@ -21,7 +21,9 @@ The Terraform MongoDB Atlas Provider version 2.0.0 has the following new feature
   - `mongodbatlas_online_archive`
   - `mongodbatlas_privatelink_endpoint`
   - `mongodbatlas_privatelink_endpoint_service`
+  - `mongodbatlas_push_based_log_export`
   - `mongodbatlas_search_deployment`
+  - `mongodbatlas_stream_processor`
 
 ## Breaking Changes
 

--- a/docs/resources/stream_processor.md
+++ b/docs/resources/stream_processor.md
@@ -132,10 +132,12 @@ output "stream_processors_results" {
 
 ### Optional
 
+- `delete_on_create_timeout` (Boolean) Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--options))
 - `state` (String) The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`. When a Stream Processor is created without specifying the state, it will default to `CREATED` state. When a Stream Processor is updated without specifying the state, it will default to the Previous state. 
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
+- `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
@@ -157,6 +159,15 @@ Required:
 - `coll` (String) Name of the collection to use for the DLQ.
 - `connection_name` (String) Name of the connection to write DLQ messages to. Must be an Atlas connection.
 - `db` (String) Name of the database to use for the DLQ.
+
+
+
+<a id="nestedatt--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import 
 Stream Processor resource can be imported using the Project ID, Stream Instance name and Stream Processor name, in the format `INSTANCE_NAME-PROJECT_ID-PROCESSOR_NAME`, e.g.

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -79,7 +80,7 @@ func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSM
 	return streamProcessorAPIParams, nil
 }
 
-func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats) (*TFStreamProcessorRSModel, diag.Diagnostics) {
+func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName string, apiResp *admin.StreamsProcessorWithStats, timeout *timeouts.Value, deleteOnCreateTimeout *types.Bool) (*TFStreamProcessorRSModel, diag.Diagnostics) {
 	if apiResp == nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("streamProcessor API response is nil", "")}
 	}
@@ -104,6 +105,12 @@ func NewStreamProcessorWithStats(ctx context.Context, projectID, instanceName st
 		ProjectID:     types.StringPointerValue(&projectID),
 		State:         types.StringPointerValue(&apiResp.State),
 		Stats:         statsTF,
+	}
+	if timeout != nil {
+		tfModel.Timeouts = *timeout
+	}
+	if deleteOnCreateTimeout != nil {
+		tfModel.DeleteOnCreateTimeout = *deleteOnCreateTimeout
 	}
 	return tfModel, nil
 }

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -230,7 +230,7 @@ func TestSDKToTFModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sdkModel := tc.sdkModel
-			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(t.Context(), projectID, instanceName, sdkModel)
+			resultModel, diags := streamprocessor.NewStreamProcessorWithStats(t.Context(), projectID, instanceName, sdkModel, nil, nil)
 			if diags.HasError() {
 				t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 			}

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -77,20 +78,28 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 			}),
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.CreateOnlyBoolPlanModifier(),
+				},
+				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+			},
 		},
 	}
 }
 
 type TFStreamProcessorRSModel struct {
-	InstanceName  types.String         `tfsdk:"instance_name"`
-	Options       types.Object         `tfsdk:"options"`
-	Pipeline      jsontypes.Normalized `tfsdk:"pipeline"`
-	ProcessorID   types.String         `tfsdk:"id"`
-	ProcessorName types.String         `tfsdk:"processor_name"`
-	ProjectID     types.String         `tfsdk:"project_id"`
-	State         types.String         `tfsdk:"state"`
-	Stats         types.String         `tfsdk:"stats"`
-	Timeouts      timeouts.Value       `tfsdk:"timeouts"`
+	InstanceName          types.String         `tfsdk:"instance_name"`
+	Options               types.Object         `tfsdk:"options"`
+	Pipeline              jsontypes.Normalized `tfsdk:"pipeline"`
+	ProcessorID           types.String         `tfsdk:"id"`
+	ProcessorName         types.String         `tfsdk:"processor_name"`
+	ProjectID             types.String         `tfsdk:"project_id"`
+	State                 types.String         `tfsdk:"state"`
+	Stats                 types.String         `tfsdk:"stats"`
+	Timeouts              timeouts.Value       `tfsdk:"timeouts"`
+	DeleteOnCreateTimeout types.Bool           `tfsdk:"delete_on_create_timeout"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -73,6 +74,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.",
 			},
+			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
+				Create: true,
+			}),
 		},
 	}
 }
@@ -86,6 +90,7 @@ type TFStreamProcessorRSModel struct {
 	ProjectID     types.String         `tfsdk:"project_id"`
 	State         types.String         `tfsdk:"state"`
 	Stats         types.String         `tfsdk:"stats"`
+	Timeouts      timeouts.Value       `tfsdk:"timeouts"`
 }
 
 type TFOptionsModel struct {

--- a/internal/service/streamprocessor/state_transition.go
+++ b/internal/service/streamprocessor/state_transition.go
@@ -24,15 +24,21 @@ const (
 const (
 	ErrorUpdateStateTransition = "Stream Processor must be in %s state to transition to %s state"
 	ErrorUpdateToCreatedState  = "Stream Processor cannot transition from %s to CREATED"
+	defaultTimeout             = 5 * time.Minute // big pipelines can take a while to stop due to checkpointing. By default, we prefer the API to raise the error (~ 3min) than having to expose custom timeouts.
+	minTimeout                 = 3 * time.Second
 )
 
 func WaitStateTransition(ctx context.Context, requestParams *admin.GetStreamProcessorApiParams, client admin.StreamsApi, pendingStates, desiredStates []string) (*admin.StreamsProcessorWithStats, error) {
+	return WaitStateTransitionWithTimeout(ctx, requestParams, client, pendingStates, desiredStates, defaultTimeout)
+}
+
+func WaitStateTransitionWithTimeout(ctx context.Context, requestParams *admin.GetStreamProcessorApiParams, client admin.StreamsApi, pendingStates, desiredStates []string, timeout time.Duration) (*admin.StreamsProcessorWithStats, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:    pendingStates,
 		Target:     desiredStates,
 		Refresh:    refreshFunc(ctx, requestParams, client),
-		Timeout:    5 * time.Minute, // big pipelines can take a while to stop due to checkpointing. We prefer the API to raise the error (~ 3min) than having to expose custom timeouts.
-		MinTimeout: 3 * time.Second,
+		Timeout:    timeout,
+		MinTimeout: minTimeout,
 		Delay:      0,
 	}
 


### PR DESCRIPTION
## Description

Added delete_on_create_timeout: New optional field (defaults to true) that automatically deletes the resource if creation times out
Add timeout field for create operation

Link to any related issue(s): CLOUDP-334371

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
