### PR TITLE
feat: Supports GCP for `mongodbatlas_cloud_provider_access_authorization` resource

### DIFF
--- a/.changelog/3639.txt
+++ b/.changelog/3639.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_cloud_provider_access_authorization: Supports GCP cloud provider
+```

--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -142,6 +142,8 @@ Conditional
 * `id`               - Unique identifier used by terraform for internal management.
 * `authorized_date`  - Date on which this role was authorized.
 * `feature_usages`   - Atlas features this AWS IAM role is linked to.
+* `gcp`
+   * `service_account_for_atlas` - Email address for the Google Service Account created by Atlas.
 
 
 

--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -135,7 +135,10 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
 Conditional 
 * `aws`
    * `iam_assumed_role_arn` - (Required) ARN of the IAM Role that Atlas assumes when accessing resources in your AWS account. This value is required after the creation (register of the role) as part of [Set Up Unified AWS Access](https://docs.atlas.mongodb.com/security/set-up-unified-aws-access/#set-up-unified-aws-access).
-   
+* `azure`
+   * `atlas_azure_app_id` - (Required) Azure Active Directory Application ID of Atlas.
+   * `service_principal_id` - (Required) UUID string that identifies the Azure Service Principal.
+   * `tenant_id` - (Required) UUID String that identifies the Azure Active Directory Tenant ID.
 
 ## Attributes Reference
 

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -198,6 +198,7 @@ func roleToSchemaAuthorization(role *admin.CloudProviderAccessRole) map[string]a
 			"iam_assumed_role_arn": role.GetIamAssumedRoleArn(),
 		}},
 		"authorized_date": conversion.TimeToString(role.GetAuthorizedDate()),
+		"gcp":             []any{map[string]any{}},
 	}
 
 	if role.ProviderName == "AZURE" {
@@ -209,6 +210,7 @@ func roleToSchemaAuthorization(role *admin.CloudProviderAccessRole) map[string]a
 				"tenant_id":            role.GetTenantId(),
 			}},
 			"authorized_date": conversion.TimeToString(role.GetAuthorizedDate()),
+			"gcp":             []any{map[string]any{}},
 		}
 	}
 	if role.ProviderName == "GCP" {

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -73,7 +73,7 @@ func ResourceAuthorization() *schema.Resource {
 			"gcp": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"service_account_for_atlas": {

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -180,6 +180,10 @@ func resourceCloudProviderAccessAuthorizationUpdate(ctx context.Context, d *sche
 	}
 
 	if d.HasChange("aws") || d.HasChange("azure") {
+		// Re-authorize the role with updated AWS or Azure configuration.
+		// GCP authorization only requires a role ID and has no additional configuration to update.
+		// Therefore, "updating" a GCP role would effectively be creating a new authorization,
+		// which should be handled by creating a new resource rather than updating an existing one.
 		return authorizeRole(ctx, conn, d, projectID, targetRole)
 	}
 

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -72,7 +72,6 @@ func ResourceAuthorization() *schema.Resource {
 			},
 			"gcp": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -179,7 +179,7 @@ func resourceCloudProviderAccessAuthorizationUpdate(ctx context.Context, d *sche
 		return diag.FromErr(fmt.Errorf(ErrorCloudProviderGetRead, "cloud provider access role not found in mongodbatlas, please create it first"))
 	}
 
-	if d.HasChange("aws") || d.HasChange("azure") || d.HasChange("gcp") {
+	if d.HasChange("aws") || d.HasChange("azure") {
 		return authorizeRole(ctx, conn, d, projectID, targetRole)
 	}
 


### PR DESCRIPTION
## Description

Supports GCP for `mongodbatlas_cloud_provider_access_authorization` resource.

**Important:** Tests for this changes will be added once changes for `mongodbatlas_cloud_provider_access_setup` are complete (CLOUDP-341438 & CLOUDP-341440) so that we can test the entire flow in 1 test)

Link to any related issue(s): CLOUDP-341441

Tested the following configuration successfully : 
```terraform
resource "mongodbatlas_cloud_provider_access_authorization" "test" {
  project_id = var.project_id
  role_id = "68b6accc1e53df2ae1ac0054"
}
```
<img width="834" height="405" alt="Screenshot 2025-09-02 at 10 46 24" src="https://github.com/user-attachments/assets/35afa3f6-29d7-48aa-ae8f-0b162e08068d" />


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
