### PR TITLE
chore: Add autogen type override support for sets and lists

### DIFF
--- a/internal/serviceapi/orgserviceaccountapi/resource_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource_schema.go
@@ -35,7 +35,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.",
 				PlanModifiers:       []planmodifier.String{customplanmodifier.CreateOnly()},
 			},
-			"roles": schema.ListAttribute{
+			"roles": schema.SetAttribute{
 				Required:            true,
 				MarkdownDescription: "A list of organization-level roles for the Service Account.",
 				ElementType:         types.StringType,
@@ -83,7 +83,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Roles                   types.List   `tfsdk:"roles"`
+	Roles                   types.Set    `tfsdk:"roles"`
 	Secrets                 types.Set    `tfsdk:"secrets" autogen:"omitjson"`
 	ClientId                types.String `tfsdk:"client_id" autogen:"omitjson"`
 	CreatedAt               types.String `tfsdk:"created_at" autogen:"omitjson"`

--- a/internal/serviceapi/orgserviceaccountapi/resource_test.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource_test.go
@@ -50,7 +50,6 @@ func TestAccOrgServiceAccountAPI_basic(t *testing.T) {
 }
 
 func TestAccOrgServiceAccountAPI_rolesOrdering(t *testing.T) {
-	t.Skip("Roles is currently incorrectly defined as a List leading to inconsistent result after apply, to be addressed in CLOUDP-349935")
 	var (
 		orgID = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		name  = acc.RandomName()
@@ -99,7 +98,7 @@ func TestAccOrgServiceAccountAPI_createOnlyAttributes(t *testing.T) {
 }
 
 func configBasic(orgID, name, description string, roles []string, secretExpiresAfterHours int) string {
-	rolesStr := fmt.Sprintf(`%q`, strings.Join(roles, `", "`))
+	rolesStr := `"` + strings.Join(roles, `", "`) + `"`
 	rolesHCL := fmt.Sprintf("[%s]", rolesStr)
 	return fmt.Sprintf(`
 		resource "mongodbatlas_org_service_account_api" "test" {

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -663,17 +663,17 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 							TFSchemaName:             "list_string",
 							TFModelName:              "ListString",
 							ComputedOptionalRequired: codespec.Required,
-							Description:              conversion.StringPtr("List overridden to set"),
-							Set:                      &codespec.SetAttribute{ElementType: codespec.String},
-							ReqBodyUsage:             codespec.AllRequestBodies,
+							// List overridden to set
+							Set:          &codespec.SetAttribute{ElementType: codespec.String},
+							ReqBodyUsage: codespec.AllRequestBodies,
 						},
 						{
 							TFSchemaName:             "set_string",
 							TFModelName:              "SetString",
 							ComputedOptionalRequired: codespec.Required,
-							Description:              conversion.StringPtr("Set overridden to list"),
-							List:                     &codespec.ListAttribute{ElementType: codespec.String},
-							ReqBodyUsage:             codespec.AllRequestBodies,
+							// Set overridden to list
+							List:         &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage: codespec.AllRequestBodies,
 						},
 					},
 				},

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -632,6 +632,77 @@ func TestConvertToProviderSpec_singletonResourceNoDeleteOperation(t *testing.T) 
 	runTestCase(t, tc)
 }
 
+func TestConvertToProviderSpec_typeOverride(t *testing.T) {
+	tc := convertToSpecTestCase{
+		inputOpenAPISpecPath: testDataAPISpecPath,
+		inputConfigPath:      testDataConfigPath,
+		inputResourceName:    "test_resource_with_overridden_collection_types",
+
+		expectedResult: &codespec.Model{
+			Resources: []codespec.Resource{{
+				Schema: &codespec.Schema{
+					Description: conversion.StringPtr(testResourceDesc),
+					Attributes: codespec.Attributes{
+						{
+							TFSchemaName:             "flag",
+							TFModelName:              "Flag",
+							ComputedOptionalRequired: codespec.Required,
+							Bool:                     &codespec.BoolAttribute{},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+						},
+						{
+							TFSchemaName:             "group_id",
+							TFModelName:              "GroupId",
+							ComputedOptionalRequired: codespec.Required,
+							String:                   &codespec.StringAttribute{},
+							Description:              conversion.StringPtr(testPathParamDesc),
+							ReqBodyUsage:             codespec.OmitAlways,
+							CreateOnly:               true,
+						},
+						{
+							TFSchemaName:             "list_string",
+							TFModelName:              "ListString",
+							ComputedOptionalRequired: codespec.Required,
+							Description:              conversion.StringPtr("List overridden to set"),
+							Set:                      &codespec.SetAttribute{ElementType: codespec.String},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+						},
+						{
+							TFSchemaName:             "set_string",
+							TFModelName:              "SetString",
+							ComputedOptionalRequired: codespec.Required,
+							Description:              conversion.StringPtr("Set overridden to list"),
+							List:                     &codespec.ListAttribute{ElementType: codespec.String},
+							ReqBodyUsage:             codespec.AllRequestBodies,
+						},
+					},
+				},
+				Name: "test_resource_with_overridden_collection_types",
+				Operations: codespec.APIOperations{
+					Create: codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceWithCollections",
+						HTTPMethod: "POST",
+					},
+					Read: codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceWithCollections",
+						HTTPMethod: "GET",
+					},
+					Update: codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceWithCollections",
+						HTTPMethod: "PATCH",
+					},
+					Delete: &codespec.APIOperation{
+						Path:       "/api/atlas/v2/groups/{groupId}/testResourceWithCollections",
+						HTTPMethod: "DELETE",
+					},
+					VersionHeader: "application/vnd.atlas.2023-01-01+json",
+				},
+			}},
+		},
+	}
+	runTestCase(t, tc)
+}
+
 func runTestCase(t *testing.T, tc convertToSpecTestCase) {
 	t.Helper()
 	result, err := codespec.ToCodeSpecModel(tc.inputOpenAPISpecPath, tc.inputConfigPath, &tc.inputResourceName)

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -142,7 +142,31 @@ func applyOverrides(attr *Attribute, attrPathName string, schemaOptions config.S
 		if override.IncludeNullOnUpdate != nil && *override.IncludeNullOnUpdate {
 			attr.ReqBodyUsage = IncludeNullOnUpdate
 		}
+		if override.Type != nil {
+			applyTypeOverride(&override, attr)
+		}
 	}
+}
+
+func applyTypeOverride(override *config.Override, attr *Attribute) {
+	switch *override.Type {
+	case config.Set:
+		if attr.List != nil {
+			attr.Set = &SetAttribute{ElementType: attr.List.ElementType}
+			attr.List = nil
+			return
+		}
+	case config.List:
+		if attr.Set != nil {
+			attr.List = &ListAttribute{ElementType: attr.Set.ElementType}
+			attr.Set = nil
+			return
+		}
+	default:
+		log.Printf("[WARN] %s - Unsupported type override defined in configuration: %s", attr.TFSchemaName, *override.Type)
+		return
+	}
+	log.Printf("[WARN] %s - Unsupported override from original type to: %s", attr.TFSchemaName, *override.Type)
 }
 
 func getComputabilityFromConfig(computability config.Computability) ComputedOptionalRequired {

--- a/tools/codegen/codespec/testdata/api-spec.yml
+++ b/tools/codegen/codespec/testdata/api-spec.yml
@@ -366,6 +366,89 @@ paths:
       summary: Update the Test Singleton Resource feature for a project
       tags:
         - Test Singleton Resource
+  "/api/atlas/v2/groups/{groupId}/testResourceWithCollections":
+    delete:
+      description: DELETE API description
+      operationId: deleteTestResourceConfiguration
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Disable the Test Resource feature for a project.
+      tags:
+        - Test Resource
+    get:
+      description: GET API description
+      operationId: getTestResourceConfiguration
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              schema:
+                $ref: "#/components/schemas/TestResourceWithCollections"
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Get the Test Resource configuration for a project
+      tags:
+        - Test Resource
+    patch:
+      description: PATCH API description
+      operationId: updateTestResourceConfiguration
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceWithCollections"
+            x-xgen-version: 2023-01-01
+        description: Patch request description
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Update the Test Resource feature for a project
+      tags:
+        - Test Resource
+    post:
+      description: POST API description
+      operationId: createTestResourceConfiguration
+      parameters:
+        - $ref: "#/components/parameters/groupId"
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            schema:
+              $ref: "#/components/schemas/TestResourceWithCollections"
+            x-xgen-version: 2023-01-01
+        description: Create request description
+        required: true
+      responses:
+        "200":
+          content:
+            application/vnd.atlas.2023-01-01+json:
+              x-xgen-version: 2023-01-01
+          description: OK
+      security:
+        - DigestAuth: []
+      summary: Enable the Test Resource feature for a project
+      tags:
+        - Test Resource
 components:
   parameters:
     groupId:
@@ -613,3 +696,21 @@ components:
       properties:
         flag:
           type: boolean
+    TestResourceWithCollections:
+      type: object
+      properties:
+        flag:
+          type: boolean
+        listString:
+          type: array
+          items:
+            type: string
+        setString:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+      required:
+        - flag
+        - listString
+        - setString

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -53,3 +53,25 @@ resources:
     update:
       path: /api/atlas/v2/groups/{groupId}/testSingletonResource
       method: PATCH
+
+  test_resource_with_overridden_collection_types:
+    create:
+      path: /api/atlas/v2/groups/{groupId}/testResourceWithCollections
+      method: POST
+    read:
+      path: /api/atlas/v2/groups/{groupId}/testResourceWithCollections
+      method: GET
+    update:
+      path: /api/atlas/v2/groups/{groupId}/testResourceWithCollections
+      method: PATCH
+    delete:
+      path: /api/atlas/v2/groups/{groupId}/testResourceWithCollections
+      method: DELETE
+    schema:
+      overrides:
+        list_string:
+          type: set
+          description: "List overridden to set"
+        set_string:
+          type: list
+          description: "Set overridden to list"

--- a/tools/codegen/codespec/testdata/config.yml
+++ b/tools/codegen/codespec/testdata/config.yml
@@ -71,7 +71,5 @@ resources:
       overrides:
         list_string:
           type: set
-          description: "List overridden to set"
         set_string:
           type: list
-          description: "Set overridden to list"

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -518,3 +518,5 @@ resources:
       overrides:
         secrets.secret:
           sensitive: true
+        roles:
+          type: set

--- a/tools/codegen/config/config_model.go
+++ b/tools/codegen/config/config_model.go
@@ -40,6 +40,7 @@ type Override struct {
 	Computability       *Computability `yaml:"computability,omitempty"`
 	Sensitive           *bool          `yaml:"sensitive"`
 	IncludeNullOnUpdate *bool          `yaml:"include_null_on_update"`
+	Type                *Type          `yaml:"type"`
 	Description         string         `yaml:"description"`
 	PlanModifiers       []PlanModifier `yaml:"plan_modifiers"`
 	Validators          []Validator    `yaml:"validators"`
@@ -60,3 +61,10 @@ type Computability struct {
 	Computed bool `yaml:"computed"`
 	Required bool `yaml:"required"`
 }
+
+type Type string
+
+const (
+	List Type = "list"
+	Set  Type = "set"
+)

--- a/tools/codegen/models/org_service_account_api.yaml
+++ b/tools/codegen/models/org_service_account_api.yaml
@@ -41,7 +41,7 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: true
-        - list:
+        - set:
             element_type: 4
           description: A list of organization-level roles for the Service Account.
           computed_optional_required: required


### PR DESCRIPTION
## Description

Allow overriding an attribute's type in the autogen config. 
Currently supporting `set` to `list` and `list` to `set` overrides.
> Any other override requires more complexity in the conversion and is unlikely to be required.

- Overriding the `roles` attribute in the `org_service_account_api` resource from `list` to `set`. This is necessary since the API spec is missing the `uniqueItems: true` configuration (see CLOUDP-348768).

- Enabling the `TestAccOrgServiceAccountAPI_rolesOrdering` acceptance test.

Link to any related issue(s): CLOUDP-349935

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
