### PR TITLE
chore: Add acceptance tests for GCP on `mongodbatlas_cloud_provider_access_authorization`

### DIFF
--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -40,7 +40,7 @@ func TestAccCloudProviderAccessAuthorizationAzure_basic(t *testing.T) {
 
 func TestAccCloudProviderAccessAuthorizationGCP_basic(t *testing.T) {
 	var (
-		resourceName = "mongodbatlas_cloud_provider_access_authorization.auth_role"
+		resourceName = "mongodbatlas_cloud_provider_access_authorization.this"
 		projectID    = acc.ProjectIDExecution(t)
 	)
 
@@ -69,7 +69,7 @@ func configAuthorizationGCP(projectID string) string {
 		provider_name = "GCP"
 	}
 
-	resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
+	resource "mongodbatlas_cloud_provider_access_authorization" "this" {
 		project_id = mongodbatlas_cloud_provider_access_setup.gcp_setup.project_id
 		role_id    = mongodbatlas_cloud_provider_access_setup.gcp_setup.role_id
 	}

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -56,7 +56,6 @@ func TestAccCloudProviderAccessAuthorizationGCP_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
 					resource.TestCheckResourceAttrSet(resourceName, "role_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "gcp.0.service_account_for_atlas"),
-					resource.TestCheckResourceAttrSet(resourceName, "gcp.0.status"),
 				),
 			},
 		},

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization_test.go
@@ -64,7 +64,7 @@ func TestAccCloudProviderAccessAuthorizationGCP_basic(t *testing.T) {
 
 func configAuthorizationGCP(projectID string) string {
 	return fmt.Sprintf(`
-	resource "mongodbatlas_cloud_provider_access_setup" "gcp_setup"{
+	resource "mongodbatlas_cloud_provider_access_setup" "gcp_setup" {
 		project_id    = %[1]q
 		provider_name = "GCP"
 	}


### PR DESCRIPTION
## Description

Add acceptance tests on GCP for `mongodbatlas_cloud_provider_access_authorization`. These tests were not included earlier due to the requirement of implementing [CLOUDP-341438](https://jira.mongodb.org/browse/CLOUDP-341438) & [CLOUDP-341440](https://jira.mongodb.org/browse/CLOUDP-341440) first. 

Link to any related issue(s): CLOUDP-342526

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
