### PR TITLE
chore: Cache plugins in tf-validate GitHub action

### DIFF
--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -22,6 +22,11 @@ find ./examples -type f -name ".terraform.lock.hcl" -exec rm -f {} +
 
 export TF_CLI_CONFIG_FILE="$PWD/bin-examples/tf-validate.tfrc"
 
+# Cache plugins so no need to download them every time
+CACHE_DIR="$PWD/cache-examples"
+mkdir -p "$CACHE_DIR"
+export TF_PLUGIN_CACHE_DIR="$CACHE_DIR"
+
 # Use local provider to validate examples
 go build -o bin-examples/terraform-provider-mongodbatlas .
 


### PR DESCRIPTION
## Description

Cache plugins in tf-validate so no need to download them every time

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
