### PR TITLE
chore: Supports backport releases for v1.x

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - master-v1
     paths-ignore: # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
       - '*.md'
       - 'examples/**'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - master-v1
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -2,7 +2,7 @@ name: Generate Changelog
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [master, master-v1]
     paths:
       - .changelog/**
   workflow_dispatch:

--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -1,0 +1,243 @@
+name: "New Release (v1 Backport)"
+run-name: "Release ${{ inputs.version_number }} from master-v1 (skip tests: ${{ inputs.skip_tests }}, use existing tag: ${{ inputs.use_existing_tag}})"
+
+# Used for creating a new release from the master-v1 branch. This workflow will run qa acceptance tests, create a new tag, and generate the release with GoReleaser.
+# Note: After a v1.x release, CHANGELOG.md changes from master-v1 branch should be manually merged to master branch.
+on:
+    workflow_dispatch:
+        inputs:
+            version_number:
+                description: "Version number (e.g., v1.0.0, v1.0.0-pre, v1.0.0-pre1)"
+                required: true
+            skip_tests:
+                description: "Set value to `true` to skip QA acceptance tests, default is `false`"
+                default: "false"
+            use_existing_tag:
+                description: "Set value to `true` to use an existing tag for the release process, default is `false`"
+                default: "false"
+
+jobs:
+    release-config:
+        runs-on: ubuntu-latest
+        permissions: {}
+        outputs:
+            creates_new_tag: ${{ steps.evaluate_inputs.outputs.creates_new_tag }}
+            is_official_release: ${{ steps.evaluate_inputs.outputs.is_official_release }}
+            runs_tests: ${{ steps.evaluate_inputs.outputs.runs_tests }}
+        steps:
+            - id: evaluate_inputs
+              run: |
+                  {
+                    echo "creates_new_tag=$(if [ '${{ inputs.use_existing_tag }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
+                    echo "is_official_release=$(if echo '${{ inputs.version_number }}' | grep -q 'pre'; then echo 'false'; else echo 'true'; fi)"
+                    echo "runs_tests=$(if [ '${{ inputs.skip_tests }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
+                  } >> "$GITHUB_OUTPUT"
+
+    validate-inputs:
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            - name: Validation of version format
+              run: |
+                  echo "${{ inputs.version_number }}" | grep -P '^v1\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: ${{ inputs.use_existing_tag == 'true' && inputs.version_number || 'master-v1' }}
+            - name: Check for Upgrade Guide
+              run: "./scripts/check-upgrade-guide-exists.sh ${{inputs.version_number}}"
+
+    update-examples-reference-in-docs:
+        needs: [release-config, validate-inputs]
+        if: >-
+            !cancelled()
+            && !contains(needs.*.result, 'failure')
+            && needs.release-config.outputs.creates_new_tag == 'true'
+            && needs.release-config.outputs.is_official_release == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: master-v1
+            - uses: ./.github/templates/run-script-and-commit
+              with:
+                  script_call: "./scripts/update-examples-reference-in-docs.sh ${{inputs.version_number}}"
+                  file_to_commit: "docs/* templates/*" # only docs files are updated
+                  commit_message: "chore: Update example links in registry docs for ${{ github.event.inputs.version_number }} release"
+                  apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
+                  remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}
+                  gpg_private_key: ${{ secrets.APIX_BOT_GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.APIX_BOT_PASSPHRASE }}
+
+    update-changelog-header:
+        needs:
+            [release-config, validate-inputs, update-examples-reference-in-docs]
+        if: >-
+            !cancelled()
+            && !contains(needs.*.result, 'failure')
+            && needs.release-config.outputs.creates_new_tag == 'true'
+            && needs.release-config.outputs.is_official_release == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: master-v1
+            - uses: ./.github/templates/run-script-and-commit
+              with:
+                  script_call: "./scripts/update-changelog-header-for-release.sh ${{inputs.version_number}}"
+                  file_to_commit: "CHANGELOG.md"
+                  commit_message: "chore: Updates CHANGELOG.md header for ${{ github.event.inputs.version_number }} release"
+                  apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
+                  remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}
+                  gpg_private_key: ${{ secrets.APIX_BOT_GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.APIX_BOT_PASSPHRASE }}
+
+    create-tag:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        needs:
+            [
+                release-config,
+                validate-inputs,
+                update-examples-reference-in-docs,
+                update-changelog-header,
+            ]
+        if: >-
+            !cancelled()
+            && !contains(needs.*.result, 'failure') 
+            && needs.release-config.outputs.creates_new_tag == 'true'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: "master-v1"
+            - name: Get the latest commit SHA
+              id: get-sha
+              run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            - name: Create release tag
+              uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+              with:
+                  tag: ${{ inputs.version_number }}
+                  commit_sha: ${{ steps.get-sha.outputs.sha }}
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  gpg_passphrase: ${{ secrets.PASSPHRASE }}
+
+    run-qa-acceptance-tests:
+        needs:
+            [
+                release-config,
+                validate-inputs,
+                update-examples-reference-in-docs,
+                update-changelog-header,
+                create-tag,
+            ]
+        if: >-
+            !cancelled()
+            && !contains(needs.*.result, 'failure')
+            && needs.release-config.outputs.runs_tests == 'true'
+        secrets: inherit
+        uses: ./.github/workflows/acceptance-tests.yml
+        with:
+            atlas_cloud_env: "qa"
+            ref: ${{ inputs.version_number }}
+
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        needs:
+            [
+                validate-inputs,
+                update-examples-reference-in-docs,
+                update-changelog-header,
+                create-tag,
+                run-qa-acceptance-tests,
+            ]
+        # Release is skipped if there are failures in previous steps
+        if: >-
+            !cancelled()
+            && !contains(needs.*.result, 'failure')
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: ${{ inputs.version_number }}
+            - name: Set up Go
+              uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+              with:
+                  go-version-file: "go.mod"
+            - name: Import GPG key
+              id: import_gpg
+              uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.PASSPHRASE }}
+            - name: Run GoReleaser
+              uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
+              with:
+                  version: "~> v2"
+                  args: release --clean
+              env:
+                  GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    compliance:
+        runs-on: ubuntu-latest
+        needs: [release-config, release]
+        if: >-
+            !cancelled()
+            && needs.release.result == 'success'
+            && needs.release-config.outputs.is_official_release == 'true'
+        env:
+            SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: ${{ inputs.version_number }}
+            - name: Generate SBOM
+              run: make gen-purls generate-sbom
+            - name: Upload SBOM to Kondukto
+              run: make upload-sbom
+              env:
+                  KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
+                  KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
+                  KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
+            - name: Upload SBOM as release artifact
+              uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+              with:
+                  files: compliance/sbom.json
+                  tag_name: ${{ inputs.version_number }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    generate-ssdlc-report:
+        needs: [release-config, release, compliance]
+        if: >-
+            !cancelled()
+            && needs.release.result == 'success'
+            && needs.release-config.outputs.is_official_release == 'true'
+            && needs.compliance.result == 'success'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+              with:
+                  ref: master-v1
+            - uses: ./.github/templates/run-script-and-commit
+              with:
+                  script_call: |
+                      TAG="${{ inputs.version_number }}"
+                      VERSION="${TAG#v}"
+                      AUTHOR="${{ github.actor }}"
+                      export AUTHOR VERSION
+                      ./scripts/compliance/gen-ssdlc-report.sh
+                  file_to_commit: "compliance/v*/ssdlc-compliance-*.md"
+                  commit_message: "chore: Update SSDLC report for ${{ inputs.version_number }}"
+                  apix_bot_pat: ${{ secrets.APIX_BOT_PAT }}
+                  remote: https://svc-apix-bot:${{ secrets.APIX_BOT_PAT }}@github.com/${{ github.repository }}
+                  gpg_private_key: ${{ secrets.APIX_BOT_GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.APIX_BOT_PASSPHRASE }}


### PR DESCRIPTION
## Description

Adds support for backport releases of v1.x versions and includes `master-v1` branch in the generate changelog action, so that when a PR is merged into `master-v1` branch, changelog is generated from the changelog entries

### Differences Between `release.yml` and `release-v1.yml`

#### Overview

The `release-v1.yml` workflow is a **specialized version** of `release.yml` designed specifically for releasing v1.x backport versions from the `master-v1` branch.

---

#### 1. Workflow Identification
**Lines: 1-2, 4-5**

| `release.yml` | `release-v1.yml` |
|--------------|------------------|
| `name: 'New Release'` | `name: "New Release (v1 Backport)"` |
| `run-name: 'Release ${{ inputs.version_number }} ...'` | `run-name: "Release ${{ inputs.version_number }} from master-v1 ..."` |
| Comment: "Used for creating a new release." | Comment: "Used for creating a new release from the master-v1 branch." + added note about manual CHANGELOG sync |

**Purpose**: Clearly distinguishes the v1 backport workflow from the main release workflow.

---

#### 2. Version Validation ⚠️ **CHANGE**
**Lines: 40-42**

| `release.yml` | `release-v1.yml` |
|--------------|------------------|
| `grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'` | `grep -P '^v1\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'` |

**Purpose**: Enforces that only v1.X.X versions can be released through this workflow. This prevents accidental use of the v1 backport workflow for v2.x or other major versions.

**Example:**
- ✅ Accepts: `v1.40.0`, `v1.40.1`, `v1.41.0-pre`
- ❌ Rejects: `v2.0.0`, `v0.9.0`

---

#### 3. Branch References ⚠️ **CHANGE**
All hard-coded `'master'` references replaced with `'master-v1'`:

| Job | Line | Original | Modified |
|-----|------|----------|----------|
| `validate-inputs` | 46 | `ref: ... \|\| 'master'` | `ref: ... \|\| 'master-v1'` |
| `update-examples-reference-in-docs` | 60/62 | Implicit `master` checkout | Explicit `ref: master-v1` |
| `update-changelog-header` | 81/86 | Implicit `master` checkout | Explicit `ref: master-v1` |
| `create-tag` | 105/116 | `ref: 'master'` | `ref: "master-v1"` |
| `generate-ssdlc-report` | 202/229 | Implicit `master` checkout | Explicit `ref: master-v1` |

**Purpose**: Ensures all operations are performed on the `master-v1` branch, keeping backport releases isolated from the main development branch.

---

#### 4. Jira Integration Removed 🗑️
**Lines: 218-228 (removed entirely)**

The `jira-release-version` job has been completely removed:

```yaml
# ❌ REMOVED from release-v1.yml
jira-release-version:
  needs: [ release-config, release ]
  if: >-
    !cancelled()
    && needs.release.result == 'success'
    && needs.release-config.outputs.is_official_release == 'true'
  secrets: inherit
  uses: ./.github/workflows/jira-release-version.yml
  with:
    version_number: ${{ inputs.version_number }}
```

**Purpose**: Keeps the v1 backport release process lightweight and manual, as these are maintenance releases that don't require automated Jira updates.

---

#### 5. Jobs Retained (Unchanged Functionality)

All other critical automation remains intact:
- ✅ `release-config` - Configuration evaluation
- ✅ `validate-inputs` - Version format validation and upgrade guide check
- ✅ `update-examples-reference-in-docs` - Documentation updates
- ✅ `update-changelog-header` - Changelog preparation
- ✅ `create-tag` - Git tag creation
- ✅ `run-qa-acceptance-tests` - QA acceptance testing
- ✅ `release` - GoReleaser execution and artifact creation
- ✅ `compliance` - SBOM generation and upload
- ✅ `generate-ssdlc-report` - Security compliance reporting

---

## Summary

The `release-v1.yml` workflow is a **specialized version** of `release.yml` designed specifically for releasing v1.x maintenance versions from the `master-v1` branch. The key functional differences are:

1. **Branch Isolation**: All operations target `master-v1` instead of `master`
2. **Version Enforcement**: Only v1.X.X versions are accepted
3. **Simplified Process**: Jira integration removed for a more manual, lightweight approach
4. **Clear Identification**: Workflow name and comments clearly identify it as a v1 backport process

---

## Important Note

⚠️ **After a successful v1.x release using this workflow, `CHANGELOG.md` changes from the `master-v1` branch must be manually merged to the `master` branch.**


Link to any related issue(s): CLOUDP-348399

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
