### PR TITLE
chore: Bring SA dev branch non-production changes to master

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -536,7 +536,8 @@ jobs:
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_REGEX_RUN: '^TestAccServiceAccount'
+          ACCTEST_REGEX_RUN: '^TestUnexisting' # TODO: SA not implemented in master yet
+          # ACCTEST_REGEX_RUN: '^TestAccServiceAccount'
           ACCTEST_PACKAGES: ./internal/provider
         run: make testacc
       - name: Acceptance Tests (Service Account smoke tests) # small selection of fast tests to run with SA
@@ -546,7 +547,7 @@ jobs:
           MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
           MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_REGEX_RUN: '^TestAcc' # don't run migration tests because previous provider versions don't support SA
+          ACCTEST_REGEX_RUN: '^TestUnexisting' # TODO: SA not implemented in master yet
           ACCTEST_PACKAGES: |
             ./internal/service/alertconfiguration
             ./internal/service/databaseuser

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -102,9 +102,6 @@ on:
       mongodb_atlas_federated_settings_associated_domain:
         type: string
         required: true
-      mongodb_atlas_project_ear_pe_id:
-        type: string
-        required: true
       azure_private_endpoint_region:
         type: string
         required: true
@@ -112,18 +109,6 @@ on:
         type: string
         required: true
       confluent_cloud_privatelink_access_id:
-        type: string
-        required: true
-      aws_ear_role_id:
-        type: string
-        required: true
-      mongodb_atlas_project_ear_pe_aws_id:
-        type: string
-        required: true
-      mongodb_atlas_asp_project_ear_pe_id:
-        type: string
-        required: true
-      mongodb_atlas_asp_project_aws_role_arn:
         type: string
         required: true
       mongodb_atlas_last_1x_version:
@@ -781,7 +766,6 @@ jobs:
           ACCTEST_PACKAGES: |
            ./internal/service/encryptionatrest
            ./internal/service/encryptionatrestprivateendpoint
-          MONGODB_ATLAS_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_project_ear_pe_id }}
           AZURE_PRIVATE_ENDPOINT_REGION: ${{ inputs.azure_private_endpoint_region }}
           AZURE_CLIENT_ID: ${{ secrets.azure_client_id }}
           AZURE_RESOURCE_GROUP_NAME: ${{ secrets.azure_resource_group_name }}
@@ -796,10 +780,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_CUSTOMER_MASTER_KEY_ID: ${{ secrets.aws_customer_master_key_id }}
-          MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID: ${{ inputs.mongodb_atlas_project_ear_pe_aws_id }}
-          AWS_EAR_ROLE_ID: ${{ inputs.aws_ear_role_id }}
-          MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
-          MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
         run: make testacc
 
   event_trigger:
@@ -1215,11 +1195,11 @@ jobs:
             CONFLUENT_CLOUD_API_SECRET: ${{ secrets.confluent_cloud_api_secret }}
             CONFLUENT_CLOUD_NETWORK_ID: ${{ inputs.confluent_cloud_network_id }}
             CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID: ${{ inputs.confluent_cloud_privatelink_access_id }}
-            AWS_REGION: ${{ vars.AWS_REGION }}
+            AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
             AWS_VPC_CIDR_BLOCK: ${{ vars.AWS_VPC_CIDR_BLOCK }}
             AWS_VPC_ID: ${{ vars.AWS_VPC_ID }}
-            MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
-            MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
             ACCTEST_PACKAGES: |
               ./internal/service/streamaccountdetails
               ./internal/service/streamconnection

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -29,9 +29,7 @@ on:
         description: 'If run only minimum tests for advanced_cluster, e.g. in PRs'
         type: boolean
         required: false
-        default: false
-        
-
+        default: false    
       use_sa:
         description: "Run tests using Service Account instead of API Keys"
         type: boolean
@@ -216,7 +214,6 @@ env:
   MONGODB_ATLAS_GOV_BASE_URL:  ${{ inputs.mongodb_atlas_gov_base_url }}
   MONGODB_ATLAS_GOV_ORG_ID:  ${{ inputs.mongodb_atlas_gov_org_id }}
 
-
 jobs:  
 
   get-provider-version:
@@ -242,6 +239,7 @@ jobs:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
+      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
       authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
       autogen: ${{ steps.filter.outputs.autogen == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
@@ -275,6 +273,9 @@ jobs:
         filters: |
           advanced_cluster:
             - 'internal/service/advancedcluster/*.go'
+          assume_role:
+            - 'internal/config/*.go'
+            - 'internal/provider/*.go'
           authentication:
             - 'internal/config/*.go'
             - 'internal/provider/*.go'
@@ -455,10 +456,27 @@ jobs:
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  authentication:
+  assume_role:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
+    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Secret and STS Endpoint in same region
+          - name: same-region-us-east-1
+            aws_region: US_EAST_1
+            sts_endpoint: https://sts.us-east-1.amazonaws.com/
+          # Secret and STS Endpoint in different regions(Cross-region)
+          - name: cross-sts-us-east-1-secret-eu-north-1
+            aws_region: EU_NORTH_1
+            sts_endpoint: https://sts.us-east-1.amazonaws.com/
+          # Global STS endpoint (signs as us-east-1), secrets in eu-west-1
+          - name: global-sts-secret-eu-west-1
+            aws_region: EU_WEST_1
+            sts_endpoint: https://sts.amazonaws.com
+    name: assume_role – ${{ matrix.name }}
     permissions: {}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -480,23 +498,38 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests (STS Assume Role)
+      - name: Acceptance Tests (matrix)
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
-          MONGODB_ATLAS_CLIENT_ID: ""
-          MONGODB_ATLAS_CLIENT_SECRET: ""
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
+          AWS_REGION: ${{ matrix.aws_region }}
+          STS_ENDPOINT: ${{ matrix.sts_endpoint }}
           SECRET_NAME: ${{ inputs.aws_secret_name }}
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_REGEX_RUN: '^TestAccSTSAssumeRole'
           ACCTEST_PACKAGES: ./internal/provider
+          ACCTEST_REGEX_RUN: ^TestAccSTSAssumeRole_basic$
         run: make testacc
+
+  authentication:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false    
       - name: Acceptance Tests (Service Account)
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
@@ -520,6 +553,7 @@ jobs:
             ./internal/service/databaseuser
             ./internal/service/maintenancewindow
         run: make testacc
+
   autogen:
     needs: [change-detection, get-provider-version]
     if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -406,6 +406,7 @@ jobs:
  
   advanced_cluster_tpf_mig_from_sdkv2:
     needs: [ change-detection, get-provider-version ]
+    # Previous advanced_cluster versions don't support SA.
     if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -431,6 +432,7 @@ jobs:
 
   advanced_cluster_tpf_mig_from_tpf_preview:
     needs: [ change-detection, get-provider-version ]
+    # Previous advanced_cluster versions don't support SA.
     if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -818,7 +820,7 @@ jobs:
 
   event_trigger:
     needs: [change-detection, get-provider-version]
-    # Realm SDK doesn't support SA
+    # Realm SDK doesn't support SA.
     if: ${{ inputs.use_sa == false && (needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger') }}
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: false
         
+
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
       mongodb_atlas_org_id:
         type: string
         required: true
@@ -97,6 +102,9 @@ on:
       mongodb_atlas_federated_settings_associated_domain:
         type: string
         required: true
+      mongodb_atlas_project_ear_pe_id:
+        type: string
+        required: true
       azure_private_endpoint_region:
         type: string
         required: true
@@ -104,6 +112,18 @@ on:
         type: string
         required: true
       confluent_cloud_privatelink_access_id:
+        type: string
+        required: true
+      aws_ear_role_id:
+        type: string
+        required: true
+      mongodb_atlas_project_ear_pe_aws_id:
+        type: string
+        required: true
+      mongodb_atlas_asp_project_ear_pe_id:
+        type: string
+        required: true
+      mongodb_atlas_asp_project_aws_role_arn:
         type: string
         required: true
       mongodb_atlas_last_1x_version:
@@ -156,6 +176,10 @@ on:
         required: true
       mongodb_atlas_rp_public_key:
         required: true
+      mongodb_atlas_client_id:
+        required: true
+      mongodb_atlas_client_secret:
+        required: true
       azure_directory_id:
         required: true
       azure_resource_group_name:
@@ -189,14 +213,17 @@ env:
   TF_ACC: 1
   TF_LOG: ${{ vars.LOG_LEVEL }}
   ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
-  # Only Migration tests are run when a specific previous provider version is set
-  # If the name (regex) of the test is set, only that test is run
-  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
+  # Only Migration tests are run when a specific previous provider version is set.
+  # Don't run migration tests if using Service Accounts because previous provider versions don't support SA yet.
+  # If the name (regex) of the test is set, only that test is run.
+  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.use_sa && '^TestAcc' || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
   MONGODB_REALM_BASE_URL: ${{ inputs.mongodb_realm_base_url }}
   MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}
-  MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.mongodb_atlas_public_key }}
-  MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.mongodb_atlas_private_key }}
+  MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa == false && secrets.mongodb_atlas_public_key || '' }}
+  MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa == false && secrets.mongodb_atlas_private_key || '' }}
+  MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa  && secrets.mongodb_atlas_client_id || '' }}
+  MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa && secrets.mongodb_atlas_client_secret || '' }}
   MONGODB_ATLAS_PUBLIC_KEY_READ_ONLY: ${{ secrets.mongodb_atlas_public_key_read_only }}
   MONGODB_ATLAS_PRIVATE_KEY_READ_ONLY: ${{ secrets.mongodb_atlas_private_key_read_only }}
   MONGODB_ATLAS_GOV_PUBLIC_KEY: ${{ secrets.mongodb_atlas_gov_public_key }}
@@ -230,7 +257,7 @@ jobs:
       mustTrigger: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_group == '' )  }}
     outputs: # ensure resources are sorted alphabetically
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
-      assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
+      authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
       autogen: ${{ steps.filter.outputs.autogen == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
       control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
@@ -263,7 +290,8 @@ jobs:
         filters: |
           advanced_cluster:
             - 'internal/service/advancedcluster/*.go'
-          assume_role:
+          authentication:
+            - 'internal/config/*.go'
             - 'internal/provider/*.go'
           autogen:
             - 'internal/common/autogen/*.go'
@@ -388,13 +416,12 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           HTTP_MOCKER_CAPTURE: 'true'
           ACCTEST_REGEX_RUN: ${{ inputs.reduced_tests && '^TestAccMockable' || env.ACCTEST_REGEX_RUN }}
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
  
   advanced_cluster_tpf_mig_from_sdkv2:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.reduced_tests == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
+    if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -414,13 +441,12 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'true'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
   advanced_cluster_tpf_mig_from_tpf_preview:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.reduced_tests == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
+    if: ${{ inputs.reduced_tests == false && inputs.use_sa == false && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -441,31 +467,13 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'false'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  assume_role:
+  authentication:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.assume_role == 'true' || inputs.test_group == 'assume_role' }}
+    if: ${{ needs.change-detection.outputs.authentication == 'true' || inputs.test_group == 'authentication' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Secret and STS Endpoint in same region
-          - name: same-region-us-east-1
-            aws_region: US_EAST_1
-            sts_endpoint: https://sts.us-east-1.amazonaws.com/
-          # Secret and STS Endpoint in different regions(Cross-region)
-          - name: cross-sts-us-east-1-secret-eu-north-1
-            aws_region: EU_NORTH_1
-            sts_endpoint: https://sts.us-east-1.amazonaws.com/
-          # Global STS endpoint (signs as us-east-1), secrets in eu-west-1
-          - name: global-sts-secret-eu-west-1
-            aws_region: EU_WEST_1
-            sts_endpoint: https://sts.amazonaws.com
-    name: assume_role – ${{ matrix.name }}
     permissions: {}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -487,24 +495,48 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
         run: bash ./scripts/generate-credentials-with-sts-assume-role.sh
-      - name: Acceptance Tests (matrix)
+      - name: Acceptance Tests (STS Assume Role)
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ""
           MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ""
+          MONGODB_ATLAS_CLIENT_SECRET: ""
           ASSUME_ROLE_ARN: ${{ vars.ASSUME_ROLE_ARN }}
-          AWS_REGION: ${{ matrix.aws_region }}
-          STS_ENDPOINT: ${{ matrix.sts_endpoint }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          STS_ENDPOINT: ${{ vars.STS_ENDPOINT }}
           SECRET_NAME: ${{ inputs.aws_secret_name }}
           AWS_ACCESS_KEY_ID: ${{ steps.sts-assume-role.outputs.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.sts-assume-role.outputs.aws_secret_access_key }}
           AWS_SESSION_TOKEN: ${{ steps.sts-assume-role.outputs.AWS_SESSION_TOKEN }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAccSTSAssumeRole'
           ACCTEST_PACKAGES: ./internal/provider
-          ACCTEST_REGEX_RUN: ^TestAccSTSAssumeRole_basic$
         run: make testacc
-
+      - name: Acceptance Tests (Service Account)
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAccServiceAccount'
+          ACCTEST_PACKAGES: ./internal/provider
+        run: make testacc
+      - name: Acceptance Tests (Service Account smoke tests) # small selection of fast tests to run with SA
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ""
+          MONGODB_ATLAS_PRIVATE_KEY: ""
+          MONGODB_ATLAS_CLIENT_ID: ${{ secrets.mongodb_atlas_client_id }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ secrets.mongodb_atlas_client_secret }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_REGEX_RUN: '^TestAcc' # don't run migration tests because previous provider versions don't support SA
+          ACCTEST_PACKAGES: |
+            ./internal/service/alertconfiguration
+            ./internal/service/databaseuser
+            ./internal/service/maintenancewindow
+        run: make testacc
   autogen:
-    needs: [ change-detection, get-provider-version ]
+    needs: [change-detection, get-provider-version]
     if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -749,6 +781,7 @@ jobs:
           ACCTEST_PACKAGES: |
            ./internal/service/encryptionatrest
            ./internal/service/encryptionatrestprivateendpoint
+          MONGODB_ATLAS_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_project_ear_pe_id }}
           AZURE_PRIVATE_ENDPOINT_REGION: ${{ inputs.azure_private_endpoint_region }}
           AZURE_CLIENT_ID: ${{ secrets.azure_client_id }}
           AZURE_RESOURCE_GROUP_NAME: ${{ secrets.azure_resource_group_name }}
@@ -763,11 +796,16 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_CUSTOMER_MASTER_KEY_ID: ${{ secrets.aws_customer_master_key_id }}
+          MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID: ${{ inputs.mongodb_atlas_project_ear_pe_aws_id }}
+          AWS_EAR_ROLE_ID: ${{ inputs.aws_ear_role_id }}
+          MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
+          MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
         run: make testacc
 
   event_trigger:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger' }}
+    needs: [change-detection, get-provider-version]
+    # Realm SDK doesn't support SA
+    if: ${{ inputs.use_sa == false && (needs.change-detection.outputs.event_trigger == 'true' || inputs.test_group == 'event_trigger') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -1177,11 +1215,11 @@ jobs:
             CONFLUENT_CLOUD_API_SECRET: ${{ secrets.confluent_cloud_api_secret }}
             CONFLUENT_CLOUD_NETWORK_ID: ${{ inputs.confluent_cloud_network_id }}
             CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID: ${{ inputs.confluent_cloud_privatelink_access_id }}
-            AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+            AWS_REGION: ${{ vars.AWS_REGION }}
             AWS_VPC_CIDR_BLOCK: ${{ vars.AWS_VPC_CIDR_BLOCK }}
             AWS_VPC_ID: ${{ vars.AWS_VPC_ID }}
+            MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN: ${{ inputs.mongodb_atlas_asp_project_aws_role_arn }}
+            MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID: ${{ inputs.mongodb_atlas_asp_project_ear_pe_id }}
             ACCTEST_PACKAGES: |
               ./internal/service/streamaccountdetails
               ./internal/service/streamconnection

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -196,10 +196,9 @@ env:
   TF_ACC: 1
   TF_LOG: ${{ vars.LOG_LEVEL }}
   ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
-  # Only Migration tests are run when a specific previous provider version is set.
-  # Don't run migration tests if using Service Accounts because previous provider versions don't support SA yet.
-  # If the name (regex) of the test is set, only that test is run.
-  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.use_sa && '^TestAcc' || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
+  # Only Migration tests are run when a specific previous provider version is set
+  # If the name (regex) of the test is set, only that test is run
+  ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
   MONGODB_REALM_BASE_URL: ${{ inputs.mongodb_realm_base_url }}
   MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_org_id }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,5 +1,5 @@
 name: 'Acceptance Tests'
-run-name: 'Acceptance Tests ${{ inputs.atlas_cloud_env }} ${{ inputs.test_group }}'
+run-name: "Acceptance Tests ${{ inputs.atlas_cloud_env }} ${{ inputs.test_group }} ${{ inputs.use_sa && 'sa' || 'pak'}}"
 
 # Used for running acceptance tests, either triggered manually or called by other workflows. 
 on:
@@ -29,6 +29,11 @@ on:
         description: 'The branch, tag or SHA where tests will run, e.g. v1.14.0, empty for default branch'
         type: string
         required: false  
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
+
   workflow_call: # workflow runs after Test Suite or code-health
     inputs:
       terraform_version:
@@ -52,6 +57,11 @@ on:
         type: boolean
         required: false
   
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
+
 jobs:
   tests:
     name: tests-${{ inputs.terraform_version || 'latest' }}-${{ inputs.provider_version || 'latest' }}-${{ inputs.atlas_cloud_env || 'dev' }}
@@ -65,6 +75,8 @@ jobs:
       mongodb_atlas_gov_private_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_GOV_PRIVATE_KEY_QA || secrets.MONGODB_ATLAS_GOV_PRIVATE_KEY_DEV }}
       mongodb_atlas_rp_public_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_DEV }}
       mongodb_atlas_rp_private_key: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_DEV }}
+      mongodb_atlas_client_id: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_CLIENT_ID_QA || secrets.MONGODB_ATLAS_CLIENT_ID_DEV }}
+      mongodb_atlas_client_secret: ${{ inputs.atlas_cloud_env == 'qa' && secrets.MONGODB_ATLAS_CLIENT_SECRET_QA || secrets.MONGODB_ATLAS_CLIENT_SECRET_DEV }}
       ca_cert: ${{ secrets.CA_CERT }}
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -103,6 +115,7 @@ jobs:
       test_group: ${{ inputs.test_group }}
       test_name: ${{ inputs.test_name }}
       reduced_tests: ${{ inputs.reduced_tests || false }}
+      use_sa: ${{ inputs.use_sa || false }}
       aws_region_federation: ${{ vars.AWS_REGION_FEDERATION }}
       mongodb_atlas_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ORG_ID_CLOUD_QA || vars.MONGODB_ATLAS_ORG_ID_CLOUD_DEV }}
       mongodb_atlas_base_url: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_BASE_URL_QA || vars.MONGODB_ATLAS_BASE_URL }}
@@ -124,8 +137,13 @@ jobs:
       mongodb_atlas_gov_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_ORG_ID_QA || vars.MONGODB_ATLAS_GOV_ORG_ID_DEV }}
       mongodb_atlas_gov_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_DEV }}
       mongodb_atlas_federated_settings_associated_domain: ${{ vars.MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN }}
+      mongodb_atlas_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_DEV }}
+      mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
+      aws_ear_role_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AWS_EAR_ROLE_ID_QA || vars.AWS_EAR_ROLE_ID_DEV }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}
       confluent_cloud_network_id: ${{ vars.CONFLUENT_CLOUD_NETWORK_ID }} 
       confluent_cloud_privatelink_access_id: ${{ vars.CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID }}
+      mongodb_atlas_asp_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID_DEV }}
+      mongodb_atlas_asp_project_aws_role_arn: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN_QA || vars.MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN_DEV }}
       mongodb_atlas_last_1x_version: ${{ vars.MONGODB_ATLAS_LAST_1X_VERSION }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -56,7 +56,6 @@ on:
         description: 'If run only minimum tests for advanced_cluster, e.g. in PRs'
         type: boolean
         required: false
-  
       use_sa:
         description: "Run tests using Service Account instead of API Keys"
         type: boolean
@@ -107,7 +106,6 @@ jobs:
       confluent_cloud_api_secret: ${{ secrets.CONFLUENT_CLOUD_API_SECRET }}
       aws_customer_master_key_id: ${{ secrets.AWS_CUSTOMER_MASTER_KEY_ID }}
 
-
     with:
       terraform_version: ${{ inputs.terraform_version || '1.13.x' }}
       provider_version: ${{ inputs.provider_version }}
@@ -137,13 +135,8 @@ jobs:
       mongodb_atlas_gov_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_ORG_ID_QA || vars.MONGODB_ATLAS_GOV_ORG_ID_DEV }}
       mongodb_atlas_gov_project_owner_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_QA || vars.MONGODB_ATLAS_GOV_PROJECT_OWNER_ID_DEV }}
       mongodb_atlas_federated_settings_associated_domain: ${{ vars.MONGODB_ATLAS_FEDERATED_SETTINGS_ASSOCIATED_DOMAIN }}
-      mongodb_atlas_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_ID_DEV }}
-      mongodb_atlas_project_ear_pe_aws_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_QA || vars.MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID_DEV }}
-      aws_ear_role_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.AWS_EAR_ROLE_ID_QA || vars.AWS_EAR_ROLE_ID_DEV }}
       azure_private_endpoint_region: ${{ vars.AZURE_PRIVATE_ENDPOINT_REGION }}
       mongodb_atlas_rp_org_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || vars.MONGODB_ATLAS_RP_ORG_ID_DEV }}
       confluent_cloud_network_id: ${{ vars.CONFLUENT_CLOUD_NETWORK_ID }} 
       confluent_cloud_privatelink_access_id: ${{ vars.CONFLUENT_CLOUD_PRIVATELINK_ACCESS_ID }}
-      mongodb_atlas_asp_project_ear_pe_id: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID_QA || vars.MONGODB_ATLAS_ASP_PROJECT_EAR_PE_ID_DEV }}
-      mongodb_atlas_asp_project_aws_role_arn: ${{ inputs.atlas_cloud_env == 'qa' && vars.MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN_QA || vars.MONGODB_ATLAS_ASP_PROJECT_AWS_ROLE_ARN_DEV }}
       mongodb_atlas_last_1x_version: ${{ vars.MONGODB_ATLAS_LAST_1X_VERSION }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -38,9 +38,9 @@ on:
         description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
         default: true
-
   schedule:
     - cron: "0 0 2-31 * *" # workflow runs every day at midnight UTC except on the first day of the month
+
 concurrency:
   group: '${{ github.workflow }}'
   cancel-in-progress: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,6 +17,10 @@ on:
         description: 'Send the Slack notification if any of the tests fail.'
         type: boolean
         default: false
+      use_sa:
+        description: "Run tests using Service Account instead of API Keys"
+        type: boolean
+        required: false
   workflow_call:
     inputs:
       terraform_matrix:
@@ -70,13 +74,14 @@ jobs:
       matrix:
         terraform_version: ${{ fromJSON(needs.variables.outputs.terraform_matrix) }}
         provider_version: ${{ fromJSON(needs.variables.outputs.provider_matrix) }}
-    name: ${{ matrix.terraform_version || 'latest' }}-${{ matrix.provider_version || 'latest' }}
+    name: ${{ matrix.terraform_version || 'latest' }}-${{ matrix.provider_version || 'latest' }}-${{ inputs.use_sa && 'sa' || 'pak' }}
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:
       terraform_version: ${{ matrix.terraform_version }}
       provider_version: ${{ matrix.provider_version }}
       atlas_cloud_env: ${{ inputs.atlas_cloud_env || needs.variables.outputs.is_sun == 'true' && 'qa' || '' }} # Run against QA on Sundays
+      use_sa: ${{ inputs.use_sa || false }}
   clean-after:
     needs: tests
     if: ${{ !cancelled() }}

--- a/internal/config/transport_test.go
+++ b/internal/config/transport_test.go
@@ -160,9 +160,11 @@ func TestAccNetworkLogging(t *testing.T) {
 	log.SetOutput(&logOutput)
 	defer log.SetOutput(os.Stderr)
 	cfg := &config.Config{
-		PublicKey:  os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
-		PrivateKey: os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
-		BaseURL:    os.Getenv("MONGODB_ATLAS_BASE_URL"),
+		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
+		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
+		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
+		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 	}
 	clientInterface, err := cfg.NewClient(t.Context())
 	require.NoError(t, err)

--- a/internal/config/transport_test.go
+++ b/internal/config/transport_test.go
@@ -160,11 +160,9 @@ func TestAccNetworkLogging(t *testing.T) {
 	log.SetOutput(&logOutput)
 	defer log.SetOutput(os.Stderr)
 	cfg := &config.Config{
-		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
-		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
-		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
-		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
-		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
+		PublicKey:  os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
+		PrivateKey: os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		BaseURL:    os.Getenv("MONGODB_ATLAS_BASE_URL"),
 	}
 	clientInterface, err := cfg.NewClient(t.Context())
 	require.NoError(t, err)

--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 func TestAccSTSAssumeRole_basic(t *testing.T) {
+	acc.SkipInPAK(t, "skipping as this test is for AWS credentials only")
+	acc.SkipInSA(t, "skipping as this test is for AWS credentials only")
 	var (
 		resourceName = "mongodbatlas_project.test"
 		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName  = acc.RandomProjectName()
 	)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckSTSAssumeRole(t); acc.PreCheckRegularCredsAreEmpty(t) },
+		PreCheck:                 func() { acc.PreCheckSTSAssumeRole(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyProject,
 		Steps: []resource.TestStep{
@@ -40,6 +42,48 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 	})
 }
 
+func TestAccServiceAccount_basic(t *testing.T) {
+	acc.SkipInPAK(t, "skipping as this test is for SA only")
+	var (
+		resourceName = "data.mongodbatlas_organization.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configDataSourceOrg(orgID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAccessToken_basic(t *testing.T) {
+	acc.SkipTestForCI(t) // access token has a validity period of 1 hour, so it cannot be used in CI reliably
+	acc.SkipInPAK(t, "skipping as this test is for Token credentials only")
+	acc.SkipInSA(t, "skipping as this test is for Token credentials only")
+	var (
+		resourceName = "data.mongodbatlas_organization.test"
+		orgID        = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckAccessToken(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config: configDataSourceOrg(orgID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "org_id"),
+				),
+			},
+		},
+	})
+}
+
 func configProject(orgID, projectName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_project" "test" {
@@ -47,4 +91,12 @@ func configProject(orgID, projectName string) string {
 			name  			 = %[2]q
 		}
 	`, orgID, projectName)
+}
+
+func configDataSourceOrg(orgID string) string {
+	return fmt.Sprintf(`
+		data "mongodbatlas_organization" "test" {
+  			org_id = %[1]q
+		}
+	`, orgID)
 }

--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -43,6 +43,7 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 }
 
 func TestAccServiceAccount_basic(t *testing.T) {
+	acc.SkipInSA(t, "skipping because SA is not implemented in master yet") // TODO: remove this skip in SA dev branch
 	acc.SkipInPAK(t, "skipping as this test is for SA only")
 	var (
 		resourceName = "data.mongodbatlas_organization.test"

--- a/internal/provider/provider_authentication_test.go
+++ b/internal/provider/provider_authentication_test.go
@@ -43,7 +43,6 @@ func TestAccSTSAssumeRole_basic(t *testing.T) {
 }
 
 func TestAccServiceAccount_basic(t *testing.T) {
-	acc.SkipInSA(t, "skipping because SA is not implemented in master yet") // TODO: remove this skip in SA dev branch
 	acc.SkipInPAK(t, "skipping as this test is for SA only")
 	var (
 		resourceName = "data.mongodbatlas_organization.test"

--- a/internal/service/organization/resource_organization_test.go
+++ b/internal/service/organization/resource_organization_test.go
@@ -481,10 +481,10 @@ func checkAggr(orgOwnerID, name, description string, settings *admin.Organizatio
 		"name":                       name,
 		"org_owner_id":               orgOwnerID,
 		"description":                description,
-		"api_access_list_required":   strconv.FormatBool(*settings.ApiAccessListRequired),
-		"multi_factor_auth_required": strconv.FormatBool(*settings.MultiFactorAuthRequired),
-		"restrict_employee_access":   strconv.FormatBool(*settings.RestrictEmployeeAccess),
-		"gen_ai_features_enabled":    strconv.FormatBool(*settings.GenAIFeaturesEnabled),
+		"api_access_list_required":   strconv.FormatBool(settings.GetApiAccessListRequired()),
+		"multi_factor_auth_required": strconv.FormatBool(settings.GetMultiFactorAuthRequired()),
+		"restrict_employee_access":   strconv.FormatBool(settings.GetRestrictEmployeeAccess()),
+		"gen_ai_features_enabled":    strconv.FormatBool(settings.GetGenAIFeaturesEnabled()),
 		"security_contact":           settings.GetSecurityContact(),
 	}
 	checks := []resource.TestCheckFunc{

--- a/internal/service/project/resource_project_migration_test.go
+++ b/internal/service/project/resource_project_migration_test.go
@@ -153,6 +153,7 @@ func TestMigProject_withLimits(t *testing.T) {
 
 // based on bug report: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/2263
 func TestMigGovProject_regionUsageRestrictionsDefault(t *testing.T) {
+	acc.SkipInSA(t, "SA not supported in Gov tests yet")
 	var (
 		orgID       = os.Getenv("MONGODB_ATLAS_GOV_ORG_ID")
 		projectName = acc.RandomProjectName()

--- a/internal/service/project/resource_project_test.go
+++ b/internal/service/project/resource_project_test.go
@@ -638,6 +638,7 @@ func TestAccProject_basic(t *testing.T) {
 }
 
 func TestAccGovProject_withProjectOwner(t *testing.T) {
+	acc.SkipInSA(t, "SA not supported in Gov tests yet")
 	var (
 		orgID          = os.Getenv("MONGODB_ATLAS_GOV_ORG_ID")
 		projectOwnerID = os.Getenv("MONGODB_ATLAS_GOV_PROJECT_OWNER_ID")

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -52,6 +52,12 @@ func ConnV2UsingGov() *admin.APIClient {
 }
 
 func init() {
+	if InUnitTest() { // Dummy credentials for unit tests
+		os.Setenv("MONGODB_ATLAS_PUBLIC_KEY", "dummy")
+		os.Setenv("MONGODB_ATLAS_PRIVATE_KEY", "dummy")
+		os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
+		os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
+	}
 	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
 			return provider.MuxProviderFactory()(), nil
@@ -60,6 +66,8 @@ func init() {
 	cfg := config.Config{
 		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
+		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
+		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
 	}

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -66,8 +66,6 @@ func init() {
 	cfg := config.Config{
 		PublicKey:    os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"),
 		PrivateKey:   os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"),
-		ClientID:     os.Getenv("MONGODB_ATLAS_CLIENT_ID"),
-		ClientSecret: os.Getenv("MONGODB_ATLAS_CLIENT_SECRET"),
 		BaseURL:      os.Getenv("MONGODB_ATLAS_BASE_URL"),
 		RealmBaseURL: os.Getenv("MONGODB_REALM_BASE_URL"),
 	}

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -48,14 +48,6 @@ func PreCheck(tb testing.TB) {
 	}
 }
 
-func PreCheckEncryptionAtRestPrivateEndpoint(tb testing.TB) {
-	tb.Helper()
-	PreCheckBasic(tb)
-	if os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PROJECT_EAR_PE_ID` must be set for acceptance testing")
-	}
-}
-
 func PreCheckCert(tb testing.TB) {
 	tb.Helper()
 	PreCheckBasic(tb)

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -236,9 +236,8 @@ func PreCheckEncryptionAtRestEnvAWS(tb testing.TB) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
 		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" ||
 		os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") == "" ||
 		os.Getenv("AWS_REGION") == "" {
-		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID`, `AWS_REGION` and `MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID` must be set for acceptance testing")
+		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID` and `AWS_REGION` must be set for acceptance testing")
 	}
 }
 

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -11,10 +11,14 @@ import (
 
 func PreCheckBasic(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	if os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	}
+	if HasPAKCreds() && HasSACreds() {
+		tb.Fatal("PAK and SA credentials are defined in this test but only one should be set.")
+	}
+	if !HasPAKCreds() && !HasSACreds() {
+		tb.Fatal("No credentials are defined in this test, PAK or SA credentials should be set.")
 	}
 }
 
@@ -38,21 +42,25 @@ func PreCheckBasicSleep(tb testing.TB, clusterInfo *ClusterInfo, projectID, clus
 // Use PreCheckBasic instead.
 func PreCheck(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" {
-		tb.Fatal("`MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, `MONGODB_ATLAS_PROJECT_ID` and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	PreCheckBasic(tb)
+	if os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_ID` must be set for acceptance testing")
+	}
+}
+
+func PreCheckEncryptionAtRestPrivateEndpoint(tb testing.TB) {
+	tb.Helper()
+	PreCheckBasic(tb)
+	if os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_ID") == "" {
+		tb.Fatal("`MONGODB_ATLAS_PROJECT_EAR_PE_ID` must be set for acceptance testing")
 	}
 }
 
 func PreCheckCert(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") == "" ||
-		os.Getenv("MONGODB_ATLAS_ORG_ID") == "" ||
-		os.Getenv("CA_CERT") == "" {
-		tb.Fatal("`CA_CERT, MONGODB_ATLAS_PUBLIC_KEY`, `MONGODB_ATLAS_PRIVATE_KEY`, and `MONGODB_ATLAS_ORG_ID` must be set for acceptance testing")
+	PreCheckBasic(tb)
+	if os.Getenv("CA_CERT") == "" {
+		tb.Fatal("`CA_CERT` must be set for acceptance testing")
 	}
 }
 
@@ -236,8 +244,9 @@ func PreCheckEncryptionAtRestEnvAWS(tb testing.TB) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
 		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" ||
 		os.Getenv("AWS_CUSTOMER_MASTER_KEY_ID") == "" ||
+		os.Getenv("MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID") == "" ||
 		os.Getenv("AWS_REGION") == "" {
-		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID` and `AWS_REGION` must be set for acceptance testing")
+		tb.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_VPC_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_CUSTOMER_MASTER_KEY_ID`, `AWS_REGION` and `MONGODB_ATLAS_PROJECT_EAR_PE_AWS_ID` must be set for acceptance testing")
 	}
 }
 
@@ -258,35 +267,13 @@ func PreCheckAwsEnvPrivateLinkEndpointService(tb testing.TB) {
 	}
 }
 
-func PreCheckRegularCredsAreEmpty(tb testing.TB) {
-	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != "" {
-		tb.Fatal(`"MONGODB_ATLAS_PUBLIC_KEY" and "MONGODB_ATLAS_PRIVATE_KEY" are defined in this test and they should not.`)
-	}
-}
-
 func PreCheckSTSAssumeRole(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("AWS_REGION") == "" {
-		tb.Fatal(`'AWS_REGION' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("STS_ENDPOINT") == "" {
-		tb.Fatal(`'STS_ENDPOINT' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("ASSUME_ROLE_ARN") == "" {
-		tb.Fatal(`'ASSUME_ROLE_ARN' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		tb.Fatal(`'AWS_ACCESS_KEY_ID' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		tb.Fatal(`'AWS_SECRET_ACCESS_KEY' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("AWS_SESSION_TOKEN") == "" {
-		tb.Fatal(`'AWS_SESSION_TOKEN' must be set for acceptance testing with STS Assume Role.`)
-	}
-	if os.Getenv("SECRET_NAME") == "" {
-		tb.Fatal(`'SECRET_NAME' must be set for acceptance testing with STS Assume Role.`)
+	envVars := []string{"AWS_REGION", "STS_ENDPOINT", "ASSUME_ROLE_ARN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "SECRET_NAME"}
+	for _, envVar := range envVars {
+		if os.Getenv(envVar) == "" {
+			tb.Fatalf("`%s` must be set for acceptance testing with STS Assume Role.", envVar)
+		}
 	}
 }
 
@@ -364,5 +351,12 @@ func PreCheckAwsMsk(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("AWS_MSK_ARN") == "" {
 		tb.Fatal("`AWS_MSK_ARN` must be set for AWS MSK acceptance testing")
+	}
+}
+
+func PreCheckAccessToken(tb testing.TB) {
+	tb.Helper()
+	if os.Getenv("MONGODB_ATLAS_OAUTH_TOKEN") == "" {
+		tb.Fatal("`MONGODB_ATLAS_OAUTH_TOKEN` must be set for Atlas Access Token acceptance testing")
 	}
 }

--- a/internal/testutil/acc/skip.go
+++ b/internal/testutil/acc/skip.go
@@ -2,7 +2,7 @@ package acc
 
 import (
 	"os"
-	"strings"
+	"strconv"
 	"testing"
 )
 
@@ -15,7 +15,8 @@ func SkipTestForCI(tb testing.TB) {
 }
 
 func InCI() bool {
-	return strings.EqualFold(os.Getenv("CI"), "true")
+	val, _ := strconv.ParseBool(os.Getenv("CI"))
+	return val
 }
 
 // SkipInUnitTest allows skipping a test entirely when TF_ACC=1 is not defined.
@@ -29,4 +30,26 @@ func SkipInUnitTest(tb testing.TB) {
 
 func InUnitTest() bool {
 	return os.Getenv("TF_ACC") == ""
+}
+
+func HasPAKCreds() bool {
+	return os.Getenv("MONGODB_ATLAS_PUBLIC_KEY") != "" || os.Getenv("MONGODB_ATLAS_PRIVATE_KEY") != ""
+}
+
+func HasSACreds() bool {
+	return os.Getenv("MONGODB_ATLAS_CLIENT_ID") != "" || os.Getenv("MONGODB_ATLAS_CLIENT_SECRET") != ""
+}
+
+func SkipInSA(tb testing.TB, description string) {
+	tb.Helper()
+	if HasSACreds() {
+		tb.Skip(description)
+	}
+}
+
+func SkipInPAK(tb testing.TB, description string) {
+	tb.Helper()
+	if HasPAKCreds() {
+		tb.Skip(description)
+	}
 }

--- a/internal/testutil/unit/http_mocker.go
+++ b/internal/testutil/unit/http_mocker.go
@@ -80,6 +80,7 @@ type mockClientModifier struct {
 	config           *MockHTTPDataConfig
 	mockRoundTripper http.RoundTripper
 	oldRoundTripper  http.RoundTripper
+	skipReset        bool // When true, skip reset to avoid data races with shared clients
 }
 
 func (c *mockClientModifier) ModifyHTTPClient(httpClient *http.Client) error {
@@ -89,6 +90,10 @@ func (c *mockClientModifier) ModifyHTTPClient(httpClient *http.Client) error {
 }
 
 func (c *mockClientModifier) ResetHTTPClient(httpClient *http.Client) {
+	// Skip reset when using copied HTTP clients to avoid data races
+	if c.skipReset {
+		return
+	}
 	if c.oldRoundTripper != nil {
 		httpClient.Transport = c.oldRoundTripper
 	}


### PR DESCRIPTION
## Description

Bring SA dev branch `CLOUDP-334161-service-accounts-dev` non-production changes to master. 

This makes the branches closer without affecting negatively to master branch as the SA functionality is not brought yet.  Only test files and GHA config is brought to master. 
**Note:** Even if `use_sa` is available to run acc tests, tests will fail is trying to use it as SA functionality is not in master yet.

All the code changes in this PR has already been reviewed in the corresponding PRs to `CLOUDP-334161-service-accounts-dev` branch.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
