### PR TITLE
doc: Updates project_id references in migration example to use variable instead of managed resource

### DIFF
--- a/examples/migrate_team_project_assignment/v2/main.tf
+++ b/examples/migrate_team_project_assignment/v2/main.tf
@@ -10,20 +10,20 @@ locals {
   }
 }
 
-# Ignore the deprecated teams block in mongodbatlas_project
-resource "mongodbatlas_project" "this" {
-  name   = "this"
-  org_id = var.org_id
-  lifecycle {
-    ignore_changes = [teams]
-  }
-}
+# If you are managing your project you need to ignore the deprecated teams block in mongodbatlas_project
+# resource "mongodbatlas_project" "this" {
+#   name   = "this"
+#   org_id = var.org_id
+#   lifecycle {
+#     ignore_changes = [teams]
+#   }
+# }
 
 # Use the new mongodbatlas_team_project_assignment resource
 resource "mongodbatlas_team_project_assignment" "this" {
   for_each = local.team_map
 
-  project_id = mongodbatlas_project.this.id
+  project_id = var.project_id
   team_id    = each.key
   role_names = each.value
 }
@@ -32,7 +32,7 @@ resource "mongodbatlas_team_project_assignment" "this" {
 import {
   for_each = local.team_map
   to       = mongodbatlas_team_project_assignment.this[each.key]
-  id       = "${mongodbatlas_project.this.id}/${each.key}"
+  id       = "${var.project_id}/${each.key}"
 }
 
 # Example outputs showing team assignments in various formats
@@ -57,7 +57,7 @@ output "team_project_assignments_map" {
 
 # Data source to read current team assignments for the project
 data "mongodbatlas_team_project_assignment" "this" {
-  project_id = mongodbatlas_project.this.id
+  project_id = var.project_id
   team_id    = var.team_id_1 # Example for one team; repeat for others as needed
 }
 

--- a/examples/migrate_team_project_assignment/v2/variables.tf
+++ b/examples/migrate_team_project_assignment/v2/variables.tf
@@ -1,8 +1,3 @@
-variable "org_id" {
-  description = "The ID of the MongoDB Atlas organization"
-  type        = string
-}
-
 variable "team_id_1" {
   description = "The ID of the first team"
   type        = string

--- a/examples/migrate_team_project_assignment/v2/variables.tf
+++ b/examples/migrate_team_project_assignment/v2/variables.tf
@@ -33,3 +33,9 @@ variable "private_key" {
   type        = string
   default     = ""
 }
+
+variable "project_id" {
+  description = "Atlas project ID"
+  type        = string
+
+}


### PR DESCRIPTION
## Description

Updates project_id references in migration example to use variable instead of managed resource

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
