### PR TITLE
fix: Remove https_ca_pem from the Kafka stream connection

### DIFF
--- a/.changelog/3715.txt
+++ b/.changelog/3715.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/mongodbatlas_stream_connection: remove https_ca_pem from the Kafka stream connection
+```
+
+```release-note:bug
+data-source/mongodbatlas_stream_connection: remove https_ca_pem from the Kafka stream connection
+```
+
+```release-note:bug
+data-source/mongodbatlas_stream_connections: remove https_ca_pem from the Kafka stream connection
+```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -55,7 +55,6 @@ If `type` is of value `Https` the following additional attributes are defined:
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Kafka clients use this to specify the scope of the access request to the broker.
 * `sasl_oauthbearer_extensions` - Additional information to be provided to the Kafka broker.
-* `https_ca_pem` - The CA certificates as a PEM string.
 
 ### Security
 

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -66,7 +66,6 @@ If `type` is of value `Https` the following additional attributes are defined:
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Kafka clients use this to specify the scope of the access request to the broker.
 * `sasl_oauthbearer_extensions` - Additional information to be provided to the Kafka broker.
-* `https_ca_pem` - The CA certificates as a PEM string.
 
 ### Security
 

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -77,7 +77,6 @@ resource "mongodbatlas_stream_connection" "example-kafka-oauthbearer" {
         client_secret  = var.kafka_client_secret
         scope = "read:messages write:messages"
         sasl_oauthbearer_extensions = "logicalCluster=lkc-kmom,identityPoolId=pool-lAr"
-        https_ca_pem = "pemtext"
     }
     bootstrap_servers = "localhost:9092,localhost:9092"
     config = {
@@ -185,7 +184,6 @@ If `type` is of value `Https` the following additional attributes are defined:
 * `client_secret` - Secret known only to the Kafka client and the authorization server.
 * `scope` - Kafka clients use this to specify the scope of the access request to the broker.
 * `sasl_oauthbearer_extensions` - Additional information to be provided to the Kafka broker.
-* `https_ca_pem` - The CA certificates as a PEM string.
 
 ### Security
 

--- a/examples/mongodbatlas_stream_connection/main.tf
+++ b/examples/mongodbatlas_stream_connection/main.tf
@@ -68,7 +68,6 @@ resource "mongodbatlas_stream_connection" "example-kafka-oauthbearer" {
     client_secret               = var.kafka_client_secret
     scope                       = "read:messages write:messages"
     sasl_oauthbearer_extensions = "logicalCluster=lkc-kmom,identityPoolId=pool-lAr"
-    https_ca_pem                = "pemtext"
   }
   bootstrap_servers = "localhost:9092,localhost:9092"
   config = {

--- a/internal/service/streamconnection/model_stream_connection.go
+++ b/internal/service/streamconnection/model_stream_connection.go
@@ -35,7 +35,6 @@ func NewStreamConnectionReq(ctx context.Context, plan *TFStreamConnectionModel) 
 			ClientSecret:              authenticationModel.ClientSecret.ValueStringPointer(),
 			Scope:                     authenticationModel.Scope.ValueStringPointer(),
 			SaslOauthbearerExtensions: authenticationModel.SaslOauthbearerExtensions.ValueStringPointer(),
-			HttpsCaPem:                authenticationModel.HTTPSCaPem.ValueStringPointer(),
 		}
 	}
 	if !plan.Security.IsNull() {
@@ -227,7 +226,6 @@ func newTFConnectionAuthenticationModel(ctx context.Context, currAuthConfig *typ
 			ClientID:                  types.StringPointerValue(authResp.ClientId),
 			Scope:                     types.StringPointerValue(authResp.Scope),
 			SaslOauthbearerExtensions: types.StringPointerValue(authResp.SaslOauthbearerExtensions),
-			HTTPSCaPem:                types.StringPointerValue(authResp.HttpsCaPem),
 		}
 
 		if currAuthConfig != nil && !currAuthConfig.IsNull() { // if config is available (create & update of resource) password value is set in new state

--- a/internal/service/streamconnection/model_stream_connection_test.go
+++ b/internal/service/streamconnection/model_stream_connection_test.go
@@ -25,7 +25,6 @@ const (
 	tokenEndpointURL          = "https://your-domain.com/oauth2/token"
 	scope                     = "read:messages write:messages"
 	saslOauthbearerExtentions = "logicalCluster=cluster-kmo17m,identityPoolId=pool-l7Arl"
-	httpsCaPem                = "MHWER3343"
 	securityProtocol          = "SASL_SSL"
 	bootstrapServers          = "localhost:9092,another.host:9092"
 	dbRole                    = "customRole"
@@ -58,7 +57,7 @@ type sdkToTFModelTestCase struct {
 
 func TestStreamConnectionSDKToTFModel(t *testing.T) {
 	var authConfigWithPasswordDefined = tfAuthenticationObject(t, authMechanism, authUsername, "raw password")
-	var authConfigWithOAuth = tfAuthenticationObjectForOAuth(t, authMechanismOAuth, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtentions, httpsCaPem)
+	var authConfigWithOAuth = tfAuthenticationObjectForOAuth(t, authMechanismOAuth, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtentions)
 
 	testCases := []sdkToTFModelTestCase{
 		{
@@ -166,7 +165,6 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 					TokenEndpointUrl:          admin.PtrString(tokenEndpointURL),
 					Scope:                     admin.PtrString(scope),
 					SaslOauthbearerExtensions: admin.PtrString(saslOauthbearerExtentions),
-					HttpsCaPem:                admin.PtrString(httpsCaPem),
 				},
 				BootstrapServers: admin.PtrString(bootstrapServers),
 				Config:           &configMap,
@@ -183,7 +181,7 @@ func TestStreamConnectionSDKToTFModel(t *testing.T) {
 				InstanceName:     types.StringValue(instanceName),
 				ConnectionName:   types.StringValue(connectionName),
 				Type:             types.StringValue("Kafka"),
-				Authentication:   tfAuthenticationObjectForOAuth(t, authMechanismOAuth, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtentions, httpsCaPem), // password value is obtained from config, not api resp.
+				Authentication:   tfAuthenticationObjectForOAuth(t, authMechanismOAuth, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtentions), // password value is obtained from config, not api resp.
 				BootstrapServers: types.StringValue(bootstrapServers),
 				Config:           tfConfigMap(t, configMap),
 				Security:         tfSecurityObject(t, DummyCACert, securityProtocol),
@@ -643,7 +641,7 @@ func tfAuthenticationObject(t *testing.T, mechanism, username, password string) 
 	return auth
 }
 
-func tfAuthenticationObjectForOAuth(t *testing.T, mechanism, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtensions, httpsCaPem string) types.Object {
+func tfAuthenticationObjectForOAuth(t *testing.T, mechanism, clientID, clientSecret, tokenEndpointURL, scope, saslOauthbearerExtensions string) types.Object {
 	t.Helper()
 	auth, diags := types.ObjectValueFrom(t.Context(), streamconnection.ConnectionAuthenticationObjectType.AttrTypes, streamconnection.TFConnectionAuthenticationModel{
 		Mechanism:                 types.StringValue(mechanism),
@@ -652,7 +650,6 @@ func tfAuthenticationObjectForOAuth(t *testing.T, mechanism, clientID, clientSec
 		TokenEndpointURL:          types.StringValue(tokenEndpointURL),
 		Scope:                     types.StringValue(scope),
 		SaslOauthbearerExtensions: types.StringValue(saslOauthbearerExtensions),
-		HTTPSCaPem:                types.StringValue(httpsCaPem),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data model: %s", diags.Errors()[0].Summary())

--- a/internal/service/streamconnection/resource_schema.go
+++ b/internal/service/streamconnection/resource_schema.go
@@ -98,9 +98,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"sasl_oauthbearer_extensions": schema.StringAttribute{
 						Optional: true,
 					},
-					"https_ca_pem": schema.StringAttribute{
-						Optional: true,
-					},
 				},
 			},
 			"bootstrap_servers": schema.StringAttribute{

--- a/internal/service/streamconnection/resource_stream_connection.go
+++ b/internal/service/streamconnection/resource_stream_connection.go
@@ -62,7 +62,6 @@ type TFConnectionAuthenticationModel struct {
 	ClientSecret              types.String `tfsdk:"client_secret"`
 	Scope                     types.String `tfsdk:"scope"`
 	SaslOauthbearerExtensions types.String `tfsdk:"sasl_oauthbearer_extensions"`
-	HTTPSCaPem                types.String `tfsdk:"https_ca_pem"`
 }
 
 var ConnectionAuthenticationObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -74,7 +73,6 @@ var ConnectionAuthenticationObjectType = types.ObjectType{AttrTypes: map[string]
 	"client_secret":               types.StringType,
 	"scope":                       types.StringType,
 	"sasl_oauthbearer_extensions": types.StringType,
-	"https_ca_pem":                types.StringType,
 }}
 
 type TFConnectionSecurityModel struct {

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -81,7 +81,7 @@ func testCaseKafkaPlaintext(t *testing.T, nameSuffix string) *resource.TestCase 
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: dataSourcesConfig + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092,localhost:9092", "earliest", "", false),
+				Config: dataSourcesConfig + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", ""), "localhost:9092,localhost:9092", "earliest", "", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkKafkaAttributes(resourceName, instanceName, connectionName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, true),
 					checkKafkaAttributes(dataSourceName, instanceName, connectionName, "user", "rawpassword", "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, false),
@@ -89,7 +89,7 @@ func testCaseKafkaPlaintext(t *testing.T, nameSuffix string) *resource.TestCase 
 				),
 			},
 			{
-				Config: dataSourcesWithPagination + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user2", "otherpassword", "", "", "", "", "", ""), "localhost:9093", "latest", kafkaNetworkingPublic, false),
+				Config: dataSourcesWithPagination + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("PLAIN", "user2", "otherpassword", "", "", "", "", ""), "localhost:9093", "latest", kafkaNetworkingPublic, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkKafkaAttributes(resourceName, instanceName, connectionName, "user2", "otherpassword", "localhost:9093", "latest", networkingTypePublic, false, true),
 					checkKafkaAttributes(dataSourceName, instanceName, connectionName, "user2", "otherpassword", "localhost:9093", "latest", networkingTypePublic, false, false),
@@ -120,7 +120,7 @@ func TestAccStreamRSStreamConnection_kafkaOAuthBearer(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: dataSourcesConfig + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, httpsCaPem), "localhost:9092,localhost:9092", "earliest", "", false),
+				Config: dataSourcesConfig + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions), "localhost:9092,localhost:9092", "earliest", "", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, true),
 					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, false),
@@ -128,7 +128,7 @@ func TestAccStreamRSStreamConnection_kafkaOAuthBearer(t *testing.T) {
 				),
 			},
 			{
-				Config: dataSourcesWithPagination + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, httpsCaPem), "localhost:9093", "latest", kafkaNetworkingPublic, false),
+				Config: dataSourcesWithPagination + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions), "localhost:9093", "latest", kafkaNetworkingPublic, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, "localhost:9093", "latest", networkingTypePublic, false, true),
 					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, "localhost:9093", "latest", networkingTypePublic, false, false),
@@ -164,7 +164,7 @@ func TestAccStreamRSStreamConnection_kafkaNetworkingVPC(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config: networkPeeringConfig + configureKafka(projectID, instanceName, "kafka-conn-vpc", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				Check:  checkKafkaAttributes(resourceName, instanceName, "kafka-conn-vpc", "user", "rawpassword", "localhost:9092", "earliest", networkingTypeVPC, true, true),
 			},
 			{
@@ -195,7 +195,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 		CheckDestroy:             CheckDestroyStreamConnection,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf("%s\n%s", configureKafka(projectID, instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPublic, true), dataSourceConfig),
+				Config: fmt.Sprintf("%s\n%s", configureKafka(projectID, instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPublic, true), dataSourceConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkKafkaAttributes(resourceName, instanceName, "kafka-conn-ssl", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, true, true),
 					checkKafkaAttributes(dataSourceName, instanceName, "kafka-conn-ssl", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePublic, true, false),
@@ -203,7 +203,7 @@ func TestAccStreamRSStreamConnection_kafkaSSL(t *testing.T) {
 			},
 			// cannot change networking access type once set
 			{
-				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
+				Config:      networkPeeringConfig + configureKafka(projectID, instanceName, "kafka-conn-ssl", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingVPC, true),
 				ExpectError: regexp.MustCompile("STREAM_NETWORKING_ACCESS_TYPE_CANNOT_BE_MODIFIED"),
 			},
 			{
@@ -360,7 +360,7 @@ func TestAccStreamPrivatelinkEndpoint_streamConnection(t *testing.T) {
 				Config: fmt.Sprintf(`
 					%[1]s
 					%[2]s
-				`, privatelinkConfig, configureKafka(projectID, instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)),
+				`, privatelinkConfig, configureKafka(projectID, instanceName, "kafka-conn-privatelink", getKafkaAuthenticationConfig("PLAIN", "user", "rawpassword", "", "", "", "", ""), "localhost:9092", "earliest", kafkaNetworkingPrivatelink, true)),
 				Check: checkKafkaAttributes(resourceName, instanceName, "kafka-conn-privatelink", "user", "rawpassword", "localhost:9092", "earliest", networkingTypePrivatelink, true, true),
 			},
 			{

--- a/internal/service/streamconnection/resource_stream_connection_test.go
+++ b/internal/service/streamconnection/resource_stream_connection_test.go
@@ -122,16 +122,16 @@ func TestAccStreamRSStreamConnection_kafkaOAuthBearer(t *testing.T) {
 			{
 				Config: dataSourcesConfig + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, httpsCaPem), "localhost:9092,localhost:9092", "earliest", "", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, httpsCaPem, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, true),
-					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, httpsCaPem, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, false),
+					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, true),
+					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtentions, "localhost:9092,localhost:9092", "earliest", networkingTypePublic, false, false),
 					streamConnectionsAttributeChecks(pluralDataSourceName, nil, nil),
 				),
 			},
 			{
 				Config: dataSourcesWithPagination + configureKafka(projectID, instanceName, connectionName, getKafkaAuthenticationConfig("OAUTHBEARER", "", "", tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, httpsCaPem), "localhost:9093", "latest", kafkaNetworkingPublic, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, httpsCaPem, "localhost:9093", "latest", networkingTypePublic, false, true),
-					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, httpsCaPem, "localhost:9093", "latest", networkingTypePublic, false, false),
+					checkKafkaOAuthAttributes(resourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, "localhost:9093", "latest", networkingTypePublic, false, true),
+					checkKafkaOAuthAttributes(dataSourceName, instanceName, connectionName, tokenEndpointURL, "clientId2", "clientSecret", scope, saslOauthbearerExtentions, "localhost:9093", "latest", networkingTypePublic, false, false),
 					streamConnectionsAttributeChecks(pluralDataSourceName, conversion.Pointer(2), conversion.Pointer(1)),
 				),
 			},
@@ -400,7 +400,7 @@ func TestAccStreamRSStreamConnection_AWSLambda(t *testing.T) {
 	})
 }
 
-func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, httpsCaPem string) string {
+func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions string) string {
 	if mechanism == "PLAIN" {
 		return fmt.Sprintf(`authentication = {
 			mechanism = %[1]q
@@ -415,8 +415,7 @@ func getKafkaAuthenticationConfig(mechanism, username, password, tokenEndpointUR
 			client_secret = %[4]q
 			scope = %[5]q
 			sasl_oauthbearer_extensions = %[6]q
-			https_ca_pem = %[7]q
-		}`, mechanism, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, httpsCaPem)
+		}`, mechanism, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions)
 }
 
 func configureKafka(projectID, instanceName, connectionName, authenticationConfig, bootstrapServers, configValue, networkingConfig string, useSSL bool) string {
@@ -519,7 +518,7 @@ func checkKafkaAttributes(
 }
 
 func checkKafkaOAuthAttributes(
-	resourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, httpsCaPem, bootstrapServers, configValue, networkingType string, usesSSL, checkClientSecret bool) resource.TestCheckFunc {
+	resourceName, instanceName, connectionName, tokenEndpointURL, clientID, clientSecret, scope, saslOauthbearerExtensions, bootstrapServers, configValue, networkingType string, usesSSL, checkClientSecret bool) resource.TestCheckFunc {
 	resourceChecks := []resource.TestCheckFunc{
 		checkStreamConnectionExists(),
 		resource.TestCheckResourceAttrSet(resourceName, "project_id"),
@@ -531,7 +530,6 @@ func checkKafkaOAuthAttributes(
 		resource.TestCheckResourceAttr(resourceName, "authentication.client_id", clientID),
 		resource.TestCheckResourceAttr(resourceName, "authentication.scope", scope),
 		resource.TestCheckResourceAttr(resourceName, "authentication.sasl_oauthbearer_extensions", saslOauthbearerExtensions),
-		resource.TestCheckResourceAttr(resourceName, "authentication.https_ca_pem", httpsCaPem),
 		resource.TestCheckResourceAttr(resourceName, "bootstrap_servers", bootstrapServers),
 		resource.TestCheckResourceAttr(resourceName, "config.auto.offset.reset", configValue),
 	}

--- a/internal/serviceapi/streaminstanceapi/resource_schema.go
+++ b/internal/serviceapi/streaminstanceapi/resource_schema.go
@@ -30,10 +30,6 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 									MarkdownDescription: "OIDC client secret for authentication to the Kafka cluster.",
 									Sensitive:           true,
 								},
-								"https_ca_pem": schema.StringAttribute{
-									Computed:            true,
-									MarkdownDescription: "HTTPS CA certificate in PEM format for SSL/TLS verification.",
-								},
 								"mechanism": schema.StringAttribute{
 									Computed:            true,
 									MarkdownDescription: "Style of authentication. Can be one of PLAIN, SCRAM-256, SCRAM-512, or OAUTHBEARER.",
@@ -259,7 +255,6 @@ type TFConnectionsModel struct {
 type TFConnectionsAuthenticationModel struct {
 	ClientId                  types.String `tfsdk:"client_id" autogen:"omitjson"`
 	ClientSecret              types.String `tfsdk:"client_secret" autogen:"omitjson"`
-	HttpsCaPem                types.String `tfsdk:"https_ca_pem" autogen:"omitjson"`
 	Mechanism                 types.String `tfsdk:"mechanism" autogen:"omitjson"`
 	Password                  types.String `tfsdk:"password" autogen:"omitjson"`
 	SaslOauthbearerExtensions types.String `tfsdk:"sasl_oauthbearer_extensions" autogen:"omitjson"`


### PR DESCRIPTION
## Description
This change removes https_ca_pem attribute from the stream connection for Kafka type

Link to any related issue(s):
https://jira.mongodb.org/browse/CLOUDP-347512

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
