### PR TITLE
test: Use shared project in EAR AWS tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -106,9 +106,6 @@ on:
       confluent_cloud_privatelink_access_id:
         type: string
         required: true
-      mongodb_atlas_project_ear_pe_aws_id:
-        type: string
-        required: true
       mongodb_atlas_asp_project_ear_pe_id:
         type: string
         required: true
@@ -754,7 +751,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_CUSTOMER_MASTER_KEY_ID: ${{ secrets.aws_customer_master_key_id }}
-          MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID: ${{ inputs.mongodb_atlas_project_ear_pe_aws_id }}
           MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
           MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -109,9 +109,6 @@ on:
       confluent_cloud_privatelink_access_id:
         type: string
         required: true
-      aws_ear_role_id:
-        type: string
-        required: true
       mongodb_atlas_project_ear_pe_aws_id:
         type: string
         required: true
@@ -762,7 +759,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_CUSTOMER_MASTER_KEY_ID: ${{ secrets.aws_customer_master_key_id }}
           MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID: ${{ inputs.mongodb_atlas_project_ear_pe_aws_id }}
-          AWS_EAR_ROLE_ID: ${{ inputs.aws_ear_role_id }}
           MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
           MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
         run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -97,9 +97,6 @@ on:
       mongodb_atlas_federated_settings_associated_domain:
         type: string
         required: true
-      mongodb_atlas_project_ear_pe_id:
-        type: string
-        required: true
       azure_private_endpoint_region:
         type: string
         required: true
@@ -743,7 +740,6 @@ jobs:
           ACCTEST_PACKAGES: |
            ./internal/service/encryptionatrest
            ./internal/service/encryptionatrestprivateendpoint
-          MONGODB_ATLAS_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_project_ear_pe_id }}
           AZURE_PRIVATE_ENDPOINT_REGION: ${{ inputs.azure_private_endpoint_region }}
           AZURE_CLIENT_ID: ${{ secrets.azure_client_id }}
           AZURE_RESOURCE_GROUP_NAME: ${{ secrets.azure_resource_group_name }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -124,7 +124,6 @@ jobs:
       mongodb_atlas_gov_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_ORG_ID_QA || vars.MONGODB_ATLAS_GOV_ORG_ID_DEV }}
       mongodb_atlas_gov_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_DEV }}
       mongodb_atlas_federated_settings_associated_domain: ${{ vars.MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN }}
-      mongodb_atlas_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_DEV }}
       mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -126,7 +126,6 @@ jobs:
       mongodb_atlas_federated_settings_associated_domain: ${{ vars.MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN }}
       mongodb_atlas_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_DEV }}
       mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
-      aws_ear_role_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AWS_EAR_ROLE_ID_QA || vars.AWS_EAR_ROLE_ID_DEV }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}
       confluent_cloud_network_id: ${{ vars.CONFLUENT_CLOUD_NETWORK_ID }} 

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -124,7 +124,6 @@ jobs:
       mongodb_atlas_gov_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_ORG_ID_QA || vars.MONGODB_ATLAS_GOV_ORG_ID_DEV }}
       mongodb_atlas_gov_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_DEV }}
       mongodb_atlas_federated_settings_associated_domain: ${{ vars.MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN }}
-      mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}
       confluent_cloud_network_id: ${{ vars.CONFLUENT_CLOUD_NETWORK_ID }} 

--- a/contributing/development-setup.md
+++ b/contributing/development-setup.md
@@ -39,7 +39,7 @@
   ```bash
   export TF_CLI_CONFIG_FILE=PATH/TO/dev.trfc
   ```
-- Run `terraform init` to inizialize terraform
+- Run `terraform init` to initialize terraform
 - Run `terraform apply` to use terraform with the local binary
 
 For more explained information about plugin override check [Development Overrides for Provider Developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers)

--- a/internal/service/encryptionatrest/resource_migration_test.go
+++ b/internal/service/encryptionatrest/resource_migration_test.go
@@ -1,6 +1,7 @@
 package encryptionatrest_test
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -17,13 +18,15 @@ import (
 func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 	var (
 		resourceName = "mongodbatlas_encryption_at_rest.test"
-		projectID    = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
+		projectID    = acc.ProjectIDExecution(t)
+
+		awsIAMRoleName       = acc.RandomIAMRole()
+		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:             conversion.Pointer(true),
 			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
 			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
-			RoleId:              conversion.StringPtr(os.Getenv("AWS_EAR_ROLE_ID")),
 		}
 		useDatasource               = mig.IsProviderVersionAtLeast("1.19.0") // data source introduced in this version
 		useRequirePrivateNetworking = mig.IsProviderVersionAtLeast("1.28.0") // require_private_networking introduced in this version
@@ -35,23 +38,16 @@ func TestMigEncryptionAtRest_basicAWS(t *testing.T) {
 		CheckDestroy: acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
-				ExternalProviders: mig.ExternalProviders(),
-				Config:            acc.ConfigAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking, useEnabledForSearchNodes),
+				ExternalProviders: mig.ExternalProvidersWithAWS(),
+				Config:            acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms, useDatasource, useRequirePrivateNetworking, useEnabledForSearchNodes),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acc.CheckEARExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
 				),
 			},
-			mig.TestStepCheckEmptyPlan(acc.ConfigAwsKms(projectID, &awsKms, useDatasource, useRequirePrivateNetworking, useEnabledForSearchNodes)),
+			mig.TestStepCheckEmptyPlan(acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms, useDatasource, useRequirePrivateNetworking, useEnabledForSearchNodes)),
 		},
 	})
-}
-
-func TestMigEncryptionAtRest_withRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t) // needs AWS configuration
-	mig.SkipIfVersionBelow(t, "1.28.0")
-
-	mig.CreateTestAndRunUseExternalProviderNonParallel(t, testCaseWithRoleBasicAWS(t), mig.ExternalProvidersWithAWS(), nil)
 }
 
 func TestMigEncryptionAtRest_basicAzure(t *testing.T) {

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -28,13 +28,15 @@ const (
 
 func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 	var (
-		projectID = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") // to use RequirePrivateNetworking, Atlas Project is required to have FF enabled
+		projectID = acc.ProjectIDExecution(t)
+
+		awsIAMRoleName       = acc.RandomIAMRole()
+		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
 
 		awsKms = admin.AWSKMSConfiguration{
 			Enabled:                  conversion.Pointer(true),
 			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
 			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
-			RoleId:                   conversion.StringPtr(os.Getenv("AWS_EAR_ROLE_ID")),
 			RequirePrivateNetworking: conversion.Pointer(false),
 		}
 		awsKmsAttrMap = acc.ConvertToAwsKmsEARAttrMap(&awsKms)
@@ -43,28 +45,27 @@ func TestAccEncryptionAtRest_basicAWS(t *testing.T) {
 			Enabled:                  conversion.Pointer(true),
 			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
 			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
-			RoleId:                   conversion.StringPtr(os.Getenv("AWS_EAR_ROLE_ID")),
 			RequirePrivateNetworking: conversion.Pointer(true),
 		}
-		awsKmsUpdatedAttrMap  = acc.ConvertToAwsKmsEARAttrMap(&awsKmsUpdated)
-		enabledForSearchNodes = true
+		awsKmsUpdatedAttrMap = acc.ConvertToAwsKmsEARAttrMap(&awsKmsUpdated)
 	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckAwsEnv(t) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.EARDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: acc.ConfigAwsKms(projectID, &awsKms, true, false, false),
+				Config: acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms, true, false, false),
 				Check:  checkEARResourceAWS(projectID, false, awsKmsAttrMap),
 			},
 			{
-				Config: acc.ConfigAwsKms(projectID, &awsKmsUpdated, true, true, enabledForSearchNodes),
-				Check:  checkEARResourceAWS(projectID, enabledForSearchNodes, awsKmsUpdatedAttrMap),
+				Config: acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKmsUpdated, true, true, true),
+				Check:  checkEARResourceAWS(projectID, true, awsKmsUpdatedAttrMap),
 			},
 			{
-				Config: acc.ConfigAwsKms(projectID, &awsKmsUpdated, true, true, false),
+				Config: acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKmsUpdated, true, true, false),
 				Check:  checkEARResourceAWS(projectID, false, awsKmsUpdatedAttrMap),
 			},
 			{
@@ -239,53 +240,6 @@ func TestAccEncryptionAtRest_basicGCPWithRole(t *testing.T) {
 			},
 		},
 	})
-}
-
-func TestAccEncryptionAtRestWithRole_basicAWS(t *testing.T) {
-	acc.SkipTestForCI(t) // needs AWS configuration. This test case is similar to TestAccEncryptionAtRest_basicAWS except that it creates it's own AWS resources such as IAM roles, cloud provider access, etc so we don't need to run this in CI but may be used for local testing.
-
-	resource.Test(t, *testCaseWithRoleBasicAWS(t))
-}
-
-func testCaseWithRoleBasicAWS(t *testing.T) *resource.TestCase {
-	t.Helper()
-	var (
-		projectID            = acc.ProjectIDExecution(t)
-		awsIAMRoleName       = acc.RandomIAMRole()
-		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
-		awsKeyName           = acc.RandomName()
-		awsKms               = admin.AWSKMSConfiguration{
-			Enabled:             conversion.Pointer(true),
-			Region:              conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
-			CustomerMasterKeyID: conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
-		}
-	)
-
-	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAwsEnv(t) },
-		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.EARDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName, &awsKms),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					acc.CheckEARExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "aws_kms_config.0.role_id"),
-					resource.TestCheckResourceAttr(resourceName, "aws_kms_config.0.enabled", "true"),
-
-					resource.TestCheckNoResourceAttr(resourceName, "azure_key_vault_config.#"),
-					resource.TestCheckNoResourceAttr(resourceName, "google_cloud_kms_config.#"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: acc.EARImportStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	}
 }
 
 var (
@@ -559,94 +513,6 @@ func configGoogleCloudKmsWithRole(projectID string, google *admin.GoogleCloudKMS
 		return fmt.Sprintf(`%s %s`, config, acc.EARDatasourceConfig())
 	}
 	return config
-}
-
-func testAccMongoDBAtlasEncryptionAtRestConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKeyName string, awsEar *admin.AWSKMSConfiguration) string {
-	test := fmt.Sprintf(`
-	locals {
-		project_id = %[1]q
-		aws_iam_role_policy_name = %[2]q
-		aws_iam_role_name        = %[3]q
-		aws_kms_key_name         = %[4]q
-	  }
-
-		  %[5]s	
-`, projectID, awsIAMRolePolicyName, awsIAMRoleName, awsKeyName, awsIAMroleAuthAndEarConfigUsingLocals(awsEar))
-	return test
-}
-
-func awsIAMroleAuthAndEarConfigUsingLocals(awsEar *admin.AWSKMSConfiguration) string {
-	return fmt.Sprintf(`  
-	resource "aws_iam_role_policy" "test_policy" {
-		name = local.aws_iam_role_policy_name
-		role = aws_iam_role.test_role.id
-	  
-		policy = jsonencode({
-		  "Version" : "2012-10-17",
-		  "Statement" : [
-			{
-			  "Effect" : "Allow",
-			  "Action" : [
-				"kms:Decrypt",
-				"kms:Encrypt",
-				"kms:DescribeKey"
-			  ],
-			  "Resource" : [
-				%[3]q
-			  ]
-			}
-		  ]
-		})
-	  }
-	  
-	resource "aws_iam_role" "test_role" {
-		name = local.aws_iam_role_name
-	  
-		assume_role_policy = jsonencode({
-		  "Version" : "2012-10-17",
-		  "Statement" : [
-			{
-			  "Effect" : "Allow",
-			  "Principal" : {
-				"AWS" : "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config[0].atlas_aws_account_arn}"
-			  },
-			  "Action" : "sts:AssumeRole",
-			  "Condition" : {
-				"StringEquals" : {
-				  "sts:ExternalId" : "${mongodbatlas_cloud_provider_access_setup.setup_only.aws_config[0].atlas_assumed_role_external_id}"
-				}
-			  }
-			}
-		  ]
-		})
-	  }
-
-	resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
-		project_id    = local.project_id
-		provider_name = "AWS"
-	  }
-	  
-	  resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
-		project_id = local.project_id
-		role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
-	  
-		aws {
-		  iam_assumed_role_arn = aws_iam_role.test_role.arn
-		}
-	  }
-
-resource "mongodbatlas_encryption_at_rest" "test" {
-  project_id = local.project_id
-
-  aws_kms_config {
-    enabled                = %[1]t
-    customer_master_key_id = %[3]q
-	region                 = %[2]q
-    role_id                = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
-	require_private_networking = %[4]t
-  }
-}
-	`, awsEar.GetEnabled(), awsEar.GetRegion(), awsEar.GetCustomerMasterKeyID(), awsEar.GetRequirePrivateNetworking())
 }
 
 // Helper function to perform common AWS resource checks

--- a/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_migration_test.go
@@ -15,5 +15,5 @@ func TestMigEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
 func TestMigEncryptionAtRestPrivateEndpoint_AWS_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.28.0")
 	testCase := basicTestCaseAWS(t)
-	mig.CreateAndRunTestNonParallel(t, testCase)
+	mig.CreateTestAndRunUseExternalProviderNonParallel(t, testCase, mig.ExternalProvidersWithAWS(), nil)
 }

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -26,7 +26,6 @@ const (
 	dataSourceName       = "data.mongodbatlas_encryption_at_rest_private_endpoint.test"
 	pluralDataSourceName = "data.mongodbatlas_encryption_at_rest_private_endpoints.test"
 	earResourceName      = "mongodbatlas_encryption_at_rest.test"
-	earDatasourceName    = "data.mongodbatlas_encryption_at_rest.test"
 )
 
 func TestAccEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
@@ -34,27 +33,37 @@ func TestAccEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
 }
 
 func TestAccEncryptionAtRestPrivateEndpoint_createTimeoutWithDeleteOnCreate(t *testing.T) {
-	// This test is skipped because it creates a race condition with other tests:
-	// 1. This test creates an encryption at rest private endpoint with a 1s timeout, causing it to fail and trigger cleanup
-	// 2. The private endpoint deletion doesn't complete immediately
-	// 3. Other tests share the same project and attempt to disable encryption at rest during cleanup
-	// 4. MongoDB Atlas returns "CANNOT_DISABLE_ENCRYPTION_AT_REST_REQUIRE_PRIVATE_NETWORKING_WHILE_PRIVATE_ENDPOINTS_EXIST"
-	//    because the private endpoint from this test is still being deleted
-	// This race condition occurs even when tests don't run in parallel due to the async nature of private endpoint deletion.
+	// This test is skipped because the deletion of the private endpoint when delete_on_create_timeout is true is currently failing
+	// due to a change in the Atlas API which prevents the deletion of private endpoints during provisioning.
+	//  - When attempting deletion, we get a ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_DELETE_BLOCKED_DURING_PROVISIONING error.
+	// A long term solution is in the works by the API team which will re-allow deletion of private endpoints during provisioning.
 	acc.SkipTestForCI(t)
+
 	var (
 		createTimeout         = "1s"
 		deleteOnCreateTimeout = true
-		region                = conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))
-		// Create encryption at rest configuration outside of test configuration to avoid cleanup issues
-		projectID = acc.EncryptionAtRestExecution(t)
+
+		orgID       = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		projectName = acc.RandomProjectName()
+
+		awsIAMRoleName       = acc.RandomIAMRole()
+		awsIAMRolePolicyName = fmt.Sprintf("%s-policy", awsIAMRoleName)
+
+		awsKms = admin.AWSKMSConfiguration{
+			Enabled:                  conversion.Pointer(true),
+			CustomerMasterKeyID:      conversion.StringPtr(os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID")),
+			Region:                   conversion.StringPtr(conversion.AWSRegionToMongoDBRegion(os.Getenv("AWS_REGION"))),
+			RequirePrivateNetworking: conversion.Pointer(true),
+		}
 	)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckEncryptionAtRestEnvAWS(t) },
+		ExternalProviders:        acc.ExternalProvidersOnlyAWS(),
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configEARPrivateEndpointWithTimeout(projectID, region, acc.TimeoutConfig(&createTimeout, nil, nil), &deleteOnCreateTimeout),
+				Config:      configAWSProject(projectName, orgID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms, acc.TimeoutConfig(&createTimeout, nil, nil), &deleteOnCreateTimeout),
 				ExpectError: regexp.MustCompile("will run cleanup because delete_on_create_timeout is true"),
 			},
 		},
@@ -350,6 +359,19 @@ func checkBasic(projectID, cloudProvider, region string, expectApproved bool) re
 
 func configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName string, awsKms *admin.AWSKMSConfiguration) string {
 	encryptionAtRestConfig := acc.ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName, awsKms, false, true, false)
+	return configEARPrivateEndpoint(encryptionAtRestConfig, awsKms, "", nil)
+}
+
+func configAWSProject(projectName, orgID, awsIAMRoleName, awsIAMRolePolicyName string, awsKms *admin.AWSKMSConfiguration, timeoutConfig string, deleteOnCreateTimeout *bool) string {
+	encryptionAtRestConfig := acc.ConfigProjectWithAwsKmsPrivateNetworking(projectName, orgID, awsIAMRoleName, awsIAMRolePolicyName, awsKms, false, true, false)
+	return configEARPrivateEndpoint(encryptionAtRestConfig, awsKms, timeoutConfig, deleteOnCreateTimeout)
+}
+
+func configEARPrivateEndpoint(encryptionAtRestConfig string, awsKms *admin.AWSKMSConfiguration, timeoutConfig string, deleteOnCreateTimeout *bool) string {
+	deleteOnCreateTimeoutConfig := ""
+	if deleteOnCreateTimeout != nil {
+		deleteOnCreateTimeoutConfig = fmt.Sprintf("delete_on_create_timeout = %t", *deleteOnCreateTimeout)
+	}
 
 	config := fmt.Sprintf(`
 		%[1]s
@@ -358,34 +380,12 @@ func configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName string, awsK
 		    project_id = mongodbatlas_encryption_at_rest.test.project_id
 		    cloud_provider = "AWS"
 		    region_name = %[2]q
-		}
-
-		%[3]s
-	`, encryptionAtRestConfig, awsKms.GetRegion(), configDS())
-
-	return config
-}
-
-func configEARPrivateEndpointWithTimeout(projectID, region, timeoutConfig string, deleteOnCreateTimeout *bool) string {
-	deleteOnCreateTimeoutConfig := ""
-	if deleteOnCreateTimeout != nil {
-		deleteOnCreateTimeoutConfig = fmt.Sprintf(`
-			delete_on_create_timeout = %[1]t
-		`, *deleteOnCreateTimeout)
-	}
-
-	config := fmt.Sprintf(`
-		resource "mongodbatlas_encryption_at_rest_private_endpoint" "test" {
-		    project_id = %[1]q
-		    cloud_provider = "AWS"
-		    region_name = %[2]q
 		    %[3]s
 		    %[4]s
 		}
 
 		%[5]s
-
-	`, projectID, region, deleteOnCreateTimeoutConfig, timeoutConfig, configDS())
+	`, encryptionAtRestConfig, awsKms.GetRegion(), deleteOnCreateTimeoutConfig, timeoutConfig, configDS())
 
 	return config
 }

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -64,7 +64,8 @@ func TestAccEncryptionAtRestPrivateEndpoint_createTimeoutWithDeleteOnCreate(t *t
 func basicTestCaseAzure(tb testing.TB) *resource.TestCase {
 	tb.Helper()
 	var (
-		projectID     = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
+		projectID = acc.ProjectIDExecution(tb)
+
 		azureKeyVault = &admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),
 			RequirePrivateNetworking: conversion.Pointer(true),
@@ -111,9 +112,10 @@ func TestAccEncryptionAtRestPrivateEndpoint_approveEndpointWithAzureProvider(t *
 	acc.SkipTestForCI(t) // uses azure/azapi Terraform provider which can log sensitive information in CI like Azure subscriptionID used in parent_id of the resource
 
 	var (
+		projectID = acc.ProjectIDExecution(t)
+
 		subscriptionID    = os.Getenv("AZURE_SUBSCRIPTION_ID")
 		resourceGroupName = os.Getenv("AZURE_RESOURCE_GROUP_NAME")
-		projectID         = os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID")
 		keyVaultName      = os.Getenv("AZURE_KEY_VAULT_NAME")
 		azureKeyVault     = &admin.AzureKeyVault{
 			Enabled:                  conversion.Pointer(true),

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -36,7 +36,7 @@ func TestAccEncryptionAtRestPrivateEndpoint_createTimeoutWithDeleteOnCreate(t *t
 	// This test is skipped because the deletion of the private endpoint when delete_on_create_timeout is true is currently failing
 	// due to a change in the Atlas API which prevents the deletion of private endpoints during provisioning.
 	//  - When attempting deletion, we get a ENCRYPTION_AT_REST_PRIVATE_ENDPOINT_DELETE_BLOCKED_DURING_PROVISIONING error.
-	// A long term solution is in the works by the API team which will re-allow deletion of private endpoints during provisioning.
+	// A long term solution is in the works by the API team which will re-allow deletion of private endpoints during provisioning: CLOUDP-344647
 	acc.SkipTestForCI(t)
 
 	var (

--- a/internal/testutil/acc/encryption_at_rest.go
+++ b/internal/testutil/acc/encryption_at_rest.go
@@ -19,7 +19,7 @@ func ConfigEARAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useReq
 
 	config := fmt.Sprintf(`
 		resource "mongodbatlas_encryption_at_rest" "test" {
-			project_id = "%[1]s"
+			project_id = %[1]q
 
 			azure_key_vault_config {
 				enabled             = %[2]t

--- a/internal/testutil/acc/encryption_at_rest.go
+++ b/internal/testutil/acc/encryption_at_rest.go
@@ -23,19 +23,19 @@ func ConfigEARAzureKeyVault(projectID string, azure *admin.AzureKeyVault, useReq
 
 	config := fmt.Sprintf(`
 		resource "mongodbatlas_encryption_at_rest" "test" {
-			project_id = "%s"
+			project_id = "%[1]s"
 
-		  azure_key_vault_config {
-				enabled             = %t
-				client_id           = "%s"
-				azure_environment   = "%s"
-				subscription_id     = "%s"
-				resource_group_name = "%s"
-				key_vault_name      = "%s"
-				key_identifier      = "%s"
-				secret  		    = "%s"
-				tenant_id  		    = "%s"
-				%s
+			azure_key_vault_config {
+				enabled             = %[2]t
+				client_id           = %[3]q
+				azure_environment   = %[4]q
+				subscription_id     = %[5]q
+				resource_group_name = %[6]q
+				key_vault_name      = %[7]q
+				key_identifier      = %[8]q
+				secret  		    = %[9]q
+				tenant_id  		    = %[10]q
+				%[11]s
 			}
 		}
 	`, projectID, *azure.Enabled, azure.GetClientID(), azure.GetAzureEnvironment(), azure.GetSubscriptionID(), azure.GetResourceGroupName(),
@@ -61,17 +61,8 @@ func ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName string
 		datasourceStr = EARDatasourceConfig()
 	}
 	config := fmt.Sprintf(`
-		locals {
-			project_id                 = %[1]q
-			aws_ear_enabled			   = %[2]t
-			aws_iam_role_name          = %[3]q
-			aws_iam_role_policy_name   = %[4]q
-			aws_customer_master_key_id = %[5]q
-			aws_region				   = %[6]q
-		}
-
 		resource "aws_iam_role_policy" "test_policy" {
-			name = local.aws_iam_role_policy_name
+			name = %[4]q
 			role = aws_iam_role.test_role.id
 	  
 			policy = jsonencode({
@@ -85,7 +76,7 @@ func ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName string
 							"kms:DescribeKey"
 						],
 						"Resource" : [
-							"${local.aws_customer_master_key_id}"
+ 							%[5]q
 						]
 					}
 			  ]
@@ -93,7 +84,7 @@ func ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName string
 		}
 	  
 		resource "aws_iam_role" "test_role" {
-			name = local.aws_iam_role_name
+			name = %[3]q
 	  
 			assume_role_policy = jsonencode({
 				"Version" : "2012-10-17",
@@ -115,12 +106,12 @@ func ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName string
 		}
 
 		resource "mongodbatlas_cloud_provider_access_setup" "setup_only" {
-			project_id    = local.project_id
+			project_id    = %[1]q
 			provider_name = "AWS"
 		}
 	  
 		resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
-			project_id = local.project_id
+			project_id = %[1]q
 			role_id    = mongodbatlas_cloud_provider_access_setup.setup_only.role_id
 	  
 			aws {
@@ -129,12 +120,12 @@ func ConfigAwsKmsWithRole(projectID, awsIAMRoleName, awsIAMRolePolicyName string
 		}
 
 		resource "mongodbatlas_encryption_at_rest" "test" {
-			project_id = local.project_id
+			project_id = %[1]q
 
 			aws_kms_config {
-				enabled                = local.aws_ear_enabled
-				customer_master_key_id = local.aws_customer_master_key_id
-				region                 = local.aws_region
+				enabled                = %[2]t
+				customer_master_key_id = %[5]q
+				region                 = %[6]q
 				role_id                = mongodbatlas_cloud_provider_access_authorization.auth_role.role_id
 				%[7]s
 			}

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -46,16 +46,6 @@ func PreCheck(tb testing.TB) {
 	}
 }
 
-func PreCheckEncryptionAtRestPrivateEndpoint(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_EAR_PE_ID` and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
-	}
-}
-
 func PreCheckCert(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
@@ -246,9 +236,8 @@ func PreCheckEncryptionAtRestEnvAWS(tb testing.TB) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
 		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" ||
 		os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") == "" ||
 		os.Getenv("AWS_REGION") == "" {
-		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID`, `AWS_REGION` and `MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID` must be set for acceptance testing")
+		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID` and `AWS_REGION` must be set for acceptance testing")
 	}
 }
 

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -50,14 +50,6 @@ func cleanupSharedResources() {
 		fmt.Printf("Deleting execution private link endpoint: %s, project id: %s, provider: %s\n", sharedInfo.privateLinkEndpointID, projectID, sharedInfo.privateLinkProviderName)
 		deletePrivateLinkEndpoint(projectID, sharedInfo.privateLinkProviderName, sharedInfo.privateLinkEndpointID)
 	}
-	if sharedInfo.encryptionAtRestEnabled {
-		projectID := sharedInfo.projectID
-		if projectID == "" {
-			projectID = projectIDLocal()
-		}
-		fmt.Printf("Deleting execution encryption at rest: project id: %s\n", projectID)
-		deleteEncryptionAtRest(projectID)
-	}
 	if sharedInfo.projectID != "" {
 		fmt.Printf("Deleting execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
 		deleteProject(sharedInfo.projectID)
@@ -230,7 +222,6 @@ var sharedInfo = struct {
 	projects                []projectInfo
 	mu                      sync.Mutex
 	muSleep                 sync.Mutex
-	encryptionAtRestEnabled bool
 	init                    bool
 }{
 	projects: []projectInfo{},


### PR DESCRIPTION
## Description

A feature flag is no longer needed for Encryption At Rest AWS tests, so using a static project is no longer necessary. Moving acc/mig tests to use the shared test project.

Link to any related issue(s): CLOUDP-342235

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
