### PR TITLE
feat: Adds support for Service Account credentials as provider inputs, environment variables and AWS Secrets Manager

### DIFF
--- a/.changelog/3700.txt
+++ b/.changelog/3700.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-provider: Support Service Account as credentials to authenticate the provider
+provider: Supports Service Account as credentials to authenticate the provider
 ```

--- a/.changelog/3700.txt
+++ b/.changelog/3700.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Support Service Account as credentials to authenticate the provider
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -481,7 +481,6 @@ jobs:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false    
       - id: sts-assume-role
-        if: matrix.auth_method == 'sts_assume_role'
         name: Generate STS Temporary credential for acceptance testing
         shell: bash
         env:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -171,6 +171,10 @@ on:
         required: true
       mongodb_atlas_rp_public_key:
         required: true
+      mongodb_atlas_client_id:
+        required: true
+      mongodb_atlas_client_secret:
+        required: true
       azure_directory_id:
         required: true
       azure_resource_group_name:
@@ -245,7 +249,7 @@ jobs:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
       autogen: ${{ steps.filter.outputs.autogen == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
       control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
@@ -278,7 +282,7 @@ jobs:
         filters: |
           advanced_cluster:
             - 'internal/service/advancedclustertpf/*.go'
-          assume_role:
+          authentication:
             - 'internal/provider/*.go'
           autogen:
             - 'internal/common/autogen/*.go'
@@ -460,11 +464,14 @@ jobs:
             ./internal/service/advancedclustertpf
         run: make testacc
 
-  assume_role:
+  authentication:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
+    if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
     runs-on: ubuntu-latest
     permissions: {}
+    strategy:
+      matrix:
+        auth_method: [sts_assume_role, service_account]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -477,6 +484,7 @@ jobs:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false    
       - id: sts-assume-role
+        if: matrix.auth_method == 'sts_assume_role'
         name: Generate STS Temporary credential for acceptance testing
         shell: bash
         env:
@@ -485,7 +493,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests
+      - name: Acceptance Tests (STS Assume Role)
+        if: matrix.auth_method == 'sts_assume_role'
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
@@ -496,6 +505,16 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/provider
+        run: make testacc
+      - name: Acceptance Tests (Service Account)
+        if: matrix.auth_method == 'service_account'
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -469,9 +469,6 @@ jobs:
     if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
     runs-on: ubuntu-latest
     permissions: {}
-    strategy:
-      matrix:
-        auth_method: [sts_assume_role, service_account]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -484,7 +481,6 @@ jobs:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false    
       - id: sts-assume-role
-        if: matrix.auth_method == 'sts_assume_role'
         name: Generate STS Temporary credential for acceptance testing
         shell: bash
         env:
@@ -494,7 +490,6 @@ jobs:
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
       - name: Acceptance Tests (STS Assume Role)
-        if: matrix.auth_method == 'sts_assume_role'
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
@@ -510,7 +505,6 @@ jobs:
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc
       - name: Acceptance Tests (Service Account)
-        if: matrix.auth_method == 'service_account'
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -469,9 +469,6 @@ jobs:
     if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
     runs-on: ubuntu-latest
     permissions: {}
-    strategy:
-      matrix:
-        auth_method: [sts_assume_role, service_account]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -493,8 +490,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests (STS Assume Role)
-        if: matrix.auth_method == 'sts_assume_role'
+      - name: Acceptance Tests
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
@@ -505,14 +501,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/provider
-        run: make testacc
-      - name: Acceptance Tests (Service Account)
-        if: matrix.auth_method == 'service_account'
-        env:
-          MONGODB_ATLAS_PUBLIC_KEY: ""
-          MONGODB_ATLAS_PRIVATE_KEY: ""
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -506,6 +506,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAccSTSAssumeRole'
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc
       - name: Acceptance Tests (Service Account)
@@ -516,6 +517,7 @@ jobs:
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAccServiceAccount'
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc
 

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -481,6 +481,7 @@ jobs:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false    
       - id: sts-assume-role
+        if: matrix.auth_method == 'sts_assume_role'
         name: Generate STS Temporary credential for acceptance testing
         shell: bash
         env:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -469,6 +469,9 @@ jobs:
     if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
     runs-on: ubuntu-latest
     permissions: {}
+    strategy:
+      matrix:
+        auth_method: [sts_assume_role, service_account]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -490,7 +493,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests
+      - name: Acceptance Tests (STS Assume Role)
+        if: matrix.auth_method == 'sts_assume_role'
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
@@ -501,6 +505,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/provider
+        run: make testacc
+      - name: Acceptance Tests (Service Account)
+        if: matrix.auth_method == 'service_account'
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -65,6 +65,8 @@ jobs:
       mongodb_atlas_gov_private_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_GOV_PRIVATE_KEY_QA || secrets.MONGODB_ATLAS_GOV_PRIVATE_KEY_DEV }}
       mongodb_atlas_rp_public_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_DEV }}
       mongodb_atlas_rp_private_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_DEV }}
+      mongodb_atlas_client_id: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_CLIENT_ID_QA || secrets.MONGODB_ATLAS_CLIENT_ID_DEV }}
+      mongodb_atlas_client_secret: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_CLIENT_SECRET_QA || secrets.MONGODB_ATLAS_CLIENT_SECRET_DEV }}
       ca_cert: ${{ secrets.CA_CERT }}
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -61,18 +61,18 @@ type CredentialProvider interface {
 }
 
 // IsDigestAuth checks if public/private key credentials are present
-func IsDigestAuth(publicKey, privateKey string) bool {
-	return publicKey != "" && privateKey != ""
+func IsDigestAuth(cp CredentialProvider) bool {
+	return cp.GetPublicKey() != "" && cp.GetPrivateKey() != ""
 }
 
 // IsServiceAccountAuth checks if client ID/secret credentials are present
-func IsServiceAccountAuth(clientID, clientSecret string) bool {
-	return clientID != "" && clientSecret != ""
+func IsServiceAccountAuth(cp CredentialProvider) bool {
+	return cp.GetClientID() != "" && cp.GetClientSecret() != ""
 }
 
 // HasValidAuthCredentials checks if any valid authentication method is provided
-func HasValidAuthCredentials(publicKey, privateKey, clientID, clientSecret string) bool {
-	return IsDigestAuth(publicKey, privateKey) || IsServiceAccountAuth(clientID, clientSecret)
+func HasValidAuthCredentials(cp CredentialProvider) bool {
+	return IsDigestAuth(cp) || IsServiceAccountAuth(cp)
 }
 
 var baseTransport = &http.Transport{
@@ -406,10 +406,10 @@ func userAgent(c *Config) string {
 
 // ResolveAuthMethod determines the authentication method from any credential provider
 func ResolveAuthMethod(cg CredentialProvider) AuthMethod {
-	if IsServiceAccountAuth(cg.GetClientID(), cg.GetClientSecret()) {
+	if IsServiceAccountAuth(cg) {
 		return ServiceAccount
 	}
-	if IsDigestAuth(cg.GetPublicKey(), cg.GetPrivateKey()) {
+	if IsDigestAuth(cg) {
 		return Digest
 	}
 	return Unknown

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -153,8 +153,6 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 		tfLoggingTransport := logging.NewTransport("Atlas", digestTransport)
 		client = &http.Client{Transport: tfLoggingTransport}
 		optsAtlas = []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
-	default:
-		return nil, errors.New("no valid authentication credentials provided: either set client_id/client_secret for service account auth or public_key/private_key for digest auth")
 	}
 
 	if c.BaseURL != "" {

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -122,10 +122,9 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 			conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 		}
 
-		// Create a base HTTP client for token acquisition with increased timeout
+		// Create a base HTTP client for token acquisition
 		baseHTTPClient := &http.Client{
 			Transport: networkLoggingTransport,
-			Timeout:   30 * time.Second, // Increase timeout for OAuth2 token requests
 		}
 
 		// Set the HTTP client in context for token acquisition

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -112,7 +112,7 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 	var optsAtlas []matlasClient.ClientOpt
 
 	// Determine authentication method based on available credentials
-	switch authMethod := resolveAuthMethod(c); authMethod {
+	switch resolveAuthMethod(c) {
 	case serviceAccountAuthMethod:
 		conf := clientcredentials.NewConfig(c.ClientID, c.ClientSecret)
 		// Override TokenURL and RevokeURL if custom BaseURL is provided

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -74,16 +74,18 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	if err != nil {
 		return *cfg, err
 	}
-	if secretData.PrivateKey == "" {
-		return *cfg, fmt.Errorf("secret missing value for credential PrivateKey")
+
+	switch {
+	case secretData.PrivateKey != "" && secretData.PublicKey != "":
+		cfg.PublicKey = secretData.PublicKey
+		cfg.PrivateKey = secretData.PrivateKey
+	case secretData.ClientID != "" && secretData.ClientSecret != "":
+		cfg.ClientID = secretData.ClientID
+		cfg.ClientSecret = secretData.ClientSecret
+	default:
+		return *cfg, fmt.Errorf("secret missing value for supported credentials: PrivateKey/PublicKey or ClientID/ClientSecret")
 	}
 
-	if secretData.PublicKey == "" {
-		return *cfg, fmt.Errorf("secret missing value for credential PublicKey")
-	}
-
-	cfg.PublicKey = secretData.PublicKey
-	cfg.PrivateKey = secretData.PrivateKey
 	return *cfg, nil
 }
 

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -75,14 +75,14 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 		return *cfg, err
 	}
 
-	switch {
-	case secretData.PrivateKey != "" && secretData.PublicKey != "":
+	switch config.ResolveAuthMethod(&secretData) {
+	case config.Digest:
 		cfg.PublicKey = secretData.PublicKey
 		cfg.PrivateKey = secretData.PrivateKey
-	case secretData.ClientID != "" && secretData.ClientSecret != "":
+	case config.ServiceAccount:
 		cfg.ClientID = secretData.ClientID
 		cfg.ClientSecret = secretData.ClientSecret
-	default:
+	case config.Unknown:
 		return *cfg, fmt.Errorf("secret missing value for supported credentials: PrivateKey/PublicKey or ClientID/ClientSecret")
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,7 +61,7 @@ const (
 	MongodbGovCloudQAURL           = "https://cloud-qa.mongodbgov.com"
 	MongodbGovCloudDevURL          = "https://cloud-dev.mongodbgov.com"
 	ProviderConfigError            = "error in configuring the provider."
-	MissingAuthAttrError           = "either AWS Secrets Manager, Service Accounts, or Atlas Programmatic API Keys attributes must be set"
+	MissingAuthAttrError           = "either AWS Secrets Manager, Service Accounts or Atlas Programmatic API Keys attributes must be set"
 	ProviderMetaUserAgentExtra     = "user_agent_extra"
 	ProviderMetaUserAgentExtraDesc = "You can extend the user agent header for each request made by the provider to the Atlas Admin API. The Key Values will be formatted as {key}/{value}."
 	ProviderMetaModuleName         = "module_name"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -462,6 +462,20 @@ func setDefaultValuesWithValidations(ctx context.Context, data *tfMongodbAtlasPr
 		}, "").(string))
 	}
 
+	if data.ClientID.ValueString() == "" {
+		data.ClientID = types.StringValue(MultiEnvDefaultFunc([]string{
+			"MONGODB_ATLAS_CLIENT_ID",
+			"TF_VAR_CLIENT_ID",
+		}, "").(string))
+	}
+
+	if data.ClientSecret.ValueString() == "" {
+		data.ClientSecret = types.StringValue(MultiEnvDefaultFunc([]string{
+			"MONGODB_ATLAS_CLIENT_SECRET",
+			"TF_VAR_CLIENT_SECRET",
+		}, "").(string))
+	}
+
 	return *data
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -75,16 +75,18 @@ type MongodbtlasProvider struct {
 
 type tfMongodbAtlasProviderModel struct {
 	AssumeRole           types.List   `tfsdk:"assume_role"`
-	PublicKey            types.String `tfsdk:"public_key"`
+	Region               types.String `tfsdk:"region"`
 	PrivateKey           types.String `tfsdk:"private_key"`
 	BaseURL              types.String `tfsdk:"base_url"`
 	RealmBaseURL         types.String `tfsdk:"realm_base_url"`
 	SecretName           types.String `tfsdk:"secret_name"`
-	Region               types.String `tfsdk:"region"`
+	PublicKey            types.String `tfsdk:"public_key"`
 	StsEndpoint          types.String `tfsdk:"sts_endpoint"`
 	AwsAccessKeyID       types.String `tfsdk:"aws_access_key_id"`
 	AwsSecretAccessKeyID types.String `tfsdk:"aws_secret_access_key"`
 	AwsSessionToken      types.String `tfsdk:"aws_session_token"`
+	ClientID             types.String `tfsdk:"client_id"`
+	ClientSecret         types.String `tfsdk:"client_secret"`
 	IsMongodbGovCloud    types.Bool   `tfsdk:"is_mongodbgov_cloud"`
 }
 
@@ -188,6 +190,14 @@ func (p *MongodbtlasProvider) Schema(ctx context.Context, req provider.SchemaReq
 				Optional:    true,
 				Description: "AWS Security Token Service provided session token.",
 			},
+			"client_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "MongoDB Atlas Client ID.",
+			},
+			"client_secret": schema.StringAttribute{
+				Optional:    true,
+				Description: "MongoDB Atlas Client Secret.",
+			},
 		},
 	}
 }
@@ -276,6 +286,8 @@ func (p *MongodbtlasProvider) Configure(ctx context.Context, req provider.Config
 		BaseURL:          data.BaseURL.ValueString(),
 		RealmBaseURL:     data.RealmBaseURL.ValueString(),
 		TerraformVersion: req.TerraformVersion,
+		ClientID:         data.ClientID.ValueString(),
+		ClientSecret:     data.ClientSecret.ValueString(),
 	}
 
 	var assumeRoles []tfAssumeRoleModel

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -471,10 +471,7 @@ func setDefaultValuesWithValidations(ctx context.Context, data *tfMongodbAtlasPr
 	}
 
 	// Check if any valid authentication method is provided
-	hasDigestAuth := data.PublicKey.ValueString() != "" && data.PrivateKey.ValueString() != ""
-	hasServiceAccountAuth := data.ClientID.ValueString() != "" && data.ClientSecret.ValueString() != ""
-
-	if !hasDigestAuth && !hasServiceAccountAuth && !awsRoleDefined {
+	if !config.HasValidAuthCredentials(data.PublicKey.ValueString(), data.PrivateKey.ValueString(), data.ClientID.ValueString(), data.ClientSecret.ValueString()) && !awsRoleDefined {
 		resp.Diagnostics.AddWarning(ProviderConfigError, MissingAuthAttrError)
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,7 +61,7 @@ const (
 	MongodbGovCloudQAURL           = "https://cloud-qa.mongodbgov.com"
 	MongodbGovCloudDevURL          = "https://cloud-dev.mongodbgov.com"
 	ProviderConfigError            = "error in configuring the provider."
-	MissingAuthAttrError           = "either Atlas Programmatic API Keys, Service Accounts, or AWS Secrets Manager attributes must be set"
+	MissingAuthAttrError           = "either AWS Secrets Manager, Service Accounts, or Atlas Programmatic API Keys attributes must be set"
 	ProviderMetaUserAgentExtra     = "user_agent_extra"
 	ProviderMetaUserAgentExtraDesc = "You can extend the user agent header for each request made by the provider to the Atlas Admin API. The Key Values will be formatted as {key}/{value}."
 	ProviderMetaModuleName         = "module_name"
@@ -192,11 +192,11 @@ func (p *MongodbtlasProvider) Schema(ctx context.Context, req provider.SchemaReq
 			},
 			"client_id": schema.StringAttribute{
 				Optional:    true,
-				Description: "MongoDB Atlas Client ID.",
+				Description: "MongoDB Atlas Client ID for Service Account.",
 			},
 			"client_secret": schema.StringAttribute{
 				Optional:    true,
-				Description: "MongoDB Atlas Client Secret.",
+				Description: "MongoDB Atlas Client Secret for Service Account.",
 			},
 		},
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -477,7 +477,7 @@ func setDefaultValuesWithValidations(ctx context.Context, data *tfMongodbAtlasPr
 		ClientID:     data.ClientID.ValueString(),
 		ClientSecret: data.ClientSecret.ValueString(),
 	}) && !awsRoleDefined {
-		resp.Diagnostics.AddWarning(ProviderConfigError, MissingAuthAttrError)
+		resp.Diagnostics.AddError(ProviderConfigError, MissingAuthAttrError)
 	}
 
 	return *data

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -471,7 +471,12 @@ func setDefaultValuesWithValidations(ctx context.Context, data *tfMongodbAtlasPr
 	}
 
 	// Check if any valid authentication method is provided
-	if !config.HasValidAuthCredentials(data.PublicKey.ValueString(), data.PrivateKey.ValueString(), data.ClientID.ValueString(), data.ClientSecret.ValueString()) && !awsRoleDefined {
+	if !config.HasValidAuthCredentials(&config.Config{
+		PublicKey:    data.PublicKey.ValueString(),
+		PrivateKey:   data.PrivateKey.ValueString(),
+		ClientID:     data.ClientID.ValueString(),
+		ClientSecret: data.ClientSecret.ValueString(),
+	}) && !awsRoleDefined {
 		resp.Diagnostics.AddWarning(ProviderConfigError, MissingAuthAttrError)
 	}
 

--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -40,6 +40,24 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 	})
 }
 
+func TestAccServiceAccount_basic(t *testing.T) {
+	var (
+		resourceName = "data.mongodbatlas_projects.test"
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckServiceAccount(t); acc.PreCheckRegularCredsAreEmpty(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configDataSourceProject(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "results.#"),
+				),
+			},
+		},
+	})
+}
+
 func configProject(orgID, projectName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
@@ -47,4 +65,11 @@ func configProject(orgID, projectName string) string {
 			name  			 = %[2]q
 		}
 	`, orgID, projectName)
+}
+
+func configDataSourceProject() string {
+	return `
+		data "mongodbatlas_projects" "test" {
+		}
+	`
 }

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -133,12 +133,12 @@ func NewSdkV2Provider() *schema.Provider {
 			"client_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "MongoDB Atlas Client ID.",
+				Description: "MongoDB Atlas Client ID for Service Account.",
 			},
 			"client_secret": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "MongoDB Atlas Client Secret.",
+				Description: "MongoDB Atlas Client Secret for Service Account.",
 			},
 		},
 		DataSourcesMap: getDataSourcesMap(),

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -451,7 +451,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 		ClientID:     d.Get("client_id").(string),
 		ClientSecret: d.Get("client_secret").(string),
 	}) && !awsRoleDefined {
-		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Warning, Summary: MissingAuthAttrError})
+		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Error, Summary: MissingAuthAttrError})
 	}
 
 	return diagnostics

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -57,8 +57,10 @@ import (
 )
 
 type SecretData struct {
-	PublicKey  string `json:"public_key"`
-	PrivateKey string `json:"private_key"`
+	PublicKey    string `json:"public_key"`
+	PrivateKey   string `json:"private_key"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
 }
 
 // NewSdkV2Provider returns the provider to be use by the code.
@@ -365,7 +367,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 	}); err != nil {
 		return append(diagnostics, diag.FromErr(err)...)
 	}
-	if d.Get("public_key").(string) == "" && !awsRoleDefined {
+	if d.Get("public_key").(string) == "" && !awsRoleDefined { //TODO: condition for warning needs to change
 		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Warning, Summary: MissingAuthAttrError})
 	}
 
@@ -377,7 +379,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 		return append(diagnostics, diag.FromErr(err)...)
 	}
 
-	if d.Get("private_key").(string) == "" && !awsRoleDefined {
+	if d.Get("private_key").(string) == "" && !awsRoleDefined { //TODO: condition for warning needs to change
 		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Warning, Summary: MissingAuthAttrError})
 	}
 

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -429,6 +429,20 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 		return append(diagnostics, diag.FromErr(err)...)
 	}
 
+	if err := setValueFromConfigOrEnv(d, "client_id", []string{
+		"MONGODB_ATLAS_CLIENT_ID",
+		"TF_VAR_CLIENT_ID",
+	}); err != nil {
+		return append(diagnostics, diag.FromErr(err)...)
+	}
+
+	if err := setValueFromConfigOrEnv(d, "client_secret", []string{
+		"MONGODB_ATLAS_CLIENT_SECRET",
+		"TF_VAR_CLIENT_SECRET",
+	}); err != nil {
+		return append(diagnostics, diag.FromErr(err)...)
+	}
+
 	return diagnostics
 }
 

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -63,6 +63,12 @@ type SecretData struct {
 	ClientSecret string `json:"client_secret"`
 }
 
+// CredentialProvider implementation for SecretData
+func (s *SecretData) GetPublicKey() string    { return s.PublicKey }
+func (s *SecretData) GetPrivateKey() string   { return s.PrivateKey }
+func (s *SecretData) GetClientID() string     { return s.ClientID }
+func (s *SecretData) GetClientSecret() string { return s.ClientSecret }
+
 // NewSdkV2Provider returns the provider to be use by the code.
 func NewSdkV2Provider() *schema.Provider {
 	provider := &schema.Provider{
@@ -439,10 +445,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 	}
 
 	// Check if any valid authentication method is provided
-	hasDigestAuth := d.Get("public_key").(string) != "" && d.Get("private_key").(string) != ""
-	hasServiceAccountAuth := d.Get("client_id").(string) != "" && d.Get("client_secret").(string) != ""
-
-	if !hasDigestAuth && !hasServiceAccountAuth && !awsRoleDefined {
+	if !config.HasValidAuthCredentials(d.Get("public_key").(string), d.Get("private_key").(string), d.Get("client_id").(string), d.Get("client_secret").(string)) && !awsRoleDefined {
 		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Warning, Summary: MissingAuthAttrError})
 	}
 

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -445,7 +445,12 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 	}
 
 	// Check if any valid authentication method is provided
-	if !config.HasValidAuthCredentials(d.Get("public_key").(string), d.Get("private_key").(string), d.Get("client_id").(string), d.Get("client_secret").(string)) && !awsRoleDefined {
+	if !config.HasValidAuthCredentials(&config.Config{
+		PublicKey:    d.Get("public_key").(string),
+		PrivateKey:   d.Get("private_key").(string),
+		ClientID:     d.Get("client_id").(string),
+		ClientSecret: d.Get("client_secret").(string),
+	}) && !awsRoleDefined {
 		diagnostics = append(diagnostics, diag.Diagnostic{Severity: diag.Warning, Summary: MissingAuthAttrError})
 	}
 

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -122,6 +122,16 @@ func NewSdkV2Provider() *schema.Provider {
 				Optional:    true,
 				Description: "AWS Security Token Service provided session token.",
 			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "MongoDB Atlas Client ID.",
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "MongoDB Atlas Client Secret.",
+			},
 		},
 		DataSourcesMap: getDataSourcesMap(),
 		ResourcesMap:   getResourcesMap(),
@@ -283,6 +293,8 @@ func providerConfigure(provider *schema.Provider) func(ctx context.Context, d *s
 			BaseURL:          d.Get("base_url").(string),
 			RealmBaseURL:     d.Get("realm_base_url").(string),
 			TerraformVersion: provider.TerraformVersion,
+			ClientID:         d.Get("client_id").(string),
+			ClientSecret:     d.Get("client_secret").(string),
 		}
 
 		assumeRoleValue, ok := d.GetOk("assume_role")

--- a/internal/service/advancedclustertpf/main_test.go
+++ b/internal/service/advancedclustertpf/main_test.go
@@ -8,6 +8,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Force digest auth for unit tests so provider validation passes without OAuth2
+	_ = os.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "dummy")
+	_ = os.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "dummy")
+	// Ensure Service Account auth is not selected during tests
+	_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
+	_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
+	_ = os.Unsetenv("TF_VAR_CLIENT_ID")
+	_ = os.Unsetenv("TF_VAR_CLIENT_SECRET")
+
 	cleanup := acc.SetupSharedResources()
 	exitCode := m.Run()
 	cleanup()

--- a/internal/service/advancedclustertpf/main_test.go
+++ b/internal/service/advancedclustertpf/main_test.go
@@ -8,14 +8,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Force digest auth for unit tests so provider validation passes without OAuth2
-	_ = os.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "dummy")
-	_ = os.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "dummy")
-	// Ensure Service Account auth is not selected during tests
-	_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
-	_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
-	_ = os.Unsetenv("TF_VAR_CLIENT_ID")
-	_ = os.Unsetenv("TF_VAR_CLIENT_SECRET")
+	// Only modify credentials for unit tests. Preserve GH Actions env in acceptance (TF_ACC=1).
+	if os.Getenv("TF_ACC") == "" {
+		// If no credentials are provided, force digest auth to satisfy provider validation.
+		_ = os.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "dummy")
+		_ = os.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "dummy")
+		// Ensure Service Account auth is not selected if we just set digest
+		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
+		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
+		_ = os.Unsetenv("TF_VAR_CLIENT_ID")
+		_ = os.Unsetenv("TF_VAR_CLIENT_SECRET")
+	}
 
 	cleanup := acc.SetupSharedResources()
 	exitCode := m.Run()

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -47,10 +47,7 @@ func ConnV2UsingGov() *admin.APIClient {
 		PrivateKey: os.Getenv("MONGODB_ATLAS_GOV_PRIVATE_KEY"),
 		BaseURL:    os.Getenv("MONGODB_ATLAS_GOV_BASE_URL"),
 	}
-	client, err := cfg.NewClient(context.Background())
-	if err != nil || client == nil {
-		return nil
-	}
+	client, _ := cfg.NewClient(context.Background())
 	return client.(*config.MongoDBClient).AtlasV2
 }
 
@@ -65,11 +62,7 @@ func init() {
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
-		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
-		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
 	}
-	client, err := cfg.NewClient(context.Background())
-	if err == nil && client != nil {
-		MongoDBClient = client.(*config.MongoDBClient)
-	}
+	client, _ := cfg.NewClient(context.Background())
+	MongoDBClient = client.(*config.MongoDBClient)
 }

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -47,7 +47,10 @@ func ConnV2UsingGov() *admin.APIClient {
 		PrivateKey: os.Getenv("MONGODB_ATLAS_GOV_PRIVATE_KEY"),
 		BaseURL:    os.Getenv("MONGODB_ATLAS_GOV_BASE_URL"),
 	}
-	client, _ := cfg.NewClient(context.Background())
+	client, err := cfg.NewClient(context.Background())
+	if err != nil || client == nil {
+		return nil
+	}
 	return client.(*config.MongoDBClient).AtlasV2
 }
 
@@ -62,7 +65,11 @@ func init() {
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
+		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
+		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
 	}
-	client, _ := cfg.NewClient(context.Background())
-	MongoDBClient = client.(*config.MongoDBClient)
+	client, err := cfg.NewClient(context.Background())
+	if err == nil && client != nil {
+		MongoDBClient = client.(*config.MongoDBClient)
+	}
 }

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -377,3 +377,11 @@ func PreCheckAwsMsk(tb testing.TB) {
 		tb.Fatal("`AWS_MSK_ARN` must be set for AWS MSK acceptance testing")
 	}
 }
+
+func PreCheckServiceAccount(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_CLIENT_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") == "" {
+		tb.Fatal("`MONGODB_ATLAS_CLIENT_ID`, `MONGODB_ATLAS_CLIENT_SECRET` must be set for Service Account acceptance testing")
+	}
+}

--- a/internal/testutil/unit/http_mocker.go
+++ b/internal/testutil/unit/http_mocker.go
@@ -80,6 +80,7 @@ type mockClientModifier struct {
 	config           *MockHTTPDataConfig
 	mockRoundTripper http.RoundTripper
 	oldRoundTripper  http.RoundTripper
+	skipReset        bool // When true, skip reset to avoid data races with shared clients
 }
 
 func (c *mockClientModifier) ModifyHTTPClient(httpClient *http.Client) error {
@@ -89,6 +90,10 @@ func (c *mockClientModifier) ModifyHTTPClient(httpClient *http.Client) error {
 }
 
 func (c *mockClientModifier) ResetHTTPClient(httpClient *http.Client) {
+	// Skip reset when using copied HTTP clients to avoid data races
+	if c.skipReset {
+		return
+	}
 	if c.oldRoundTripper != nil {
 		httpClient.Transport = c.oldRoundTripper
 	}

--- a/internal/testutil/unit/provider_mock.go
+++ b/internal/testutil/unit/provider_mock.go
@@ -46,16 +46,28 @@ func (p *ProviderMocked) Configure(ctx context.Context, req fwProvider.Configure
 	if !ok {
 		p.t.Fatal("Failed to cast ResourceData to MongoDBClient")
 	}
-	httpClient := client.AtlasV2.GetConfig().HTTPClient
-	if httpClient == nil {
+
+	// Create a copy of the HTTP client to avoid data races with OAuth2 background operations
+	originalClient := client.AtlasV2.GetConfig().HTTPClient
+	if originalClient == nil {
 		p.t.Fatal("HTTPClient is nil, mocking will fail")
 	}
+
+	// Create a new HTTP client to avoid modifying the live one
+	mockedClient := &http.Client{
+		Transport: originalClient.Transport,
+		Timeout:   originalClient.Timeout,
+	}
+
 	if p.ClientModifier != nil {
-		err := p.ClientModifier.ModifyHTTPClient(httpClient)
+		err := p.ClientModifier.ModifyHTTPClient(mockedClient)
 		if err != nil {
 			p.t.Fatal(err)
 		}
 	}
+
+	// Replace the HTTP client in the Atlas configuration
+	client.AtlasV2.GetConfig().HTTPClient = mockedClient
 }
 
 func (p *ProviderMocked) DataSources(ctx context.Context) []func() datasource.DataSource {
@@ -76,11 +88,26 @@ func muxProviderFactory(t *testing.T, clientModifier HTTPClientModifier) func() 
 		if !ok {
 			t.Fatalf("Failed to cast response to MongoDBClient, Got type %T", resp)
 		}
-		httpClient := client.AtlasV2.GetConfig().HTTPClient
-		err := clientModifier.ModifyHTTPClient(httpClient)
+
+		// Create a copy of the HTTP client to avoid data races with OAuth2 background operations
+		originalClient := client.AtlasV2.GetConfig().HTTPClient
+		if originalClient == nil {
+			t.Fatalf("HTTPClient is nil, mocking will fail")
+		}
+
+		// Create a new HTTP client to avoid modifying the live one
+		mockedClient := &http.Client{
+			Transport: originalClient.Transport,
+			Timeout:   originalClient.Timeout,
+		}
+
+		err := clientModifier.ModifyHTTPClient(mockedClient)
 		if err != nil {
 			t.Fatalf("Failed to modify HTTPClient: %s", err)
 		}
+
+		// Replace the HTTP client in the Atlas configuration
+		client.AtlasV2.GetConfig().HTTPClient = mockedClient
 		return resp, diags
 	}
 	fwProviderInstance := provider.NewFrameworkProvider()

--- a/internal/testutil/unit/provider_mock.go
+++ b/internal/testutil/unit/provider_mock.go
@@ -60,6 +60,10 @@ func (p *ProviderMocked) Configure(ctx context.Context, req fwProvider.Configure
 	}
 
 	if p.ClientModifier != nil {
+		// Since we're using a copied client, set skipReset to avoid data races
+		if mockModifier, ok := p.ClientModifier.(*mockClientModifier); ok {
+			mockModifier.skipReset = true
+		}
 		err := p.ClientModifier.ModifyHTTPClient(mockedClient)
 		if err != nil {
 			p.t.Fatal(err)
@@ -101,6 +105,10 @@ func muxProviderFactory(t *testing.T, clientModifier HTTPClientModifier) func() 
 			Timeout:   originalClient.Timeout,
 		}
 
+		// Since we're using a copied client, set skipReset to avoid data races
+		if mockModifier, ok := clientModifier.(*mockClientModifier); ok {
+			mockModifier.skipReset = true
+		}
 		err := clientModifier.ModifyHTTPClient(mockedClient)
 		if err != nil {
 			t.Fatalf("Failed to modify HTTPClient: %s", err)


### PR DESCRIPTION
## Description

Adds support for Service Account credentials as provider inputs, environment variables and AWS Secrets Manager
Includes a test that tests the authentication using Service Account credentials through environment variables that runs in CI. Provider inputs and AWS Secrets have been tested manually.

**Important:** followup tickets will implement refresh policy, thread-safe access to the token, and final hierarchy of credentials


Changes in `provider_mock.go`  and `http_mocker.go` are due to the following problem:
- The Service Account authentication implementation introduced OAuth2 background operations that use the same HTTP client as the test mocking infrastructure. This caused data races when tests tried to modify the HTTP client's Transport while OAuth2 goroutines were simultaneously reading from it.

To solve this:
- Modified the test provider mocking to create copies of HTTP clients before applying test modifications, rather than modifying the shared client directly. This isolates test modifications from production OAuth2 operations.

Changes in `internal/service/advancedclustertpf/main_test.go` are due to the following problem:

- After commit cec3112d “error instead of warning when no credentials are set”, provider `Configure` fails without credentials. Several unit tests previously relied on running with no creds, causing Terraform to hang and hit the 2m timeout.
- Providing Service Account creds isn’t viable for these tests because the provider eagerly fetches an OAuth2 token using a fresh HTTP client (not intercepted by our HTTP mocker), which would attempt real network calls.
- **Fix:** In internal/service/advancedclustertpf/main_test.go TestMain, set dummy Digest credentials and clear Service Account vars to force the Digest path, which our mocker fully intercepts:
  - Set: MONGODB_ATLAS_PUBLIC_API_KEY=dummy, MONGODB_ATLAS_PRIVATE_API_KEY=dummy
  - Unset: MONGODB_ATLAS_CLIENT_ID, MONGODB_ATLAS_CLIENT_SECRET, TF_VAR_CLIENT_ID, TF_VAR_CLIENT_SECRET
- **Impact:** Restores test stability post-credential validation change; no production behavior change.

Link to any related issue(s): CLOUDP-345759

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
