### PR TITLE
test: Correct error message for invalid tags in `mongodbatlas_project` resource tests

### DIFF
--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -1053,11 +1053,11 @@ func TestAccProject_withTags(t *testing.T) {
 			},
 			{
 				Config:      configWithTags(orgID, projectName, map[string]string{"invalid-tag-value": "test/test"}),
-				ExpectError: regexp.MustCompile(`contains invalid characters\W+Allowable characters include`),
+				ExpectError: regexp.MustCompile(`The request parameters are not valid.`),
 			},
 			{
 				Config:      configWithTags(orgID, projectName, map[string]string{"long-tag": longTagValue}),
-				ExpectError: regexp.MustCompile(`exceeded the maximum allowed length of \d+ characters`),
+				ExpectError: regexp.MustCompile(`The request parameters are not valid.`),
 			},
 			{
 				Config: configWithTags(orgID, projectName, tagsEmpty),


### PR DESCRIPTION
## Description

This test has become flaky because the API no longer returns the error messages it once did. Changed the tests accordingly

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
