### PR TITLE
feat: Changes default value of `delete_on_create_timeout` to true in `mongodbatlas_advanced_cluster` and `mongodbatlas_search_deployment` resources

### DIFF
--- a/.changelog/3595.txt
+++ b/.changelog/3595.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/mongodbatlas_advanced_cluster: Changes default value of `delete_on_create_timeout` to `true`
+```
+
+```release-note:breaking-change
+resource/mongodbatlas_search_deployment: Changes default value of `delete_on_create_timeout` to `true`
+```

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -137,7 +137,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	isFlex := IsFlex(latestReq.ReplicationSpecs)
 	projectID, clusterName := waitParams.ProjectID, waitParams.ClusterName
 	clusterDetailStr := fmt.Sprintf("Cluster name %s (project_id=%s).", clusterName, projectID)
-	if plan.DeleteOnCreateTimeout.ValueBool() {
+	if cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout) {
 		var deferCall func()
 		ctx, deferCall = cleanup.OnTimeout(
 			ctx, waitParams.Timeout, diags.AddWarning, clusterDetailStr, DeleteClusterNoWait(r.Client, projectID, clusterName, isFlex),

--- a/internal/service/searchdeployment/resource.go
+++ b/internal/service/searchdeployment/resource.go
@@ -76,10 +76,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		RetryTimeConfig(createTimeout, minTimeoutCreateUpdate))
 	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout), err, func(ctxCleanup context.Context) error {
 		_, err := connV2.AtlasSearchApi.DeleteAtlasSearchDeployment(ctxCleanup, projectID, clusterName).Execute()
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 	if err != nil {
 		diags.AddError("error during search deployment creation", err.Error())

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -85,7 +85,7 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configWithTimeout(timeoutStrNoDeleteOnCreate),
-				ExpectError: regexp.MustCompile("will not run cleanup because delete_on_create_timeout is false"),
+				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},
 			{
 				Config:      configWithTimeout(timeoutsStrShort),

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/cleanup"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/searchdeployment"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 )
@@ -81,7 +80,7 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configWithTimeout(timeoutsStrShort),
-				ExpectError: regexp.MustCompile(cleanup.TimeoutReachedPrefix),
+				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},
 			{
 				PreConfig: func() {

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -88,6 +88,11 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},
 			{
+				PreConfig: func() {
+					timeoutConfig := searchdeployment.RetryTimeConfig(deleteTimeout, 30*time.Second)
+					err := searchdeployment.WaitSearchNodeDelete(t.Context(), projectID, clusterName, acc.ConnV2().AtlasSearchApi, timeoutConfig)
+					require.NoError(t, err)
+				},
 				Config:      configWithTimeout(timeoutsStrShort),
 				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -59,6 +59,11 @@ const deleteTimeout = 30 * time.Minute
 
 func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 	var (
+		timeoutStrNoDeleteOnCreate = `
+			timeouts = {
+				create = "90s"
+			}
+		`
 		timeoutsStrShort = `
 			timeouts = {
 				create = "90s"
@@ -78,6 +83,10 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
+			{
+				Config:      configWithTimeout(timeoutStrNoDeleteOnCreate),
+				ExpectError: regexp.MustCompile("will not run cleanup because delete_on_create_timeout is false"),
+			},
 			{
 				Config:      configWithTimeout(timeoutsStrShort),
 				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),


### PR DESCRIPTION
## Description

Changes default value of `delete_on_create_timeout` to true in `mongodbatlas_advanced_cluster` and `mongodbatlas_search_deployment` resources.
- Documentation changes were done in https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3552
- For `mongodbatlas_search_deployment` resource, implementation of the `delete_on_create_timeout` logic has been changed to use the one we are using in the other resources. This is to unify the implementation and be consistent across the resources where we can. In `mongodbatlas_advanced_cluster` is not possible because the creation logic is more complex and there are multiple API calls, making it necessary to use the `ReplaceContextDeadlineExceededDiags` and `deferCall` implementation

Link to any related issue(s): CLOUDP-335991

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
