### PR TITLE
feat: Long-running operation improvements for `mongodbatlas_cloud_provider_access_setup` resource 

### DIFF
--- a/.changelog/3660.txt
+++ b/.changelog/3660.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/mongodbatlas_cloud_provider_access_setup: Adds `timeouts` attribute for create operation
+```
+
+```release-note:enhancement
+resource/mongodbatlas_cloud_provider_access_setup: Adds `delete_on_create_timeout` attribute to indicate whether to delete the resource if its creation times out
+```

--- a/docs/guides/2.0.0-upgrade-guide.md
+++ b/docs/guides/2.0.0-upgrade-guide.md
@@ -17,6 +17,7 @@ Use this guide to understand what’s new, what requires migration, and how to u
 
 Multiple resources now support a `delete_on_create_timeout` boolean attribute that controls cleanup behavior when resource creation times out. When set to `true` (default), the provider will delete the underlying resource if the create operation times out, helping to avoid orphaned resources. This attribute is available in the following resources:
   - `mongodbatlas_advanced_cluster`
+  - `mongodbatlas_cloud_provider_access_setup`
   - `mongodbatlas_cloud_backup_snapshot` 
   - `mongodbatlas_cluster_outage_simulation`
   - `mongodbatlas_encryption_at_rest_private_endpoint`

--- a/docs/resources/cloud_provider_access.md
+++ b/docs/resources/cloud_provider_access.md
@@ -62,6 +62,7 @@ resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
 ### Further Examples
 - [AWS Cloud Provider Access](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_cloud_provider_access/aws)
 - [Azure Cloud Provider Access](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_cloud_provider_access/azure)
+- [GCP Cloud Provider Access](https://github.com/mongodb/terraform-provider-mongodbatlas/tree/master/examples/mongodbatlas_cloud_provider_access/gcp)
 
 
 ## Argument Reference
@@ -72,6 +73,8 @@ resource "mongodbatlas_cloud_provider_access_setup" "test_role" {
    * `atlas_azure_app_id` - Azure Active Directory Application ID of Atlas. This property is required when `provider_name = "AZURE".`
    * `service_principal_id`- UUID string that identifies the Azure Service Principal. This property is required when `provider_name = "AZURE".`
    * `tenant_id`          - UUID String that identifies the Azure Active Directory Tenant ID. This property is required when `provider_name = "AZURE".`
+* `timeouts`- (Optional) The duration of time to wait for the resource to be created. The default timeout is `1h`. The timeout value is defined by a signed sequence of decimal numbers with a time unit suffix such as: `1h45m`, `300s`, `10m`, etc. The valid time units are:  `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. Learn more about timeouts [here](https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts).
+* `delete_on_create_timeout`- (Optional) Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
 
 ## Attributes Reference
 

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/cleanup"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
@@ -34,12 +35,15 @@ const (
 
 func ResourceSetup() *schema.Resource {
 	return &schema.Resource{
-		ReadContext:   resourceCloudProviderAccessSetupRead,
-		CreateContext: resourceCloudProviderAccessSetupCreate,
-		UpdateContext: resourceCloudProviderAccessAuthorizationPlaceHolder,
-		DeleteContext: resourceCloudProviderAccessSetupDelete,
+		ReadWithoutTimeout:   resourceCloudProviderAccessSetupRead,
+		CreateWithoutTimeout: resourceCloudProviderAccessSetupCreate,
+		UpdateWithoutTimeout: resourceCloudProviderAccessAuthorizationPlaceHolder,
+		DeleteWithoutTimeout: resourceCloudProviderAccessSetupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceCloudProviderAccessSetupImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(defaultTimeout),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -116,6 +120,11 @@ func ResourceSetup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"delete_on_create_timeout": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+			},
 		},
 	}
 }
@@ -181,7 +190,11 @@ func resourceCloudProviderAccessSetupCreate(ctx context.Context, d *schema.Resou
 	}
 
 	if role.ProviderName == constant.GCP {
-		r, err := waitForGCPProviderAccessCompletion(ctx, projectID, resourceID, conn)
+		deleteOnCreateTimeout := true // default value when not set
+		if v, ok := d.GetOkExists("delete_on_create_timeout"); ok {
+			deleteOnCreateTimeout = v.(bool)
+		}
+		r, err := waitForGCPProviderAccessCompletion(ctx, projectID, resourceID, conn, d.Timeout(schema.TimeoutCreate), deleteOnCreateTimeout)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -209,7 +222,7 @@ func resourceCloudProviderAccessSetupCreate(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func waitForGCPProviderAccessCompletion(ctx context.Context, projectID, resourceID string, conn *admin.APIClient) (*admin.CloudProviderAccessRole, error) {
+func waitForGCPProviderAccessCompletion(ctx context.Context, projectID, resourceID string, conn *admin.APIClient, timeout time.Duration, deleteOnCreateTimeout bool) (*admin.CloudProviderAccessRole, error) {
 	requestParams := &admin.GetCloudProviderAccessApiParams{
 		RoleId:  resourceID,
 		GroupId: projectID,
@@ -219,12 +232,16 @@ func waitForGCPProviderAccessCompletion(ctx context.Context, projectID, resource
 		Pending:    []string{"IN_PROGRESS", "NOT_INITIATED"},
 		Target:     []string{"COMPLETE", "FAILED"},
 		Refresh:    resourceRefreshFunc(ctx, requestParams, conn),
-		Timeout:    defaultTimeout,
+		Timeout:    timeout,
 		MinTimeout: 60 * time.Second,
 		Delay:      30 * time.Second,
 	}
 
 	finalResponse, err := stateConf.WaitForStateContext(ctx)
+	err = cleanup.HandleCreateTimeout(deleteOnCreateTimeout, err, func(ctxCleanup context.Context) error {
+		_, errCleanup := conn.CloudProviderAccessApi.DeauthorizeProviderAccessRole(ctxCleanup, projectID, constant.GCP, resourceID).Execute()
+		return errCleanup
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -15,6 +16,10 @@ import (
 
 func TestAccCloudProviderAccessSetupAWS_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicSetupTestCase(t))
+}
+
+func TestAccCloudProviderAccessSetupAWS_createTimeoutWithDeleteOnCreateTimeout(t *testing.T) {
+	resource.Test(t, *basicSetupTestCaseWithDeleteOnCreateTimeout(t))
 }
 
 const (
@@ -123,6 +128,25 @@ func basicSetupTestCase(tb testing.TB) *resource.TestCase {
 	}
 }
 
+func basicSetupTestCaseWithDeleteOnCreateTimeout(tb testing.TB) *resource.TestCase {
+	tb.Helper()
+
+	var (
+		projectID = acc.ProjectIDExecution(tb)
+	)
+
+	return &resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      configSetupAWSWithTimeoutAndDeleteOnCreateTimeout(projectID),
+				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
+			},
+		},
+	}
+}
+
 func configSetupAWS(projectID string) string {
 	return fmt.Sprintf(`
 	resource "mongodbatlas_cloud_provider_access_setup" "test" {
@@ -136,6 +160,19 @@ func configSetupAWS(projectID string) string {
 		role_id =  mongodbatlas_cloud_provider_access_setup.test.role_id
 	 }
 
+	`, projectID)
+}
+
+func configSetupAWSWithTimeoutAndDeleteOnCreateTimeout(projectID string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_cloud_provider_access_setup" "test" {
+			project_id = %[1]q
+			provider_name = "AWS"
+			delete_on_create_timeout = true
+			timeouts = {
+				create = "1s"
+			}
+		}
 	`, projectID)
 }
 

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -169,7 +169,7 @@ func configSetupAWSWithTimeoutAndDeleteOnCreateTimeout(projectID string) string 
 			project_id = %[1]q
 			provider_name = "AWS"
 			delete_on_create_timeout = true
-			timeouts = {
+			timeouts {
 				create = "1s"
 			}
 		}

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -137,6 +137,7 @@ func basicSetupTestCaseWithDeleteOnCreateTimeout(tb testing.TB) *resource.TestCa
 
 	return &resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(tb) },
+		CheckDestroy:             checkDestroy,
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -140,7 +140,7 @@ func basicSetupTestCaseWithDeleteOnCreateTimeout(tb testing.TB) *resource.TestCa
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configSetupAWSWithTimeoutAndDeleteOnCreateTimeout(projectID),
+				Config:      configSetupGCPWithTimeoutAndDeleteOnCreateTimeout(projectID),
 				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},
 		},
@@ -163,11 +163,11 @@ func configSetupAWS(projectID string) string {
 	`, projectID)
 }
 
-func configSetupAWSWithTimeoutAndDeleteOnCreateTimeout(projectID string) string {
+func configSetupGCPWithTimeoutAndDeleteOnCreateTimeout(projectID string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cloud_provider_access_setup" "test" {
 			project_id = %[1]q
-			provider_name = "AWS"
+			provider_name = "GCO"
 			delete_on_create_timeout = true
 			timeouts {
 				create = "1s"

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup_test.go
@@ -167,7 +167,7 @@ func configSetupGCPWithTimeoutAndDeleteOnCreateTimeout(projectID string) string 
 	return fmt.Sprintf(`
 		resource "mongodbatlas_cloud_provider_access_setup" "test" {
 			project_id = %[1]q
-			provider_name = "GCO"
+			provider_name = "GCP"
 			delete_on_create_timeout = true
 			timeouts {
 				create = "1s"


### PR DESCRIPTION
## Description

Long-running operation improvements for `mongodbatlas_cloud_provider_access_setup` resource for the creation when the cloud provider is GCP

Link to any related issue(s): CLOUDP-342848

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
