### PR TITLE
feat: Add workspace_name field in stream_processor resource and datasource

### DIFF
--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -102,6 +102,13 @@ data "mongodbatlas_stream_processor" "example-stream-processor" {
   processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
 }
 
+# Example using workspace_name instead of instance_name
+data "mongodbatlas_stream_processor" "example-stream-processor-workspace" {
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
+  processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
+}
+
 # example making use of data sources
 output "stream_processors_state" {
   value = data.mongodbatlas_stream_processor.example-stream-processor.state
@@ -117,11 +124,17 @@ output "stream_processors_results" {
 
 ### Required
 
-- `instance_name` (String) Human-readable label that identifies the stream instance.
 - `processor_name` (String) Human-readable label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+
+**NOTE**: Either `instance_name` or `workspace_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is provided as an alias for `instance_name`.
+
+### Optional
+
+- `instance_name` (String) Human-readable label that identifies the stream instance. Conflicts with `workspace_name`.
+- `workspace_name` (String) Human-readable label that identifies the stream instance. This is an alias for `instance_name`. Conflicts with `instance_name`.
 
 ### Read-Only
 

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -96,6 +96,12 @@ data "mongodbatlas_stream_processors" "example-stream-processors" {
   instance_name = mongodbatlas_stream_instance.example.instance_name
 }
 
+# Example using workspace_name instead of instance_name
+data "mongodbatlas_stream_processors" "example-stream-processors-workspace" {
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
+}
+
 data "mongodbatlas_stream_processor" "example-stream-processor" {
   project_id     = var.project_id
   instance_name  = mongodbatlas_stream_instance.example.instance_name
@@ -117,10 +123,16 @@ output "stream_processors_results" {
 
 ### Required
 
-- `instance_name` (String) Human-readable label that identifies the stream instance.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+
+**NOTE**: Either `instance_name` or `workspace_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is provided as an alias for `instance_name`.
+
+### Optional
+
+- `instance_name` (String) Human-readable label that identifies the stream instance. Conflicts with `workspace_name`.
+- `workspace_name` (String) Human-readable label that identifies the stream instance. This is an alias for `instance_name`. Conflicts with `instance_name`.
 
 ### Read-Only
 

--- a/internal/service/streamprocessor/data_source.go
+++ b/internal/service/streamprocessor/data_source.go
@@ -25,8 +25,19 @@ type StreamProccesorDS struct {
 
 func (d *StreamProccesorDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.DataSourceSchemaRequest{
-		RequiredFields: []string{"project_id", "instance_name", "processor_name"},
+		RequiredFields: []string{"project_id", "processor_name"},
 	})
+}
+
+// getEffectiveInstanceNameForDS returns the instance name from either instance_name or workspace_name field for datasource model
+func getEffectiveInstanceNameForDS(model *TFStreamProcessorDSModel) string {
+	if !model.InstanceName.IsNull() && !model.InstanceName.IsUnknown() {
+		return model.InstanceName.ValueString()
+	}
+	if !model.WorkspaceName.IsNull() && !model.WorkspaceName.IsUnknown() {
+		return model.WorkspaceName.ValueString()
+	}
+	return ""
 }
 
 func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -38,7 +49,11 @@ func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest
 
 	connV2 := d.Client.AtlasV2
 	projectID := streamProccesorConfig.ProjectID.ValueString()
-	instanceName := streamProccesorConfig.InstanceName.ValueString()
+	instanceName := getEffectiveInstanceNameForDS(&streamProccesorConfig)
+	if instanceName == "" {
+		resp.Diagnostics.AddError("validation error", "either instance_name or workspace_name must be provided")
+		return
+	}
 	processorName := streamProccesorConfig.ProcessorName.ValueString()
 	apiResp, _, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, instanceName, processorName).Execute()
 
@@ -47,7 +62,7 @@ func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	newStreamTFStreamprocessorDSModelModel, diags := NewTFStreamprocessorDSModel(ctx, projectID, instanceName, apiResp)
+	newStreamTFStreamprocessorDSModelModel, diags := NewTFStreamprocessorDSModelWithOriginal(ctx, projectID, instanceName, apiResp, &streamProccesorConfig)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return


### PR DESCRIPTION
## Description

JIRA: [CLOUDP-340024](https://jira.mongodb.org/browse/CLOUDP-340024)

As part of an ongoing effort to rename stream instances to stream workspaces, we will support a `workspace_name` field for the `stream_processor` resource and datasource that will function identically to 1instance_name`. To avoid confusion, only one of instance_name or workspace name will be allowed to be set

In a future major version of terraform, we will remove the instance_name field

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
