### PR TITLE
deprecate: Deprecates `mongodbatlas_cluster` resource & datasources

### DIFF
--- a/.changelog/3594.txt
+++ b/.changelog/3594.txt
@@ -1,0 +1,11 @@
+```release-note:note
+resource/mongodbatlas_cluster: Deprecates this resource in favour of `mongodbatlas_advanced_cluster`
+```
+
+```release-note:note
+data-source/mongodbatlas_cluster: Deprecates this datasource in favour of `data.mongodbatlas_advanced_cluster`
+```
+
+```release-note:note
+data-source/mongodbatlas_clusters: Deprecates this datasource in favour of `data.mongodbatlas_advanced_clusters`
+```

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -2,6 +2,8 @@
 
 `mongodbatlas_cluster` describes a Cluster. The data source requires your Project ID.
 
+**WARNING:** This datasource is deprecated and will be removed in the next major release. Please use `mongodbatlas_advanced_cluster`. For more details, see [our migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide).
+
 ~> **IMPORTANT:**
 <br> &#8226; Multi Region Cluster: The `mongodbatlas_cluster` data source doesn't return the `container_id` for each region utilized by the cluster. For retrieving the `container_id`, we recommend the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) data source instead.
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -2,6 +2,8 @@
 
 `mongodbatlas_cluster` describes all Clusters by the provided project_id. The data source requires your Project ID.
 
+**WARNING:** This datasource is deprecated and will be removed in the next major release. Please use `mongodbatlas_advanced_clusters`. For more details, see [our migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide).
+
 ~> **IMPORTANT:**
 <br> &#8226; Multi Region Cluster: The `mongodbatlas_cluster` data source doesn't return the `container_id` for each region utilized by the cluster. For retrieving the `container_id`, we recommend the [`mongodbatlas_advanced_cluster`](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_clusters) data source instead.
 <br> &#8226; Changes to cluster configurations can affect costs. Before making changes, please see [Billing](https://docs.atlas.mongodb.com/billing/).

--- a/docs/guides/cluster-to-advanced-cluster-migration-guide.md
+++ b/docs/guides/cluster-to-advanced-cluster-migration-guide.md
@@ -4,7 +4,7 @@ page_title: "Migration Guide: Cluster to Advanced Cluster"
 
 # Migration Guide: Cluster to Advanced Cluster
 
-**Objective**: This guide explains how to replace the `mongodbatlas_cluster` resource with the `mongodbatlas_advanced_cluster` resource. For data source migrations, refer to the [output changes](#output-changes) section. If you're transitioning to independent sharding, additional guidance is available in the [Advanced Cluster New Sharding Configurations Migration Guide](advanced-cluster-new-sharding-schema#data-source-transition-for-asymmetric-clusters).
+**Objective**: This guide explains how to replace the deprecated `mongodbatlas_cluster` resource with the `mongodbatlas_advanced_cluster` resource. For data source migrations, refer to the [output changes](#output-changes) section. If you're transitioning to independent sharding, additional guidance is available in the [Advanced Cluster New Sharding Configurations Migration Guide](advanced-cluster-new-sharding-schema#data-source-transition-for-asymmetric-clusters).
 
 ## Why do we have both `mongodbatlas_cluster` and `mongodbatlas_advanced_cluster` resources?
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -2,6 +2,9 @@
 
 `mongodbatlas_cluster` provides a Cluster resource. The resource lets you create, edit and delete clusters. The resource requires your Project ID.
 
+**WARNING:** This resource is deprecated and will be removed in the next major release. Please use `mongodbatlas_advanced_cluster`. For more details, see [our migration guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide).
+
+
 ~> **IMPORTANT:** We recommend all new MongoDB Atlas Terraform users start with the [`mongodbatlas_advanced_cluster`](advanced_cluster) resource.  Key differences between [`mongodbatlas_cluster`](cluster) and [`mongodbatlas_advanced_cluster`](advanced_cluster) include support for [Multi-Cloud Clusters](https://www.mongodb.com/blog/post/introducing-multicloud-clusters-on-mongodb-atlas), [Asymmetric Sharding](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/advanced-cluster-new-sharding-schema), and [Independent Scaling of Analytics Node Tiers](https://www.mongodb.com/blog/post/introducing-ability-independently-scale-atlas-analytics-node-tiers).  For existing [`mongodbatlas_cluster`](cluster) resource users see our [Migration Guide](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide). 
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find group_id in the official documentation.

--- a/internal/service/cluster/data_source_cluster.go
+++ b/internal/service/cluster/data_source_cluster.go
@@ -10,13 +10,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 )
 
 func DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationNextMajorWithReplacementGuide, "datasource", "mongodbatlas_advanced_cluster", clusterToAdvancedClusterGuide),
+		ReadContext:        dataSourceRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/cluster/data_source_clusters.go
+++ b/internal/service/cluster/data_source_clusters.go
@@ -14,13 +14,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
 )
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourcePluralRead,
+		DeprecationMessage: fmt.Sprintf(constant.DeprecationNextMajorWithReplacementGuide, "datasource", "mongodbatlas_advanced_clusters", clusterToAdvancedClusterGuide),
+		ReadContext:        dataSourcePluralRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,

--- a/internal/service/cluster/resource_cluster.go
+++ b/internal/service/cluster/resource_cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/spf13/cast"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -35,12 +36,14 @@ const (
 	errorClusterUpdate            = "error updating MongoDB Cluster (%s): %s"
 	errorAdvancedConfUpdate       = "error updating Advanced Configuration Option %s for MongoDB Cluster (%s): %s"
 	ErrorSnapshotBackupPolicyRead = "error getting a Cloud Provider Snapshot Backup Policy for the cluster(%s): %s"
+	clusterToAdvancedClusterGuide = "https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/cluster-to-advanced-cluster-migration-guide"
 )
 
 var defaultLabel = matlas.Label{Key: advancedclustertpf.LegacyIgnoredLabelKey, Value: "MongoDB Atlas Terraform Provider"}
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   fmt.Sprintf(constant.DeprecationNextMajorWithReplacementGuide, "resource", "mongodbatlas_advanced_cluster", clusterToAdvancedClusterGuide),
 		CreateWithoutTimeout: resourceCreate,
 		ReadWithoutTimeout:   resourceRead,
 		UpdateWithoutTimeout: resourceUpdate,

--- a/internal/service/cluster/resource_cluster_state_upgrader_test.go
+++ b/internal/service/cluster/resource_cluster_state_upgrader_test.go
@@ -2,6 +2,7 @@ package cluster_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -39,7 +40,7 @@ func TestAccClusterRSClusterMigrateState_empty_advancedConfig(t *testing.T) {
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 {
+	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 
@@ -83,7 +84,7 @@ func TestAccClusterRSClusterMigrateState_with_advancedConfig(t *testing.T) {
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 {
+	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 
@@ -127,7 +128,7 @@ func TestAccClusterRSClusterMigrateState_with_defaultAdvancedConfig_v0_5_1(t *te
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 {
+	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 

--- a/internal/service/cluster/resource_cluster_state_upgrader_test.go
+++ b/internal/service/cluster/resource_cluster_state_upgrader_test.go
@@ -5,10 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/cluster"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+const (
+	deprecatedResourceDiagSummary = "Deprecated Resource"
 )
 
 func TestAccClusterRSClusterMigrateState_empty_advancedConfig(t *testing.T) {
@@ -40,7 +45,7 @@ func TestAccClusterRSClusterMigrateState_empty_advancedConfig(t *testing.T) {
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
+	if isErrorDiags(diags) {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 
@@ -84,7 +89,7 @@ func TestAccClusterRSClusterMigrateState_with_advancedConfig(t *testing.T) {
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
+	if isErrorDiags(diags) {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 
@@ -128,10 +133,14 @@ func TestAccClusterRSClusterMigrateState_with_defaultAdvancedConfig_v0_5_1(t *te
 
 	v1Config := terraform.NewResourceConfigRaw(v1State)
 	diags = cluster.Resource().Validate(v1Config)
-	if len(diags) > 0 && !strings.Contains(diags[0].Summary, "Deprecated Resource") {
+	if isErrorDiags(diags) {
 		fmt.Println(diags)
 		t.Error("migrated cluster advanced config is invalid")
 
 		return
 	}
+}
+
+func isErrorDiags(diags diag.Diagnostics) bool {
+	return len(diags) > 0 && !strings.Contains(diags[0].Summary, deprecatedResourceDiagSummary)
 }


### PR DESCRIPTION
## Description

 Deprecates `mongodbatlas_cluster` resource & datasources

Link to any related issue(s): [CLOUDP-334499](https://jira.mongodb.org/browse/CLOUDP-334499)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
