### PR TITLE
feat: Changes to `project_id` or `role_id` will now result in the destruction and recreation of the `mongodbatlas_cloud_provider_access_authorization` resource

### DIFF
--- a/.changelog/3646.txt
+++ b/.changelog/3646.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/mongodbatlas_cloud_provider_access_authorization: Changes to `project_id` or `role_id` will now result in the destruction and recreation of the resource
+resource/mongodbatlas_cloud_provider_access_authorization: Changes to `project_id` or `role_id` will now result in the destruction and recreation of the authorization resource
 ```

--- a/.changelog/3646.txt
+++ b/.changelog/3646.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_cloud_provider_access_authorization: Changes to `project_id` or `role_id` will now result in the destruction and recreation of the resource
+```

--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -93,7 +93,7 @@ $ terraform import mongodbatlas_cloud_provider_access_setup.my_role 1112222b3bf9
 This is the second resource in the two-resource path as described above.
 `mongodbatlas_cloud_provider_access_authorization`  Allows you to authorize an AWS or AZURE IAM roles in Atlas.
 
--> **IMPORTANT:** Changes to `project_id` or `role_id` will result in the destruction and recreation of the authorization resource. This is because these fields uniquely identify the authorization and cannot be modified in-place.
+-> **IMPORTANT:** Changes to `project_id` or `role_id` will result in the destruction and recreation of the authorization resource. This action happens as these fields uniquely identify the authorization and cannot be modified in-place.
 
 ## Example Usage with AWS
 ```terraform

--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -93,6 +93,8 @@ $ terraform import mongodbatlas_cloud_provider_access_setup.my_role 1112222b3bf9
 This is the second resource in the two-resource path as described above.
 `mongodbatlas_cloud_provider_access_authorization`  Allows you to authorize an AWS or AZURE IAM roles in Atlas.
 
+-> **IMPORTANT:** Changes to `project_id` or `role_id` will result in the destruction and recreation of the authorization resource. This is because these fields uniquely identify the authorization and cannot be modified in-place.
+
 ## Example Usage with AWS
 ```terraform
 
@@ -143,8 +145,8 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
 
 ## Argument Reference
 
-* `project_id` - (Required) The unique ID for the project
-* `role_id`    - (Required) Unique ID of this role returned by mongodb atlas api
+* `project_id` - (Required) The unique ID for the project. **WARNING**: Changing the `project_id` will result in destruction of the existing authorization resource and the creation of a new authorization resource.
+* `role_id`    - (Required) Unique ID of this role returned by mongodb atlas api. **WARNING**: Changing the `role_id` will result in destruction of the existing authorization resource and the creation of a new authorization resource.
 
 Conditional 
 * `aws`

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go
@@ -31,10 +31,12 @@ func ResourceAuthorization() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"role_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"aws": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
## Description

Changes to project_id or role_id will now result in the destruction and recreation of the mongodbatlas_cloud_provider_access_authorization resource. Before, when those attributes were updated, nothing was done, it now recreates it with the updated values. 

Link to any related issue(s): CLOUDP-342580

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
