### PR TITLE
fix: Fixes STS region resolution when using cross-region authentication

### DIFF
--- a/.changelog/3718.txt
+++ b/.changelog/3718.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixes STS region resolution when using cross-region authentication
+```

--- a/.changelog/3718.txt
+++ b/.changelog/3718.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fixes STS region resolution when using cross-region authentication
+provider: Fixes STS region resolution when using cross-region authentication
 ```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -459,7 +459,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Same-region
+          # Same region
           - name: same-region-us-east-1
             aws_region: US_EAST_1
             sts_endpoint: https://sts.us-east-1.amazonaws.com/

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -463,12 +463,10 @@ jobs:
           - name: same-region-us-east-1
             aws_region: US_EAST_1
             sts_endpoint: https://sts.us-east-1.amazonaws.com/
-
-          # Cross-region: STS east-1, secrets eu-north-1
+          # Cross-region
           - name: cross-sts-us-east-1-secret-eu-north-1
             aws_region: EU_NORTH_1
             sts_endpoint: https://sts.us-east-1.amazonaws.com/
-
           # Global STS endpoint (signs as us-east-1), secrets in eu-west-1
           - name: global-sts-secret-eu-west-1
             aws_region: EU_WEST_1

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -455,6 +455,25 @@ jobs:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Same-region
+          - name: same-region-us-east-1
+            aws_region: US_EAST_1
+            sts_endpoint: https://sts.us-east-1.amazonaws.com/
+
+          # Cross-region: STS east-1, secrets eu-north-1
+          - name: cross-sts-us-east-1-secret-eu-north-1
+            aws_region: EU_NORTH_1
+            sts_endpoint: https://sts.us-east-1.amazonaws.com/
+
+          # Global STS endpoint (signs as us-east-1), secrets in eu-west-1
+          - name: global-sts-secret-eu-west-1
+            aws_region: EU_WEST_1
+            sts_endpoint: https://sts.amazonaws.com
+    name: assume_role – ${{ matrix.name }}
     permissions: {}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -476,19 +495,20 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests
+      - name: Acceptance Tests (matrix)
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
+          AWS_REGION: ${{ matrix.aws_region }}
+          STS_ENDPOINT: ${{ matrix.sts_endpoint }}
           SECRET_NAME: ${{ inputs.aws_secret_name }}
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/provider
+          ACCTEST_REGEX_RUN: ^TestAccSTSAssumeRole_basic$
         run: make testacc
 
   autogen:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -459,11 +459,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Same region
+          # Secret and STS Endpoint in same region
           - name: same-region-us-east-1
             aws_region: US_EAST_1
             sts_endpoint: https://sts.us-east-1.amazonaws.com/
-          # Cross-region
+          # Secret and STS Endpoint in different regions(Cross-region)
           - name: cross-sts-us-east-1-secret-eu-north-1
             aws_region: EU_NORTH_1
             sts_endpoint: https://sts.us-east-1.amazonaws.com/

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	endPointSTSHostnameDefault = "sts.amazonaws.com"
-	DefaultRegionSTS           = "us-east-1"
+	endPointSTSHostnameDefault    = "sts.amazonaws.com"
+	DefaultRegionSTS              = "us-east-1"
+	minSegmentsForSTSRegionalHost = 4
 )
 
 func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint string) (config.Config, error) {
@@ -94,7 +95,7 @@ func DeriveSTSRegionFromEndpoint(ep string) string {
 	}
 
 	parts := strings.Split(host, ".")
-	if len(parts) >= 4 && parts[0] == "sts" {
+	if len(parts) >= minSegmentsForSTSRegionalHost && parts[0] == "sts" {
 		return parts[1]
 	}
 	return DefaultRegionSTS

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -21,14 +21,14 @@ import (
 
 const (
 	endPointSTSHostnameDefault = "sts.amazonaws.com"
-	defaultRegionSTS           = "us-east-1"
+	DefaultRegionSTS           = "us-east-1"
 )
 
 func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint string) (config.Config, error) {
 	defaultResolver := endpoints.DefaultResolver()
 	stsCustResolverFn := func(service, _ string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		if service == sts.EndpointsID {
-			resolved, err := resolveSTSEndpoint(endpoint, region)
+			resolved, err := ResolveSTSEndpoint(endpoint, region)
 			if err != nil {
 				return endpoints.ResolvedEndpoint{}, err
 			}
@@ -79,38 +79,38 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	return *cfg, nil
 }
 
-func deriveSTSRegionFromEndpoint(ep string) string {
+func DeriveSTSRegionFromEndpoint(ep string) string {
 	if ep == "" {
 		return ""
 	}
 	u, err := url.Parse(ep)
 	if err != nil {
-		return defaultRegionSTS
+		return DefaultRegionSTS
 	}
 	host := u.Hostname() // valid values: sts.us-west-2.amazonaws.com or sts.amazonaws.com
 
 	if host == endPointSTSHostnameDefault {
-		return defaultRegionSTS
+		return DefaultRegionSTS
 	}
 
 	parts := strings.Split(host, ".")
 	if len(parts) >= 4 && parts[0] == "sts" {
 		return parts[1]
 	}
-	return defaultRegionSTS
+	return DefaultRegionSTS
 }
 
-func resolveSTSEndpoint(stsEndpoint, secretsRegion string) (endpoints.ResolvedEndpoint, error) {
+func ResolveSTSEndpoint(stsEndpoint, secretsRegion string) (endpoints.ResolvedEndpoint, error) {
 	ep := stsEndpoint
 	if ep == "" {
 		r := secretsRegion
 		if r == "" {
-			r = defaultRegionSTS
+			r = DefaultRegionSTS
 		}
 		ep = fmt.Sprintf("https://sts.%s.amazonaws.com/", r)
 	}
 
-	signingRegion := deriveSTSRegionFromEndpoint(ep)
+	signingRegion := DeriveSTSRegionFromEndpoint(ep)
 
 	return endpoints.ResolvedEndpoint{
 		URL:           ep,

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	endPointSTSHostnameDefault = "sts.amazonaws.com"
-	defaultRegionSTS   = "us-east-1"
+	defaultRegionSTS           = "us-east-1"
 )
 
 func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint string) (config.Config, error) {
@@ -36,12 +36,11 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 		}
 		return defaultResolver.EndpointFor(service, region, optFns...)
 	}
-	
 
 	sess := session.Must(session.NewSession(&aws.Config{
-		Region:              aws.String(region),
-		Credentials:         credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, awsSessionToken),
-		EndpointResolver:    endpoints.ResolverFunc(stsCustResolverFn),
+		Region:           aws.String(region),
+		Credentials:      credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, awsSessionToken),
+		EndpointResolver: endpoints.ResolverFunc(stsCustResolverFn),
 	}))
 
 	creds := stscreds.NewCredentials(sess, cfg.AssumeRole.RoleARN)
@@ -80,47 +79,44 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	return *cfg, nil
 }
 
-
 func deriveSTSRegionFromEndpoint(ep string) string {
-    if ep == "" {
-        return ""
-    }
-    u, err := url.Parse(ep)
-    if err != nil {
-        return defaultRegionSTS
-    }
-    host := u.Hostname() // valid values: sts.us-west-2.amazonaws.com or sts.amazonaws.com
+	if ep == "" {
+		return ""
+	}
+	u, err := url.Parse(ep)
+	if err != nil {
+		return defaultRegionSTS
+	}
+	host := u.Hostname() // valid values: sts.us-west-2.amazonaws.com or sts.amazonaws.com
 
-    if host == endPointSTSHostnameDefault {
-        return defaultRegionSTS
-    }
+	if host == endPointSTSHostnameDefault {
+		return defaultRegionSTS
+	}
 
-    parts := strings.Split(host, ".")
-    if len(parts) >= 4 && parts[0] == "sts" {
-        return parts[1]
-    }
-    return defaultRegionSTS
+	parts := strings.Split(host, ".")
+	if len(parts) >= 4 && parts[0] == "sts" {
+		return parts[1]
+	}
+	return defaultRegionSTS
 }
 
 func resolveSTSEndpoint(stsEndpoint, secretsRegion string) (endpoints.ResolvedEndpoint, error) {
-    ep := stsEndpoint
-    if ep == "" {
-        r := secretsRegion
-        if r == "" {
-            r = defaultRegionSTS
-        }
-        ep = fmt.Sprintf("https://sts.%s.amazonaws.com/", r)
-    }
+	ep := stsEndpoint
+	if ep == "" {
+		r := secretsRegion
+		if r == "" {
+			r = defaultRegionSTS
+		}
+		ep = fmt.Sprintf("https://sts.%s.amazonaws.com/", r)
+	}
 
-    signingRegion := deriveSTSRegionFromEndpoint(ep)
+	signingRegion := deriveSTSRegionFromEndpoint(ep)
 
-    return endpoints.ResolvedEndpoint{
-        URL:           ep,
-        SigningRegion: signingRegion,
-    }, nil
+	return endpoints.ResolvedEndpoint{
+		URL:           ep,
+		SigningRegion: signingRegion,
+	}, nil
 }
-
-
 
 func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secret string) (string, error) {
 	svc := secretsmanager.New(sess, creds)

--- a/internal/provider/credentials.go
+++ b/internal/provider/credentials.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -12,48 +14,38 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
 
 const (
-	endPointSTSDefault = "https://sts.amazonaws.com"
+	endPointSTSHostnameDefault = "sts.amazonaws.com"
+	defaultRegionSTS   = "us-east-1"
 )
 
 func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID, awsSecretAccessKey, awsSessionToken, endpoint string) (config.Config, error) {
-	ep, err := endpoints.GetSTSRegionalEndpoint("regional")
-	if err != nil {
-		log.Printf("GetSTSRegionalEndpoint error: %s", err)
-		return *cfg, err
-	}
-
 	defaultResolver := endpoints.DefaultResolver()
-	stsCustResolverFn := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+	stsCustResolverFn := func(service, _ string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 		if service == endpoints.StsServiceID {
-			if endpoint == "" {
-				return endpoints.ResolvedEndpoint{
-					URL:           endPointSTSDefault,
-					SigningRegion: region,
-				}, nil
+			resolved, err := resolveSTSEndpoint(endpoint, region)
+			if err != nil {
+				return endpoints.ResolvedEndpoint{}, err
 			}
-			return endpoints.ResolvedEndpoint{
-				URL:           endpoint,
-				SigningRegion: region,
-			}, nil
+			return resolved, nil
 		}
-
 		return defaultResolver.EndpointFor(service, region, optFns...)
 	}
+	
 
 	sess := session.Must(session.NewSession(&aws.Config{
 		Region:              aws.String(region),
 		Credentials:         credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, awsSessionToken),
-		STSRegionalEndpoint: ep,
 		EndpointResolver:    endpoints.ResolverFunc(stsCustResolverFn),
 	}))
 
 	creds := stscreds.NewCredentials(sess, cfg.AssumeRole.RoleARN)
 
-	_, err = sess.Config.Credentials.Get()
+	_, err := sess.Config.Credentials.Get()
 	if err != nil {
 		log.Printf("Session get credentials error: %s", err)
 		return *cfg, err
@@ -86,6 +78,48 @@ func configureCredentialsSTS(cfg *config.Config, secret, region, awsAccessKeyID,
 	cfg.PrivateKey = secretData.PrivateKey
 	return *cfg, nil
 }
+
+
+func deriveSTSRegionFromEndpoint(ep string) string {
+    if ep == "" {
+        return ""
+    }
+    u, err := url.Parse(ep)
+    if err != nil {
+        return defaultRegionSTS
+    }
+    host := u.Hostname() // valid values: sts.us-west-2.amazonaws.com or sts.amazonaws.com
+
+    if host == endPointSTSHostnameDefault {
+        return defaultRegionSTS
+    }
+
+    parts := strings.Split(host, ".")
+    if len(parts) >= 4 && parts[0] == "sts" {
+        return parts[1]
+    }
+    return defaultRegionSTS
+}
+
+func resolveSTSEndpoint(stsEndpoint, secretsRegion string) (endpoints.ResolvedEndpoint, error) {
+    ep := stsEndpoint
+    if ep == "" {
+        r := secretsRegion
+        if r == "" {
+            r = defaultRegionSTS
+        }
+        ep = fmt.Sprintf("https://sts.%s.amazonaws.com/", r)
+    }
+
+    signingRegion := deriveSTSRegionFromEndpoint(ep)
+
+    return endpoints.ResolvedEndpoint{
+        URL:           ep,
+        SigningRegion: signingRegion,
+    }, nil
+}
+
+
 
 func secretsManagerGetSecretValue(sess *session.Session, creds *aws.Config, secret string) (string, error) {
 	svc := secretsmanager.New(sess, creds)

--- a/internal/provider/credentials_test.go
+++ b/internal/provider/credentials_test.go
@@ -1,0 +1,99 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
+)
+
+func Test_deriveSTSRegionFromEndpoint(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty endpoint returns empty": {
+			input:    "",
+			expected: "",
+		},
+		"global endpoint -> us-east-1": {
+			input:    "https://sts.amazonaws.com",
+			expected: provider.DefaultRegionSTS,
+		},
+		"regional us-east-1": {
+			input:    "https://sts.us-east-1.amazonaws.com/",
+			expected: "us-east-1",
+		},
+		"regional eu-north-1": {
+			input:    "https://sts.eu-north-1.amazonaws.com/",
+			expected: "eu-north-1",
+		},
+		"malformed url -> default": {
+			input:    "://not-a-url",
+			expected: provider.DefaultRegionSTS,
+		},
+		"unexpected host shape -> default": {
+			input:    "https://sts.something-weird",
+			expected: provider.DefaultRegionSTS,
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			got := provider.DeriveSTSRegionFromEndpoint(tc.input)
+			if got != tc.expected {
+				t.Fatalf("deriveSTSRegionFromEndpoint(%q) = %q; want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func Test_resolveSTSEndpoint(t *testing.T) {
+	testCases := map[string]struct {
+		stsEndpoint   string
+		secretsRegion string
+		expectedURL   string
+		expectedSign  string
+	}{
+		"explicit regional endpoint wins": {
+			stsEndpoint:   "https://sts.eu-north-1.amazonaws.com/",
+			secretsRegion: "us-east-1",
+			expectedURL:   "https://sts.eu-north-1.amazonaws.com/",
+			expectedSign:  "eu-north-1",
+		},
+		"global endpoint -> us-east-1 signing": {
+			stsEndpoint:   "https://sts.amazonaws.com",
+			secretsRegion: "eu-west-1",
+			expectedURL:   "https://sts.amazonaws.com",
+			expectedSign:  provider.DefaultRegionSTS,
+		},
+		"no endpoint builds from secrets region": {
+			stsEndpoint:   "",
+			secretsRegion: "us-west-2",
+			expectedURL:   "https://sts.us-west-2.amazonaws.com/",
+			expectedSign:  "us-west-2",
+		},
+		"no endpoint and empty region defaults to us-east-1": {
+			stsEndpoint:   "",
+			secretsRegion: "",
+			expectedURL:   "https://sts.us-east-1.amazonaws.com/",
+			expectedSign:  provider.DefaultRegionSTS,
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			ep, err := provider.ResolveSTSEndpoint(tc.stsEndpoint, tc.secretsRegion)
+			if err != nil {
+				t.Fatalf("resolveSTSEndpoint unexpected error: %v", err)
+			}
+			if ep.URL != tc.expectedURL {
+				t.Fatalf("URL = %q; want %q", ep.URL, tc.expectedURL)
+			}
+			if ep.SigningRegion != tc.expectedSign {
+				t.Fatalf("SigningRegion = %q; want %q", ep.SigningRegion, tc.expectedSign)
+			}
+		})
+	}
+}

--- a/internal/provider/credentials_test.go
+++ b/internal/provider/credentials_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_deriveSTSRegionFromEndpoint(t *testing.T) {
@@ -83,17 +85,10 @@ func Test_resolveSTSEndpoint(t *testing.T) {
 
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
 			ep, err := provider.ResolveSTSEndpoint(tc.stsEndpoint, tc.secretsRegion)
-			if err != nil {
-				t.Fatalf("resolveSTSEndpoint unexpected error: %v", err)
-			}
-			if ep.URL != tc.expectedURL {
-				t.Fatalf("URL = %q; want %q", ep.URL, tc.expectedURL)
-			}
-			if ep.SigningRegion != tc.expectedSign {
-				t.Fatalf("SigningRegion = %q; want %q", ep.SigningRegion, tc.expectedSign)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedURL, ep.URL)
+			assert.Equal(t, tc.expectedSign, ep.SigningRegion)
 		})
 	}
 }

--- a/internal/provider/credentials_test.go
+++ b/internal/provider/credentials_test.go
@@ -11,15 +11,15 @@ func Test_deriveSTSRegionFromEndpoint(t *testing.T) {
 		input    string
 		expected string
 	}{
-		"empty endpoint returns empty": {
+		"empty endpoint": {
 			input:    "",
 			expected: "",
 		},
-		"global endpoint -> us-east-1": {
+		"global endpoint": {
 			input:    "https://sts.amazonaws.com",
 			expected: provider.DefaultRegionSTS,
 		},
-		"regional us-east-1": {
+		"regional": {
 			input:    "https://sts.us-east-1.amazonaws.com/",
 			expected: "us-east-1",
 		},
@@ -27,11 +27,11 @@ func Test_deriveSTSRegionFromEndpoint(t *testing.T) {
 			input:    "https://sts.eu-north-1.amazonaws.com/",
 			expected: "eu-north-1",
 		},
-		"malformed url -> default": {
+		"malformed url": {
 			input:    "://not-a-url",
 			expected: provider.DefaultRegionSTS,
 		},
-		"unexpected host shape -> default": {
+		"unexpected host shape": {
 			input:    "https://sts.something-weird",
 			expected: provider.DefaultRegionSTS,
 		},
@@ -55,25 +55,25 @@ func Test_resolveSTSEndpoint(t *testing.T) {
 		expectedURL   string
 		expectedSign  string
 	}{
-		"explicit regional endpoint wins": {
+		"explicit regional endpoint": {
 			stsEndpoint:   "https://sts.eu-north-1.amazonaws.com/",
 			secretsRegion: "us-east-1",
 			expectedURL:   "https://sts.eu-north-1.amazonaws.com/",
 			expectedSign:  "eu-north-1",
 		},
-		"global endpoint -> us-east-1 signing": {
+		"global endpoint - us-east-1 signing": {
 			stsEndpoint:   "https://sts.amazonaws.com",
 			secretsRegion: "eu-west-1",
 			expectedURL:   "https://sts.amazonaws.com",
 			expectedSign:  provider.DefaultRegionSTS,
 		},
-		"no endpoint builds from secrets region": {
+		"no endpoint - uses secrets region": {
 			stsEndpoint:   "",
 			secretsRegion: "us-west-2",
 			expectedURL:   "https://sts.us-west-2.amazonaws.com/",
 			expectedSign:  "us-west-2",
 		},
-		"no endpoint and empty region defaults to us-east-1": {
+		"no endpoint and empty region": {
 			stsEndpoint:   "",
 			secretsRegion: "",
 			expectedURL:   "https://sts.us-east-1.amazonaws.com/",


### PR DESCRIPTION
## Description

Fixes STS region resolution when using cross-region authentication in the MongoDB Atlas Terraform provider. The fix addresses an issue where the provider wasn't correctly handling STS endpoint configuration when AWS credentials are in one region but the STS endpoint is in another region.

Link to any related issue(s): CLOUDP-347906

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
