### PR TITLE
chore: Remove one minute reduction for timeout field on `mongodbatlas_cluster_outage_simulation`

### DIFF
--- a/internal/service/clusteroutagesimulation/resource.go
+++ b/internal/service/clusteroutagesimulation/resource.go
@@ -105,7 +105,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"START_REQUESTED", "STARTING"},
 		Target:     []string{"SIMULATING"},
 		Refresh:    resourceRefreshFunc(ctx, clusterName, projectID, connV2),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - oneMinute, // When using a CRUD function with a timeout, any StateChangeConf timeouts must be configured below that duration to avoid returning the SDK context: deadline exceeded error instead of the retry logic error.
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: oneMinute,
 		Delay:      oneMinute,
 	}


### PR DESCRIPTION
## Description

This fix removes the unnecessary 1-minute reduction applied to the `timeouts` field in the `mongodbatlas_cluster_outage_simulation` resource.  

The reduction is no longer needed because the field already uses `CreateWithoutTimeout` as its timeout implementation.

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-343632

## Type of change:

- [] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
