### PR TITLE
chore: Remove provider version constraint in examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,9 @@ __debug_*
 compliance/sbom.json
 compliance/augmented-sbom-v*.json
 
+.terraform
+.terraform.lock.hcl
+terraform.tfvars
+
 #used for schema code generation but is not commited to avoid constant updates
 tools/codegen/open-api-spec.yml

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ docs: ## Give URL to test Terraform documentation
 
 .PHONY: tflint
 tflint: fmtcheck ## Linter for Terraform files in examples/ dir (avoid `internal/**/testdata/main*.tf`)
-	tflint --chdir=examples/ -f compact --recursive --minimum-failure-severity=warning
+	tflint --chdir=examples/ -f compact --recursive --minimum-failure-severity=warning --disable-rule=terraform_required_providers
 
 .PHONY: tf-validate
 tf-validate: fmtcheck ## Validate Terraform files

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,9 @@ tools:  ## Install the dev tools (dependencies)
 docs: ## Give URL to test Terraform documentation
 	@echo "Use this site to preview markdown rendering: https://registry.terraform.io/tools/doc-preview"
 
+
 .PHONY: tflint
-tflint: fmtcheck ## Linter for Terraform files in examples/ dir (avoid `internal/**/testdata/main*.tf`)
+tflint: fmtcheck ## Linter for Terraform files in examples/ dir (avoid `internal/**/testdata/main*.tf`), disable terraform_required_providers rule as we intentionally omit the provider version
 	tflint --chdir=examples/ -f compact --recursive --minimum-failure-severity=warning --disable-rule=terraform_required_providers
 
 .PHONY: tf-validate

--- a/examples/migrate_cluster_to_advanced_cluster/basic/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/basic/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.8" # Minimum moved block supported version

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v1/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v2/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.8" # Minimum moved block supported version

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v3/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.8" # Minimum moved block supported version

--- a/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v4/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_maintainer/v4/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v1/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v1/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v2/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v2/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.8" # Minimum moved block supported version

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v3/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v3/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.8" # Minimum moved block supported version

--- a/examples/migrate_cluster_to_advanced_cluster/module_user/v4/versions.tf
+++ b/examples/migrate_cluster_to_advanced_cluster/module_user/v4/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/asymmetric-sharded-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/asymmetric-sharded-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/auto-scaling-per-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/auto-scaling-per-shard/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/flex-upgrade/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/flex-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/global-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/global-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/multi-cloud/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/multi-cloud/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/tenant-upgrade/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/tenant-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/version-upgrade-with-pinned-fcv/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster (preview provider 2.0.0)/version-upgrade-with-pinned-fcv/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.29"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/asymmetric-sharded-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/auto-scaling-per-shard/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/auto-scaling-per-shard/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.22"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/flex-upgrade/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/flex-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/global-cluster/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/global-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/multi-cloud/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/multi-cloud/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/tenant-upgrade/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/tenant-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_advanced_cluster/version-upgrade-with-pinned-fcv/versions.tf
+++ b/examples/mongodbatlas_advanced_cluster/version-upgrade-with-pinned-fcv/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.22"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_alert_configuration/versions.tf
+++ b/examples/mongodbatlas_alert_configuration/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_api_key/versions.tf
+++ b/examples/mongodbatlas_api_key/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.37.0"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_api_key/versions.tf
+++ b/examples/mongodbatlas_api_key/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_api_key_assignment/module/new_module/versions.tf
+++ b/examples/mongodbatlas_api_key_assignment/module/new_module/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.37.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_api_key_assignment/module/old_module/versions.tf
+++ b/examples/mongodbatlas_api_key_assignment/module/old_module/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.37.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_api_key_assignment/module/versions.tf
+++ b/examples/mongodbatlas_api_key_assignment/module/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.37.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_atlas_user/versions.tf
+++ b/examples/mongodbatlas_atlas_user/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.12"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_backup_compliance_policy/module/modules/cluster_with_schedule/main.tf
+++ b/examples/mongodbatlas_backup_compliance_policy/module/modules/cluster_with_schedule/main.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.34"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_backup_compliance_policy/module/versions.tf
+++ b/examples/mongodbatlas_backup_compliance_policy/module/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.34"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_backup_compliance_policy/resource/versions.tf
+++ b/examples/mongodbatlas_backup_compliance_policy/resource/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.34"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_backup_schedule/versions.tf
+++ b/examples/mongodbatlas_cloud_backup_schedule/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 0.13"

--- a/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/aws/versions.tf
+++ b/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/aws/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/azure/versions.tf
+++ b/examples/mongodbatlas_cloud_backup_snapshot_export_bucket/azure/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_backup_snapshot_export_job/versions.tf
+++ b/examples/mongodbatlas_cloud_backup_snapshot_export_job/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_provider_access/aws/versions.tf
+++ b/examples/mongodbatlas_cloud_provider_access/aws/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_cloud_provider_access/azure/versions.tf
+++ b/examples/mongodbatlas_cloud_provider_access/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.11.0"
+      source = "mongodb/mongodbatlas"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/examples/mongodbatlas_cloud_provider_snapshot_restore_job/point-in-time-advanced-cluster/versions.tf
+++ b/examples/mongodbatlas_cloud_provider_snapshot_restore_job/point-in-time-advanced-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_provider_snapshot_restore_job/point-in-time/versions.tf
+++ b/examples/mongodbatlas_cloud_provider_snapshot_restore_job/point-in-time/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cluster/nvme-upgrade/versions.tf
+++ b/examples/mongodbatlas_cluster/nvme-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.9"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cluster/tenant-upgrade/versions.tf
+++ b/examples/mongodbatlas_cluster/tenant-upgrade/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cluster_outage_simulation/versions.tf
+++ b/examples/mongodbatlas_cluster_outage_simulation/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_control_plane_ip_addresses/versions.tf
+++ b/examples/mongodbatlas_control_plane_ip_addresses/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.17"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_data_lake_pipeline/versions.tf
+++ b/examples/mongodbatlas_data_lake_pipeline/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_database_user/versions.tf
+++ b/examples/mongodbatlas_database_user/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_encryption_at_rest/aws/atlas-cluster/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest/aws/atlas-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_encryption_at_rest/aws/multi-region-cluster/modules/multi-region-cluster/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest/aws/multi-region-cluster/modules/multi-region-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_encryption_at_rest/aws/multi-region-cluster/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest/aws/multi-region-cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10.0"
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_encryption_at_rest/azure/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_encryption_at_rest_private_endpoint/aws/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest_private_endpoint/aws/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.28"
+      source = "mongodb/mongodbatlas"
     }
 
     aws = {

--- a/examples/mongodbatlas_encryption_at_rest_private_endpoint/azure/versions.tf
+++ b/examples/mongodbatlas_encryption_at_rest_private_endpoint/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
 
     azapi = {

--- a/examples/mongodbatlas_federated_database_instance/aws/versions.tf
+++ b/examples/mongodbatlas_federated_database_instance/aws/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_federated_database_instance/azure/versions.tf
+++ b/examples/mongodbatlas_federated_database_instance/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.39.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_federated_query_limit/versions.tf
+++ b/examples/mongodbatlas_federated_query_limit/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_federated_settings_identity_provider/azure/versions.tf
+++ b/examples/mongodbatlas_federated_settings_identity_provider/azure/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "2.3.4"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = ">=1.17.0"
+      source = "mongodb/mongodbatlas"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/mongodbatlas_federated_settings_org_role_mapping/versions.tf
+++ b/examples/mongodbatlas_federated_settings_org_role_mapping/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_flex_cluster/versions.tf
+++ b/examples/mongodbatlas_flex_cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.21.3"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_maintenance_window/versions.tf
+++ b/examples/mongodbatlas_maintenance_window/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_mongodb_employee_access_grant/versions.tf
+++ b/examples/mongodbatlas_mongodb_employee_access_grant/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_network_peering/aws/versions.tf
+++ b/examples/mongodbatlas_network_peering/aws/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_network_peering/azure/versions.tf
+++ b/examples/mongodbatlas_network_peering/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/examples/mongodbatlas_network_peering/gcp/versions.tf
+++ b/examples/mongodbatlas_network_peering/gcp/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/mongodbatlas_online_archive/versions.tf
+++ b/examples/mongodbatlas_online_archive/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_organization/organization-import/versions.tf
+++ b/examples/mongodbatlas_organization/organization-import/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_organization/organization-step-1/versions.tf
+++ b/examples/mongodbatlas_organization/organization-step-1/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_organization/organization-step-2/versions.tf
+++ b/examples/mongodbatlas_organization/organization-step-2/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cluster-geosharded/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cluster-geosharded/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cluster/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cluster/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/data-federation-online-archive/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.10"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/azure/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/azure/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/gcp/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/gcp/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
 
     google = {

--- a/examples/mongodbatlas_project/versions.tf
+++ b/examples/mongodbatlas_project/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.11"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_project_ip_access_list/versions.tf
+++ b/examples/mongodbatlas_project_ip_access_list/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_project_ip_addresses/versions.tf
+++ b/examples/mongodbatlas_project_ip_addresses/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.17"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_push_based_log_export/versions.tf
+++ b/examples/mongodbatlas_push_based_log_export/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     mongodbatlas = {
       source = "mongodb/mongodbatlas"
-      version = "~> 1.16.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_push_based_log_export/versions.tf
+++ b/examples/mongodbatlas_push_based_log_export/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
+      source = "mongodb/mongodbatlas"
       version = "~> 1.16.0"
     }
     aws = {

--- a/examples/mongodbatlas_resource_policy/versions.tf
+++ b/examples/mongodbatlas_resource_policy/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "0.2.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.31"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_search_deployment/versions.tf
+++ b/examples/mongodbatlas_search_deployment/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_account_details/versions.tf
+++ b/examples/mongodbatlas_stream_account_details/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.36"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_connection/versions.tf
+++ b/examples/mongodbatlas_stream_connection/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.14"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_instance/versions.tf
+++ b/examples/mongodbatlas_stream_instance/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.14"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_privatelink_endpoint/aws_msk_cluster/versions.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/aws_msk_cluster/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.81"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.30"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_privatelink_endpoint/azure/versions.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/azure/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.30"
+      source = "mongodb/mongodbatlas"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/mongodbatlas_stream_privatelink_endpoint/confluent_dedicated_cluster/versions.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/confluent_dedicated_cluster/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "1.24.0"
+      source = "mongodb/mongodbatlas"
     }
     confluent = {
       source  = "confluentinc/confluent"

--- a/examples/mongodbatlas_stream_privatelink_endpoint/confluent_serverless/versions.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/confluent_serverless/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.24"
+      source = "mongodb/mongodbatlas"
     }
     confluent = {
       source  = "confluentinc/confluent"

--- a/examples/mongodbatlas_stream_privatelink_endpoint/s3/versions.tf
+++ b/examples/mongodbatlas_stream_privatelink_endpoint/s3/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.81"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.30"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_stream_processor/versions.tf
+++ b/examples/mongodbatlas_stream_processor/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.18"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_third_party_integration/datadog/versions.tf
+++ b/examples/mongodbatlas_third_party_integration/datadog/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/mongodbatlas_third_party_integration/prometheus-and-teams/versions.tf
+++ b/examples/mongodbatlas_third_party_integration/prometheus-and-teams/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
 
     template = {

--- a/examples/starter/versions.tf
+++ b/examples/starter/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-335982

All version constraints associated to our provider are removed. This implies examples run successfully using our latest version.

The only case in which an upper limit constraint (`~> 1.0`) will be needed is for our 2.0.0 release branch. The 2.0.0 release contains some migration examples which leverage resources/attributes only present in `1.x`.

**Next step**: Merge these master changes into the dev branch and revise version constraints taking into account new examples.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
