### PR TITLE
feat: Adds support for JWT Token credentials as provider inputs, environment variables and AWS Secrets Manager

### DIFF
--- a/.changelog/3716.txt
+++ b/.changelog/3716.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+provider: Supports JWT Token as credentials to authenticate the provider
+```

--- a/.changelog/3716.txt
+++ b/.changelog/3716.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-provider: Supports JWT Token as credentials to authenticate the provider
+provider: Supports Service Account JWT Token as credentials to authenticate the provider
 ```

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -64,23 +64,23 @@ type CredentialProvider interface {
 }
 
 // IsDigestAuth checks if public/private key credentials are present
-func IsDigestAuth(cp CredentialProvider) bool {
+func IsDigestAuthPresent(cp CredentialProvider) bool {
 	return cp.GetPublicKey() != "" && cp.GetPrivateKey() != ""
 }
 
 // IsServiceAccountAuth checks if client ID/secret credentials are present
-func IsServiceAccountAuth(cp CredentialProvider) bool {
+func IsServiceAccountAuthPresent(cp CredentialProvider) bool {
 	return cp.GetClientID() != "" && cp.GetClientSecret() != ""
 }
 
 // IsAccessTokenAuth checks if access token credentials are present
-func IsAccessTokenAuth(cp CredentialProvider) bool {
+func IsAccessTokenAuthPresent(cp CredentialProvider) bool {
 	return cp.GetAccessToken() != ""
 }
 
 // HasValidAuthCredentials checks if any valid authentication method is provided
 func HasValidAuthCredentials(cp CredentialProvider) bool {
-	return IsDigestAuth(cp) || IsServiceAccountAuth(cp) || IsAccessTokenAuth(cp)
+	return IsDigestAuthPresent(cp) || IsServiceAccountAuthPresent(cp) || IsAccessTokenAuthPresent(cp)
 }
 
 var baseTransport = &http.Transport{
@@ -427,13 +427,13 @@ func userAgent(c *Config) string {
 
 // ResolveAuthMethod determines the authentication method from any credential provider
 func ResolveAuthMethod(cg CredentialProvider) AuthMethod {
-	if IsAccessTokenAuth(cg) {
+	if IsAccessTokenAuthPresent(cg) {
 		return AccessToken
 	}
-	if IsServiceAccountAuth(cg) {
+	if IsServiceAccountAuthPresent(cg) {
 		return ServiceAccount
 	}
-	if IsDigestAuth(cg) {
+	if IsDigestAuthPresent(cg) {
 		return Digest
 	}
 	return Unknown

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -29,6 +29,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312007/auth/clientcredentials"
 
 	"go.mongodb.org/atlas-sdk/v20250312007/auth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -49,6 +50,7 @@ type AuthMethod int
 const (
 	ServiceAccount AuthMethod = iota
 	Digest
+	AccessToken
 	Unknown
 )
 
@@ -58,6 +60,7 @@ type CredentialProvider interface {
 	GetPrivateKey() string
 	GetClientID() string
 	GetClientSecret() string
+	GetAccessToken() string
 }
 
 // IsDigestAuth checks if public/private key credentials are present
@@ -70,9 +73,14 @@ func IsServiceAccountAuth(cp CredentialProvider) bool {
 	return cp.GetClientID() != "" && cp.GetClientSecret() != ""
 }
 
+// IsAccessTokenAuth checks if access token credentials are present
+func IsAccessTokenAuth(cp CredentialProvider) bool {
+	return cp.GetAccessToken() != ""
+}
+
 // HasValidAuthCredentials checks if any valid authentication method is provided
 func HasValidAuthCredentials(cp CredentialProvider) bool {
-	return IsDigestAuth(cp) || IsServiceAccountAuth(cp)
+	return IsDigestAuth(cp) || IsServiceAccountAuth(cp) || IsAccessTokenAuth(cp)
 }
 
 var baseTransport = &http.Transport{
@@ -108,6 +116,7 @@ type Config struct {
 	TerraformVersion                string
 	ClientID                        string
 	ClientSecret                    string
+	AccessToken                     string
 	PreviewV2AdvancedClusterEnabled bool
 }
 
@@ -116,6 +125,7 @@ func (c *Config) GetPublicKey() string    { return c.PublicKey }
 func (c *Config) GetPrivateKey() string   { return c.PrivateKey }
 func (c *Config) GetClientID() string     { return c.ClientID }
 func (c *Config) GetClientSecret() string { return c.ClientSecret }
+func (c *Config) GetAccessToken() string  { return c.AccessToken }
 
 type AssumeRole struct {
 	Tags              map[string]string
@@ -186,6 +196,17 @@ func (c *Config) NewClient(ctx context.Context) (any, error) {
 		// Don't change logging.NewTransport to NewSubsystemLoggingHTTPTransport until all resources are in TPF.
 		tfLoggingTransport := logging.NewTransport("Atlas", digestTransport)
 		client = &http.Client{Transport: tfLoggingTransport}
+		optsAtlas = []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
+	case AccessToken:
+		// Use a static bearer token with oauth2 transport
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: c.AccessToken,
+			TokenType:   "Bearer",
+		})
+		oauthClient := auth.NewClient(ctx, tokenSource)
+		tfLoggingTransport := logging.NewTransport("Atlas", oauthClient.Transport)
+		oauthClient.Transport = tfLoggingTransport
+		client = oauthClient
 		optsAtlas = []matlasClient.ClientOpt{matlasClient.SetUserAgent(userAgent(c))}
 	case Unknown:
 	}
@@ -411,6 +432,9 @@ func ResolveAuthMethod(cg CredentialProvider) AuthMethod {
 	}
 	if IsDigestAuth(cg) {
 		return Digest
+	}
+	if IsAccessTokenAuth(cg) {
+		return AccessToken
 	}
 	return Unknown
 }

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -76,14 +76,14 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	}
 
 	switch config.ResolveAuthMethod(&secretData) {
+	case config.AccessToken:
+		cfg.AccessToken = secretData.AccessToken
 	case config.Digest:
 		cfg.PublicKey = secretData.PublicKey
 		cfg.PrivateKey = secretData.PrivateKey
 	case config.ServiceAccount:
 		cfg.ClientID = secretData.ClientID
 		cfg.ClientSecret = secretData.ClientSecret
-	case config.AccessToken:
-		cfg.AccessToken = secretData.AccessToken
 	case config.Unknown:
 		return *cfg, fmt.Errorf("secret missing value for supported credentials: PrivateKey/PublicKey, ClientID/ClientSecret or AccessToken")
 	}

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -82,8 +82,10 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	case config.ServiceAccount:
 		cfg.ClientID = secretData.ClientID
 		cfg.ClientSecret = secretData.ClientSecret
+	case config.AccessToken:
+		cfg.AccessToken = secretData.AccessToken
 	case config.Unknown:
-		return *cfg, fmt.Errorf("secret missing value for supported credentials: PrivateKey/PublicKey or ClientID/ClientSecret")
+		return *cfg, fmt.Errorf("secret missing value for supported credentials: PrivateKey/PublicKey, ClientID/ClientSecret or AccessToken")
 	}
 
 	return *cfg, nil

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -269,10 +269,17 @@ func PreCheckAwsEnvPrivateLinkEndpointService(tb testing.TB) {
 	}
 }
 
-func PreCheckRegularCredsAreEmpty(tb testing.TB) {
+func PreCheckPAKCredsAreEmpty(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != "" {
 		tb.Fatal(`"MONGODB_ATLAS_PUBLIC_KEY" and "MONGODB_ATLAS_PRIVATE_KEY" are defined in this test and they should not.`)
+	}
+}
+
+func PreCheckSACredsAreEmpty(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != "" {
+		tb.Fatal(`"MONGODB_ATLAS_CLIENT_ID" and "MONGODB_ATLAS_CLIENT_SECRET" are defined in this test and they should not.`)
 	}
 }
 
@@ -383,5 +390,12 @@ func PreCheckServiceAccount(tb testing.TB) {
 	if os.Getenv("MONGODB_ATLAS_CLIENT_ID") == "" ||
 		os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") == "" {
 		tb.Fatal("`MONGODB_ATLAS_CLIENT_ID`, `MONGODB_ATLAS_CLIENT_SECRET` must be set for Service Account acceptance testing")
+	}
+}
+
+func PreCheckAccessToken(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_OAUTH_TOKEN") == "" {
+		tb.Fatal("`MONGODB_ATLAS_OAUTH_TOKEN` must be set for Atlas Programmatic API Key acceptance testing")
 	}
 }

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -396,6 +396,6 @@ func PreCheckServiceAccount(tb testing.TB) {
 func PreCheckAccessToken(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_OAUTH_TOKEN") == "" {
-		tb.Fatal("`MONGODB_ATLAS_OAUTH_TOKEN` must be set for Atlas Programmatic API Key acceptance testing")
+		tb.Fatal("`MONGODB_ATLAS_OAUTH_TOKEN` must be set for Atlas Access Token acceptance testing")
 	}
 }


### PR DESCRIPTION
## Description

Adds support for JWT Token as an authentication method credential. Input can be provider inputs, environment variables and AWS Secrets Manager

Includes a test that tests the authentication using JWT token credentials through environment variables. Can't run in CI because tokens expire after 1 hour

Test has been successful locally:
<img width="1428" height="95" alt="Screenshot 2025-09-26 at 12 55 33" src="https://github.com/user-attachments/assets/6c3e40cc-f274-4fef-b48b-8bef5058b8bd" />


Link to any related issue(s): CLOUDP-345761

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
