### PR TITLE
feat: Add workspace_name field in stream_processor resource and datasource

### DIFF
--- a/.changelog/3793.txt
+++ b/.changelog/3793.txt
@@ -1,11 +1,11 @@
 ```release-note:note
-resource/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
+resource/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute, use `workspace_name` instead
 
 ```
 ```release-note:note
-data-source/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
+data-source/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute, use `workspace_name` instead
 ```
 
 ```release-note:note
-data-source/mongodbatlas_stream_processors: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
+data-source/mongodbatlas_stream_processors: Deprecates the `instance_name` attribute, use `workspace_name` instead
 ```

--- a/.changelog/3793.txt
+++ b/.changelog/3793.txt
@@ -1,0 +1,11 @@
+```release-note:note
+resource/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+
+```
+```release-note:note
+data-source/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+```
+
+```release-note:note
+data-source/mongodbatlas_stream_processors: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+```

--- a/.changelog/3793.txt
+++ b/.changelog/3793.txt
@@ -1,11 +1,11 @@
 ```release-note:note
-resource/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+resource/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
 
 ```
 ```release-note:note
-data-source/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+data-source/mongodbatlas_stream_processor: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
 ```
 
 ```release-note:note
-data-source/mongodbatlas_stream_processors: Deprecates the `instance_name` attribute. All configurations using `instance_name` should be updated to use the new `workspace_name` attribute instead
+data-source/mongodbatlas_stream_processors: Deprecates the `instance_name` attribute. Update all configurations using `instance_name` to use the new `workspace_name` attribute instead.
 ```

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -30,7 +30,7 @@ data "mongodbatlas_stream_connection" "example" {
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
 * `instance_name` - (Deprecated) Human-readable label that identifies the stream instance. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
-* `workspace_name` - (Optional) Human-readable label that identifies the stream instance. Conflicts with `workspace_name`.
+* `workspace_name` - (Optional) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
 * `connection_name` - (Required) Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
 
 ~> **NOTE:** Either `workspace_name` or `instance_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is an alias for `instance_name`. `workspace_name` should be used instead of `instance_name`.

--- a/docs/data-sources/stream_connection.md
+++ b/docs/data-sources/stream_connection.md
@@ -29,9 +29,9 @@ data "mongodbatlas_stream_connection" "example" {
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
-* `instance_name` - (Deprecated) Human-readable label that identifies the stream instance. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
-* `workspace_name` - (Optional) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
-* `connection_name` - (Required) Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
+* `instance_name` - (Deprecated) Label that identifies the stream processing workspace. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
+* `workspace_name` - (Optional) Label that identifies the stream processing workspace. Conflicts with `instance_name`.
+* `connection_name` - (Required) Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
 
 ~> **NOTE:** Either `workspace_name` or `instance_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is an alias for `instance_name`. `workspace_name` should be used instead of `instance_name`.
 

--- a/docs/data-sources/stream_connections.md
+++ b/docs/data-sources/stream_connections.md
@@ -18,8 +18,8 @@ data "mongodbatlas_stream_connections" "test" {
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
-* `instance_name` - (Deprecated) Human-readable label that identifies the stream instance. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
-* `workspace_name` - (Optional) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
+* `instance_name` - (Deprecated) Label that identifies the stream processing workspace. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
+* `workspace_name` - (Optional) Label that identifies the stream processing workspace. Conflicts with `instance_name`.
 
 ~> **NOTE:** Either `workspace_name` or `instance_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is an alias for `instance_name`. `workspace_name` should be used instead of `instance_name`.
 
@@ -37,8 +37,8 @@ In addition to all arguments above, it also exports the following attributes:
 ### Stream Connection
 
 * `project_id` - Unique 24-hexadecimal digit string that identifies your project.
-* `workspace_name` - Human-readable label that identifies the stream instance.
-* `connection_name` - Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
+* `workspace_name` - Label that identifies the stream processing workspace.
+* `connection_name` - Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
 * `type` - Type of connection. `AWSLambda`, `Cluster`, `Https`, `Kafka` or `Sample`.
 
 If `type` is of value `Cluster` the following additional attributes are defined:

--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -121,15 +121,15 @@ output "stream_processors_results" {
 
 ### Required
 
-- `processor_name` (String) Human-readable label that identifies the stream processor.
+- `processor_name` (String) Label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
 
 ### Optional
 
-- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
-- `workspace_name` (String) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
+- `instance_name` (String, Deprecated) Label that identifies the stream processing workspace.
+- `workspace_name` (String) Label that identifies the stream processing workspace. Conflicts with `instance_name`.
 
 ### Read-Only
 

--- a/docs/data-sources/stream_processor.md
+++ b/docs/data-sources/stream_processor.md
@@ -19,14 +19,14 @@ resource "mongodbatlas_stream_instance" "example" {
 
 resource "mongodbatlas_stream_connection" "example-sample" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "sample_stream_solar"
   type            = "Sample"
 }
 
 resource "mongodbatlas_stream_connection" "example-cluster" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "ClusterConnection"
   type            = "Cluster"
   cluster_name    = var.cluster_name
@@ -38,7 +38,7 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
 
 resource "mongodbatlas_stream_connection" "example-kafka" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "KafkaPlaintextConnection"
   type            = "Kafka"
   authentication = {
@@ -57,7 +57,7 @@ resource "mongodbatlas_stream_connection" "example-kafka" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "sampleProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } },
@@ -68,7 +68,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "clusterProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } },
@@ -79,7 +79,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-exam
 
 resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "kafkaProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_source" } },
@@ -96,13 +96,13 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
 }
 
 data "mongodbatlas_stream_processors" "example-stream-processors" {
-  project_id    = var.project_id
-  instance_name = mongodbatlas_stream_instance.example.instance_name
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
 }
 
 data "mongodbatlas_stream_processor" "example-stream-processor" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
 }
 
@@ -121,11 +121,15 @@ output "stream_processors_results" {
 
 ### Required
 
-- `instance_name` (String) Human-readable label that identifies the stream instance.
 - `processor_name` (String) Human-readable label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+
+### Optional
+
+- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
+- `workspace_name` (String) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
 
 ### Read-Only
 

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -127,8 +127,8 @@ output "stream_processors_results" {
 
 ### Optional
 
-- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
-- `workspace_name` (String) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
+- `instance_name` (String, Deprecated) Label that identifies the stream processing workspace.
+- `workspace_name` (String) Label that identifies the stream processing workspace. Conflicts with `instance_name`.
 
 ### Read-Only
 
@@ -144,10 +144,10 @@ role or Project Stream Processing Owner role. (see [below for nested schema](#ne
 Read-Only:
 
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
-- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
+- `instance_name` (String, Deprecated) Label that identifies the stream processing workspace.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--results--options))
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data. [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/#std-label-stream-aggregation) contain more information. Using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode) is recommended when setting this attribute. For more details see the [Aggregation Pipelines Documentation](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/)
-- `processor_name` (String) Human-readable label that identifies the stream processor.
+- `processor_name` (String) Label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
@@ -155,7 +155,7 @@ Read-Only:
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `stats` (String) The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.
-- `workspace_name` (String) Human-readable label that identifies the stream instance.
+- `workspace_name` (String) Label that identifies the stream processing workspace.
 
 <a id="nestedatt--results--options"></a>
 ### Nested Schema for `results.options`

--- a/docs/data-sources/stream_processors.md
+++ b/docs/data-sources/stream_processors.md
@@ -19,14 +19,14 @@ resource "mongodbatlas_stream_instance" "example" {
 
 resource "mongodbatlas_stream_connection" "example-sample" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "sample_stream_solar"
   type            = "Sample"
 }
 
 resource "mongodbatlas_stream_connection" "example-cluster" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "ClusterConnection"
   type            = "Cluster"
   cluster_name    = var.cluster_name
@@ -38,7 +38,7 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
 
 resource "mongodbatlas_stream_connection" "example-kafka" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "KafkaPlaintextConnection"
   type            = "Kafka"
   authentication = {
@@ -57,7 +57,7 @@ resource "mongodbatlas_stream_connection" "example-kafka" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "sampleProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } },
@@ -68,7 +68,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "clusterProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } },
@@ -79,7 +79,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-exam
 
 resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "kafkaProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_source" } },
@@ -96,13 +96,13 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
 }
 
 data "mongodbatlas_stream_processors" "example-stream-processors" {
-  project_id    = var.project_id
-  instance_name = mongodbatlas_stream_instance.example.instance_name
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
 }
 
 data "mongodbatlas_stream_processor" "example-stream-processor" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
 }
 
@@ -121,10 +121,14 @@ output "stream_processors_results" {
 
 ### Required
 
-- `instance_name` (String) Human-readable label that identifies the stream instance.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+
+### Optional
+
+- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
+- `workspace_name` (String) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
 
 ### Read-Only
 
@@ -140,7 +144,7 @@ role or Project Stream Processing Owner role. (see [below for nested schema](#ne
 Read-Only:
 
 - `id` (String) Unique 24-hexadecimal character string that identifies the stream processor.
-- `instance_name` (String) Human-readable label that identifies the stream instance.
+- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--results--options))
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data. [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/#std-label-stream-aggregation) contain more information. Using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode) is recommended when setting this attribute. For more details see the [Aggregation Pipelines Documentation](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/)
 - `processor_name` (String) Human-readable label that identifies the stream processor.
@@ -151,6 +155,7 @@ Read-Only:
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `stats` (String) The stats associated with the stream processor. Refer to the [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/manage-stream-processor/#view-statistics-of-a-stream-processor) for more information.
+- `workspace_name` (String) Human-readable label that identifies the stream instance.
 
 <a id="nestedatt--results--options"></a>
 ### Nested Schema for `results.options`

--- a/docs/resources/stream_connection.md
+++ b/docs/resources/stream_connection.md
@@ -152,9 +152,9 @@ resource "mongodbatlas_stream_connection" "example-https" {
 ## Argument Reference
 
 * `project_id` - (Required) Unique 24-hexadecimal digit string that identifies your project.
-* `instance_name` - (Deprecated) Human-readable label that identifies the stream instance. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
-* `workspace_name` - (Optional) Human-readable label that identifies the stream instance. Conflicts with `instance_name`.
-* `connection_name` - (Required) Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
+* `instance_name` - (Deprecated) Label that identifies the stream processing workspace. Attribute is deprecated and will be removed in following major versions in favor of `workspace_name`.
+* `workspace_name` - (Optional) Label that identifies the stream processing workspace. Conflicts with `instance_name`.
+* `connection_name` - (Required) Label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source.
 * `type` - (Required) Type of connection. Can be `AWSLambda`, `Cluster`, `Https`, `Kafka` or `Sample`.
 
 ~> **NOTE:** Either `workspace_name` or `instance_name` must be provided, but not both. These fields are functionally identical and `workspace_name` is an alias for `instance_name`. `workspace_name` should be used instead of `instance_name`.

--- a/docs/resources/stream_processor.md
+++ b/docs/resources/stream_processor.md
@@ -25,14 +25,14 @@ resource "mongodbatlas_stream_instance" "example" {
 
 resource "mongodbatlas_stream_connection" "example-sample" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "sample_stream_solar"
   type            = "Sample"
 }
 
 resource "mongodbatlas_stream_connection" "example-cluster" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "ClusterConnection"
   type            = "Cluster"
   cluster_name    = var.cluster_name
@@ -44,7 +44,7 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
 
 resource "mongodbatlas_stream_connection" "example-kafka" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "KafkaPlaintextConnection"
   type            = "Kafka"
   authentication = {
@@ -63,7 +63,7 @@ resource "mongodbatlas_stream_connection" "example-kafka" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "sampleProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } },
@@ -74,7 +74,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "clusterProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } },
@@ -85,7 +85,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-exam
 
 resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "kafkaProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_source" } },
@@ -102,13 +102,13 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
 }
 
 data "mongodbatlas_stream_processors" "example-stream-processors" {
-  project_id    = var.project_id
-  instance_name = mongodbatlas_stream_instance.example.instance_name
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
 }
 
 data "mongodbatlas_stream_processor" "example-stream-processor" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
 }
 
@@ -130,7 +130,6 @@ output "stream_processors_results" {
 
 ### Required
 
-- `instance_name` (String) Human-readable label that identifies the stream instance.
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data. [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/#std-label-stream-aggregation) contain more information. Using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode) is recommended when setting this attribute. For more details see the [Aggregation Pipelines Documentation](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/)
 - `processor_name` (String) Human-readable label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
@@ -140,11 +139,13 @@ output "stream_processors_results" {
 ### Optional
 
 - `delete_on_create_timeout` (Boolean) Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
+- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--options))
 - `state` (String) The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`. When a Stream Processor is created without specifying the state, it will default to `CREATED` state. When a Stream Processor is updated without specifying the state, it will default to the Previous state. 
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+- `workspace_name` (String) Human-readable label that identifies the stream instance.
 
 ### Read-Only
 

--- a/docs/resources/stream_processor.md
+++ b/docs/resources/stream_processor.md
@@ -131,7 +131,7 @@ output "stream_processors_results" {
 ### Required
 
 - `pipeline` (String) Stream aggregation pipeline you want to apply to your streaming data. [MongoDB Atlas Docs](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/#std-label-stream-aggregation) contain more information. Using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode) is recommended when setting this attribute. For more details see the [Aggregation Pipelines Documentation](https://www.mongodb.com/docs/atlas/atlas-stream-processing/stream-aggregation/)
-- `processor_name` (String) Human-readable label that identifies the stream processor.
+- `processor_name` (String) Label that identifies the stream processor.
 - `project_id` (String) Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
 
 **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
@@ -139,13 +139,13 @@ output "stream_processors_results" {
 ### Optional
 
 - `delete_on_create_timeout` (Boolean) Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
-- `instance_name` (String, Deprecated) Human-readable label that identifies the stream instance.
+- `instance_name` (String, Deprecated) Label that identifies the stream processing workspace.
 - `options` (Attributes) Optional configuration for the stream processor. (see [below for nested schema](#nestedatt--options))
 - `state` (String) The state of the stream processor. Commonly occurring states are 'CREATED', 'STARTED', 'STOPPED' and 'FAILED'. Used to start or stop the Stream Processor. Valid values are `CREATED`, `STARTED` or `STOPPED`. When a Stream Processor is created without specifying the state, it will default to `CREATED` state. When a Stream Processor is updated without specifying the state, it will default to the Previous state. 
 
 **NOTE** When a Stream Processor is updated without specifying the state, it is stopped and then restored to previous state upon update completion.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `workspace_name` (String) Human-readable label that identifies the stream instance.
+- `workspace_name` (String) Label that identifies the stream processing workspace.
 
 ### Read-Only
 

--- a/examples/mongodbatlas_stream_processor/main.tf
+++ b/examples/mongodbatlas_stream_processor/main.tf
@@ -9,14 +9,14 @@ resource "mongodbatlas_stream_instance" "example" {
 
 resource "mongodbatlas_stream_connection" "example-sample" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "sample_stream_solar"
   type            = "Sample"
 }
 
 resource "mongodbatlas_stream_connection" "example-cluster" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "ClusterConnection"
   type            = "Cluster"
   cluster_name    = var.cluster_name
@@ -28,7 +28,7 @@ resource "mongodbatlas_stream_connection" "example-cluster" {
 
 resource "mongodbatlas_stream_connection" "example-kafka" {
   project_id      = var.project_id
-  instance_name   = mongodbatlas_stream_instance.example.instance_name
+  workspace_name  = mongodbatlas_stream_instance.example.instance_name
   connection_name = "KafkaPlaintextConnection"
   type            = "Kafka"
   authentication = {
@@ -47,7 +47,7 @@ resource "mongodbatlas_stream_connection" "example-kafka" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "sampleProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-sample.connection_name } },
@@ -58,7 +58,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-sample-example" {
 
 resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "clusterProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-cluster.connection_name } },
@@ -69,7 +69,7 @@ resource "mongodbatlas_stream_processor" "stream-processor-cluster-to-kafka-exam
 
 resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-example" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = "kafkaProcessorName"
   pipeline = jsonencode([
     { "$source" = { "connectionName" = resource.mongodbatlas_stream_connection.example-kafka.connection_name, "topic" : "topic_source" } },
@@ -86,13 +86,13 @@ resource "mongodbatlas_stream_processor" "stream-processor-kafka-to-cluster-exam
 }
 
 data "mongodbatlas_stream_processors" "example-stream-processors" {
-  project_id    = var.project_id
-  instance_name = mongodbatlas_stream_instance.example.instance_name
+  project_id     = var.project_id
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
 }
 
 data "mongodbatlas_stream_processor" "example-stream-processor" {
   project_id     = var.project_id
-  instance_name  = mongodbatlas_stream_instance.example.instance_name
+  workspace_name = mongodbatlas_stream_instance.example.instance_name
   processor_name = mongodbatlas_stream_processor.stream-processor-sample-example.processor_name
 }
 

--- a/internal/service/streamconnection/data_source_stream_connection.go
+++ b/internal/service/streamconnection/data_source_stream_connection.go
@@ -35,7 +35,7 @@ func (d *streamConnectionDS) Schema(ctx context.Context, req datasource.SchemaRe
 		OverridenFields: map[string]dsschema.Attribute{
 			"instance_name": dsschema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance. Conflicts with `workspace_name`.",
+				MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `workspace_name`.",
 				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("workspace_name")),
@@ -43,7 +43,7 @@ func (d *streamConnectionDS) Schema(ctx context.Context, req datasource.SchemaRe
 			},
 			"workspace_name": dsschema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance. This is an alias for `instance_name`. Conflicts with `instance_name`.",
+				MarkdownDescription: "Label that identifies the stream processing workspace. This is an alias for `instance_name`. Conflicts with `instance_name`.",
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("instance_name")),
 				},

--- a/internal/service/streamconnection/data_source_stream_connections.go
+++ b/internal/service/streamconnection/data_source_stream_connections.go
@@ -38,7 +38,7 @@ func (d *streamConnectionsDS) Schema(ctx context.Context, req datasource.SchemaR
 		OverridenRootFields: map[string]dsschema.Attribute{
 			"instance_name": dsschema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance. Conflicts with `workspace_name`.",
+				MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `workspace_name`.",
 				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("workspace_name")),
@@ -46,7 +46,7 @@ func (d *streamConnectionsDS) Schema(ctx context.Context, req datasource.SchemaR
 			},
 			"workspace_name": dsschema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance. This is an alias for `instance_name`. Conflicts with `instance_name`.",
+				MarkdownDescription: "Label that identifies the stream processing workspace. This is an alias for `instance_name`. Conflicts with `instance_name`.",
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("instance_name")),
 				},

--- a/internal/service/streamprocessor/data_source.go
+++ b/internal/service/streamprocessor/data_source.go
@@ -2,8 +2,14 @@ package streamprocessor
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -25,8 +31,36 @@ type StreamProccesorDS struct {
 
 func (d *StreamProccesorDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.DataSourceSchemaRequest{
-		RequiredFields: []string{"project_id", "instance_name", "processor_name"},
+		RequiredFields: []string{"project_id", "processor_name"},
+		OverridenFields: map[string]dsschema.Attribute{
+			"instance_name": dsschema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("workspace_name")),
+				},
+			},
+			"workspace_name": dsschema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Human-readable label that identifies the stream instance. Conflicts with `instance_name`.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("instance_name")),
+				},
+			},
+		},
 	})
+}
+
+// getWorkspaceOrInstanceNameForDS returns the workspace name from workspace_name or instance_name field for datasource model
+func getWorkspaceOrInstanceNameForDS(model *TFStreamProcessorDSModel) string {
+	if !model.WorkspaceName.IsNull() && !model.WorkspaceName.IsUnknown() {
+		return model.WorkspaceName.ValueString()
+	}
+	if !model.InstanceName.IsNull() && !model.InstanceName.IsUnknown() {
+		return model.InstanceName.ValueString()
+	}
+	return ""
 }
 
 func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -38,16 +72,24 @@ func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest
 
 	connV2 := d.Client.AtlasV2
 	projectID := streamProccesorConfig.ProjectID.ValueString()
-	instanceName := streamProccesorConfig.InstanceName.ValueString()
+	workspaceOrInstanceName := getWorkspaceOrInstanceNameForDS(&streamProccesorConfig)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
+
 	processorName := streamProccesorConfig.ProcessorName.ValueString()
-	apiResp, _, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, instanceName, processorName).Execute()
+	apiResp, _, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, workspaceOrInstanceName, processorName).Execute()
 
 	if err != nil {
 		resp.Diagnostics.AddError("error fetching resource", err.Error())
 		return
 	}
 
-	newStreamTFStreamprocessorDSModelModel, diags := NewTFStreamprocessorDSModel(ctx, projectID, instanceName, apiResp)
+	instanceName := streamProccesorConfig.InstanceName.ValueString()
+	workspaceName := streamProccesorConfig.WorkspaceName.ValueString()
+
+	newStreamTFStreamprocessorDSModelModel, diags := NewTFStreamprocessorDSModel(ctx, projectID, instanceName, workspaceName, apiResp)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/service/streamprocessor/data_source.go
+++ b/internal/service/streamprocessor/data_source.go
@@ -31,25 +31,29 @@ type StreamProccesorDS struct {
 
 func (d *StreamProccesorDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.DataSourceSchemaRequest{
-		RequiredFields: []string{"project_id", "processor_name"},
-		OverridenFields: map[string]dsschema.Attribute{
-			"instance_name": dsschema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Label that identifies the stream processing workspace.",
-				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.MatchRoot("workspace_name")),
-				},
-			},
-			"workspace_name": dsschema.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `instance_name`.",
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.MatchRoot("instance_name")),
-				},
+		RequiredFields:  []string{"project_id", "processor_name"},
+		OverridenFields: dataSourceOverridenFields(),
+	})
+}
+
+func dataSourceOverridenFields() map[string]dsschema.Attribute {
+	return map[string]dsschema.Attribute{
+		"instance_name": dsschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Label that identifies the stream processing workspace.",
+			DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.MatchRoot("workspace_name")),
 			},
 		},
-	})
+		"workspace_name": dsschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `instance_name`.",
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.MatchRoot("instance_name")),
+			},
+		},
+	}
 }
 
 func (d *StreamProccesorDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -12,15 +12,12 @@ import (
 	"go.mongodb.org/atlas-sdk/v20250312008/admin"
 )
 
-// getWorkspaceOrInstanceNameFromModel returns the workspace name from workspace_name or instance_name field
-func getWorkspaceOrInstanceNameFromModel(model *TFStreamProcessorRSModel) string {
-	if !model.WorkspaceName.IsNull() && !model.WorkspaceName.IsUnknown() {
-		return model.WorkspaceName.ValueString()
+// GetWorkspaceOrInstanceName returns the workspace name from workspace_name or instance_name field. Assumes exactly one of the two is set.
+func GetWorkspaceOrInstanceName(workspaceName types.String, instanceName types.String) string {
+	if !workspaceName.IsNull() && !workspaceName.IsUnknown() {
+		return workspaceName.ValueString()
 	}
-	if !model.InstanceName.IsNull() && !model.InstanceName.IsUnknown() {
-		return model.InstanceName.ValueString()
-	}
-	return ""
+	return instanceName.ValueString()
 }
 
 func NewStreamProcessorReq(ctx context.Context, plan *TFStreamProcessorRSModel) (*admin.StreamsProcessor, diag.Diagnostics) {
@@ -60,7 +57,7 @@ func NewStreamProcessorUpdateReq(ctx context.Context, plan *TFStreamProcessorRSM
 		return nil, diags
 	}
 
-	workspaceOrInstanceName := getWorkspaceOrInstanceNameFromModel(plan)
+	workspaceOrInstanceName := GetWorkspaceOrInstanceName(plan.WorkspaceName, plan.InstanceName)
 
 	streamProcessorAPIParams := &admin.UpdateStreamProcessorApiParams{
 		GroupId:       plan.ProjectID.ValueString(),

--- a/internal/service/streamprocessor/model.go
+++ b/internal/service/streamprocessor/model.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetWorkspaceOrInstanceName returns the workspace name from workspace_name or instance_name field. Assumes exactly one of the two is set.
-func GetWorkspaceOrInstanceName(workspaceName types.String, instanceName types.String) string {
+func GetWorkspaceOrInstanceName(workspaceName, instanceName types.String) string {
 	if !workspaceName.IsNull() && !workspaceName.IsUnknown() {
 		return workspaceName.ValueString()
 	}

--- a/internal/service/streamprocessor/model_test.go
+++ b/internal/service/streamprocessor/model_test.go
@@ -398,7 +398,7 @@ func TestPluralDSSDKToTFModelWithInstanceName(t *testing.T) {
 	}
 }
 
-func TestGetWorkspaceOrInstanceNameFromModel(t *testing.T) {
+func TestNewStreamProcessorUpdateReq(t *testing.T) {
 	validPipeline := jsontypes.NewNormalizedValue("[{\"$source\":{\"connectionName\":\"sample_stream_solar\"}},{\"$emit\":{\"connectionName\":\"__testLog\"}}]")
 
 	testCases := map[string]struct {
@@ -461,6 +461,49 @@ func TestGetWorkspaceOrInstanceNameFromModel(t *testing.T) {
 					t.Fatalf("unexpected errors found: %s", diags.Errors()[0].Summary())
 				}
 				assert.Equal(t, tc.expectedResult, updateReq.TenantName)
+			}
+		})
+	}
+}
+
+func TestGetWorkspaceOrInstanceName(t *testing.T) {
+	testCases := map[string]struct {
+		workspaceName types.String
+		instanceName  types.String
+		expected      string
+	}{
+		"workspace_name provided": {
+			workspaceName: types.StringValue(workspaceName),
+			instanceName:  types.StringNull(),
+			expected:      workspaceName,
+		},
+		"instance_name provided": {
+			workspaceName: types.StringNull(),
+			instanceName:  types.StringValue(instanceName),
+			expected:      instanceName,
+		},
+		"both provided": {
+			workspaceName: types.StringValue(workspaceName),
+			instanceName:  types.StringValue(instanceName),
+			expected:      workspaceName,
+		},
+		"workspace_name empty_string": {
+			workspaceName: types.StringValue(""),
+			instanceName:  types.StringNull(),
+			expected:      "",
+		},
+		"instance_namee empty_string": {
+			workspaceName: types.StringNull(),
+			instanceName:  types.StringValue(""),
+			expected:      "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := streamprocessor.GetWorkspaceOrInstanceName(tc.workspaceName, tc.instanceName)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
 			}
 		})
 	}

--- a/internal/service/streamprocessor/plural_data_source.go
+++ b/internal/service/streamprocessor/plural_data_source.go
@@ -5,12 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
-	dsschemaattr "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -34,25 +29,9 @@ type streamProcessorsDS struct {
 
 func (d *streamProcessorsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = conversion.PluralDataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.PluralDataSourceSchemaRequest{
-		RequiredFields:     []string{"project_id"},
-		OverrideResultsDoc: "Returns all Stream Processors within the specified stream instance.\n\nTo use this resource, the requesting API Key must have the Project Owner\n\nrole or Project Stream Processing Owner role.",
-		OverridenRootFields: map[string]dsschemaattr.Attribute{
-			"instance_name": dsschemaattr.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Label that identifies the stream processing workspace.",
-				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.MatchRoot("workspace_name")),
-				},
-			},
-			"workspace_name": dsschemaattr.StringAttribute{
-				Optional:            true,
-				MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `instance_name`.",
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.MatchRoot("instance_name")),
-				},
-			},
-		},
+		RequiredFields:      []string{"project_id"},
+		OverrideResultsDoc:  "Returns all Stream Processors within the specified stream instance.\n\nTo use this resource, the requesting API Key must have the Project Owner\n\nrole or Project Stream Processing Owner role.",
+		OverridenRootFields: dataSourceOverridenFields(),
 	})
 }
 

--- a/internal/service/streamprocessor/plural_data_source.go
+++ b/internal/service/streamprocessor/plural_data_source.go
@@ -39,7 +39,7 @@ func (d *streamProcessorsDS) Schema(ctx context.Context, req datasource.SchemaRe
 		OverridenRootFields: map[string]dsschemaattr.Attribute{
 			"instance_name": dsschemaattr.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				MarkdownDescription: "Label that identifies the stream processing workspace.",
 				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
 				Validators: []validator.String{
 					stringvalidator.ExactlyOneOf(path.MatchRoot("workspace_name")),
@@ -47,7 +47,7 @@ func (d *streamProcessorsDS) Schema(ctx context.Context, req datasource.SchemaRe
 			},
 			"workspace_name": dsschemaattr.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance. Conflicts with `instance_name`.",
+				MarkdownDescription: "Label that identifies the stream processing workspace. Conflicts with `instance_name`.",
 				Validators: []validator.String{
 					stringvalidator.ExactlyOneOf(path.MatchRoot("instance_name")),
 				},

--- a/internal/service/streamprocessor/plural_data_source.go
+++ b/internal/service/streamprocessor/plural_data_source.go
@@ -5,7 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschemaattr "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
@@ -29,9 +34,37 @@ type streamProcessorsDS struct {
 
 func (d *streamProcessorsDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = conversion.PluralDataSourceSchemaFromResource(ResourceSchema(ctx), &conversion.PluralDataSourceSchemaRequest{
-		RequiredFields:     []string{"project_id", "instance_name"},
+		RequiredFields:     []string{"project_id"},
 		OverrideResultsDoc: "Returns all Stream Processors within the specified stream instance.\n\nTo use this resource, the requesting API Key must have the Project Owner\n\nrole or Project Stream Processing Owner role.",
+		OverridenRootFields: map[string]dsschemaattr.Attribute{
+			"instance_name": dsschemaattr.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("workspace_name")),
+				},
+			},
+			"workspace_name": dsschemaattr.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Human-readable label that identifies the stream instance. Conflicts with `instance_name`.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("instance_name")),
+				},
+			},
+		},
 	})
+}
+
+// getWorkspaceOrInstanceNameForPluralDS returns the workspace name from workspace_name or instance_name field for plural datasource model
+func getWorkspaceOrInstanceNameForPluralDS(model *TFStreamProcessorsDSModel) string {
+	if !model.WorkspaceName.IsNull() && !model.WorkspaceName.IsUnknown() {
+		return model.WorkspaceName.ValueString()
+	}
+	if !model.InstanceName.IsNull() && !model.InstanceName.IsUnknown() {
+		return model.InstanceName.ValueString()
+	}
+	return ""
 }
 
 func (d *streamProcessorsDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -43,11 +76,15 @@ func (d *streamProcessorsDS) Read(ctx context.Context, req datasource.ReadReques
 
 	connV2 := d.Client.AtlasV2
 	projectID := streamConnectionsConfig.ProjectID.ValueString()
-	instanceName := streamConnectionsConfig.InstanceName.ValueString()
+	workspaceOrInstanceName := getWorkspaceOrInstanceNameForPluralDS(&streamConnectionsConfig)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
 
 	params := admin.GetStreamProcessorsApiParams{
 		GroupId:    projectID,
-		TenantName: instanceName,
+		TenantName: workspaceOrInstanceName,
 	}
 	sdkProcessors, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.StreamsProcessorWithStats], *http.Response, error) {
 		request := connV2.StreamsApi.GetStreamProcessorsWithParams(ctx, &params)

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -44,6 +44,17 @@ func (r *streamProcessorRS) Schema(ctx context.Context, req resource.SchemaReque
 	conversion.UpdateSchemaDescription(&resp.Schema)
 }
 
+// getWorkspaceOrInstanceName returns the workspace name from workspace_name or instance_name field
+func getWorkspaceOrInstanceName(model *TFStreamProcessorRSModel) string {
+	if !model.WorkspaceName.IsNull() && !model.WorkspaceName.IsUnknown() {
+		return model.WorkspaceName.ValueString()
+	}
+	if !model.InstanceName.IsNull() && !model.InstanceName.IsUnknown() {
+		return model.InstanceName.ValueString()
+	}
+	return ""
+}
+
 func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan TFStreamProcessorRSModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -72,9 +83,14 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 
 	connV2 := r.Client.AtlasV2
 	projectID := plan.ProjectID.ValueString()
-	instanceName := plan.InstanceName.ValueString()
+	workspaceOrInstanceName := getWorkspaceOrInstanceName(&plan)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
+
 	processorName := plan.ProcessorName.ValueString()
-	_, _, err := connV2.StreamsApi.CreateStreamProcessor(ctx, projectID, instanceName, streamProcessorReq).Execute()
+	_, _, err := connV2.StreamsApi.CreateStreamProcessor(ctx, projectID, workspaceOrInstanceName, streamProcessorReq).Execute()
 
 	if err != nil {
 		resp.Diagnostics.AddError("error creating resource", err.Error())
@@ -83,7 +99,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 
 	streamProcessorParams := &admin.GetStreamProcessorApiParams{
 		GroupId:       projectID,
-		TenantName:    instanceName,
+		TenantName:    workspaceOrInstanceName,
 		ProcessorName: processorName,
 	}
 
@@ -94,7 +110,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 
 	streamProcessorResp, err := WaitStateTransitionWithTimeout(ctx, streamProcessorParams, connV2.StreamsApi, []string{InitiatingState, CreatingState}, []string{CreatedState}, createTimeout)
 	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout), err, func(ctxCleanup context.Context) error {
-		_, err := connV2.StreamsApi.DeleteStreamProcessor(ctxCleanup, projectID, instanceName, processorName).Execute()
+		_, err := connV2.StreamsApi.DeleteStreamProcessor(ctxCleanup, projectID, workspaceOrInstanceName, processorName).Execute()
 		if err != nil {
 			return err
 		}
@@ -109,7 +125,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		_, err := connV2.StreamsApi.StartStreamProcessorWithParams(ctx,
 			&admin.StartStreamProcessorApiParams{
 				GroupId:       projectID,
-				TenantName:    instanceName,
+				TenantName:    workspaceOrInstanceName,
 				ProcessorName: processorName,
 			},
 		).Execute()
@@ -124,7 +140,9 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, &plan.Timeouts, &plan.DeleteOnCreateTimeout)
+	instanceName := plan.InstanceName.ValueString()
+	workspaceName := plan.WorkspaceName.ValueString()
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, workspaceName, streamProcessorResp, &plan.Timeouts, &plan.DeleteOnCreateTimeout)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -142,8 +160,13 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 	connV2 := r.Client.AtlasV2
 
 	projectID := state.ProjectID.ValueString()
-	instanceName := state.InstanceName.ValueString()
-	streamProcessor, apiResp, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, instanceName, state.ProcessorName.ValueString()).Execute()
+	workspaceOrInstanceName := getWorkspaceOrInstanceName(&state)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
+
+	streamProcessor, apiResp, err := connV2.StreamsApi.GetStreamProcessor(ctx, projectID, workspaceOrInstanceName, state.ProcessorName.ValueString()).Execute()
 	if err != nil {
 		if validate.StatusNotFound(apiResp) {
 			resp.State.RemoveResource(ctx)
@@ -153,7 +176,9 @@ func (r *streamProcessorRS) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessor, &state.Timeouts, &state.DeleteOnCreateTimeout)
+	instanceName := state.InstanceName.ValueString()
+	workspaceName := state.WorkspaceName.ValueString()
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, workspaceName, streamProcessor, &state.Timeouts, &state.DeleteOnCreateTimeout)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -177,7 +202,11 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	projectID := plan.ProjectID.ValueString()
-	instanceName := plan.InstanceName.ValueString()
+	workspaceOrInstanceName := getWorkspaceOrInstanceName(&plan)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
 	processorName := plan.ProcessorName.ValueString()
 	currentState := state.State.ValueString()
 	connV2 := r.Client.AtlasV2
@@ -186,7 +215,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 	// requestParams are needed for the state transition via the GET API
 	requestParams := &admin.GetStreamProcessorApiParams{
 		GroupId:       projectID,
-		TenantName:    instanceName,
+		TenantName:    workspaceOrInstanceName,
 		ProcessorName: processorName,
 	}
 
@@ -200,7 +229,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		_, err := connV2.StreamsApi.StopStreamProcessorWithParams(ctx,
 			&admin.StopStreamProcessorApiParams{
 				GroupId:       plan.ProjectID.ValueString(),
-				TenantName:    plan.InstanceName.ValueString(),
+				TenantName:    workspaceOrInstanceName,
 				ProcessorName: plan.ProcessorName.ValueString(),
 			},
 		).Execute()
@@ -234,7 +263,7 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		_, err := r.Client.AtlasV2.StreamsApi.StartStreamProcessorWithParams(ctx,
 			&admin.StartStreamProcessorApiParams{
 				GroupId:       projectID,
-				TenantName:    instanceName,
+				TenantName:    workspaceOrInstanceName,
 				ProcessorName: processorName,
 			},
 		).Execute()
@@ -251,7 +280,9 @@ func (r *streamProcessorRS) Update(ctx context.Context, req resource.UpdateReque
 		}
 	}
 
-	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, streamProcessorResp, &plan.Timeouts, &plan.DeleteOnCreateTimeout)
+	instanceName := plan.InstanceName.ValueString()
+	workspaceName := plan.WorkspaceName.ValueString()
+	newStreamProcessorModel, diags := NewStreamProcessorWithStats(ctx, projectID, instanceName, workspaceName, streamProcessorResp, &plan.Timeouts, &plan.DeleteOnCreateTimeout)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -267,25 +298,31 @@ func (r *streamProcessorRS) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	connV2 := r.Client.AtlasV2
-	if _, err := connV2.StreamsApi.DeleteStreamProcessor(ctx, streamProcessorState.ProjectID.ValueString(), streamProcessorState.InstanceName.ValueString(), streamProcessorState.ProcessorName.ValueString()).Execute(); err != nil {
+	workspaceOrInstanceName := getWorkspaceOrInstanceName(streamProcessorState)
+	if workspaceOrInstanceName == "" {
+		resp.Diagnostics.AddError("validation error", "workspace_name must be provided")
+		return
+	}
+	if _, err := connV2.StreamsApi.DeleteStreamProcessor(ctx, streamProcessorState.ProjectID.ValueString(), workspaceOrInstanceName, streamProcessorState.ProcessorName.ValueString()).Execute(); err != nil {
 		resp.Diagnostics.AddError("error deleting resource", err.Error())
 		return
 	}
 }
 
 func (r *streamProcessorRS) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	projectID, instanceName, processorName, err := splitImportID(req.ID)
+	projectID, workspaceName, processorName, err := splitImportID(req.ID)
 	if err != nil {
 		resp.Diagnostics.AddError("error splitting import ID", err.Error())
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), projectID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("instance_name"), instanceName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("instance_name"), workspaceName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_name"), workspaceName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("processor_name"), processorName)...)
 }
 
-func splitImportID(id string) (projectID, instanceName, processorName *string, err error) {
+func splitImportID(id string) (projectID, workspaceName, processorName *string, err error) {
 	var re = regexp.MustCompile(`^(.*)-([0-9a-fA-F]{24})-(.*)$`)
 	parts := re.FindStringSubmatch(id)
 
@@ -294,7 +331,7 @@ func splitImportID(id string) (projectID, instanceName, processorName *string, e
 		return
 	}
 
-	instanceName = &parts[1]
+	workspaceName = &parts[1]
 	projectID = &parts[2]
 	processorName = &parts[3]
 

--- a/internal/service/streamprocessor/resource_migration_test.go
+++ b/internal/service/streamprocessor/resource_migration_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestMigStreamProcessor_basic(t *testing.T) {
 	mig.SkipIfVersionBelow(t, "1.19.0") // when resource 1st released
-	mig.CreateAndRunTest(t, basicTestCase(t))
+	mig.CreateAndRunTest(t, basicTestCaseMigration(t))
 }

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -2,14 +2,19 @@ package streamprocessor
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
@@ -24,8 +29,23 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				},
 			},
 			"instance_name": schema.StringAttribute{
-				Required:            true,
+				Optional:            true,
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRelative().AtParent().AtName("workspace_name"),
+					}...),
+				},
+			},
+			"workspace_name": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRelative().AtParent().AtName("instance_name"),
+					}...),
+				},
 			},
 			"pipeline": schema.StringAttribute{
 				CustomType: jsontypes.NormalizedType{},
@@ -91,6 +111,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 
 type TFStreamProcessorRSModel struct {
 	InstanceName          types.String         `tfsdk:"instance_name"`
+	WorkspaceName         types.String         `tfsdk:"workspace_name"`
 	Options               types.Object         `tfsdk:"options"`
 	Pipeline              jsontypes.Normalized `tfsdk:"pipeline"`
 	ProcessorID           types.String         `tfsdk:"id"`
@@ -126,6 +147,7 @@ var DlqObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 type TFStreamProcessorDSModel struct {
 	ID            types.String `tfsdk:"id"`
 	InstanceName  types.String `tfsdk:"instance_name"`
+	WorkspaceName types.String `tfsdk:"workspace_name"`
 	Options       types.Object `tfsdk:"options"`
 	Pipeline      types.String `tfsdk:"pipeline"`
 	ProcessorName types.String `tfsdk:"processor_name"`
@@ -135,7 +157,8 @@ type TFStreamProcessorDSModel struct {
 }
 
 type TFStreamProcessorsDSModel struct {
-	ProjectID    types.String               `tfsdk:"project_id"`
-	InstanceName types.String               `tfsdk:"instance_name"`
-	Results      []TFStreamProcessorDSModel `tfsdk:"results"`
+	ProjectID     types.String               `tfsdk:"project_id"`
+	InstanceName  types.String               `tfsdk:"instance_name"`
+	WorkspaceName types.String               `tfsdk:"workspace_name"`
+	Results       []TFStreamProcessorDSModel `tfsdk:"results"`
 }

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -30,19 +30,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"instance_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				MarkdownDescription: "Label that identifies the stream processing workspace.",
 				DeprecationMessage:  fmt.Sprintf(constant.DeprecationParamWithReplacement, "workspace_name"),
 				Validators: []validator.String{
-					stringvalidator.ConflictsWith(path.Expressions{
+					stringvalidator.ExactlyOneOf(path.Expressions{
 						path.MatchRelative().AtParent().AtName("workspace_name"),
 					}...),
 				},
 			},
 			"workspace_name": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream instance.",
+				MarkdownDescription: "Label that identifies the stream processing workspace.",
 				Validators: []validator.String{
-					stringvalidator.ConflictsWith(path.Expressions{
+					stringvalidator.ExactlyOneOf(path.Expressions{
 						path.MatchRelative().AtParent().AtName("instance_name"),
 					}...),
 				},
@@ -55,7 +55,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			},
 			"processor_name": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Human-readable label that identifies the stream processor.",
+				MarkdownDescription: "Label that identifies the stream processor.",
 			},
 			"project_id": schema.StringAttribute{
 				Required:            true,

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -914,7 +914,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
 		connectionConfig = fmt.Sprintf(`
             data "mongodbatlas_stream_connection" "sample" {
                 project_id      = %[1]q
-                instanceName   = %[2]q
+                instance_name   = %[2]q
                 connection_name = "sample_stream_solar"
             }
         `, projectID, workspaceName)

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -862,7 +862,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
             resource "mongodbatlas_stream_connection" %[4]q {
                 project_id      = %[1]q
                 cluster_name    = %[2]q
-                workspace_name   = %[5]q
+                instance_name   = %[5]q
                 connection_name = %[3]q
                 type            = "Cluster"
                 db_role_to_execute = {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -356,6 +356,9 @@ func checkExists(resourceName string) resource.TestCheckFunc {
 		}
 		projectID := rs.Primary.Attributes["project_id"]
 		workspaceName := rs.Primary.Attributes["workspace_name"]
+		if workspaceName == "" {
+			workspaceName = rs.Primary.Attributes["instance_name"]
+		}
 		processorName := rs.Primary.Attributes["processor_name"]
 		_, _, err := acc.ConnV2().StreamsApi.GetStreamProcessor(context.Background(), projectID, workspaceName, processorName).Execute()
 

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -870,7 +870,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
                     type = "BUILT_IN"
                 }
             }
-        `, projectID, clusterName, connectionName, resourceName, workspaceName)
+        `, projectID, clusterName, connectionName, resourceName, instanceName)
 		resourceID = fmt.Sprintf("mongodbatlas_stream_connection.%s", resourceName)
 		pipelineStep = fmt.Sprintf("{\"connectionName\":%q}", connectionName)
 		return connectionConfig, resourceID, pipelineStep
@@ -904,7 +904,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
                     protocol = "SASL_PLAINTEXT"
                 }
             }
-        `, projectID, connectionName, resourceName, workspaceName)
+        `, projectID, connectionName, resourceName, instanceName)
 		resourceID = fmt.Sprintf("mongodbatlas_stream_connection.%s", resourceName)
 		return connectionConfig, resourceID, pipelineStep
 	case "Sample":
@@ -917,7 +917,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
                 instance_name   = %[2]q
                 connection_name = "sample_stream_solar"
             }
-        `, projectID, workspaceName)
+        `, projectID, instanceName)
 		resourceID = "data.mongodbatlas_stream_connection.sample"
 		if config.extraWhitespace {
 			pipelineStep = "{\"connectionName\": \"sample_stream_solar\"}"

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -646,13 +646,13 @@ func config(t *testing.T, projectID, workspaceName, processorName, state, nameSu
 		project_id = %[1]q
 		workspace_name = %[2]q
 		processor_name = %[3]q
-		depends_on = [%4s]
+		depends_on = [%[4]s]
 	}`, projectID, workspaceName, processorName, resourceName)
 	dataSourcePlural := fmt.Sprintf(`
 	data "mongodbatlas_stream_processors" "test" {
 		project_id = %[1]q
 		workspace_name = %[2]q
-		depends_on = [%3s]
+		depends_on = [%[3]s]
 	}`, projectID, workspaceName, resourceName)
 	otherConfig := connectionConfigSrc + connectionConfigDest + dataSource + dataSourcePlural
 
@@ -712,13 +712,13 @@ func configMigration(t *testing.T, projectID, instanceName, processorName, state
 		project_id = %[1]q
 		instance_name = %[2]q
 		processor_name = %[3]q
-		depends_on = [%4s]
+		depends_on = [%[4]s]
 	}`, projectID, instanceName, processorName, resourceName)
 	dataSourcePlural := fmt.Sprintf(`
 	data "mongodbatlas_stream_processors" "test" {
 		project_id = %[1]q
 		instance_name = %[2]q
-		depends_on = [%3s]
+		depends_on = [%[3]s]
 	}`, projectID, instanceName, resourceName)
 	otherConfig := connectionConfigSrc + connectionConfigDest + dataSource + dataSourcePlural
 
@@ -888,7 +888,7 @@ func configConnectionMigration(t *testing.T, projectID, instanceName string, con
 		connectionConfig = fmt.Sprintf(`
             resource "mongodbatlas_stream_connection" %[3]q{
                 project_id      = %[1]q
-                instanceName   = %[4]q
+                instance_name   = %[4]q
                 connection_name = %[2]q
                 type            = "Kafka"
                 authentication = {

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -646,13 +646,13 @@ func config(t *testing.T, projectID, workspaceName, processorName, state, nameSu
 		project_id = %[1]q
 		workspace_name = %[2]q
 		processor_name = %[3]q
-		depends_on = [%[4]s]
+		depends_on = [%4s]
 	}`, projectID, workspaceName, processorName, resourceName)
 	dataSourcePlural := fmt.Sprintf(`
 	data "mongodbatlas_stream_processors" "test" {
 		project_id = %[1]q
 		workspace_name = %[2]q
-		depends_on = [%[3]s]
+		depends_on = [%3s]
 	}`, projectID, workspaceName, resourceName)
 	otherConfig := connectionConfigSrc + connectionConfigDest + dataSource + dataSourcePlural
 
@@ -712,13 +712,13 @@ func configMigration(t *testing.T, projectID, instanceName, processorName, state
 		project_id = %[1]q
 		instance_name = %[2]q
 		processor_name = %[3]q
-		depends_on = [%[4]s]
+		depends_on = [%4s]
 	}`, projectID, instanceName, processorName, resourceName)
 	dataSourcePlural := fmt.Sprintf(`
 	data "mongodbatlas_stream_processors" "test" {
 		project_id = %[1]q
 		instance_name = %[2]q
-		depends_on = [%[3]s]
+		depends_on = [%3s]
 	}`, projectID, instanceName, resourceName)
 	otherConfig := connectionConfigSrc + connectionConfigDest + dataSource + dataSourcePlural
 


### PR DESCRIPTION
## Description

JIRA: [CLOUDP-340024](https://jira.mongodb.org/browse/CLOUDP-340024), following the plan discussed with APIx team in [CLOUDP-336156](https://jira.mongodb.org/browse/CLOUDP-336156)

As part of an ongoing effort to rename stream instances to stream workspaces, we will support a `workspace_name` field for the `stream_processor` resource and datasource that will function identically to 1instance_name`. To avoid confusion, only one of instance_name or workspace name will be allowed to be set

In a future major version of terraform, we will remove the instance_name field

Link to any related issue(s):
Similar change was performed in [CLOUDP-339895](https://jira.mongodb.org/browse/CLOUDP-339895)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
