### PR TITLE
doc: Minor doc fixes to user invitation migration guide

### DIFF
--- a/docs/guides/atlas-user-management.md
+++ b/docs/guides/atlas-user-management.md
@@ -212,7 +212,7 @@ resource "mongodbatlas_cloud_user_team_assignment" "team" {
 
   org_id  = local.org_id
   team_id = each.key
-  user_id = mongodbatlas_cloud_user_org_assignment.this.id
+  user_id = mongodbatlas_cloud_user_org_assignment.this.user_id
 }
 
 # Import existing team assignments (root module only)
@@ -553,8 +553,8 @@ module "user_team_assignment" {
 5. **Run `terraform apply` to apply the migration.**
 
 For complete working examples, see:
-- [Old module example](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module/old_module/)
-- [New module example](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module/new_module/)
+- [Old module definition](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module_maintainer/v1) and [old module usage](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module_user/v1).
+- [New module definition](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module_maintainer/v2) and [new module usage](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/examples/migrate_user_team_assignment/module_user/v2).
 
 ---
 ### Notes and tips
@@ -743,7 +743,7 @@ A: No — using `ignore_changes` ensures they remain in Atlas until the provider
 ### What’s changing?
 
 - `mongodbatlas_project_invitation` only managed invitations and is deprecated. If the user accepted the invitation and is now a project member, the provider removed the invitation from Terraform state and you should remove it from your configuration as well. See the resource [documentation](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/project_invitation) for more details.
-- `mongodbatlas_cloud_user_project_assignment` manages the user’s project membership (active members).
+- `mongodbatlas_cloud_user_project_assignment` manages the user’s project membership (both invited and active members).
 - Pending project invitations are not discoverable with the new APIs. The only migration path for existing PENDING invites is to re-create them using `mongodbatlas_cloud_user_project_assignment` with the same `username` and `roles`.
  - For details on the new resource, see the `mongodbatlas_cloud_user_project_assignment` resource documentation: https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/cloud_user_project_assignment
  

--- a/docs/guides/atlas-user-management.md
+++ b/docs/guides/atlas-user-management.md
@@ -844,7 +844,7 @@ These examples provide practical validation of the migration steps and demonstra
 
 - `mongodbatlas_atlas_user` returned a user profile by `user_id` or `username` and is deprecated. Replace it with `mongodbatlas_cloud_user_org_assignment` which reads a user's assignment in a specific organization using either `username` or `user_id` together with `org_id`. For details, see the `mongodbatlas_cloud_user_org_assignment` data source [documentation](../data-sources/cloud_user_org_assignment).
 
-- `mongodbatlas_atlas_users` returned lists of users by `org_id`, `project_id`, or `team_id` and is deprecated. Replace it with the `users` attribute available on `mongodbatlas_organization`, `mongodbatlas_project`, or `mongodbatlas_team` data sources, respectively.
+- `mongodbatlas_atlas_users` returned lists of users by `org_id`, `project_id`, or `team_id` and is deprecated. Replace it with the `users` attribute available on `mongodbatlas_organization`, `mongodbatlas_project`, or `mongodbatlas_team` data sources, respectively. The resulting `users` list now includes both active and pending users.
 - Attribute structure differences: The new organization users API does not return `email_address` as a separate field and replaces the consolidated `roles` with structured `org_roles` and `project_role_assignments`.
 
 ---


### PR DESCRIPTION
## Description

Small inconsistencies while doing bug bash of user invitation.
Additionally adds note in `Atlas User/Users Data Sources` section that new `users` attribute returns both pending and active users.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
