### PR TITLE
chore: Implement Service Account token refresh policy

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: false
         
+
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
       mongodb_atlas_org_id:
         type: string
         required: true
@@ -214,8 +219,10 @@ env:
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
   MONGODB_REALM_BASE_URL: ${{ inputs.mongodb_realm_base_url }}
   MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
-  MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
-  MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
+  MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa == false && secrets.mongodb_atlas_public_key || '' }}
+  MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa == false && secrets.mongodb_atlas_private_key || '' }}
+  MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa  && secrets.mongodb_atlas_client_id || '' }}
+  MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa && secrets.mongodb_atlas_client_secret || '' }}
   MONGODB_ATLAS_PUBLIC_KEY_READ_ONLY: ${{ secrets.mongodb_atlas_public_key_read_only }}
   MONGODB_ATLAS_PRIVATE_KEY_READ_ONLY: ${{ secrets.mongodb_atlas_private_key_read_only }}
   MONGODB_ATLAS_GOV_PUBLIC_KEY: ${{ secrets.mongodb_atlas_gov_public_key }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -537,8 +537,7 @@ jobs:
         run: make testacc
   autogen:
     needs: [change-detection, get-provider-version]
-    # autogen doesn't support SA yet
-    if: ${{ inputs.use_sa == false && (needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen') }}
+    if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -421,7 +421,7 @@ jobs:
  
   advanced_cluster_tpf_mig_from_sdkv2:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.reduced_tests == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
+    if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -446,7 +446,7 @@ jobs:
 
   advanced_cluster_tpf_mig_from_tpf_preview:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.reduced_tests == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
+    if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -213,9 +213,10 @@ env:
   TF_ACC: 1
   TF_LOG: ${{ vars.LOG_LEVEL }}
   ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
-  # Only Migration tests are run when a specific previous provider version is set
-  # If the name (regex) of the test is set, only that test is run
-  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
+  # Only Migration tests are run when a specific previous provider version is set.
+  # Don't run migration tests if using Service Accounts because previous provider versions don't support SA yet.
+  # If the name (regex) of the test is set, only that test is run.
+  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.use_sa && '^TestAcc' || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
   MONGODB_REALM_BASE_URL: ${{ inputs.mongodb_realm_base_url }}
   MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -499,6 +499,8 @@ jobs:
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ""
+          MONGODB_ATLAS_CLIENT_SECRET: ""
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
           AWS_REGION: ${{ vars.AWS_REGION }}
           STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
@@ -534,8 +536,9 @@ jobs:
             ./internal/service/maintenancewindow
         run: make testacc
   autogen:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}
+    needs: [change-detection, get-provider-version]
+    # autogen doesn't support SA yet
+    if: ${{ inputs.use_sa == false && (needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -801,8 +804,9 @@ jobs:
         run: make testacc
 
   event_trigger:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger' }}
+    needs: [change-detection, get-provider-version]
+    # Realm SDK doesn't support SA
+    if: ${{ inputs.use_sa == false && (needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -110,6 +110,7 @@ jobs:
       test_group: ${{ inputs.test_group }}
       test_name: ${{ inputs.test_name }}
       reduced_tests: ${{ inputs.reduced_tests || false }}
+      use_sa: ${{ inputs.use_sa || false }}
       aws_region_federation: ${{ vars.AWS_REGION_FEDERATION }}
       mongodb_atlas_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA || vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
       mongodb_atlas_base_url: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_BASE_URL_QA || vars.MONGODB_ATLAS_BASE_URL }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,5 +1,5 @@
 name: 'Acceptance Tests'
-run-name: 'Acceptance Tests ${{ inputs.atlas_cloud_env }} ${{ inputs.test_group }}'
+run-name: "Acceptance Tests ${{ inputs.atlas_cloud_env }} ${{ inputs.test_group }} ${{ inputs.use_sa && 'sa' || 'pak'}}"
 
 # Used for running acceptance tests, either triggered manually or called by other workflows. 
 on:
@@ -52,6 +52,11 @@ on:
         type: boolean
         required: false
   
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
+
 jobs:
   tests:
     name: tests-${{ inputs.terraform_version || 'latest' }}-${{ inputs.provider_version || 'latest' }}-${{ inputs.atlas_cloud_env || 'dev' }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -29,6 +29,11 @@ on:
         description: 'The branch, tag or SHA where tests will run, e.g. v1.14.0, empty for default branch'
         type: string
         required: false  
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
+
   workflow_call: # workflow runs after Test Suite or code-health
     inputs:
       terraform_version:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,6 +17,10 @@ on:
         description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
         default: false
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
   workflow_call:
     inputs:
       terraform_matrix:
@@ -70,13 +74,14 @@ jobs:
       matrix:
         terraform_version: ${{ fromJSON(needs.variables.outputs.terraform_matrix) }}
         provider_version: ${{ fromJSON(needs.variables.outputs.provider_matrix) }}
-    name: ${{ matrix.terraform_version || 'latest' }}-${{ matrix.provider_version || 'latest' }}
+    name: ${{ matrix.terraform_version || 'latest' }}-${{ matrix.provider_version || 'latest' }}-${{ inputs.use_sa && 'sa' || 'pak' }}
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:
       terraform_version: ${{ matrix.terraform_version }}
       provider_version: ${{ matrix.provider_version }}
       atlas_cloud_env: ${{ inputs.atlas_cloud_env || needs.variables.outputs.is_sun == 'true' && 'qa' || '' }} # Run against QA on Sundays
+      use_sa: ${{ inputs.use_sa || false }}
   clean-after:
     needs: tests
     if: ${{ !cancelled() }}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -154,7 +154,7 @@ type UAMetadata struct {
 }
 
 func (c *Config) NewClient(ctx context.Context) (any, error) {
-	var transport = networkLoggingTransport
+	transport := networkLoggingTransport
 	switch ResolveAuthMethod(c) {
 	case AccessToken:
 		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/mongodb-forks/digest"
 	adminpreview "github.com/mongodb/atlas-sdk-go/admin"
-	"github.com/spf13/cast"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 
@@ -78,16 +77,27 @@ func HasValidAuthCredentials(cp CredentialProvider) bool {
 	return IsDigestAuthPresent(cp) || IsServiceAccountAuthPresent(cp) || IsAccessTokenAuthPresent(cp)
 }
 
-var baseTransport = &http.Transport{
-	DialContext: (&net.Dialer{
-		Timeout:   timeout,
-		KeepAlive: keepAlive,
-	}).DialContext,
-	MaxIdleConns:          maxIdleConns,
-	MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-	Proxy:                 http.ProxyFromEnvironment,
-	IdleConnTimeout:       idleConnTimeout,
-	ExpectContinueTimeout: expectContinueTimeout,
+var (
+	baseTransport http.RoundTripper = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   timeout,
+			KeepAlive: keepAlive,
+		}).DialContext,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+		Proxy:                 http.ProxyFromEnvironment,
+		IdleConnTimeout:       idleConnTimeout,
+		ExpectContinueTimeout: expectContinueTimeout,
+	}
+
+	// Network Logging transport should be used as a base for authentication transport so authentication requests can be logged.
+	networkLoggingTransport = NewTransportWithNetworkLogging(baseTransport, logging.IsDebugOrHigher())
+)
+
+// tfLoggingInterceptor should wrap the authentication transport to add Terraform logging.
+func tfLoggingInterceptor(base http.RoundTripper) http.RoundTripper {
+	// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
+	return logging.NewTransport("Atlas", base)
 }
 
 // MongoDBClient contains the mongodbatlas clients and configurations
@@ -144,44 +154,31 @@ type UAMetadata struct {
 }
 
 func (c *Config) NewClient(ctx context.Context) (any, error) {
-	// Network Logging transport is before authentication transport so it can log authentication requests
-	networkLoggingTransport := NewTransportWithNetworkLogging(baseTransport, logging.IsDebugOrHigher())
-
-	var client *http.Client
-
-	// Determine authentication method based on available credentials
+	var transport = networkLoggingTransport
 	switch ResolveAuthMethod(c) {
 	case AccessToken:
-		// Use a static bearer token with oauth2 transport
 		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
 			AccessToken: c.AccessToken,
-			TokenType:   "Bearer",
+			TokenType:   "Bearer", // Use a static bearer token with oauth2 transport.
 		})
-		oauthTransport := &oauth2.Transport{
+		transport = &oauth2.Transport{
 			Source: tokenSource,
 			Base:   networkLoggingTransport,
 		}
-		tfLoggingTransport := logging.NewTransport("Atlas", oauthTransport)
-		client = &http.Client{Transport: tfLoggingTransport}
 	case ServiceAccount:
-		tokenSource, err := tokenSource(c, networkLoggingTransport)
+		tokenSource, err := getTokenSource(c, networkLoggingTransport)
 		if err != nil {
 			return nil, err
 		}
-		oauthTransport := &oauth2.Transport{
+		transport = &oauth2.Transport{
 			Source: tokenSource,
 			Base:   networkLoggingTransport,
 		}
-		// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
-		tfLoggingTransport := logging.NewTransport("Atlas", oauthTransport)
-		client = &http.Client{Transport: tfLoggingTransport}
 	case Digest:
-		digestTransport := digest.NewTransportWithHTTPRoundTripper(cast.ToString(c.PublicKey), cast.ToString(c.PrivateKey), networkLoggingTransport)
-		// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
-		tfLoggingTransport := logging.NewTransport("Atlas", digestTransport)
-		client = &http.Client{Transport: tfLoggingTransport}
+		transport = digest.NewTransportWithHTTPRoundTripper(c.PublicKey, c.PrivateKey, networkLoggingTransport)
 	case Unknown:
 	}
+	client := &http.Client{Transport: tfLoggingInterceptor(transport)}
 
 	// Initialize the old SDK
 	optsAtlas := []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -163,7 +163,7 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 		oauthClient.Transport = tfLoggingTransport
 		client = oauthClient
 	case ServiceAccount:
-		tokenSource, err := tokenSource(ctx, c, networkLoggingTransport)
+		tokenSource, err := tokenSource(c, networkLoggingTransport)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -23,7 +23,7 @@ var saInfo = struct {
 	mu           sync.Mutex
 }{}
 
-func tokenSource(c *Config, base http.RoundTripper) (auth.TokenSource, error) {
+func getTokenSource(c *Config, tokenRenewalBase http.RoundTripper) (auth.TokenSource, error) {
 	saInfo.mu.Lock()
 	defer saInfo.mu.Unlock()
 
@@ -41,7 +41,7 @@ func tokenSource(c *Config, base http.RoundTripper) (auth.TokenSource, error) {
 		conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 	}
 	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
-	ctx := context.WithValue(context.Background(), auth.HTTPClient, &http.Client{Transport: base})
+	ctx := context.WithValue(context.Background(), auth.HTTPClient, &http.Client{Transport: tokenRenewalBase})
 	tokenSource := oauth2.ReuseTokenSourceWithExpiry(nil, conf.TokenSource(ctx), saTokenExpiryBuffer)
 	if _, err := tokenSource.Token(); err != nil { // Retrieve token to fail-fast if credentials are invalid.
 		return nil, err

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -23,7 +23,7 @@ var saInfo = struct {
 	mu           sync.Mutex
 }{}
 
-func tokenSource(ctx context.Context, c *Config, base http.RoundTripper) (auth.TokenSource, error) {
+func tokenSource(c *Config, base http.RoundTripper) (auth.TokenSource, error) {
 	saInfo.mu.Lock()
 	defer saInfo.mu.Unlock()
 
@@ -40,7 +40,8 @@ func tokenSource(ctx context.Context, c *Config, base http.RoundTripper) (auth.T
 		conf.TokenURL = baseURL + clientcredentials.TokenAPIPath
 		conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 	}
-	ctx = context.WithValue(ctx, auth.HTTPClient, &http.Client{Transport: base})
+	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
+	ctx := context.WithValue(context.Background(), auth.HTTPClient, &http.Client{Transport: base})
 	tokenSource := oauth2.ReuseTokenSourceWithExpiry(nil, conf.TokenSource(ctx), saTokenExpiryBuffer)
 	if _, err := tokenSource.Token(); err != nil { // Retrieve token to fail-fast if credentials are invalid.
 		return nil, err

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// Renew token if it expires within 10 minutes to avoid authentication errors during Atlas API calls.
 const saTokenExpiryBuffer = 10 * time.Minute
 
 var saInfo = struct {

--- a/internal/config/transport.go
+++ b/internal/config/transport.go
@@ -16,10 +16,7 @@ type NetworkLoggingTransport struct {
 
 // NewTransportWithNetworkLogging creates a new NetworkLoggingTransport that wraps
 // the provided transport with enhanced network logging capabilities.
-func NewTransportWithNetworkLogging(transport http.RoundTripper, enabled bool) *NetworkLoggingTransport {
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
+func NewTransportWithNetworkLogging(transport http.RoundTripper, enabled bool) http.RoundTripper {
 	return &NetworkLoggingTransport{
 		Transport: transport,
 		Enabled:   enabled,

--- a/internal/config/transport_test.go
+++ b/internal/config/transport_test.go
@@ -160,9 +160,11 @@ func TestAccNetworkLogging(t *testing.T) {
 	log.SetOutput(&logOutput)
 	defer log.SetOutput(os.Stderr)
 	cfg := &config.Config{
-		PublicKey:  os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
-		PrivateKey: os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
-		BaseURL:    os.Getenv("MONGODB_ATLAS_BASE_URL"),
+		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
+		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
+		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
+		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 	}
 	clientInterface, err := cfg.NewClient(t.Context())
 	require.NoError(t, err)

--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 func TestAccSTSAssumeRole_basic(t *testing.T) {
+	acc.SkipInPAK(t, "skipping as this test is for AWS credentials only")
+	acc.SkipInSA(t, "skipping as this test is for AWS credentials only")
 	var (
 		resourceName = "mongodbatlas_project.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckSTSAssumeRole(t); acc.PreCheckPAKCredsAreEmpty(t); acc.PreCheckSACredsAreEmpty(t) },
+		PreCheck:                 func() { acc.PreCheckSTSAssumeRole(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyProject,
 		Steps: []resource.TestStep{
@@ -41,12 +43,13 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 }
 
 func TestAccServiceAccount_basic(t *testing.T) {
+	acc.SkipInPAK(t, "skipping as this test is for SA only")
 	var (
 		resourceName = "data.mongodbatlas_organization.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckServiceAccount(t); acc.PreCheckPAKCredsAreEmpty(t) },
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
@@ -61,12 +64,14 @@ func TestAccServiceAccount_basic(t *testing.T) {
 
 func TestAccAccessToken_basic(t *testing.T) {
 	acc.SkipTestForCI(t) // access token has a validity period of 1 hour, so it cannot be used in CI reliably
+	acc.SkipInPAK(t, "skipping as this test is for Token credentials only")
+	acc.SkipInSA(t, "skipping as this test is for Token credentials only")
 	var (
 		resourceName = "data.mongodbatlas_organization.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckAccessToken(t); acc.PreCheckPAKCredsAreEmpty(t); acc.PreCheckSACredsAreEmpty(t) },
+		PreCheck:                 func() { acc.PreCheckAccessToken(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/project/resource_project_migration_test.go
+++ b/internal/service/project/resource_project_migration_test.go
@@ -153,6 +153,7 @@ func TestMigProject_withLimits(t *testing.T) {
 
 // based on bug report: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2263
 func TestMigGovProject_regionUsageRestrictionsDefault(t *testing.T) {
+	acc.SkipInSA(t, "SA not supported in Gov tests yet")
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_GOV_ORG_ID")
 		projectName = acc.RandomProjectName()

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -638,6 +638,7 @@ func TestAccProject_basic(t *testing.T) {
 }
 
 func TestAccGovProject_withProjectOwner(t *testing.T) {
+	acc.SkipInSA(t, "SA not supported in Gov tests yet")
 	var (
 		orgID          = os.Getenv("MONGODB_ATLAS_GOV_ORG_ID")
 		projectOwnerID = os.Getenv("MONGODB_ATLAS_GOV_PROJECT_OWNER_ID")

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -14,6 +14,12 @@ func PreCheckBasic(tb testing.TB) {
 	if os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
 		tb.Fatal("`MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
 	}
+	if HasPAKCreds() && HasSACreds() {
+		tb.Fatal("PAK and SA credentials are defined in this test but only one should be set.")
+	}
+	if !HasPAKCreds() && !HasSACreds() {
+		tb.Fatal("No credentials are defined in this test, PAK or SA credentials should be set.")
+	}
 }
 
 // PreCheckBasicSleep is a helper function to call SerialSleep, see its help for more info.
@@ -36,31 +42,25 @@ func PreCheckBasicSleep(tb testing.TB, clusterInfo *ClusterInfo, projectID, clus
 // Use PreCheckBasic instead.
 func PreCheck(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_ID` and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	PreCheckBasic(tb)
+	if os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_ID` must be set for acceptance testing")
 	}
 }
 
 func PreCheckEncryptionAtRestPrivateEndpoint(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_EAR_PE_ID` and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	PreCheckBasic(tb)
+	if os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_EAR_PE_ID` must be set for acceptance testing")
 	}
 }
 
 func PreCheckCert(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" ||
-		os.Getenv("CA_CERT") == "" {
-		tb.Fatal("`CA_CERT, MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	PreCheckBasic(tb)
+	if os.Getenv("CA_CERT") == "" {
+		tb.Fatal("`CA_CERT` must be set for acceptance testing")
 	}
 }
 
@@ -267,42 +267,13 @@ func PreCheckAwsEnvPrivateLinkEndpointService(tb testing.TB) {
 	}
 }
 
-func PreCheckPAKCredsAreEmpty(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != "" {
-		tb.Fatal(`"MONGODB_ATLAS_PUBLIC_KEY" and "MONGODB_ATLAS_PRIVATE_KEY" are defined in this test and they should not.`)
-	}
-}
-
-func PreCheckSACredsAreEmpty(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != "" {
-		tb.Fatal(`"MONGODB_ATLAS_CLIENT_ID" and "MONGODB_ATLAS_CLIENT_SECRET" are defined in this test and they should not.`)
-	}
-}
-
 func PreCheckSTSAssumeRole(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("AWS_REGION") == "" {
-		tb.Fatal(`'AWS_REGION' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("STS_ENDPOINT") == "" {
-		tb.Fatal(`'STS_ENDPOINT' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("ASSUME_ROLE_ARN") == "" {
-		tb.Fatal(`'ASSUME_ROLE_ARN' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		tb.Fatal(`'AWS_ACCESS_KEY_ID' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		tb.Fatal(`'AWS_SECRET_ACCESS_KEY' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_SESSION_TOKEN") == "" {
-		tb.Fatal(`'AWS_SESSION_TOKEN' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("SECRET_NAME") == "" {
-		tb.Fatal(`'SECRET_NAME' must be set for acceptance testing with STS Assume Role.`)
+	envVars := []string{"AWS_REGION", "STS_ENDPOINT", "ASSUME_ROLE_ARN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "SECRET_NAME"}
+	for _, envVar := range envVars {
+		if os.Getenv(envVar) == "" {
+			tb.Fatal(`'${envVar}' must be set for acceptance testing with STS Assume Role.`)
+		}
 	}
 }
 
@@ -380,14 +351,6 @@ func PreCheckAwsMsk(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_MSK_ARN") == "" {
 		tb.Fatal("`AWS_MSK_ARN` must be set for AWS MSK acceptance testing")
-	}
-}
-
-func PreCheckServiceAccount(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_CLIENT_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") == "" {
-		tb.Fatal("`MONGODB_ATLAS_CLIENT_ID`, `MONGODB_ATLAS_CLIENT_SECRET` must be set for Service Account acceptance testing")
 	}
 }
 

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -272,7 +272,7 @@ func PreCheckSTSAssumeRole(tb testing.TB) {
 	envVars := []string{"AWS_REGION", "STS_ENDPOINT", "ASSUME_ROLE_ARN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "SECRET_NAME"}
 	for _, envVar := range envVars {
 		if os.Getenv(envVar) == "" {
-			tb.Fatal(`'${envVar}' must be set for acceptance testing with STS Assume Role.`)
+			tb.Fatalf("`%s` must be set for acceptance testing with STS Assume Role.", envVar)
 		}
 	}
 }

--- a/internal/testutil/acc/skip.go
+++ b/internal/testutil/acc/skip.go
@@ -31,3 +31,25 @@ func SkipInUnitTest(tb testing.TB) {
 func InUnitTest() bool {
 	return os.Getenv("TF_ACC") == ""
 }
+
+func HasPAKCreds() bool {
+	return os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != ""
+}
+
+func HasSACreds() bool {
+	return os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != ""
+}
+
+func SkipInSA(tb testing.TB, description string) {
+	tb.Helper()
+	if HasSACreds() {
+		tb.Skip(description)
+	}
+}
+
+func SkipInPAK(tb testing.TB, description string) {
+	tb.Helper()
+	if HasPAKCreds() {
+		tb.Skip(description)
+	}
+}


### PR DESCRIPTION
Implement Service Account token refresh policy allowing a 10m expiry buffer.

Also:
- Refactor `NewClient` function to reduce duplication and make it clearer.
- Update acc test GitHub Action config and test helper functions like pre-checks to allow running acc tests with SA credentials.
- Some acc test groups are passing and some failing with SA, see an example of [execution](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/18118611301). Follow-up investigations and PRs will take care of them.  As an example, CLOUDP-348041 has been created.

Link to any related issue(s): CLOUDP-345760

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
