### PR TITLE
chore: Rename JWT token environment variable

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -478,7 +478,7 @@ func setDefaultValuesWithValidations(ctx context.Context, data *tfMongodbAtlasPr
 
 	if data.AccessToken.ValueString() == "" {
 		data.AccessToken = types.StringValue(MultiEnvDefaultFunc([]string{
-			"MONGODB_ATLAS_OAUTH_TOKEN",
+			"MONGODB_ATLAS_ACCESS_TOKEN",
 			"TF_VAR_OAUTH_TOKEN",
 		}, "").(string))
 	}

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -453,7 +453,7 @@ func setDefaultsAndValidations(d *schema.ResourceData) diag.Diagnostics {
 	}
 
 	if err := setValueFromConfigOrEnv(d, "access_token", []string{
-		"MONGODB_ATLAS_OAUTH_TOKEN",
+		"MONGODB_ATLAS_ACCESS_TOKEN",
 		"TF_VAR_OAUTH_TOKEN",
 	}); err != nil {
 		return append(diagnostics, diag.FromErr(err)...)

--- a/internal/testutil/acc/pre_check.go
+++ b/internal/testutil/acc/pre_check.go
@@ -347,7 +347,7 @@ func PreCheckAwsMsk(tb testing.TB) {
 
 func PreCheckAccessToken(tb testing.TB) {
 	tb.Helper()
-	if os.Getenv("MONGODB_ATLAS_OAUTH_TOKEN") == "" {
-		tb.Fatal("`MONGODB_ATLAS_OAUTH_TOKEN` must be set for Atlas Access Token acceptance testing")
+	if os.Getenv("MONGODB_ATLAS_ACCESS_TOKEN") == "" {
+		tb.Fatal("`MONGODB_ATLAS_ACCESS_TOKEN` must be set for Atlas Access Token acceptance testing")
 	}
 }


### PR DESCRIPTION
## Description

Rename JWT token environment variable as per discussion in the PD+Scope

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
