### PR TITLE
chore: Removing version constraint in new examples associated to 2.0 dev branch

### DIFF
--- a/examples/migrate_atlas_user_and_atlas_users/v1/versions.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v1/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_atlas_user_and_atlas_users/v2/versions.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v2/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_atlas_user_and_atlas_users/v3/versions.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_org_invitation_to_cloud_user_org_assignment/v1/versions.tf
+++ b/examples/migrate_org_invitation_to_cloud_user_org_assignment/v1/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_org_invitation_to_cloud_user_org_assignment/v2/versions.tf
+++ b/examples/migrate_org_invitation_to_cloud_user_org_assignment/v2/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_org_invitation_to_cloud_user_org_assignment/v3/versions.tf
+++ b/examples/migrate_org_invitation_to_cloud_user_org_assignment/v3/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_project_invitation_to_cloud_user_project_assignment/v1/versions.tf
+++ b/examples/migrate_project_invitation_to_cloud_user_project_assignment/v1/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0"
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_project_invitation_to_cloud_user_project_assignment/v2/versions.tf
+++ b/examples/migrate_project_invitation_to_cloud_user_project_assignment/v2/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     mongodbatlas = {
       source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
     }
   }
 }

--- a/examples/migrate_project_invitation_to_cloud_user_project_assignment/v2/versions.tf
+++ b/examples/migrate_project_invitation_to_cloud_user_project_assignment/v2/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_project_invitation_to_cloud_user_project_assignment/v3/versions.tf
+++ b/examples/migrate_project_invitation_to_cloud_user_project_assignment/v3/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_team_project_assignment/v1/versions.tf
+++ b/examples/migrate_team_project_assignment/v1/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_team_project_assignment/v2/versions.tf
+++ b/examples/migrate_team_project_assignment/v2/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_version = ">= 1.7.0"
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
 }

--- a/examples/migrate_user_team_assignment/module_maintainer/v1/versions.tf
+++ b/examples/migrate_user_team_assignment/module_maintainer/v1/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_user_team_assignment/module_maintainer/v2/versions.tf
+++ b/examples/migrate_user_team_assignment/module_maintainer/v2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source = "mongodb/mongodbatlas" 
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_user_team_assignment/module_maintainer/v2/versions.tf
+++ b/examples/migrate_user_team_assignment/module_maintainer/v2/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas" 
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_user_team_assignment/module_user/v1/versions.tf
+++ b/examples/migrate_user_team_assignment/module_user/v1/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/migrate_user_team_assignment/module_user/v2/versions.tf
+++ b/examples/migrate_user_team_assignment/module_user/v2/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_backup_snapshot_export_job/versions.tf
+++ b/examples/mongodbatlas_cloud_backup_snapshot_export_job/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_cloud_user_project_assignment/versions.tf
+++ b/examples/mongodbatlas_cloud_user_project_assignment/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.38" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_network_peering/aws/versions.tf
+++ b/examples/mongodbatlas_network_peering/aws/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/mongodbatlas_online_archive/versions.tf
+++ b/examples/mongodbatlas_online_archive/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/aws/cluster/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/aws/cluster/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/azure/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/azure/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
   }
   required_version = ">= 1.0"

--- a/examples/mongodbatlas_privatelink_endpoint/gcp/versions.tf
+++ b/examples/mongodbatlas_privatelink_endpoint/gcp/versions.tf
@@ -5,8 +5,7 @@ terraform {
       version = "~> 3.0"
     }
     mongodbatlas = {
-      source  = "mongodb/mongodbatlas"
-      version = "~> 1.0" // TODO: CLOUDP-335982: Update to 2.0.0
+      source = "mongodb/mongodbatlas"
     }
 
     google = {


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-335982

Removing version constraint for examples which have been added as part of 2.0.0 development. All our current examples can run with the latest version (assuming 2.0.0 in this case) so no examples are left with version constraint.

Examples leveraging deprecated resources (e.g. `examples/migrate_atlas_user_and_atlas_users`) can eventually be defined with an upper limit constraint if they are removed in 3.0 and still preserved.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
