### PR TITLE
chore: Fix no disk issue in tf-validate GitHub action

### DIFF
--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -42,5 +42,7 @@ for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u)
   terraform fmt -check -recursive
   terraform validate
 
+  rm -rf ".terraform"
+  rm -rf ".terraform.lock.hcl"
   popd
 done


### PR DESCRIPTION
## Description

Fix no disk issue in tf-validate GitHub action.

The tf-validate action was running out of disk space during validation of large Terraform configurations. Some examples like mongodbatlas_stream_privatelink_endpoint/aws_msk_cluster can consume up to 700 MB each, causing disk space to accumulate and eventually exhaust available storage.

In this PR we remove the files after each example is validated, preventing disk space from accumulating 

Link to any related issue(s): CLOUDP-347447

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
