### PR TITLE
chore: Fix TestMigCloudUserProjectAssignmentRS_basic

### DIFF
--- a/internal/service/cloudbackupsnapshot/resource.go
+++ b/internal/service/cloudbackupsnapshot/resource.go
@@ -165,7 +165,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"queued", "inProgress"},
 		Target:     []string{"completed", "failed"},
 		Refresh:    resourceRefreshFunc(ctx, requestParams, connV2),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: timeout,
 		Delay:      timeout,
 	}

--- a/internal/service/cloudbackupsnapshot/resource.go
+++ b/internal/service/cloudbackupsnapshot/resource.go
@@ -133,7 +133,7 @@ func Resource() *schema.Resource {
 }
 
 const (
-	oneMinute = 1 * time.Minute
+	timeout = 1 * time.Minute
 )
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -166,8 +166,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Target:     []string{"completed", "failed"},
 		Refresh:    resourceRefreshFunc(ctx, requestParams, connV2),
 		Timeout:    d.Timeout(schema.TimeoutCreate) - time.Minute,
-		MinTimeout: oneMinute,
-		Delay:      oneMinute,
+		MinTimeout: timeout,
+		Delay:      timeout,
 	}
 	_, errWait := stateConf.WaitForStateContext(ctx)
 	deleteOnCreateTimeout := true // default value when not set

--- a/internal/service/clouduserprojectassignment/resource_migration_test.go
+++ b/internal/service/clouduserprojectassignment/resource_migration_test.go
@@ -14,13 +14,12 @@ import (
 
 const (
 	resourceInvitationName            = "mongodbatlas_project_invitation.mig_test"
-	resourceProjectName               = "mongodbatlas_project.mig_test"
 	resourceUserProjectAssignmentName = "mongodbatlas_cloud_user_project_assignment.user_mig_test"
 )
 
 func TestMigCloudUserProjectAssignmentRS_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "2.0.0") // when resource 1st released
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	mig.CreateAndRunTestNonParallel(t, basicTestCase(t))
 }
 
 func TestMigCloudUserProjectAssignmentRS_migrationJourney(t *testing.T) {

--- a/internal/service/clouduserprojectassignment/resource_test.go
+++ b/internal/service/clouduserprojectassignment/resource_test.go
@@ -26,6 +26,7 @@ func TestAccCloudUserProjectAssignmentDS_error(t *testing.T) {
 	resource.ParallelTest(t, *errorTestCase(t))
 }
 
+// basicTestCase must be called in serial to avoid multiple tests to use the same Atlas resources and interfere with each other.
 func basicTestCase(t *testing.T) *resource.TestCase {
 	t.Helper()
 
@@ -39,7 +40,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 	updatedRoles := []string{"GROUP_OWNER", "GROUP_SEARCH_INDEX_EDITOR", "GROUP_READ_ONLY"}
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t); acc.PreCheckAtlasUsernames(t) },
+		PreCheck:                 func() { acc.PreCheckAtlasUsernames(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{

--- a/internal/service/clouduserprojectassignment/resource_test.go
+++ b/internal/service/clouduserprojectassignment/resource_test.go
@@ -19,7 +19,7 @@ var DSNameUsername = "data.mongodbatlas_cloud_user_project_assignment.test_usern
 var DSNameUserID = "data.mongodbatlas_cloud_user_project_assignment.test_user_id"
 
 func TestAccCloudUserProjectAssignment_basic(t *testing.T) {
-	resource.ParallelTest(t, *basicTestCase(t))
+	resource.Test(t, *basicTestCase(t))
 }
 
 func TestAccCloudUserProjectAssignmentDS_error(t *testing.T) {

--- a/internal/service/clusteroutagesimulation/resource.go
+++ b/internal/service/clusteroutagesimulation/resource.go
@@ -22,7 +22,7 @@ const (
 	errorClusterOutageSimulationDelete  = "error ending MongoDB Atlas Cluster Outage Simulation for Project (%s), Cluster (%s): %s"
 	errorClusterOutageSimulationSetting = "error setting `%s` for MongoDB Atlas Cluster Outage Simulation: %s"
 	defaultOutageFilterType             = "REGION"
-	oneMinute                           = 1 * time.Minute
+	timeout                             = 1 * time.Minute
 )
 
 func Resource() *schema.Resource {
@@ -106,8 +106,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Target:     []string{"SIMULATING"},
 		Refresh:    resourceRefreshFunc(ctx, clusterName, projectID, connV2),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: oneMinute,
-		Delay:      oneMinute,
+		MinTimeout: timeout,
+		Delay:      timeout,
 	}
 
 	_, errWait := stateConf.WaitForStateContext(ctx)
@@ -187,8 +187,8 @@ func waitForDeletableState(ctx context.Context, connV2 *admin.APIClient, project
 		Target:     []string{"SIMULATING", "FAILED", "DELETED"},
 		Refresh:    resourceRefreshFunc(ctx, clusterName, projectID, connV2),
 		Timeout:    timeout,
-		MinTimeout: oneMinute,
-		Delay:      oneMinute,
+		MinTimeout: timeout,
+		Delay:      timeout,
 	}
 
 	result, err := stateConf.WaitForStateContext(ctx)
@@ -236,8 +236,8 @@ func endOutageSimulationAndWait(ctx context.Context, connV2 *admin.APIClient, pr
 		Target:     []string{"DELETED"},
 		Refresh:    resourceRefreshFunc(ctx, clusterName, projectID, connV2),
 		Timeout:    timeout,
-		MinTimeout: oneMinute,
-		Delay:      oneMinute,
+		MinTimeout: timeout,
+		Delay:      timeout,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)

--- a/internal/service/networkpeering/resource.go
+++ b/internal/service/networkpeering/resource.go
@@ -261,7 +261,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"INITIATING", "FINALIZING", "ADDING_PEER", "WAITING_FOR_USER"},
 		Target:     []string{"FAILED", "AVAILABLE", "PENDING_ACCEPTANCE"},
 		Refresh:    resourceRefreshFunc(ctx, peerID, projectID, peerRequest.GetContainerId(), conn.NetworkPeeringApi),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - time.Minute, // When using a CRUD function with a timeout, any StateChangeConf timeouts must be configured below that duration to avoid returning the SDK context: deadline exceeded error instead of the retry logic error.
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: minTimeout,
 		Delay:      minTimeout,
 	}

--- a/internal/service/onlinearchive/resource.go
+++ b/internal/service/onlinearchive/resource.go
@@ -23,7 +23,7 @@ const (
 	errorOnlineArchivesCreate = "error creating MongoDB Atlas Online Archive:: %s"
 	errorOnlineArchivesDelete = "error deleting MongoDB Atlas Online Archive: %s archive_id (%s)"
 	scheduleTypeDefault       = "DEFAULT"
-	oneMinute                 = 1 * time.Minute
+	timeout                   = 1 * time.Minute
 )
 
 func Resource() *schema.Resource {
@@ -250,9 +250,9 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			Pending:    []string{"PENDING", "ARCHIVING", "PAUSING", "PAUSED", "ORPHANED", "REPEATING"},
 			Target:     []string{"IDLE", "ACTIVE"},
 			Refresh:    resourceOnlineRefreshFunc(ctx, projectID, clusterName, archiveID, connV2),
-			Timeout:    d.Timeout(schema.TimeoutCreate) - oneMinute, // When using a CRUD function with a timeout, any StateChangeConf timeouts must be configured below that duration to avoid returning the SDK context: deadline exceeded error instead of the retry logic error.
-			MinTimeout: oneMinute,
-			Delay:      oneMinute,
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			MinTimeout: timeout,
+			Delay:      timeout,
 		}
 
 		// Wait, catching any errors

--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -26,7 +26,6 @@ const (
 	ErrorServiceEndpointRead = "error reading MongoDB Private Service Endpoint Connection(%s): %s"
 	errorEndpointDelete      = "error deleting MongoDB Private Service Endpoint Connection(%s): %s"
 	ErrorEndpointSetting     = "error setting `%s` for MongoDB Private Service Endpoint Connection(%s): %s"
-	oneMinute                = 1 * time.Minute
 	delayAndMinTimeout       = 10 * time.Second
 )
 
@@ -183,7 +182,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"NONE", "INITIATING", "PENDING_ACCEPTANCE", "PENDING", "DELETING", "VERIFIED"},
 		Target:     []string{"AVAILABLE", "REJECTED", "DELETED", "FAILED"},
 		Refresh:    resourceRefreshFunc(ctx, connV2, projectID, providerName, privateLinkID, endpointServiceID),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - oneMinute, // When using a CRUD function with a timeout, any StateChangeConf timeouts must be configured below that duration to avoid returning the SDK context: deadline exceeded error instead of the retry logic error.
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: delayAndMinTimeout,
 		Delay:      delayAndMinTimeout,
 	}
@@ -205,7 +204,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
 		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
-		Timeout:    d.Timeout(schema.TimeoutCreate) - oneMinute, // When using a CRUD function with a timeout, any StateChangeConf timeouts must be configured below that duration to avoid returning the SDK context: deadline exceeded error instead of the retry logic error.
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: delayAndMinTimeout,
 		Delay:      delayAndMinTimeout,
 	}


### PR DESCRIPTION
## Description

Fix TestMigCloudUserProjectAssignmentRS_basic. Also fix linter issues and remove unneeded 1 minute timeout subtraction.

It's the first time Fix TestMigCloudUserProjectAssignmentRS_basic runs as it only runs from 2.0.0, change TestMigCloudUserProjectAssignmentRS_basic and TestAccCloudUserProjectAssignment_basic to run in serial so they don't interfere as they use the same user, and tests only take a couple of seconds.

Link to any related issue(s): CLOUDP-345364

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
