### PR TITLE
fix: Adds support for unknown replication_specs in the plan modifier

### DIFF
--- a/.changelog/3652.txt
+++ b/.changelog/3652.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_advanced_cluster: Fixes `Value Conversion Error` when replication_specs are unknown
+```

--- a/internal/service/advancedclustertpf/resource.go
+++ b/internal/service/advancedclustertpf/resource.go
@@ -108,6 +108,12 @@ func (r *rs) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, res
 	if diags.HasError() {
 		return
 	}
+	// The replication specs can be unknown if the cluster depends on another resource.
+	// useStateForUnknowns will try to convert the field to `Target Type: []advancedclustertpf.TFReplicationSpecsModel`.
+	// But since the field is unknown the user gets an error: `Error: Value Conversion Error`.
+	if plan.ReplicationSpecs.IsUnknown() {
+		return
+	}
 
 	useStateForUnknowns(ctx, diags, &state, &plan)
 	if diags.HasError() {


### PR DESCRIPTION
## Description
Link to any related issue(s): CLOUDP-343132

Error when replicaton_specs depends on another resource during planning

```
│ Error: Value Conversion Error
│ 
│   with module.atlas_cluster.mongodbatlas_advanced_cluster.this,
│ An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Received unknown value, however the target type cannot handle unknown values. Use the corresponding `types` package type or a custom type that handles unknown values.
│ 
│ Path: 
│ Target Type: []advancedclustertpf.TFReplicationSpecsModel
│ Suggested Type: basetypes.ListValue
``` 

Example after solution when the cluster depends on data.mongodbatlas_advanced_cluster.this. See full config here: https://github.com/EspenAlbert/tf-modules-atlas-wip/blob/main/modules/08_cluster_poc/main.tf 
Dependency happens since the instance size is calculated from existing cluster:
```
instance_size = var.auto_scaling == null ? coalesce(r.instance_size, var.instance_size, local.DEFAULT_INSTANCE_SIZE) : coalesce(
              try(local.existing_cluster.old_cluster.replication_specs[shard_index].region_configs[region_index].electable_specs.instance_size, null), # DEPENDENCY on data source
              var.auto_scaling.compute_min_instance_size
            )
```

<img width="1074" height="1763" alt="image" src="https://github.com/user-attachments/assets/29de8058-8077-4a7c-ad11-e4106d3095a2" />



## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
