### PR TITLE
feat: Adds support for `role_id` in `google_cloud_kms_config` on `mongodbatlas_encryption_at_rest` resource and data source

### DIFF
--- a/.changelog/3636.txt
+++ b/.changelog/3636.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_encryption_at_rest: Supports role_id in google_cloud_kms_config
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_encryption_at_rest: Supports role_id in google_cloud_kms_config
+```

--- a/docs/data-sources/encryption_at_rest.md
+++ b/docs/data-sources/encryption_at_rest.md
@@ -106,7 +106,7 @@ output "is_azure_encryption_at_rest_valid" {
 -> **NOTE:** It is possible to configure Atlas Encryption at Rest to communicate with Customer Managed Keys (Azure Key Vault or AWS KMS) over private network interfaces (Azure Private Link or AWS PrivateLink). This requires enabling the `azure_key_vault_config.require_private_networking` or the `aws_kms_config.require_private_networking` attribute, together with the configuration of the `mongodbatlas_encryption_at_rest_private_endpoint` resource. Please review the `mongodbatlas_encryption_at_rest_private_endpoint` resource for details.
 
 ### Configuring encryption at rest using customer key management in GCP
-For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication). Once roleId is configured, serviceAccountKey is no longer supported.
 
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {

--- a/docs/data-sources/encryption_at_rest.md
+++ b/docs/data-sources/encryption_at_rest.md
@@ -106,6 +106,8 @@ output "is_azure_encryption_at_rest_valid" {
 -> **NOTE:** It is possible to configure Atlas Encryption at Rest to communicate with Customer Managed Keys (Azure Key Vault or AWS KMS) over private network interfaces (Azure Private Link or AWS PrivateLink). This requires enabling the `azure_key_vault_config.require_private_networking` or the `aws_kms_config.require_private_networking` attribute, together with the configuration of the `mongodbatlas_encryption_at_rest_private_endpoint` resource. Please review the `mongodbatlas_encryption_at_rest_private_endpoint` resource for details.
 
 ### Configuring encryption at rest using customer key management in GCP
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id

--- a/docs/data-sources/encryption_at_rest.md
+++ b/docs/data-sources/encryption_at_rest.md
@@ -181,6 +181,7 @@ Read-Only:
 
 - `enabled` (Boolean) Flag that indicates whether someone enabled encryption at rest for the specified  project. To disable encryption at rest using customer key management and remove the configuration details, pass only this parameter with a value of `false`.
 - `key_version_resource_id` (String, Sensitive) Resource path that displays the key version resource ID for your Google Cloud KMS.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Google Cloud Provider Access Role that MongoDB Cloud uses to access the Google Cloud KMS.
 - `service_account_key` (String, Sensitive) JavaScript Object Notation (JSON) object that contains the Google Cloud Key Management Service (KMS). Format the JSON as a string and not as an object.
 - `valid` (Boolean) Flag that indicates whether the Google Cloud Key Management Service (KMS) encryption key can encrypt and decrypt data.
 

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -210,6 +210,7 @@ Optional:
 
 - `enabled` (Boolean) Flag that indicates whether someone enabled encryption at rest for the specified  project. To disable encryption at rest using customer key management and remove the configuration details, pass only this parameter with a value of `false`.
 - `key_version_resource_id` (String, Sensitive) Resource path that displays the key version resource ID for your Google Cloud KMS.
+- `role_id` (String) Unique 24-hexadecimal digit string that identifies the Google Cloud Provider Access Role that MongoDB Cloud uses to access the Google Cloud KMS.
 - `service_account_key` (String, Sensitive) JavaScript Object Notation (JSON) object that contains the Google Cloud Key Management Service (KMS). Format the JSON as a string and not as an object.
 
 Read-Only:

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -134,6 +134,8 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -134,7 +134,7 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
-For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication). Once roleId is configured, serviceAccountKey is no longer supported.
 
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {

--- a/internal/service/encryptionatrest/data_source_schema.go
+++ b/internal/service/encryptionatrest/data_source_schema.go
@@ -128,6 +128,10 @@ func DataSourceSchema(ctx context.Context) schema.Schema {
 						Computed:            true,
 						MarkdownDescription: "Flag that indicates whether the Google Cloud Key Management Service (KMS) encryption key can encrypt and decrypt data.",
 					},
+					"role_id": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Google Cloud Provider Access Role that MongoDB Cloud uses to access the Google Cloud KMS.",
+					},
 				},
 				Computed:            true,
 				MarkdownDescription: "Details that define the configuration of Encryption at Rest using Google Cloud Key Management Service (KMS).",

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -102,7 +102,7 @@ func NewTFGcpKmsConfigItem(gcpKms *admin.GoogleCloudKMS) *TFGcpKmsConfigModel {
 		KeyVersionResourceID: types.StringValue(gcpKms.GetKeyVersionResourceID()),
 		ServiceAccountKey:    conversion.StringNullIfEmpty(gcpKms.GetServiceAccountKey()),
 		Valid:                types.BoolPointerValue(gcpKms.Valid),
-		RoleID:               types.StringValue(gcpKms.GetRoleId()),
+		RoleID:               conversion.StringNullIfEmpty(gcpKms.GetRoleId()),
 	}
 }
 

--- a/internal/service/encryptionatrest/model.go
+++ b/internal/service/encryptionatrest/model.go
@@ -102,6 +102,7 @@ func NewTFGcpKmsConfigItem(gcpKms *admin.GoogleCloudKMS) *TFGcpKmsConfigModel {
 		KeyVersionResourceID: types.StringValue(gcpKms.GetKeyVersionResourceID()),
 		ServiceAccountKey:    conversion.StringNullIfEmpty(gcpKms.GetServiceAccountKey()),
 		Valid:                types.BoolPointerValue(gcpKms.Valid),
+		RoleID:               types.StringValue(gcpKms.GetRoleId()),
 	}
 }
 
@@ -134,6 +135,7 @@ func NewAtlasGcpKms(tfGcpKmsConfigSlice []TFGcpKmsConfigModel) *admin.GoogleClou
 		Enabled:              v.Enabled.ValueBoolPointer(),
 		ServiceAccountKey:    v.ServiceAccountKey.ValueStringPointer(),
 		KeyVersionResourceID: v.KeyVersionResourceID.ValueStringPointer(),
+		RoleId:               v.RoleID.ValueStringPointer(),
 	}
 }
 

--- a/internal/service/encryptionatrest/model_test.go
+++ b/internal/service/encryptionatrest/model_test.go
@@ -76,11 +76,13 @@ var (
 		Enabled:              &enabled,
 		KeyVersionResourceID: &keyVersionResourceID,
 		ServiceAccountKey:    &serviceAccountKey,
+		RoleId:               &roleID,
 	}
 	TfGcpKmsConfigModel = encryptionatrest.TFGcpKmsConfigModel{
 		Enabled:              types.BoolValue(enabled),
 		KeyVersionResourceID: types.StringValue(keyVersionResourceID),
 		ServiceAccountKey:    types.StringValue(serviceAccountKey),
+		RoleID:               types.StringValue(roleID),
 	}
 	EncryptionAtRest = &admin.EncryptionAtRest{
 		AwsKms:                AWSKMSConfiguration,

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -87,6 +87,7 @@ type TFAzureKeyVaultConfigModel struct {
 type TFGcpKmsConfigModel struct {
 	ServiceAccountKey    types.String `tfsdk:"service_account_key"`
 	KeyVersionResourceID types.String `tfsdk:"key_version_resource_id"`
+	RoleID               types.String `tfsdk:"role_id"`
 	Enabled              types.Bool   `tfsdk:"enabled"`
 	Valid                types.Bool   `tfsdk:"valid"`
 }
@@ -258,6 +259,10 @@ func (r *encryptionAtRestRS) Schema(ctx context.Context, req resource.SchemaRequ
 						"valid": schema.BoolAttribute{
 							Computed:            true,
 							MarkdownDescription: "Flag that indicates whether the Google Cloud Key Management Service (KMS) encryption key can encrypt and decrypt data.",
+						},
+						"role_id": schema.StringAttribute{
+							Optional:            true,
+							MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the Google Cloud Provider Access Role that MongoDB Cloud uses to access the Google Cloud KMS.",
 						},
 					},
 				},

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -215,6 +215,44 @@ func TestAccEncryptionAtRest_basicGCP(t *testing.T) {
 	})
 }
 
+func TestAccEncryptionAtRest_basicGCPWithRole(t *testing.T) {
+	acc.SkipTestForCI(t) // needs GCP configuration
+
+	var (
+		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+
+		googleCloudKms = admin.GoogleCloudKMS{
+			Enabled:              conversion.Pointer(true),
+			RoleId:               conversion.StringPtr(os.Getenv("GCP_ROLE_ID")),
+			KeyVersionResourceID: conversion.StringPtr(os.Getenv("GCP_KEY_VERSION_RESOURCE_ID")),
+		}
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheck(t); acc.PreCheckGCPEnvWithRole(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             acc.EARDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configGoogleCloudKmsWithRole(projectID, &googleCloudKms, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acc.CheckEARExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.role_id", os.Getenv("GCP_ROLE_ID")),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.valid", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "google_cloud_kms_config.0.key_version_resource_id"),
+
+					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.enabled", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.valid", "true"),
+					resource.TestCheckResourceAttrSet(datasourceName, "google_cloud_kms_config.key_version_resource_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
 	acc.SkipTestForCI(t) // needs AWS configuration. This test case is similar to TestAccEncryptionAtRest_basicAWS except that it creates it's own AWS resources such as IAM roles, cloud provider access, etc so we don't need to run this in CI but may be used for local testing.
 
@@ -509,6 +547,25 @@ func configGoogleCloudKms(projectID string, google *admin.GoogleCloudKMS, useDat
 			}
 		}
 	`, projectID, *google.Enabled, google.GetServiceAccountKey(), google.GetKeyVersionResourceID())
+
+	if useDatasource {
+		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
+	}
+	return config
+}
+
+func configGoogleCloudKmsWithRole(projectID string, google *admin.GoogleCloudKMS, useDatasource bool) string {
+	config := fmt.Sprintf(`
+		resource "mongodbatlas_encryption_at_rest" "test" {
+			project_id = "%s"
+
+		  google_cloud_kms_config {
+				enabled                 = %t
+				role_id                 = "%s"
+				key_version_resource_id = "%s"
+			}
+		}
+	`, projectID, *google.Enabled, google.GetRoleId(), google.GetKeyVersionResourceID())
 
 	if useDatasource {
 		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -235,19 +235,7 @@ func TestAccEncryptionAtRest_basicGCPWithRole(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configGoogleCloudKmsWithRole(projectID, &googleCloudKms, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckEARExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.role_id", os.Getenv("GCP_ROLE_ID")),
-					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.valid", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "google_cloud_kms_config.0.key_version_resource_id"),
-
-					resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
-					resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.enabled", "true"),
-					resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.valid", "true"),
-					resource.TestCheckResourceAttrSet(datasourceName, "google_cloud_kms_config.key_version_resource_id"),
-				),
+				Check:  checkEARResourceGCPWithRole(projectID),
 			},
 		},
 	})
@@ -675,5 +663,21 @@ func checkEARResourceAWS(projectID string, enabledForSearchNodes bool, awsKmsAtt
 		resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
 		resource.TestCheckResourceAttr(datasourceName, "enabled_for_search_nodes", strconv.FormatBool(enabledForSearchNodes)),
 		acc.EARCheckResourceAttr(datasourceName, "aws_kms_config.", awsKmsAttrMap),
+	)
+}
+
+func checkEARResourceGCPWithRole(projectID string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		acc.CheckEARExists(resourceName),
+		resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+		resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.role_id", os.Getenv("GCP_ROLE_ID")),
+		resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.enabled", "true"),
+		resource.TestCheckResourceAttr(resourceName, "google_cloud_kms_config.0.valid", "true"),
+		resource.TestCheckResourceAttrSet(resourceName, "google_cloud_kms_config.0.key_version_resource_id"),
+
+		resource.TestCheckResourceAttr(datasourceName, "project_id", projectID),
+		resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.enabled", "true"),
+		resource.TestCheckResourceAttr(datasourceName, "google_cloud_kms_config.valid", "true"),
+		resource.TestCheckResourceAttrSet(datasourceName, "google_cloud_kms_config.key_version_resource_id"),
 	)
 }

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -155,6 +155,13 @@ func PreCheckGPCEnv(tb testing.TB) {
 	}
 }
 
+func PreCheckGCPEnvWithRole(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("GCP_ROLE_ID") == "" || os.Getenv("GCP_KEY_VERSION_RESOURCE_ID") == "" {
+		tb.Fatal("`GCP_ROLE_ID` and `GCP_KEY_VERSION_RESOURCE_ID` must be set for acceptance testing")
+	}
+}
+
 func PreCheckPeeringEnvAWS(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_ACCOUNT_ID") == "" ||

--- a/templates/data-sources/encryption_at_rest.md.tmpl
+++ b/templates/data-sources/encryption_at_rest.md.tmpl
@@ -25,6 +25,8 @@
 -> **NOTE:** It is possible to configure Atlas Encryption at Rest to communicate with Customer Managed Keys (Azure Key Vault or AWS KMS) over private network interfaces (Azure Private Link or AWS PrivateLink). This requires enabling the `azure_key_vault_config.require_private_networking` or the `aws_kms_config.require_private_networking` attribute, together with the configuration of the `mongodbatlas_encryption_at_rest_private_endpoint` resource. Please review the `mongodbatlas_encryption_at_rest_private_endpoint` resource for details.
 
 ### Configuring encryption at rest using customer key management in GCP
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id

--- a/templates/data-sources/encryption_at_rest.md.tmpl
+++ b/templates/data-sources/encryption_at_rest.md.tmpl
@@ -25,7 +25,7 @@
 -> **NOTE:** It is possible to configure Atlas Encryption at Rest to communicate with Customer Managed Keys (Azure Key Vault or AWS KMS) over private network interfaces (Azure Private Link or AWS PrivateLink). This requires enabling the `azure_key_vault_config.require_private_networking` or the `aws_kms_config.require_private_networking` attribute, together with the configuration of the `mongodbatlas_encryption_at_rest_private_endpoint` resource. Please review the `mongodbatlas_encryption_at_rest_private_endpoint` resource for details.
 
 ### Configuring encryption at rest using customer key management in GCP
-For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication). Once roleId is configured, serviceAccountKey is no longer supported.
 
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {

--- a/templates/resources/encryption_at_rest.md.tmpl
+++ b/templates/resources/encryption_at_rest.md.tmpl
@@ -53,7 +53,7 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
-For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication). Once roleId is configured, serviceAccountKey is no longer supported.
 
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {

--- a/templates/resources/encryption_at_rest.md.tmpl
+++ b/templates/resources/encryption_at_rest.md.tmpl
@@ -53,6 +53,8 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
+For authentication, you must provide either serviceAccountKey (static credentials) or roleId (service-account–based authentication) Once roleId is configured, serviceAccountKey is no longer supported.
+
 ```terraform
 resource "mongodbatlas_encryption_at_rest" "test" {
   project_id = var.atlas_project_id


### PR DESCRIPTION
## Description

Adds support for `role_id` in `google_cloud_kms_config` on `mongodbatlas_encryption_at_rest` resource and data source.

Test can't be run in the CI in a consistent way, but have tested the changes locally and everything works:

Terraform apply of the following configuration:
```
resource "mongodbatlas_encryption_at_rest" "test" {
  project_id = var.project_id

  google_cloud_kms_config {
    enabled                 = true
    key_version_resource_id = local.gcp_key_version_resource_id
    role_id = local.gcp_role_id
  }
}

```

<img width="1167" height="581" alt="Screenshot 2025-09-01 at 10 40 19" src="https://github.com/user-attachments/assets/354cfec1-c297-424d-a647-a09fb9e166ac" />
See the UI after creating it in TF:
<img width="664" height="999" alt="Screenshot 2025-09-01 at 10 43 10" src="https://github.com/user-attachments/assets/83cfd56e-d605-476d-9de5-80afc945d216" />

Note that in order to make this work, the following needed to be run in GCP:
```
gcloud kms keys add-iam-policy-binding \
  <key-name> \
    --location <location> \
    --keyring <keyring-name> \
    --member <ATLAS_OWNED_SERVICE_ACCOUNT_EMAIL> \
    --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"

gcloud kms keys add-iam-policy-binding \
  <key-name> \
    --location <location> \
    --keyring <keyring-name> \
    --member <ATLAS_OWNED_SERVICE_ACCOUNT_EMAIL> \
    --role="roles/cloudkms.viewer"
```


Link to any related issue(s): CLOUDP-341442

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
