### PR TITLE
doc: Add migration guide for Encryption at Rest (GCP) Service Account JSON to Role-based Auth 

### DIFF
--- a/docs/guides/encryption-at-rest-gcp-role-based-migration.md
+++ b/docs/guides/encryption-at-rest-gcp-role-based-migration.md
@@ -4,15 +4,17 @@ page_title: "Migration Guide: Encryption at Rest (GCP) Service Account JSON to R
 
 # Migration Guide: Encryption at Rest (GCP) Service Account JSON to Role-based Auth
 
-**Objective**: Migrate from using a long-lived static Service Account JSON key in `mongodbatlas_encryption_at_rest.google_cloud_kms_config.service_account_key` to role-based authentication using an Atlas-managed service account via `mongodbatlas_encryption_at_rest.google_cloud_kms_config.role_id`.
+**Objective**: Migrate from using a static Service Account JSON key in `mongodbatlas_encryption_at_rest.google_cloud_kms_config.service_account_key` to role-based authentication using an Atlas-managed service account via `mongodbatlas_encryption_at_rest.google_cloud_kms_config.role_id`.
 
 ## Best Practices Before Migrating
-- Back up your Terraform state file before making changes.
 - Test the migration in a non-production environment if possible.
 
 ## Migration Steps
 
 ### Current (using Service Account JSON key)
+
+This configuration serves as the starting point for the migration.
+
 ```hcl
 resource "mongodbatlas_encryption_at_rest" "this" {
   project_id = var.atlas_project_id
@@ -68,7 +70,7 @@ resource "google_kms_crypto_key_iam_binding" "viewer_binding" {
 }
 ```
 
-Alternatively, the Google Cloud CLI can be used:
+Alternatively, you can use Google Cloud CLI:
 
 ```shell
 gcloud kms keys add-iam-policy-binding \
@@ -102,7 +104,7 @@ resource "mongodbatlas_encryption_at_rest" "this" {
 }
 ```
 
-**Note:** If KMS IAM bindings are being granted within the same apply, a `depends_on` block is required in `mongodbatlas_encryption_at_rest`. This ensures bindings are correctly configured prior to the role being configured in `mongodbatlas_encryption_at_rest` resource.
+**Note:** If you grant KMS IAM bindings within the same apply, you must add a `depends_on` block to `mongodbatlas_encryption_at_rest`. This ensures Terraform configures the bindings before it configures the role in the `mongodbatlas_encryption_at_rest` resource.
 
 ```
 resource "mongodbatlas_encryption_at_rest" "this" {

--- a/docs/guides/encryption-at-rest-gcp-role-based-migration.md
+++ b/docs/guides/encryption-at-rest-gcp-role-based-migration.md
@@ -1,0 +1,143 @@
+---
+page_title: "Migration Guide: Encryption at Rest (GCP) Service Account JSON to Role-based Auth"
+---
+
+# Migration Guide: Encryption at Rest (GCP) Service Account JSON to Role-based Auth
+
+**Objective**: Migrate from using a long-lived static Service Account JSON key in `mongodbatlas_encryption_at_rest.google_cloud_kms_config.service_account_key` to role-based authentication using an Atlas-managed service account via `mongodbatlas_encryption_at_rest.google_cloud_kms_config.role_id`.
+
+## Best Practices Before Migrating
+- Back up your Terraform state file before making changes.
+- Test the migration in a non-production environment if possible.
+
+## Migration Steps
+
+### Current (using Service Account JSON key)
+```hcl
+resource "mongodbatlas_encryption_at_rest" "test" {
+  project_id = var.atlas_project_id
+
+  google_cloud_kms_config {
+    enabled                 = true
+    service_account_key     = "{\"type\": \"service_account\",\"project_id\": \"my-project-common-0\", ...}"
+    key_version_resource_id = "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
+  }
+}
+```
+
+### 1) Obtain the Atlas-managed GCP service account
+Add the following resources to enable Atlas Cloud Provider Access for GCP and authorize it for your project:
+
+```hcl
+resource "mongodbatlas_cloud_provider_access_setup" "this" {
+  project_id    = var.atlas_project_id
+  provider_name = "GCP"
+}
+
+resource "mongodbatlas_cloud_provider_access_authorization" "this" {
+  project_id = var.atlas_project_id
+  role_id    = mongodbatlas_cloud_provider_access_setup.this.role_id
+}
+```
+
+The computed attribute `mongodbatlas_cloud_provider_access_authorization.this.gcp[0].service_account_for_atlas` contains the email address of the Google Service Account managed by Atlas.
+
+### 2) Grant KMS permissions to the Atlas service account
+
+If your KMS key is managed with Terraform, IAM bindings can be granted with the following GCP resources:
+
+```hcl
+# IAM Binding: Grant 'cryptoKeyEncrypterDecrypter' role
+resource "google_kms_crypto_key_iam_binding" "encrypter_decrypter_binding" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:${mongodbatlas_cloud_provider_access_authorization.this.gcp[0].service_account_for_atlas}"
+  ]
+}
+
+# IAM Binding: Grant 'viewer' role
+resource "google_kms_crypto_key_iam_binding" "viewer_binding" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.viewer"
+
+  members = [
+    "serviceAccount:${mongodbatlas_cloud_provider_access_authorization.this.gcp[0].service_account_for_atlas}"
+  ]
+}
+```
+
+Alternatively, the Google Cloud CLI can be used:
+
+```shell
+gcloud kms keys add-iam-policy-binding \
+  <key-name> \
+    --location <location> \
+    --keyring <keyring-name> \
+    --member <ATLAS_OWNED_SERVICE_ACCOUNT_EMAIL> \
+    --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+gcloud kms keys add-iam-policy-binding \
+  <key-name> \
+    --location <location> \
+    --keyring <keyring-name> \
+    --member <ATLAS_OWNED_SERVICE_ACCOUNT_EMAIL> \
+    --role="roles/cloudkms.viewer"
+```
+
+### 3) Update the Encryption at Rest resource to use role-based auth
+
+Replace the `service_account_key` with `role_id` using the value from the authorization resource:
+
+```hcl
+resource "mongodbatlas_encryption_at_rest" "test" {
+  project_id = var.atlas_project_id
+
+  google_cloud_kms_config {
+    enabled                 = true
+    key_version_resource_id = "projects/my-project-common-0/locations/us-east4/keyRings/my-key-ring-0/cryptoKeys/my-key-0/cryptoKeyVersions/1"
+    role_id                 = mongodbatlas_cloud_provider_access_authorization.this.role_id
+  }
+}
+```
+
+**Note:** If KMS IAM bindings are being granted within the same apply, a `depends_on` block is required in `mongodbatlas_encryption_at_rest`. This ensures bindings are correctly configured prior to the role being configured in `mongodbatlas_encryption_at_rest` resource.
+
+```
+resource "mongodbatlas_encryption_at_rest" "test" {
+  ...
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.encrypter_decrypter_binding,
+    google_kms_crypto_key_iam_binding.viewer_binding
+  ]
+}
+
+```
+
+
+Running `terraform plan` should show a change similar to:
+
+```
+# mongodbatlas_encryption_at_rest.test will be updated in-place
+  ~ resource "mongodbatlas_encryption_at_rest" "test" {
+        id                       = "66d6d2bdb181f8665222509b"
+        # (2 unchanged attributes hidden)
+
+      ~ google_cloud_kms_config {
+          + role_id                 = "68b0448ac59ddc0496f95fa5"
+          - service_account_key     = (sensitive value) -> null
+          ~ valid                   = true -> (known after apply)
+            # (2 unchanged attributes hidden)
+        }
+    }
+```
+
+### 4) Apply the changes
+
+Run `terraform apply` to complete the migration. Once applied, the migration is complete.
+
+## Additional Resources
+- Complete role-based auth example that includes GCP KMS resource creation and IAM binding setup: [examples/mongodbatlas_encryption_at_rest/gcp](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_encryption_at_rest/gcp)
+

--- a/docs/guides/encryption-at-rest-gcp-role-based-migration.md
+++ b/docs/guides/encryption-at-rest-gcp-role-based-migration.md
@@ -6,6 +6,8 @@ page_title: "Migration Guide: Encryption at Rest (GCP) Service Account JSON to R
 
 **Objective**: Migrate from using a static Service Account JSON key in `mongodbatlas_encryption_at_rest.google_cloud_kms_config.service_account_key` to role-based authentication using an Atlas-managed service account via `mongodbatlas_encryption_at_rest.google_cloud_kms_config.role_id`.
 
+**Note**: Once migrated to using role-based authentication, it is not possible to revert back to using a static Service Account JSON key.
+
 ## Best Practices Before Migrating
 - Test the migration in a non-production environment if possible.
 

--- a/docs/guides/encryption-at-rest-gcp-role-based-migration.md
+++ b/docs/guides/encryption-at-rest-gcp-role-based-migration.md
@@ -14,7 +14,7 @@ page_title: "Migration Guide: Encryption at Rest (GCP) Service Account JSON to R
 
 ### Current (using Service Account JSON key)
 ```hcl
-resource "mongodbatlas_encryption_at_rest" "test" {
+resource "mongodbatlas_encryption_at_rest" "this" {
   project_id = var.atlas_project_id
 
   google_cloud_kms_config {
@@ -91,7 +91,7 @@ gcloud kms keys add-iam-policy-binding \
 Replace the `service_account_key` with `role_id` using the value from the authorization resource:
 
 ```hcl
-resource "mongodbatlas_encryption_at_rest" "test" {
+resource "mongodbatlas_encryption_at_rest" "this" {
   project_id = var.atlas_project_id
 
   google_cloud_kms_config {
@@ -105,7 +105,7 @@ resource "mongodbatlas_encryption_at_rest" "test" {
 **Note:** If KMS IAM bindings are being granted within the same apply, a `depends_on` block is required in `mongodbatlas_encryption_at_rest`. This ensures bindings are correctly configured prior to the role being configured in `mongodbatlas_encryption_at_rest` resource.
 
 ```
-resource "mongodbatlas_encryption_at_rest" "test" {
+resource "mongodbatlas_encryption_at_rest" "this" {
   ...
 
   depends_on = [
@@ -121,7 +121,7 @@ Running `terraform plan` should show a change similar to:
 
 ```
 # mongodbatlas_encryption_at_rest.test will be updated in-place
-  ~ resource "mongodbatlas_encryption_at_rest" "test" {
+  ~ resource "mongodbatlas_encryption_at_rest" "this" {
         id                       = "66d6d2bdb181f8665222509b"
         # (2 unchanged attributes hidden)
 

--- a/docs/resources/encryption_at_rest.md
+++ b/docs/resources/encryption_at_rest.md
@@ -134,7 +134,9 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
-For GCP environments using static service account key, we recommend configuring encryption at rest with customer key management. This approach uses role-based authentication through Cloud Provider Access for a more secure solution
+For GCP environments using static service account key, we recommend configuring encryption at rest with customer key management. For more details see our [Migration Guide: Encryption at Rest (GCP) Service Account JSON to Role-based Auth](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/encryption-at-rest-gcp-role-based-migration).
+
+This approach uses role-based authentication through Cloud Provider Access for a more secure solution.
 
 ```terraform
 resource "mongodbatlas_cloud_provider_access_setup" "this" {

--- a/templates/resources/encryption_at_rest.md.tmpl
+++ b/templates/resources/encryption_at_rest.md.tmpl
@@ -53,7 +53,9 @@ Please review the [`mongodbatlas_encryption_at_rest_private_endpoint` resource d
 
 
 ### Configuring encryption at rest using customer key management in GCP
-For GCP environments using static service account key, we recommend configuring encryption at rest with customer key management. This approach uses role-based authentication through Cloud Provider Access for a more secure solution
+For GCP environments using static service account key, we recommend configuring encryption at rest with customer key management. For more details see our [Migration Guide: Encryption at Rest (GCP) Service Account JSON to Role-based Auth](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/guides/encryption-at-rest-gcp-role-based-migration).
+
+This approach uses role-based authentication through Cloud Provider Access for a more secure solution.
 
 {{ tffile (printf "examples/%s/gcp/main.tf" .Name )}}
 


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-341689

Will hold on merging until I get confirmation on steps from Oriol, will also try to run this locally to verify.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
