### PR TITLE
chore: Split autogen acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -281,30 +281,7 @@ jobs:
             - 'internal/provider/*.go'
           authentication:
             - 'internal/config/*.go'
-            - 'internal/provider/*.go'
-          autogen_generic:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/auditingapi/*.go'
-            - 'internal/serviceapi/customdbroleapi/*.go'
-            - 'internal/serviceapi/databaseuserapi/*.go'
-            - 'internal/serviceapi/maintenancewindowapi/*.go'
-            - 'internal/serviceapi/orgserviceaccountapi/*.go'
-            - 'internal/serviceapi/projectapi/*.go'
-            - 'internal/serviceapi/projectsettingsapi/*.go'
-            - 'internal/serviceapi/resourcepolicyapi/*.go'
-          autogen_cluster:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/clusterapi/*.go'
-          autogen_push_based_log_export:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/pushbasedlogexportapi/*.go'
-          autogen_stream:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/streaminstanceapi/*.go'
-            - 'internal/serviceapi/streamprocessorapi/*.go'
-          autogen_search_deployment:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/searchdeploymentapi/*.go'
+            - 'internal/provider/*.go' 
           backup:
             - 'internal/service/cloudbackupschedule/*.go'
             - 'internal/service/cloudbackupsnapshot/*.go'
@@ -393,6 +370,29 @@ jobs:
             - 'internal/service/streaminstance/*.go'
             - 'internal/service/streamprocessor/*.go'
             - 'internal/service/streamprivatelinkendpoint/*.go'
+          autogen_generic:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/auditingapi/*.go'
+            - 'internal/serviceapi/customdbroleapi/*.go'
+            - 'internal/serviceapi/databaseuserapi/*.go'
+            - 'internal/serviceapi/maintenancewindowapi/*.go'
+            - 'internal/serviceapi/orgserviceaccountapi/*.go'
+            - 'internal/serviceapi/projectapi/*.go'
+            - 'internal/serviceapi/projectsettingsapi/*.go'
+            - 'internal/serviceapi/resourcepolicyapi/*.go'
+          autogen_cluster:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/clusterapi/*.go'
+          autogen_push_based_log_export:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/pushbasedlogexportapi/*.go'
+          autogen_stream:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/streaminstanceapi/*.go'
+            - 'internal/serviceapi/streamprocessorapi/*.go'
+          autogen_search_deployment:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/searchdeploymentapi/*.go'
 
 
   advanced_cluster:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -240,7 +240,6 @@ jobs:
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
       assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
       authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
-      autogen: ${{ steps.filter.outputs.autogen == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
       control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
       cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
@@ -263,6 +262,11 @@ jobs:
       search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
+      autogen_generic: ${{ steps.filter.outputs.autogen_generic == 'true' || env.mustTrigger == 'true' }}
+      autogen_cluster: ${{ steps.filter.outputs.autogen_cluster == 'true' || env.mustTrigger == 'true' }}
+      autogen_push_based_log_export: ${{ steps.filter.outputs.autogen_push_based_log_export == 'true' || env.mustTrigger == 'true' }}
+      autogen_stream: ${{ steps.filter.outputs.autogen_stream == 'true' || env.mustTrigger == 'true' }}
+      autogen_search_deployment: ${{ steps.filter.outputs.autogen_search_deployment == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
@@ -278,18 +282,29 @@ jobs:
           authentication:
             - 'internal/config/*.go'
             - 'internal/provider/*.go'
-          autogen:
+          autogen_generic:
             - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/auditingapi/*.go'
-            - 'internal/serviceapi/clusterapi/*.go'
             - 'internal/serviceapi/customdbroleapi/*.go'
             - 'internal/serviceapi/databaseuserapi/*.go'
             - 'internal/serviceapi/maintenancewindowapi/*.go'
+            - 'internal/serviceapi/orgserviceaccountapi/*.go'
             - 'internal/serviceapi/projectapi/*.go'
+            - 'internal/serviceapi/projectsettingsapi/*.go'
+            - 'internal/serviceapi/resourcepolicyapi/*.go'
+          autogen_cluster:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/clusterapi/*.go'
+          autogen_push_based_log_export:
+            - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/pushbasedlogexportapi/*.go'
-            - 'internal/serviceapi/resourcepolicyapi/*.go'            
-            - 'internal/serviceapi/searchdeploymentapi/*.go'
+          autogen_stream:
+            - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/streaminstanceapi/*.go'
+            - 'internal/serviceapi/streamprocessorapi/*.go'
+          autogen_search_deployment:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/searchdeploymentapi/*.go'
           backup:
             - 'internal/service/cloudbackupschedule/*.go'
             - 'internal/service/cloudbackupsnapshot/*.go'
@@ -556,43 +571,6 @@ jobs:
             ./internal/service/maintenancewindow
         run: make testacc
 
-  autogen:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen == 'true' || inputs.test_group == 'autogen' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: |
-            ./internal/serviceapi/auditingapi
-            ./internal/serviceapi/clusterapi
-            ./internal/serviceapi/customdbroleapi
-            ./internal/serviceapi/databaseuserapi
-            ./internal/serviceapi/maintenancewindowapi
-            ./internal/serviceapi/projectapi
-            ./internal/serviceapi/pushbasedlogexportapi
-            ./internal/serviceapi/resourcepolicyapi
-            ./internal/serviceapi/searchdeploymentapi
-            ./internal/serviceapi/streaminstanceapi
-        run: make testacc
-        
   backup:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.backup == 'true' || inputs.test_group == 'backup' }}
@@ -1243,3 +1221,142 @@ jobs:
               ./internal/service/streamprocessor
               ./internal/service/streamprivatelinkendpoint
           run: make testacc
+
+  autogen_generic:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_generic == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_generic' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/serviceapi/auditingapi
+            ./internal/serviceapi/customdbroleapi
+            ./internal/serviceapi/databaseuserapi
+            ./internal/serviceapi/maintenancewindowapi
+            ./internal/serviceapi/orgserviceaccountapi
+            ./internal/serviceapi/projectapi
+            ./internal/serviceapi/projectsettingsapi
+            ./internal/serviceapi/resourcepolicyapi
+        run: make testacc
+
+  autogen_cluster:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_cluster == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_cluster' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/clusterapi
+        run: make testacc
+
+  autogen_push_based_log_export:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_push_based_log_export == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_push_based_log_export' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/pushbasedlogexportapi
+        run: make testacc
+
+  autogen_stream:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_stream == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_stream' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/serviceapi/streaminstanceapi
+            ./internal/serviceapi/streamprocessorapi
+        run: make testacc
+
+  autogen_search_deployment:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_search_deployment == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_search_deployment' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/searchdeploymentapi
+        run: make testacc

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -240,6 +240,11 @@ jobs:
       advanced_cluster: ${{ steps.filter.outputs.advanced_cluster == 'true' || env.mustTrigger == 'true' }}
       assume_role: ${{ steps.filter.outputs.assume_role == 'true' || env.mustTrigger == 'true' }}
       authentication: ${{ steps.filter.outputs.authentication == 'true' || env.mustTrigger == 'true' }}
+      autogen_cluster: ${{ steps.filter.outputs.autogen_cluster == 'true' || env.mustTrigger == 'true' }}
+      autogen_generic: ${{ steps.filter.outputs.autogen_generic == 'true' || env.mustTrigger == 'true' }}
+      autogen_push_based_log_export: ${{ steps.filter.outputs.autogen_push_based_log_export == 'true' || env.mustTrigger == 'true' }}
+      autogen_search_deployment: ${{ steps.filter.outputs.autogen_search_deployment == 'true' || env.mustTrigger == 'true' }}
+      autogen_stream: ${{ steps.filter.outputs.autogen_stream == 'true' || env.mustTrigger == 'true' }}
       backup: ${{ steps.filter.outputs.backup == 'true' || env.mustTrigger == 'true' }}
       control_plane_ip_addresses: ${{ steps.filter.outputs.control_plane_ip_addresses == 'true' || env.mustTrigger == 'true' }}
       cloud_user: ${{ steps.filter.outputs.cloud_user == 'true' || env.mustTrigger == 'true' }}
@@ -262,11 +267,6 @@ jobs:
       search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
-      autogen_generic: ${{ steps.filter.outputs.autogen_generic == 'true' || env.mustTrigger == 'true' }}
-      autogen_cluster: ${{ steps.filter.outputs.autogen_cluster == 'true' || env.mustTrigger == 'true' }}
-      autogen_push_based_log_export: ${{ steps.filter.outputs.autogen_push_based_log_export == 'true' || env.mustTrigger == 'true' }}
-      autogen_stream: ${{ steps.filter.outputs.autogen_stream == 'true' || env.mustTrigger == 'true' }}
-      autogen_search_deployment: ${{ steps.filter.outputs.autogen_search_deployment == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
@@ -282,6 +282,29 @@ jobs:
           authentication:
             - 'internal/config/*.go'
             - 'internal/provider/*.go' 
+          autogen_cluster:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/clusterapi/*.go'
+          autogen_generic:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/auditingapi/*.go'
+            - 'internal/serviceapi/customdbroleapi/*.go'
+            - 'internal/serviceapi/databaseuserapi/*.go'
+            - 'internal/serviceapi/maintenancewindowapi/*.go'
+            - 'internal/serviceapi/orgserviceaccountapi/*.go'
+            - 'internal/serviceapi/projectapi/*.go'
+            - 'internal/serviceapi/projectsettingsapi/*.go'
+            - 'internal/serviceapi/resourcepolicyapi/*.go'
+          autogen_push_based_log_export:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/pushbasedlogexportapi/*.go'
+          autogen_search_deployment:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/searchdeploymentapi/*.go'
+          autogen_stream:
+            - 'internal/common/autogen/*.go'
+            - 'internal/serviceapi/streaminstanceapi/*.go'
+            - 'internal/serviceapi/streamprocessorapi/*.go'
           backup:
             - 'internal/service/cloudbackupschedule/*.go'
             - 'internal/service/cloudbackupsnapshot/*.go'
@@ -369,30 +392,7 @@ jobs:
             - 'internal/service/streamconnection/*.go'
             - 'internal/service/streaminstance/*.go'
             - 'internal/service/streamprocessor/*.go'
-            - 'internal/service/streamprivatelinkendpoint/*.go'
-          autogen_generic:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/auditingapi/*.go'
-            - 'internal/serviceapi/customdbroleapi/*.go'
-            - 'internal/serviceapi/databaseuserapi/*.go'
-            - 'internal/serviceapi/maintenancewindowapi/*.go'
-            - 'internal/serviceapi/orgserviceaccountapi/*.go'
-            - 'internal/serviceapi/projectapi/*.go'
-            - 'internal/serviceapi/projectsettingsapi/*.go'
-            - 'internal/serviceapi/resourcepolicyapi/*.go'
-          autogen_cluster:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/clusterapi/*.go'
-          autogen_push_based_log_export:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/pushbasedlogexportapi/*.go'
-          autogen_stream:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/streaminstanceapi/*.go'
-            - 'internal/serviceapi/streamprocessorapi/*.go'
-          autogen_search_deployment:
-            - 'internal/common/autogen/*.go'
-            - 'internal/serviceapi/searchdeploymentapi/*.go'
+            - 'internal/service/streamprivatelinkendpoint/*.go' 
 
 
   advanced_cluster:
@@ -569,6 +569,145 @@ jobs:
             ./internal/service/alertconfiguration
             ./internal/service/databaseuser
             ./internal/service/maintenancewindow
+        run: make testacc
+
+  autogen_cluster:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_cluster == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_cluster' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/clusterapi
+        run: make testacc
+
+  autogen_generic:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_generic == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_generic' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/serviceapi/auditingapi
+            ./internal/serviceapi/customdbroleapi
+            ./internal/serviceapi/databaseuserapi
+            ./internal/serviceapi/maintenancewindowapi
+            ./internal/serviceapi/orgserviceaccountapi
+            ./internal/serviceapi/projectapi
+            ./internal/serviceapi/projectsettingsapi
+            ./internal/serviceapi/resourcepolicyapi
+        run: make testacc
+
+  autogen_push_based_log_export:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_push_based_log_export == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_push_based_log_export' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/pushbasedlogexportapi
+        run: make testacc
+
+  autogen_search_deployment:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.autogen_search_deployment == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_search_deployment' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/searchdeploymentapi
+        run: make testacc
+
+  autogen_stream:
+    needs: [ change-detection, get-provider-version ]
+    if: ${{ needs.change-detection.outputs.autogen_stream == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_stream' }}
+    runs-on: ubuntu-latest
+    permissions: { }
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/serviceapi/streaminstanceapi
+            ./internal/serviceapi/streamprocessorapi
         run: make testacc
 
   backup:
@@ -1221,142 +1360,3 @@ jobs:
               ./internal/service/streamprocessor
               ./internal/service/streamprivatelinkendpoint
           run: make testacc
-
-  autogen_generic:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen_generic == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_generic' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: |
-            ./internal/serviceapi/auditingapi
-            ./internal/serviceapi/customdbroleapi
-            ./internal/serviceapi/databaseuserapi
-            ./internal/serviceapi/maintenancewindowapi
-            ./internal/serviceapi/orgserviceaccountapi
-            ./internal/serviceapi/projectapi
-            ./internal/serviceapi/projectsettingsapi
-            ./internal/serviceapi/resourcepolicyapi
-        run: make testacc
-
-  autogen_cluster:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen_cluster == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_cluster' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/serviceapi/clusterapi
-        run: make testacc
-
-  autogen_push_based_log_export:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen_push_based_log_export == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_push_based_log_export' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/serviceapi/pushbasedlogexportapi
-        run: make testacc
-
-  autogen_stream:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen_stream == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_stream' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: |
-            ./internal/serviceapi/streaminstanceapi
-            ./internal/serviceapi/streamprocessorapi
-        run: make testacc
-
-  autogen_search_deployment:
-    needs: [change-detection, get-provider-version]
-    if: ${{ needs.change-detection.outputs.autogen_search_deployment == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_search_deployment' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests
-        env:
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          ACCTEST_PACKAGES: ./internal/serviceapi/searchdeploymentapi
-        run: make testacc


### PR DESCRIPTION
## Description

Splitting acceptance tests for autogen resources.
Added new groups for slow ones and kept quick ones together under `autogen_generic`.

Can check timings on a previous run: [link](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/18199406207/job/51814824277)

Link to any related issue(s): CLOUDP-349369

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
