### PR TITLE
doc: Update maintenance docs to clarify timezone behavior

### DIFF
--- a/docs/data-sources/maintenance_window.md
+++ b/docs/data-sources/maintenance_window.md
@@ -42,7 +42,7 @@ data "mongodbatlas_maintenance_window" "test" {
 In addition to all arguments above, the following attributes are exported:
 
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
-* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone. Defaults to 0.
+* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.

--- a/docs/data-sources/maintenance_window.md
+++ b/docs/data-sources/maintenance_window.md
@@ -4,6 +4,8 @@
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
+-> **NOTE:** Maintenance window times use the project's configured timezone. To change the timezone, update the Project Time Zone setting in the Atlas Project Settings.
+
 ## Examples Usage
 
 ```terraform
@@ -23,7 +25,7 @@ data "mongodbatlas_maintenance_window" "test" {
 ```terraform
 resource "mongodbatlas_maintenance_window" "test" {
   project_id  = "<your-project-id>"
-  start_asap  = true 
+  start_asap  = true
 }
 
 data "mongodbatlas_maintenance_window" "test" {
@@ -40,7 +42,7 @@ data "mongodbatlas_maintenance_window" "test" {
 In addition to all arguments above, the following attributes are exported:
 
 * `day_of_week` - Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
-* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12  (Time zone is UTC).
+* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone. Defaults to 0.
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
 * `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -6,6 +6,8 @@
 
 -> **NOTE:** Groups and projects are synonymous terms. You may find `groupId` in the official documentation.
 
+-> **NOTE:** Maintenance window times use the project's configured timezone. To change the timezone, update the Project Time Zone setting in the Atlas Project Settings.
+
 ## Maintenance Window Considerations:
 - Urgent Maintenance Activities Cannot Wait: Urgent maintenance activities such as security patches cannot wait for your chosen window. Atlas will start those maintenance activities when needed.
 
@@ -41,7 +43,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
-* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12 (Time zone is UTC). Defaults to 0.
+* `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone. Defaults to 0.
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If you request that maintenance begin immediately, this field returns true from the time the request was made until the time the maintenance event completes.
 * `defer` - Defer the next scheduled maintenance for the given project for one week.
 * `auto_defer` - Defer any scheduled maintenance for the given project for one week.


### PR DESCRIPTION
[CLOUDP-343674](https://jira.mongodb.org/browse/CLOUDP-343674)

Came out of [HELP-81227](https://jira.mongodb.org/browse/HELP-81227)

Essentially the docs were incorrect in specifying that maintenance used UTC. This updates the docs to clarify the actual implementation