### PR TITLE
doc: Correctly access user roles in org_users_with_roles output

### DIFF
--- a/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
@@ -63,8 +63,8 @@ output "org_users_with_roles" {
     for user in data.mongodbatlas_organization.org.users : {
       username            = user.username
       user_id             = user.id
-      org_roles           = user.roles[0].org_roles
-      project_assignments = user.roles[0].project_role_assignments
+      org_roles           = length(user.roles) > 0 ? user.roles[0].org_roles : []
+      project_assignments = length(user.roles) > 0 ? user.roles[0].project_role_assignments : []
     }
   ]
 }

--- a/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
@@ -61,8 +61,8 @@ output "org_users_with_roles" {
   description = "Organization users with their roles"
   value = [
     for user in data.mongodbatlas_organization.org.users : {
-      username            = user.username
-      user_id             = user.id
+      username = user.username
+      user_id  = user.id
       # Although the API defines roles as an object, in the organization and team data sources roles are represented as a list. This is due to SDK v2 only supporting blocks for nested elements.
       org_roles           = user.roles[0].org_roles
       project_assignments = user.roles[0].project_role_assignments

--- a/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
@@ -63,8 +63,8 @@ output "org_users_with_roles" {
     for user in data.mongodbatlas_organization.org.users : {
       username            = user.username
       user_id             = user.id
-      org_roles           = length(user.roles) > 0 ? user.roles[0].org_roles : []
-      project_assignments = length(user.roles) > 0 ? user.roles[0].project_role_assignments : []
+      org_roles           = user.roles[0].org_roles
+      project_assignments = user.roles[0].project_role_assignments
     }
   ]
 }

--- a/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
@@ -63,6 +63,7 @@ output "org_users_with_roles" {
     for user in data.mongodbatlas_organization.org.users : {
       username            = user.username
       user_id             = user.id
+      # Although the API defines roles as an object, in the organization and team data sources roles are represented as a list. This is due to SDK v2 only supporting blocks for nested elements.
       org_roles           = user.roles[0].org_roles
       project_assignments = user.roles[0].project_role_assignments
     }

--- a/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
+++ b/examples/migrate_atlas_user_and_atlas_users/v3/outputs.tf
@@ -63,8 +63,8 @@ output "org_users_with_roles" {
     for user in data.mongodbatlas_organization.org.users : {
       username            = user.username
       user_id             = user.id
-      org_roles           = user.roles.org_roles
-      project_assignments = user.roles.project_role_assignments
+      org_roles           = user.roles[0].org_roles
+      project_assignments = user.roles[0].project_role_assignments
     }
   ]
 }


### PR DESCRIPTION
## Description

Correctly access user roles in org_users_with_roles output

Before fix

<img width="830" height="114" alt="image" src="https://github.com/user-attachments/assets/e6f6b4b0-a26f-4bef-87c8-64d2c79f2d92" />

After fix

<img width="348" height="282" alt="image" src="https://github.com/user-attachments/assets/3d921fb6-f1c9-44be-b282-9dc77586a606" />


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
