### PR TITLE
chore: Implement Service Account token caching & thread-safe concurrent access

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -524,8 +524,8 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration
-            ./internal/service/databaseuser
-            ./internal/service/maintenancewindow
+            # TEMPORARY DONT MERGE, wil be uncommented before merge - ./internal/service/databaseuser
+            # TEMPORARY DONT MERGE, wil be uncommented before merge - ./internal/service/maintenancewindow
         run: make testacc
 
   autogen:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -524,8 +524,6 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration
-            # TEMPORARY DONT MERGE, wil be uncommented before merge - ./internal/service/databaseuser
-            # TEMPORARY DONT MERGE, wil be uncommented before merge - ./internal/service/maintenancewindow
         run: make testacc
 
   autogen:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -519,6 +519,7 @@ jobs:
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAcc' # don't run migration tests because previous provider versions don't support SA
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration
             ./internal/service/databaseuser

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -514,6 +514,18 @@ jobs:
           ACCTEST_REGEX_RUN: '^TestAccServiceAccount'
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc
+      - name: Acceptance Tests (Service Account smoke tests) # small selection of fast tests to run with SA
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/service/alertconfiguration
+            ./internal/service/databaseuser
+            ./internal/service/maintenancewindow
+        run: make testacc
 
   autogen:
     needs: [ change-detection, get-provider-version ]

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -283,6 +283,7 @@ jobs:
           advanced_cluster:
             - 'internal/service/advancedcluster/*.go'
           authentication:
+            - 'internal/config/*.go'
             - 'internal/provider/*.go'
           autogen:
             - 'internal/common/autogen/*.go'

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -408,8 +408,7 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
  
   advanced_cluster_tpf_mig_from_sdkv2:
@@ -434,8 +433,7 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'true'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
   advanced_cluster_tpf_mig_from_tpf_preview:
@@ -461,8 +459,7 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'false'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
   authentication:
@@ -524,8 +521,9 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration
+            ./internal/service/databaseuser
+            ./internal/service/maintenancewindow
         run: make testacc
-
   autogen:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ else
 endif
 
 ACCTEST_TIMEOUT?=300m
-PARALLEL_GO_TEST?=50
+ACCTEST_PARALLEL?=50 # wait more in I/O
+
+UNITEST_TIMEOUT?=120s
+UNITTEST_PARALLEL?=10 # more compute intensive
 
 BINARY_NAME=terraform-provider-mongodbatlas
 DESTINATION=./bin/$(BINARY_NAME)
@@ -43,7 +46,7 @@ test: fmtcheck ## Run unit tests
 	@$(eval export MONGODB_ATLAS_ORG_ID?=111111111111111111111111)
 	@$(eval export MONGODB_ATLAS_PROJECT_ID?=111111111111111111111111)
 	@$(eval export MONGODB_ATLAS_CLUSTER_NAME?=mocked-cluster)
-	go test ./... -timeout=120s -parallel=$(PARALLEL_GO_TEST) -race
+	go test ./... -timeout=$(UNITEST_TIMEOUT) -parallel=$(UNITTEST_PARALLEL) -race
 
 .PHONY: testmact
 testmact: ## Run MacT tests (mocked acc tests)
@@ -57,7 +60,7 @@ testmact: ## Run MacT tests (mocked acc tests)
 		echo "Error: ACCTEST_PACKAGES must be explicitly set for testmact target, './...' is not allowed"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testmact-capture
 testmact-capture: ## Capture HTTP traffic for MacT tests
@@ -68,12 +71,12 @@ testmact-capture: ## Capture HTTP traffic for MacT tests
 		echo "Error: ACCTEST_PACKAGES must be explicitly set for testmact-capture target, './...' is not allowed"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testacc
 testacc: fmtcheck ## Run acc & mig tests (acceptance & migration tests)
 	@$(eval ACCTEST_REGEX_RUN?=^TestAcc)
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testaccgov
 testaccgov: fmtcheck ## Run Government cloud-provider acc & mig tests

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ else
 endif
 
 ACCTEST_TIMEOUT?=300m
-ACCTEST_PARALLEL?=50 # wait more in I/O
-
-UNITEST_TIMEOUT?=120s
-UNITTEST_PARALLEL?=10 # more compute intensive
+PARALLEL_GO_TEST?=50
 
 BINARY_NAME=terraform-provider-mongodbatlas
 DESTINATION=./bin/$(BINARY_NAME)
@@ -46,7 +43,7 @@ test: fmtcheck ## Run unit tests
 	@$(eval export MONGODB_ATLAS_ORG_ID?=111111111111111111111111)
 	@$(eval export MONGODB_ATLAS_PROJECT_ID?=111111111111111111111111)
 	@$(eval export MONGODB_ATLAS_CLUSTER_NAME?=mocked-cluster)
-	go test ./... -timeout=$(UNITEST_TIMEOUT) -parallel=$(UNITTEST_PARALLEL) -race
+	go test ./... -timeout=120s -parallel=$(PARALLEL_GO_TEST) -race
 
 .PHONY: testmact
 testmact: ## Run MacT tests (mocked acc tests)
@@ -60,7 +57,7 @@ testmact: ## Run MacT tests (mocked acc tests)
 		echo "Error: ACCTEST_PACKAGES must be explicitly set for testmact target, './...' is not allowed"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testmact-capture
 testmact-capture: ## Capture HTTP traffic for MacT tests
@@ -71,12 +68,12 @@ testmact-capture: ## Capture HTTP traffic for MacT tests
 		echo "Error: ACCTEST_PACKAGES must be explicitly set for testmact-capture target, './...' is not allowed"; \
 		exit 1; \
 	fi
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testacc
 testacc: fmtcheck ## Run acc & mig tests (acceptance & migration tests)
 	@$(eval ACCTEST_REGEX_RUN?=^TestAcc)
-	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(ACCTEST_PARALLEL) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
+	TF_ACC=1 go test $(ACCTEST_PACKAGES) -run '$(ACCTEST_REGEX_RUN)' -v -parallel $(PARALLEL_GO_TEST) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -ldflags="$(LINKER_FLAGS)"
 
 .PHONY: testaccgov
 testaccgov: fmtcheck ## Run Government cloud-provider acc & mig tests

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -175,7 +175,6 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to acquire OAuth2 token: %w", err)
 		}
-
 		oauthClient := auth.NewClient(ctx, tokenSource)
 		tfLoggingTransport := logging.NewTransport("Atlas", oauthClient.Transport)
 		oauthClient.Transport = tfLoggingTransport

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 
-	"go.mongodb.org/atlas-sdk/v20250312007/auth/clientcredentials"
-
 	"go.mongodb.org/atlas-sdk/v20250312007/auth"
 )
 
@@ -141,86 +139,58 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 	networkLoggingTransport := NewTransportWithNetworkLogging(baseTransport, logging.IsDebugOrHigher())
 
 	var client *http.Client
-	var optsAtlas []matlasClient.ClientOpt
 
 	// Determine authentication method based on available credentials
 	switch ResolveAuthMethod(c) {
 	case ServiceAccount:
-		conf := clientcredentials.NewConfig(c.ClientID, c.ClientSecret)
-		// Override TokenURL and RevokeURL if custom BaseURL is provided
-		if c.BaseURL != "" {
-			baseURL := strings.TrimRight(c.BaseURL, "/")
-			conf.TokenURL = baseURL + clientcredentials.TokenAPIPath
-			conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
-		}
-
-		// Create a base HTTP client for token acquisition
-		baseHTTPClient := &http.Client{
-			Transport: networkLoggingTransport,
-		}
-
-		// Set the HTTP client in context for token acquisition
-		ctx = context.WithValue(ctx, auth.HTTPClient, baseHTTPClient)
-
-		tokenSource := conf.TokenSource(ctx)
-
-		// Acquire an initial token upfront for several reasons:
-		// 1. OAuth2 token caching: The oauth2 library only caches tokens after successful acquisition
-		// 2. Early credential validation: Fail fast during provider init rather than first resource operation
-		// 3. Performance: Subsequent requests use cached tokens instead of blocking for token acquisition
-		_, err := tokenSource.Token()
+		tokenSource, err := tokenSource(ctx, c, networkLoggingTransport)
 		if err != nil {
-			return nil, fmt.Errorf("failed to acquire OAuth2 token: %w", err)
+			return nil, err
 		}
 		oauthClient := auth.NewClient(ctx, tokenSource)
+		// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
 		tfLoggingTransport := logging.NewTransport("Atlas", oauthClient.Transport)
 		oauthClient.Transport = tfLoggingTransport
 		client = oauthClient
-		optsAtlas = []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
 	case Digest:
 		digestTransport := digest.NewTransportWithHTTPRoundTripper(cast.ToString(c.PublicKey), cast.ToString(c.PrivateKey), networkLoggingTransport)
 		// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
 		tfLoggingTransport := logging.NewTransport("Atlas", digestTransport)
 		client = &http.Client{Transport: tfLoggingTransport}
-		optsAtlas = []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
 	case Unknown:
 	}
 
+	// Initialize the old SDK
+	optsAtlas := []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
 	if c.BaseURL != "" {
 		optsAtlas = append(optsAtlas, matlasClient.SetBaseURL(c.BaseURL))
 	}
-
-	// Initialize the MongoDB Atlas API Client.
 	atlasClient, err := matlasClient.New(client, optsAtlas...)
 	if err != nil {
 		return nil, err
 	}
 
+	// Initialize the new SDK for different versions
 	sdkV2Client, err := c.newSDKV2Client(client)
 	if err != nil {
 		return nil, err
 	}
-
 	sdkPreviewClient, err := c.newSDKPreviewClient(client)
 	if err != nil {
 		return nil, err
 	}
-
 	sdkV220240530Client, err := c.newSDKV220240530Client(client)
 	if err != nil {
 		return nil, err
 	}
-
 	sdkV220240805Client, err := c.newSDKV220240805Client(client)
 	if err != nil {
 		return nil, err
 	}
-
 	sdkV220241113Client, err := c.newSDKV220241113Client(client)
 	if err != nil {
 		return nil, err
 	}
-
 	clients := &MongoDBClient{
 		Atlas:           atlasClient,
 		AtlasV2:         sdkV2Client,

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -32,9 +31,8 @@ import (
 )
 
 const (
-	toolName                             = "terraform-provider-mongodbatlas"
-	terraformPlatformName                = "Terraform"
-	previewV2AdvancedClusterEnabledUAKey = "AdvancedClusterPreview"
+	toolName              = "terraform-provider-mongodbatlas"
+	terraformPlatformName = "Terraform"
 
 	timeout               = 5 * time.Second
 	keepAlive             = 30 * time.Second
@@ -100,15 +98,14 @@ type MongoDBClient struct {
 
 // Config contains the configurations needed to use SDKs
 type Config struct {
-	AssumeRole                      *AssumeRole
-	PublicKey                       string
-	PrivateKey                      string
-	BaseURL                         string
-	RealmBaseURL                    string
-	TerraformVersion                string
-	ClientID                        string
-	ClientSecret                    string
-	PreviewV2AdvancedClusterEnabled bool
+	AssumeRole       *AssumeRole
+	PublicKey        string
+	PrivateKey       string
+	BaseURL          string
+	RealmBaseURL     string
+	TerraformVersion string
+	ClientID         string
+	ClientSecret     string
 }
 
 // CredentialProvider implementation for Config
@@ -386,14 +383,10 @@ func (c *MongoDBClient) UntypedAPICall(ctx context.Context, params *APICallParam
 }
 
 func userAgent(c *Config) string {
-	isPreviewV2AdvancedClusterEnabled := c.PreviewV2AdvancedClusterEnabled
-
 	metadata := []UAMetadata{
 		{toolName, version.ProviderVersion},
 		{terraformPlatformName, c.TerraformVersion},
-		{previewV2AdvancedClusterEnabledUAKey, strconv.FormatBool(isPreviewV2AdvancedClusterEnabled)},
 	}
-
 	var parts []string
 	for _, info := range metadata {
 		part := fmt.Sprintf("%s/%s", info.Name, info.Value)

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/mongodb/atlas-sdk-go/auth"
+	"github.com/mongodb/atlas-sdk-go/auth/clientcredentials"
+)
+
+var mu sync.Mutex
+var ts auth.TokenSource
+
+func tokenSource(ctx context.Context, c *Config, base http.RoundTripper) (auth.TokenSource, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if ts != nil {
+		return ts, nil
+	}
+
+	conf := clientcredentials.NewConfig(c.ClientID, c.ClientSecret)
+	// Override TokenURL and RevokeURL if custom BaseURL is provided
+	if c.BaseURL != "" {
+		baseURL := strings.TrimRight(c.BaseURL, "/")
+		conf.TokenURL = baseURL + clientcredentials.TokenAPIPath
+		conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
+	}
+
+	// Create a base HTTP client for token acquisition
+	baseHTTPClient := &http.Client{
+		Transport: base,
+	}
+
+	// Set the HTTP client in context for token acquisition
+	ctx = context.WithValue(ctx, auth.HTTPClient, baseHTTPClient)
+
+	tokenSource := conf.TokenSource(ctx)
+
+	// Acquire an initial token upfront for several reasons:
+	// 1. OAuth2 token caching: The oauth2 library only caches tokens after successful acquisition
+	// 2. Early credential validation: Fail fast during provider init rather than first resource operation
+	// 3. Performance: Subsequent requests use cached tokens instead of blocking for token acquisition
+	if _, err := tokenSource.Token(); err != nil {
+		return nil, err
+	}
+	ts = tokenSource
+	return tokenSource, nil
+}

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -2,50 +2,50 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/mongodb/atlas-sdk-go/auth"
 	"github.com/mongodb/atlas-sdk-go/auth/clientcredentials"
+	"golang.org/x/oauth2"
 )
 
-var mu sync.Mutex
-var ts auth.TokenSource
+var saInfo = struct {
+	tokenSource  auth.TokenSource
+	clientID     string
+	clientSecret string
+	baseURL      string
+	mu           sync.Mutex
+}{}
 
 func tokenSource(ctx context.Context, c *Config, base http.RoundTripper) (auth.TokenSource, error) {
-	mu.Lock()
-	defer mu.Unlock()
+	saInfo.mu.Lock()
+	defer saInfo.mu.Unlock()
 
-	if ts != nil {
-		return ts, nil
+	if saInfo.tokenSource != nil {
+		if saInfo.clientID != c.ClientID || saInfo.clientSecret != c.ClientSecret || saInfo.baseURL != c.BaseURL {
+			return nil, fmt.Errorf("service account credentials changed")
+		}
+		return saInfo.tokenSource, nil
 	}
 
 	conf := clientcredentials.NewConfig(c.ClientID, c.ClientSecret)
-	// Override TokenURL and RevokeURL if custom BaseURL is provided
 	if c.BaseURL != "" {
 		baseURL := strings.TrimRight(c.BaseURL, "/")
 		conf.TokenURL = baseURL + clientcredentials.TokenAPIPath
 		conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 	}
-
-	// Create a base HTTP client for token acquisition
-	baseHTTPClient := &http.Client{
-		Transport: base,
-	}
-
-	// Set the HTTP client in context for token acquisition
-	ctx = context.WithValue(ctx, auth.HTTPClient, baseHTTPClient)
-
-	tokenSource := conf.TokenSource(ctx)
-
-	// Acquire an initial token upfront for several reasons:
-	// 1. OAuth2 token caching: The oauth2 library only caches tokens after successful acquisition
-	// 2. Early credential validation: Fail fast during provider init rather than first resource operation
-	// 3. Performance: Subsequent requests use cached tokens instead of blocking for token acquisition
-	if _, err := tokenSource.Token(); err != nil {
+	ctx = context.WithValue(ctx, auth.HTTPClient, &http.Client{Transport: base})
+	token, err := conf.TokenSource(ctx).Token()
+	if err != nil {
 		return nil, err
 	}
-	ts = tokenSource
-	return tokenSource, nil
+	saInfo.clientID = c.ClientID
+	saInfo.clientSecret = c.ClientSecret
+	saInfo.baseURL = c.BaseURL
+	// TODO: token will be refreshed in a follow-up PR
+	saInfo.tokenSource = oauth2.StaticTokenSource(token)
+	return saInfo.tokenSource, nil
 }

--- a/internal/service/advancedcluster/main_test.go
+++ b/internal/service/advancedcluster/main_test.go
@@ -8,6 +8,18 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Only modify credentials for unit tests. Preserve GH Actions env in acceptance (TF_ACC=1).
+	if os.Getenv("TF_ACC") == "" {
+		// If no credentials are provided, force digest auth to satisfy provider validation.
+		_ = os.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "dummy")
+		_ = os.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "dummy")
+		// Ensure Service Account auth is not selected if we just set digest
+		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
+		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
+		_ = os.Unsetenv("TF_VAR_CLIENT_ID")
+		_ = os.Unsetenv("TF_VAR_CLIENT_SECRET")
+	}
+
 	cleanup := acc.SetupSharedResources()
 	exitCode := m.Run()
 	cleanup()

--- a/internal/service/advancedcluster/main_test.go
+++ b/internal/service/advancedcluster/main_test.go
@@ -8,18 +8,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Only modify credentials for unit tests. Preserve GH Actions env in acceptance (TF_ACC=1).
-	if os.Getenv("TF_ACC") == "" {
-		// If no credentials are provided, force digest auth to satisfy provider validation.
-		_ = os.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "dummy")
-		_ = os.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "dummy")
-		// Ensure Service Account auth is not selected if we just set digest
-		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
-		_ = os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
-		_ = os.Unsetenv("TF_VAR_CLIENT_ID")
-		_ = os.Unsetenv("TF_VAR_CLIENT_SECRET")
-	}
-
 	cleanup := acc.SetupSharedResources()
 	exitCode := m.Run()
 	cleanup()

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -481,10 +481,10 @@ func checkAggr(orgOwnerID, name, description string, settings *admin.Organizatio
 		"name":                       name,
 		"org_owner_id":               orgOwnerID,
 		"description":                description,
-		"api_access_list_required":   strconv.FormatBool(*settings.ApiAccessListRequired),
-		"multi_factor_auth_required": strconv.FormatBool(*settings.MultiFactorAuthRequired),
-		"restrict_employee_access":   strconv.FormatBool(*settings.RestrictEmployeeAccess),
-		"gen_ai_features_enabled":    strconv.FormatBool(*settings.GenAIFeaturesEnabled),
+		"api_access_list_required":   strconv.FormatBool(settings.GetApiAccessListRequired()),
+		"multi_factor_auth_required": strconv.FormatBool(settings.GetMultiFactorAuthRequired()),
+		"restrict_employee_access":   strconv.FormatBool(settings.GetRestrictEmployeeAccess()),
+		"gen_ai_features_enabled":    strconv.FormatBool(settings.GetGenAIFeaturesEnabled()),
 		"security_contact":           settings.GetSecurityContact(),
 	}
 	checks := []resource.TestCheckFunc{

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -52,6 +52,9 @@ func ConnV2UsingGov() *admin.APIClient {
 }
 
 func init() {
+	if InUnitTest() && hasAuthCredentials() {
+		panic("auth credentials can not be set in unit tests")
+	}
 	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
 			return provider.MuxProviderFactory()(), nil
@@ -65,4 +68,9 @@ func init() {
 	}
 	client, _ := cfg.NewClient(context.Background())
 	MongoDBClient = client.(*config.MongoDBClient)
+}
+
+func hasAuthCredentials() bool {
+	return os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != "" ||
+		os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != ""
 }

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -63,6 +63,8 @@ func init() {
 	cfg := config.Config{
 		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
+		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
 	}

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -52,8 +52,11 @@ func ConnV2UsingGov() *admin.APIClient {
 }
 
 func init() {
-	if InUnitTest() && hasAuthCredentials() {
-		panic("auth credentials can not be set in unit tests")
+	if InUnitTest() { // Dummy credentials for unit tests
+		os.Setenv("MONGODB_ATLAS_PUBLIC_KEY", "dummy")
+		os.Setenv("MONGODB_ATLAS_PRIVATE_KEY", "dummy")
+		os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
+		os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
 	}
 	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
@@ -70,9 +73,4 @@ func init() {
 	}
 	client, _ := cfg.NewClient(context.Background())
 	MongoDBClient = client.(*config.MongoDBClient)
-}
-
-func hasAuthCredentials() bool {
-	return os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != "" ||
-		os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != ""
 }

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -11,10 +11,8 @@ import (
 
 func PreCheckBasic(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	if os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
 	}
 }
 

--- a/internal/testutil/acc/skip.go
+++ b/internal/testutil/acc/skip.go
@@ -2,7 +2,7 @@ package acc
 
 import (
 	"os"
-	"strings"
+	"strconv"
 	"testing"
 )
 
@@ -15,7 +15,8 @@ func SkipTestForCI(tb testing.TB) {
 }
 
 func InCI() bool {
-	return strings.EqualFold(os.Getenv("CI"), "true")
+	val, _ := strconv.ParseBool(os.Getenv("CI"))
+	return val
 }
 
 // SkipInUnitTest allows skipping a test entirely when TF_ACC=1 is not defined.


### PR DESCRIPTION
Implement Service Account token caching & thread-safe concurrent access.

Refresh policy will be implemented in a follow-up PR.

Also:
- Don't send AdvancedClusterPreview in User Agent anymore as the environment variable is not longer used.

Link to any related issue(s): CLOUDP-345762

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
