### PR TITLE
chore: Revoke SA tokens after Terraform command finishes

### DIFF
--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -53,7 +52,6 @@ func getTokenSource(clientID, clientSecret, baseURL string, tokenRenewalBase htt
 	saInfo.clientSecret = clientSecret
 	saInfo.baseURL = baseURL
 	saInfo.tokenSource = tokenSource
-	log.Println("Service Account: Token source created")
 	return saInfo.tokenSource, nil
 }
 
@@ -84,12 +82,9 @@ func CloseTokenSource() {
 	saInfo.clientSecret = ""
 	saInfo.baseURL = ""
 	if err != nil {
-		log.Printf("Service Account: Error retrieving token to revoke: %v\n", err)
 		return
 	}
 	if err := conf.RevokeToken(context.Background(), token); err != nil {
-		log.Printf("Service Account: Error revoking token: %v\n", err)
 		return
 	}
-	log.Println("Service Account: Token revoked successfully")
 }

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -73,6 +73,9 @@ func getConfig(clientID, clientSecret, baseURL string) *clientcredentials.Config
 func CloseTokenSource() {
 	saInfo.mu.Lock()
 	defer saInfo.mu.Unlock()
+	if saInfo.closed {
+		return
+	}
 	saInfo.closed = true
 	if saInfo.tokenSource == nil { // No need to do anything if SA was not initialized.
 		return

--- a/internal/config/service_account.go
+++ b/internal/config/service_account.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -22,11 +23,16 @@ var saInfo = struct {
 	clientSecret string
 	baseURL      string
 	mu           sync.Mutex
+	closed       bool
 }{}
 
 func getTokenSource(clientID, clientSecret, baseURL string, tokenRenewalBase http.RoundTripper) (auth.TokenSource, error) {
 	saInfo.mu.Lock()
 	defer saInfo.mu.Unlock()
+
+	if saInfo.closed {
+		return nil, fmt.Errorf("service account token source already closed")
+	}
 
 	baseURL = NormalizeBaseURL(baseURL)
 	if saInfo.tokenSource != nil { // Token source in cache.
@@ -36,13 +42,9 @@ func getTokenSource(clientID, clientSecret, baseURL string, tokenRenewalBase htt
 		return saInfo.tokenSource, nil
 	}
 
-	conf := clientcredentials.NewConfig(clientID, clientSecret)
-	if baseURL != "" {
-		conf.TokenURL = baseURL + clientcredentials.TokenAPIPath
-		conf.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
-	}
 	// Use a new context to avoid "context canceled" errors as the token source is reused and can outlast the callee context.
 	ctx := context.WithValue(context.Background(), auth.HTTPClient, &http.Client{Transport: tokenRenewalBase})
+	conf := getConfig(clientID, clientSecret, baseURL)
 	tokenSource := oauth2.ReuseTokenSourceWithExpiry(nil, conf.TokenSource(ctx), saTokenExpiryBuffer)
 	if _, err := tokenSource.Token(); err != nil { // Retrieve token to fail-fast if credentials are invalid.
 		return nil, err
@@ -51,9 +53,43 @@ func getTokenSource(clientID, clientSecret, baseURL string, tokenRenewalBase htt
 	saInfo.clientSecret = clientSecret
 	saInfo.baseURL = baseURL
 	saInfo.tokenSource = tokenSource
+	log.Println("Service Account: Token source created")
 	return saInfo.tokenSource, nil
 }
 
 func NormalizeBaseURL(baseURL string) string {
 	return strings.TrimRight(baseURL, "/")
+}
+
+func getConfig(clientID, clientSecret, baseURL string) *clientcredentials.Config {
+	config := clientcredentials.NewConfig(clientID, clientSecret)
+	if baseURL != "" {
+		config.TokenURL = baseURL + clientcredentials.TokenAPIPath
+		config.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
+	}
+	return config
+}
+
+func CloseTokenSource() {
+	saInfo.mu.Lock()
+	defer saInfo.mu.Unlock()
+	if saInfo.tokenSource == nil {
+		return
+	}
+	conf := getConfig(saInfo.clientID, saInfo.clientSecret, saInfo.baseURL)
+	token, err := saInfo.tokenSource.Token()
+	saInfo.closed = true
+	saInfo.tokenSource = nil
+	saInfo.clientID = ""
+	saInfo.clientSecret = ""
+	saInfo.baseURL = ""
+	if err != nil {
+		log.Printf("Service Account: Error retrieving token to revoke: %v\n", err)
+		return
+	}
+	if err := conf.RevokeToken(context.Background(), token); err != nil {
+		log.Printf("Service Account: Error revoking token: %v\n", err)
+		return
+	}
+	log.Println("Service Account: Token revoked successfully")
 }

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/clean"
 	"github.com/stretchr/testify/require"
 )
@@ -58,6 +59,7 @@ func cleanupSharedResources() {
 		fmt.Printf("Deleting execution project (%d): %s, id: %s\n", i+1, project.name, project.id)
 		deleteProject(project.id)
 	}
+	config.CloseTokenSource()
 }
 
 // ProjectIDExecution returns a project id created for the execution of the tests in the resource package.

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -59,7 +59,7 @@ func cleanupSharedResources() {
 		fmt.Printf("Deleting execution project (%d): %s, id: %s\n", i+1, project.name, project.id)
 		deleteProject(project.id)
 	}
-	config.CloseTokenSource()
+	config.CloseTokenSource() // Revoke SA token when acceptance tests finish.
 }
 
 // ProjectIDExecution returns a project id created for the execution of the tests in the resource package.

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	defer config.CloseTokenSource() // Revoke SA token when the plugin is stopped because the Terraform command finishes.
+	defer config.CloseTokenSource() // Revoke SA token when the plugin is exiting because Terraform command finished.
 
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")

--- a/main.go
+++ b/main.go
@@ -5,10 +5,13 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/provider"
 )
 
 func main() {
+	defer config.CloseTokenSource() // Revoke SA token when the plugin is stopped because the Terraform command finishes.
+
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
@@ -23,6 +26,6 @@ func main() {
 		serveOpts...,
 	)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 }


### PR DESCRIPTION
## Description

Revoke SA tokens after Terraform command finishes

Link to any related issue(s): CLOUDP-352195

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
