### PR TITLE
chore: Fix cleanup GHA after SA changes

### DIFF
--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
 
@@ -35,8 +34,7 @@ func specInstanceSizeNodeCount(instanceSize string, nodeCount int) knownvalue.Ch
 	})
 }
 
-func TestAccPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
-	acc.SkipInUnitTest(t)
+func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
 	var (
 		baseConfig         = unit.NewMockPlanChecksConfig(t, &mockConfig, unit.ImportNameClusterTwoRepSpecsWithAutoScalingAndSpecs)
 		resourceName       = baseConfig.ResourceName

--- a/internal/service/advancedcluster/plan_modifier_test.go
+++ b/internal/service/advancedcluster/plan_modifier_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/unit"
 )
 
@@ -34,7 +35,8 @@ func specInstanceSizeNodeCount(instanceSize string, nodeCount int) knownvalue.Ch
 	})
 }
 
-func TestPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
+func TestAccPlanChecksClusterTwoRepSpecsWithAutoScalingAndSpecs(t *testing.T) {
+	acc.SkipInUnitTest(t)
 	var (
 		baseConfig         = unit.NewMockPlanChecksConfig(t, &mockConfig, unit.ImportNameClusterTwoRepSpecsWithAutoScalingAndSpecs)
 		resourceName       = baseConfig.ResourceName

--- a/internal/testutil/acc/factory.go
+++ b/internal/testutil/acc/factory.go
@@ -52,12 +52,6 @@ func ConnV2UsingGov() *admin.APIClient {
 }
 
 func init() {
-	if InUnitTest() { // Dummy credentials for unit tests
-		os.Setenv("MONGODB_ATLAS_PUBLIC_KEY", "dummy")
-		os.Setenv("MONGODB_ATLAS_PRIVATE_KEY", "dummy")
-		os.Unsetenv("MONGODB_ATLAS_CLIENT_ID")
-		os.Unsetenv("MONGODB_ATLAS_CLIENT_SECRET")
-	}
 	TestAccProviderV6Factories = map[string]func() (tfprotov6.ProviderServer, error){
 		ProviderNameMongoDBAtlas: func() (tfprotov6.ProviderServer, error) {
 			return provider.MuxProviderFactory()(), nil


### PR DESCRIPTION
## Description

Fix cleanup GHA after SA changes. It was affecting the cleanup process because it runs as a unit test. 
Dummy credentials in unit tests are not needed any more.

Example of cleanup execution [here](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/18205280825/job/51834043641)

Link to any related issue(s): CLOUDP-349250

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
