### PR TITLE
chore: Use Terraform provider cache in tf-validate

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,22 +19,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version-file: "go.mod"
-          cache: false
+          go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
-          terraform_version: "1.13.x"
+          terraform_version: '1.13.x'
           terraform_wrapper: false
-      - name: Prepare Go packages
-        run: make tools build
-      - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: tf-validate
         run: make tools tf-validate
   tflint:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,11 +19,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
+          cache: false
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
-          terraform_version: '1.13.x'
+          terraform_version: "1.13.x"
           terraform_wrapper: false
+      - name: Prepare Go packages
+        run: make tools build
+      - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: tf-validate
         run: make tools tf-validate
   tflint:

--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -43,6 +43,6 @@ for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u)
   terraform validate
 
   rm -rf ".terraform"
-  rm -rf ".terraform.lock.hcl"
+  rm -f ".terraform.lock.hcl"
   popd
 done

--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -38,7 +38,7 @@ for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u)
   [ ! -d "$DIR" ] && continue
   pushd "$DIR"
   echo; echo -e "\e[1;35m===> Example: $DIR <===\e[0m"; echo
-  terraform init > /dev/null # suppress output as it's very verbose
+  TF_LOG=TRACE terraform init
   terraform fmt -check -recursive
   terraform validate
 

--- a/scripts/tf-validate.sh
+++ b/scripts/tf-validate.sh
@@ -20,15 +20,19 @@ set -Eeou pipefail
 find ./examples -type d -name ".terraform" -exec rm -rf {} +
 find ./examples -type f -name ".terraform.lock.hcl" -exec rm -f {} +
 
-export TF_CLI_CONFIG_FILE="$PWD/bin-examples/tf-validate.tfrc"
+export TF_CLI_CONFIG_FILE="$PWD/examples-bin/tf-validate.tfrc"
+
+export TF_PLUGIN_CACHE_DIR="$PWD/examples-cache"
+rm -rf "$TF_PLUGIN_CACHE_DIR"
+mkdir -p "$TF_PLUGIN_CACHE_DIR"
 
 # Use local provider to validate examples
-go build -o bin-examples/terraform-provider-mongodbatlas .
+go build -o examples-bin/terraform-provider-mongodbatlas .
 
 cat << EOF > "$TF_CLI_CONFIG_FILE"
 provider_installation { 
   dev_overrides {
-    "mongodb/mongodbatlas" = "$PWD/bin-examples"
+    "mongodb/mongodbatlas" = "$PWD/examples-bin"
   }
   direct {} 
 }
@@ -41,8 +45,5 @@ for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u)
   TF_LOG=TRACE terraform init
   terraform fmt -check -recursive
   terraform validate
-
-  rm -rf ".terraform"
-  rm -f ".terraform.lock.hcl"
   popd
 done


### PR DESCRIPTION
## Description

Use Terraform provider cache in tf-validate

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
