### PR TITLE
feat: Adds support for alertConfiguration.severityOverride attribute

### DIFF
--- a/.changelog/3795.txt
+++ b/.changelog/3795.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/mongodbatlas_alert_configuration: Adds `severity_override` attribute
+```
+
+```release-note:enhancement
+resource/mongodbatlas_alert_configuration: Adds `severity_override` attribute
+```

--- a/.changelog/3795.txt
+++ b/.changelog/3795.txt
@@ -3,5 +3,9 @@ data-source/mongodbatlas_alert_configuration: Adds `severity_override` attribute
 ```
 
 ```release-note:enhancement
+data-source/mongodbatlas_alert_configurations: Adds `severity_override` attribute
+```
+
+```release-note:enhancement
 resource/mongodbatlas_alert_configuration: Adds `severity_override` attribute
 ```

--- a/contributing/testing-best-practices.md
+++ b/contributing/testing-best-practices.md
@@ -31,6 +31,7 @@
 - `Basic import tests` are done as the last step in the `basic acceptance tests`, not as a different test, e.g. [basicTestCase](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/searchindex/resource_search_index_test.go#L211). Exceptions apply for more specific import tests, e.g. testing with incorrect IDs. [Import tests](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/import#resource-acceptance-testing-implementation) verify that the [Terraform Import](https://developer.hashicorp.com/terraform/cli/import) functionality is working fine.
 - Data sources are tested in the same tests as the resources, e.g. [commonChecks](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/searchindex/resource_search_index_test.go#L262-L263).
 - Helper functions such as `resource.TestCheckTypeSetElemNestedAttrs` or `resource.TestCheckTypeSetElemAttr` can be used to check resource and data source attributes more easily, e.g. [resource_serverless_instance_test.go](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/serverlessinstance/resource_serverless_instance_test.go#L61).
+- Note: before running the acceptance tests, make sure you set the environment variable `TF_ACC=1`.
 
 ### Cloud Gov tests
 

--- a/contributing/testing-best-practices.md
+++ b/contributing/testing-best-practices.md
@@ -31,7 +31,7 @@
 - `Basic import tests` are done as the last step in the `basic acceptance tests`, not as a different test, e.g. [basicTestCase](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/searchindex/resource_search_index_test.go#L211). Exceptions apply for more specific import tests, e.g. testing with incorrect IDs. [Import tests](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/import#resource-acceptance-testing-implementation) verify that the [Terraform Import](https://developer.hashicorp.com/terraform/cli/import) functionality is working fine.
 - Data sources are tested in the same tests as the resources, e.g. [commonChecks](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/searchindex/resource_search_index_test.go#L262-L263).
 - Helper functions such as `resource.TestCheckTypeSetElemNestedAttrs` or `resource.TestCheckTypeSetElemAttr` can be used to check resource and data source attributes more easily, e.g. [resource_serverless_instance_test.go](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/66c44e62c9afe04ffe8be0dbccaec682bab830e6/internal/service/serverlessinstance/resource_serverless_instance_test.go#L61).
-- Note: before running the acceptance tests, make sure you set the environment variable `TF_ACC=1`.
+- Note: before running the acceptance tests, set the environment variable `TF_ACC=1`.
 
 ### Cloud Gov tests
 

--- a/docs/data-sources/alert_configuration.md
+++ b/docs/data-sources/alert_configuration.md
@@ -121,6 +121,7 @@ In addition to all arguments above, the following attributes are exported:
 * `metric_threshold_config` - The threshold that causes an alert to be triggered. Required if `event_type_name` : `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`. See [metric threshold config](#metric-threshold-config).
 * `threshold_config` - 	 Threshold that triggers an alert. Required if `event_type_name` is any value other than `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`. See [threshold config](#threshold-config).
 * `notifications` - List of notifications to send when an alert condition is detected. See [notifications](#notifications).
+* `severity_override` - Severity of the event.
 
   -> ***IMPORTANT:*** Event Type has many possible values. Details for both conditional and metric based alerts can be found by selecting the tabs on the [alert config page](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createalertconfiguration) and checking the latest eventTypeName options.
 

--- a/docs/data-sources/alert_configurations.md
+++ b/docs/data-sources/alert_configurations.md
@@ -64,6 +64,7 @@ In addition to all arguments above, the following attributes are exported:
 * `metric_threshold_config` - The threshold that causes an alert to be triggered. Required if `event_type_name` : `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`. See [metric threshold config](#metric-threshold-config).
 * `threshold_config` - 	 Threshold that triggers an alert. Required if `event_type_name` is any value other than `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`. See [threshold config](#threshold-config).
 * `notifications` - List of notifications to send when an alert condition is detected. See [notifications](#notifications).
+* `severity_override` - Severity of the event.
 * `output` - Requested output string format for the alert configuration
 
   -> ***IMPORTANT:*** Event Type has many possible values. Details for both conditional and metric based alerts can be found by selecting the tabs on the [alert config page](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-createalertconfiguration) and checking the latest eventTypeName options.

--- a/docs/resources/alert_configuration.md
+++ b/docs/resources/alert_configuration.md
@@ -150,7 +150,7 @@ resource "mongodbatlas_alert_configuration" "test" {
 
 
   -> **NOTE:** If `event_type` is set to `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`, the `metric_threshold_config` field must also be configured.
-* `severity_override` - (Optional) Severity of the event. For the list of accepted values please read the [Create One Alert Configuration in One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupalertconfig) API documentation
+* `severity_override` - (Optional) Severity of the event. For the list of accepted values please read the [Create One Alert Configuration in One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupalertconfig) API documentation.
 
 ### Matchers
 Rules to apply when matching an object against this alert configuration. Only entities that match all these rules are checked for an alert condition. You can filter using the matchers array only when the eventTypeName specifies an event for a host, replica set, or sharded cluster.

--- a/docs/resources/alert_configuration.md
+++ b/docs/resources/alert_configuration.md
@@ -152,8 +152,6 @@ resource "mongodbatlas_alert_configuration" "test" {
   -> **NOTE:** If `event_type` is set to `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`, the `metric_threshold_config` field must also be configured.
 * `severity_override` - (Optional) Severity of the event. For the list of accepted values please read the [Create One Alert Configuration in One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupalertconfig) API documentation
 
-  -> **NOTE:** To reset the value of this attribute to default value, you must explicity set it to ERROR (default in MongoDB Atlas)
-
 ### Matchers
 Rules to apply when matching an object against this alert configuration. Only entities that match all these rules are checked for an alert condition. You can filter using the matchers array only when the eventTypeName specifies an event for a host, replica set, or sharded cluster.
 

--- a/docs/resources/alert_configuration.md
+++ b/docs/resources/alert_configuration.md
@@ -150,6 +150,9 @@ resource "mongodbatlas_alert_configuration" "test" {
 
 
   -> **NOTE:** If `event_type` is set to `OUTSIDE_METRIC_THRESHOLD` or `OUTSIDE_SERVERLESS_METRIC_THRESHOLD`, the `metric_threshold_config` field must also be configured.
+* `severity_override` - (Optional) Severity of the event. For the list of accepted values please read the [Create One Alert Configuration in One Project](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupalertconfig) API documentation
+
+  -> **NOTE:** To reset the value of this attribute to default value, you must explicity set it to ERROR (default in MongoDB Atlas)
 
 ### Matchers
 Rules to apply when matching an object against this alert configuration. Only entities that match all these rules are checked for an alert condition. You can filter using the matchers array only when the eventTypeName specifies an event for a host, replica set, or sharded cluster.

--- a/internal/service/alertconfiguration/data_source.go
+++ b/internal/service/alertconfiguration/data_source.go
@@ -244,7 +244,7 @@ var alertConfigDSSchemaAttributes = map[string]schema.Attribute{
 		},
 	},
 	"severity_override": schema.StringAttribute{
-		Optional: true,
+		Computed: true,
 	},
 }
 

--- a/internal/service/alertconfiguration/data_source.go
+++ b/internal/service/alertconfiguration/data_source.go
@@ -27,13 +27,13 @@ type TFAlertConfigurationDSModel struct {
 	EventType             types.String                      `tfsdk:"event_type"`
 	Created               types.String                      `tfsdk:"created"`
 	Updated               types.String                      `tfsdk:"updated"`
+	SeverityOverride      types.String                      `tfsdk:"severity_override"`
 	Matcher               []TfMatcherModel                  `tfsdk:"matcher"`
 	MetricThresholdConfig []TfMetricThresholdConfigModel    `tfsdk:"metric_threshold_config"`
 	ThresholdConfig       []TfThresholdConfigModel          `tfsdk:"threshold_config"`
 	Notification          []TfNotificationModel             `tfsdk:"notification"`
 	Output                []TfAlertConfigurationOutputModel `tfsdk:"output"`
 	Enabled               types.Bool                        `tfsdk:"enabled"`
-	SeverityOverride      types.String                      `tfsdk:"severity_override"`
 }
 
 type TfAlertConfigurationOutputModel struct {

--- a/internal/service/alertconfiguration/data_source.go
+++ b/internal/service/alertconfiguration/data_source.go
@@ -33,6 +33,7 @@ type TFAlertConfigurationDSModel struct {
 	Notification          []TfNotificationModel             `tfsdk:"notification"`
 	Output                []TfAlertConfigurationOutputModel `tfsdk:"output"`
 	Enabled               types.Bool                        `tfsdk:"enabled"`
+	SeverityOverride      types.String                      `tfsdk:"severity_override"`
 }
 
 type TfAlertConfigurationOutputModel struct {
@@ -242,6 +243,9 @@ var alertConfigDSSchemaAttributes = map[string]schema.Attribute{
 			},
 		},
 	},
+	"severity_override": schema.StringAttribute{
+		Optional: true,
+	},
 }
 
 func (d *alertConfigurationDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -337,6 +341,10 @@ func outputAlertConfigurationResourceHcl(label string, alert *admin.GroupAlertsC
 	notifications := alert.GetNotifications()
 	for i := range len(notifications) {
 		appendBlockWithCtyValues(resource, "notification", []string{}, convertNotificationToCtyValues(&notifications[i]))
+	}
+
+	if alert.SeverityOverride != nil {
+		resource.SetAttributeValue("severity_override", cty.StringVal(*alert.SeverityOverride))
 	}
 
 	return string(f.Bytes())

--- a/internal/service/alertconfiguration/model.go
+++ b/internal/service/alertconfiguration/model.go
@@ -107,6 +107,7 @@ func NewTFAlertConfigurationModel(apiRespConfig *admin.GroupAlertsConfig, currSt
 		ThresholdConfig:       NewTFThresholdConfigModel(apiRespConfig.Threshold, currState.ThresholdConfig),
 		Notification:          NewTFNotificationModelList(apiRespConfig.GetNotifications(), currState.Notification),
 		Matcher:               NewTFMatcherModelList(apiRespConfig.GetMatchers(), currState.Matcher),
+		SeverityOverride:      types.StringPointerValue(apiRespConfig.SeverityOverride),
 	}
 }
 
@@ -298,6 +299,7 @@ func NewTfAlertConfigurationDSModel(apiRespConfig *admin.GroupAlertsConfig, proj
 		ThresholdConfig:       NewTFThresholdConfigModel(apiRespConfig.Threshold, []TfThresholdConfigModel{}),
 		Notification:          NewTFNotificationModelList(apiRespConfig.GetNotifications(), []TfNotificationModel{}),
 		Matcher:               NewTFMatcherModelList(apiRespConfig.GetMatchers(), []TfMatcherModel{}),
+		SeverityOverride:      types.StringPointerValue(apiRespConfig.SeverityOverride),
 	}
 }
 

--- a/internal/service/alertconfiguration/model_test.go
+++ b/internal/service/alertconfiguration/model_test.go
@@ -524,7 +524,12 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 						{
 							Type:  types.StringValue("resource_hcl"),
 							Label: types.StringValue("EventType_0"),
-							Value: types.StringValue("resource \"mongodbatlas_alert_configuration\" \"EventType_0\" {\n  project_id = \"projectId\"\n  event_type = \"EventType\"\n  enabled    = true\n}\n"),
+							Value: types.StringValue(`resource "mongodbatlas_alert_configuration" "EventType_0" {
+  project_id = "projectId"
+  event_type = "EventType"
+  enabled    = true
+}
+`),
 						},
 					},
 				},
@@ -561,7 +566,13 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 						{
 							Type:  types.StringValue("resource_hcl"),
 							Label: types.StringValue("EventType_0"),
-							Value: types.StringValue("resource \"mongodbatlas_alert_configuration\" \"EventType_0\" {\n  project_id = \"projectId\"\n  event_type = \"EventType\"\n  enabled    = true\n}\n"),
+							Value: types.StringValue(`resource "mongodbatlas_alert_configuration" "EventType_0" {
+  project_id        = "projectId"
+  event_type        = "EventType"
+  enabled           = true
+  severity_override = "WARNING"
+}
+`),
 						},
 					},
 					SeverityOverride: types.StringValue("WARNING"),

--- a/internal/service/alertconfiguration/model_test.go
+++ b/internal/service/alertconfiguration/model_test.go
@@ -248,6 +248,40 @@ func TestAlertConfigurationSDKToTFModel(t *testing.T) {
 				Enabled:               types.BoolValue(true),
 			},
 		},
+		{
+			name: "Complete SKD response with SeverityOverride",
+			SDKResp: &admin.GroupAlertsConfig{
+				Enabled:          admin.PtrBool(true),
+				EventTypeName:    admin.PtrString("EventType"),
+				GroupId:          admin.PtrString("projectId"),
+				Id:               admin.PtrString("alertConfigurationId"),
+				SeverityOverride: admin.PtrString("WARNING"),
+			},
+			currentStateAlertConfiguration: &alertconfiguration.TfAlertConfigurationRSModel{
+				ID:                    types.StringValue("id"),
+				ProjectID:             types.StringValue("projectId"),
+				AlertConfigurationID:  types.StringValue("alertConfigurationId"),
+				EventType:             types.StringValue("EventType"),
+				Matcher:               []alertconfiguration.TfMatcherModel{},
+				MetricThresholdConfig: []alertconfiguration.TfMetricThresholdConfigModel{},
+				ThresholdConfig:       []alertconfiguration.TfThresholdConfigModel{},
+				Notification:          []alertconfiguration.TfNotificationModel{},
+				Enabled:               types.BoolValue(true),
+				SeverityOverride:      types.StringValue("WARNING"),
+			},
+			expectedTFModel: alertconfiguration.TfAlertConfigurationRSModel{
+				ID:                    types.StringValue("id"),
+				ProjectID:             types.StringValue("projectId"),
+				AlertConfigurationID:  types.StringValue("alertConfigurationId"),
+				EventType:             types.StringValue("EventType"),
+				Matcher:               []alertconfiguration.TfMatcherModel{},
+				MetricThresholdConfig: []alertconfiguration.TfMetricThresholdConfigModel{},
+				ThresholdConfig:       []alertconfiguration.TfThresholdConfigModel{},
+				Notification:          []alertconfiguration.TfNotificationModel{},
+				Enabled:               types.BoolValue(true),
+				SeverityOverride:      types.StringValue("WARNING"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -493,6 +527,44 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 							Value: types.StringValue("resource \"mongodbatlas_alert_configuration\" \"EventType_0\" {\n  project_id = \"projectId\"\n  event_type = \"EventType\"\n  enabled    = true\n}\n"),
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "Complete SDK model with SeverityOverride",
+			alerts: []admin.GroupAlertsConfig{
+				{
+					Enabled:          admin.PtrBool(true),
+					EventTypeName:    admin.PtrString("EventType"),
+					GroupId:          admin.PtrString("projectId"),
+					Id:               admin.PtrString("alertConfigurationId"),
+					SeverityOverride: admin.PtrString("WARNING"),
+				},
+			},
+			projectID:      "projectId",
+			definedOutputs: []string{"resource_hcl"},
+			expectedTfModel: []alertconfiguration.TFAlertConfigurationDSModel{
+				{
+					ID: types.StringValue(conversion.EncodeStateID(map[string]string{
+						"id":         "alertConfigurationId",
+						"project_id": "projectId",
+					})),
+					ProjectID:             types.StringValue("projectId"),
+					AlertConfigurationID:  types.StringValue("alertConfigurationId"),
+					EventType:             types.StringValue("EventType"),
+					Enabled:               types.BoolValue(true),
+					Matcher:               []alertconfiguration.TfMatcherModel{},
+					MetricThresholdConfig: []alertconfiguration.TfMetricThresholdConfigModel{},
+					ThresholdConfig:       []alertconfiguration.TfThresholdConfigModel{},
+					Notification:          []alertconfiguration.TfNotificationModel{},
+					Output: []alertconfiguration.TfAlertConfigurationOutputModel{
+						{
+							Type:  types.StringValue("resource_hcl"),
+							Label: types.StringValue("EventType_0"),
+							Value: types.StringValue("resource \"mongodbatlas_alert_configuration\" \"EventType_0\" {\n  project_id = \"projectId\"\n  event_type = \"EventType\"\n  enabled    = true\n}\n"),
+						},
+					},
+					SeverityOverride: types.StringValue("WARNING"),
 				},
 			},
 		},

--- a/internal/service/alertconfiguration/model_test.go
+++ b/internal/service/alertconfiguration/model_test.go
@@ -30,14 +30,12 @@ var (
 )
 
 func TestNotificationSDKToTFModel(t *testing.T) {
-	testCases := []struct {
-		name                      string
+	testCases := map[string]struct {
 		SDKResp                   *[]admin.AlertsNotificationRootForGroup
 		currentStateNotifications []alertconfiguration.TfNotificationModel
 		expectedTFModel           []alertconfiguration.TfNotificationModel
 	}{
-		{
-			name: "Complete SDK response",
+		"Complete SDK response": {
 			SDKResp: &[]admin.AlertsNotificationRootForGroup{
 				{
 					TypeName:      admin.PtrString(group),
@@ -78,8 +76,8 @@ func TestNotificationSDKToTFModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFNotificationModelList(*tc.SDKResp, tc.currentStateNotifications)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -87,14 +85,12 @@ func TestNotificationSDKToTFModel(t *testing.T) {
 }
 
 func TestMetricThresholdSDKToTFModel(t *testing.T) {
-	testCases := []struct {
-		name                        string
+	testCases := map[string]struct {
 		SDKResp                     *admin.FlexClusterMetricThreshold
 		currentStateMetricThreshold []alertconfiguration.TfMetricThresholdConfigModel
 		expectedTFModel             []alertconfiguration.TfMetricThresholdConfigModel
 	}{
-		{
-			name: "Complete SDK response",
+		"Complete SDK response": {
 			SDKResp: &admin.FlexClusterMetricThreshold{
 				MetricName: "ASSERT_REGULAR",
 				Operator:   admin.PtrString(operator),
@@ -123,8 +119,8 @@ func TestMetricThresholdSDKToTFModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFMetricThresholdConfigModel(tc.SDKResp, tc.currentStateMetricThreshold)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -132,14 +128,12 @@ func TestMetricThresholdSDKToTFModel(t *testing.T) {
 }
 
 func TestThresholdConfigSDKToTFModel(t *testing.T) {
-	testCases := []struct {
-		name                        string
+	testCases := map[string]struct {
 		SDKResp                     *admin.StreamProcessorMetricThreshold
 		currentStateThresholdConfig []alertconfiguration.TfThresholdConfigModel
 		expectedTFModel             []alertconfiguration.TfThresholdConfigModel
 	}{
-		{
-			name: "Complete SDK response",
+		"Complete SDK response": {
 			SDKResp: &admin.StreamProcessorMetricThreshold{
 				Threshold: admin.PtrFloat64(1.0),
 				Operator:  admin.PtrString("LESS_THAN"),
@@ -162,8 +156,8 @@ func TestThresholdConfigSDKToTFModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFThresholdConfigModel(tc.SDKResp, tc.currentStateThresholdConfig)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -171,14 +165,12 @@ func TestThresholdConfigSDKToTFModel(t *testing.T) {
 }
 
 func TestMatcherSDKToTFModel(t *testing.T) {
-	testCases := []struct {
-		name                string
+	testCases := map[string]struct {
 		SDKResp             []admin.StreamsMatcher
 		currentStateMatcher []alertconfiguration.TfMatcherModel
 		expectedTFModel     []alertconfiguration.TfMatcherModel
 	}{
-		{
-			name: "Complete SDK response",
+		"Complete SDK response": {
 			SDKResp: []admin.StreamsMatcher{{
 				FieldName: "HOSTNAME",
 				Operator:  "EQUALS",
@@ -202,8 +194,8 @@ func TestMatcherSDKToTFModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFMatcherModelList(tc.SDKResp, tc.currentStateMatcher)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -211,14 +203,12 @@ func TestMatcherSDKToTFModel(t *testing.T) {
 }
 
 func TestAlertConfigurationSDKToTFModel(t *testing.T) {
-	testCases := []struct {
-		name                           string
+	testCases := map[string]struct {
 		SDKResp                        *admin.GroupAlertsConfig
 		currentStateAlertConfiguration *alertconfiguration.TfAlertConfigurationRSModel
 		expectedTFModel                alertconfiguration.TfAlertConfigurationRSModel
 	}{
-		{
-			name: "Complete SKD response",
+		"Complete SDK response": {
 			SDKResp: &admin.GroupAlertsConfig{
 				Enabled:       admin.PtrBool(true),
 				EventTypeName: admin.PtrString("EventType"),
@@ -248,8 +238,7 @@ func TestAlertConfigurationSDKToTFModel(t *testing.T) {
 				Enabled:               types.BoolValue(true),
 			},
 		},
-		{
-			name: "Complete SKD response with SeverityOverride",
+		"Complete SDK response with SeverityOverride": {
 			SDKResp: &admin.GroupAlertsConfig{
 				Enabled:          admin.PtrBool(true),
 				EventTypeName:    admin.PtrString("EventType"),
@@ -284,8 +273,8 @@ func TestAlertConfigurationSDKToTFModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFAlertConfigurationModel(tc.SDKResp, tc.currentStateAlertConfiguration)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -293,13 +282,11 @@ func TestAlertConfigurationSDKToTFModel(t *testing.T) {
 }
 
 func TestNotificationTFModelToSDK(t *testing.T) {
-	testCases := []struct {
-		name           string
+	testCases := map[string]struct {
 		expectedSDKReq *[]admin.AlertsNotificationRootForGroup
 		tfModel        []alertconfiguration.TfNotificationModel
 	}{
-		{
-			name: "Complete TF model",
+		"Complete TF model": {
 			tfModel: []alertconfiguration.TfNotificationModel{
 				{
 					TypeName:      types.StringValue(group),
@@ -325,8 +312,8 @@ func TestNotificationTFModelToSDK(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			apiReqResult, _ := alertconfiguration.NewNotificationList(tc.tfModel)
 			assert.Equal(t, *tc.expectedSDKReq, *apiReqResult, "created sdk model did not match expected output")
 		})
@@ -334,18 +321,15 @@ func TestNotificationTFModelToSDK(t *testing.T) {
 }
 
 func TestThresholdTFModelToSDK(t *testing.T) {
-	testCases := []struct {
-		name           string
+	testCases := map[string]struct {
 		expectedSDKReq *admin.StreamProcessorMetricThreshold
 		tfModel        []alertconfiguration.TfThresholdConfigModel
 	}{
-		{
-			name:           "Empty TF model",
+		"Empty TF model": {
 			tfModel:        []alertconfiguration.TfThresholdConfigModel{},
 			expectedSDKReq: nil,
 		},
-		{
-			name: "Complete TF model",
+		"Complete TF model": {
 			tfModel: []alertconfiguration.TfThresholdConfigModel{
 				{
 					Threshold: types.Float64Value(1.0),
@@ -361,8 +345,8 @@ func TestThresholdTFModelToSDK(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			apiReqResult := alertconfiguration.NewThreshold(tc.tfModel)
 			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
 		})
@@ -370,18 +354,15 @@ func TestThresholdTFModelToSDK(t *testing.T) {
 }
 
 func TestMetricThresholdTFModelToSDK(t *testing.T) {
-	testCases := []struct {
-		name           string
+	testCases := map[string]struct {
 		expectedSDKReq *admin.FlexClusterMetricThreshold
 		tfModel        []alertconfiguration.TfMetricThresholdConfigModel
 	}{
-		{
-			name:           "Empty TF model",
+		"Empty TF model": {
 			tfModel:        []alertconfiguration.TfMetricThresholdConfigModel{},
 			expectedSDKReq: nil,
 		},
-		{
-			name: "Complete TF model",
+		"Complete TF model": {
 			tfModel: []alertconfiguration.TfMetricThresholdConfigModel{
 				{
 					Threshold:  types.Float64Value(threshold),
@@ -401,8 +382,8 @@ func TestMetricThresholdTFModelToSDK(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			apiReqResult := alertconfiguration.NewMetricThreshold(tc.tfModel)
 			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
 		})
@@ -410,18 +391,15 @@ func TestMetricThresholdTFModelToSDK(t *testing.T) {
 }
 
 func TestMatcherTFModelToSDK(t *testing.T) {
-	testCases := []struct {
-		name           string
+	testCases := map[string]struct {
 		expectedSDKReq []admin.StreamsMatcher
 		tfModel        []alertconfiguration.TfMatcherModel
 	}{
-		{
-			name:           "Empty TF model",
+		"Empty TF model": {
 			tfModel:        []alertconfiguration.TfMatcherModel{},
 			expectedSDKReq: make([]admin.StreamsMatcher, 0),
 		},
-		{
-			name: "Complete TF model",
+		"Complete TF model": {
 			tfModel: []alertconfiguration.TfMatcherModel{
 				{
 					FieldName: types.StringValue("HOSTNAME"),
@@ -437,8 +415,8 @@ func TestMatcherTFModelToSDK(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			apiReqResult := *alertconfiguration.NewMatcherList(tc.tfModel)
 			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
 		})
@@ -446,14 +424,12 @@ func TestMatcherTFModelToSDK(t *testing.T) {
 }
 
 func TestAlertConfigurationSdkToTFDSModel(t *testing.T) {
-	testCases := []struct {
-		name            string
+	testCases := map[string]struct {
 		apiRespConfig   *admin.GroupAlertsConfig
 		projectID       string
 		expectedTFModel alertconfiguration.TFAlertConfigurationDSModel
 	}{
-		{
-			name: "Complete SDK model",
+		"Complete SDK model": {
 			apiRespConfig: &admin.GroupAlertsConfig{
 				Enabled:       admin.PtrBool(true),
 				EventTypeName: admin.PtrString("EventType"),
@@ -478,8 +454,8 @@ func TestAlertConfigurationSdkToTFDSModel(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTfAlertConfigurationDSModel(tc.apiRespConfig, tc.projectID)
 			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
 		})
@@ -487,15 +463,13 @@ func TestAlertConfigurationSdkToTFDSModel(t *testing.T) {
 }
 
 func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
-	testCases := []struct {
-		name            string
+	testCases := map[string]struct {
 		projectID       string
 		definedOutputs  []string
 		alerts          []admin.GroupAlertsConfig
 		expectedTfModel []alertconfiguration.TFAlertConfigurationDSModel
 	}{
-		{
-			name: "Complete SDK model",
+		"Complete SDK model": {
 			alerts: []admin.GroupAlertsConfig{
 				{
 					Enabled:       admin.PtrBool(true),
@@ -535,8 +509,7 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "Complete SDK model with SeverityOverride",
+		"Complete SDK model with SeverityOverride": {
 			alerts: []admin.GroupAlertsConfig{
 				{
 					Enabled:          admin.PtrBool(true),
@@ -581,8 +554,8 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			resultModel := alertconfiguration.NewTFAlertConfigurationDSModelList(tc.alerts, tc.projectID, tc.definedOutputs)
 			assert.Equal(t, tc.expectedTfModel, resultModel, "created terraform model did not match expected output")
 		})

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -59,12 +59,12 @@ type TfAlertConfigurationRSModel struct {
 	EventType             types.String                   `tfsdk:"event_type"`
 	Created               types.String                   `tfsdk:"created"`
 	Updated               types.String                   `tfsdk:"updated"`
+	SeverityOverride      types.String                   `tfsdk:"severity_override"`
 	Matcher               []TfMatcherModel               `tfsdk:"matcher"`
 	MetricThresholdConfig []TfMetricThresholdConfigModel `tfsdk:"metric_threshold_config"`
 	ThresholdConfig       []TfThresholdConfigModel       `tfsdk:"threshold_config"`
 	Notification          []TfNotificationModel          `tfsdk:"notification"`
 	Enabled               types.Bool                     `tfsdk:"enabled"`
-	SeverityOverride      types.String                   `tfsdk:"severity_override"`
 }
 
 type TfMatcherModel struct {

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -157,6 +157,9 @@ func (r *alertConfigurationRS) Schema(ctx context.Context, req resource.SchemaRe
 			},
 			"severity_override": schema.StringAttribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -1069,7 +1069,7 @@ func configWithEmptyOptionalBlocks(projectID string) string {
 	`, projectID)
 }
 
-func configWithSeverityOverride(projectID string, severity string) string {
+func configWithSeverityOverride(projectID, severity string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_alert_configuration" "test" {
 			project_id        = %[1]q

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -590,7 +590,7 @@ func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "severity_override", "ERROR"),
 				),
 			},
-			// todo: should check for no attr once CLOUDP-353933 is fixed
+			// TODO: Should check for no attr once CLOUDP-353933 is fixed.
 			// {
 			// 	Config: configWithSeverityOverride(projectID, nil),
 			// 	Check: resource.ComposeAggregateTestCheckFunc(
@@ -1084,7 +1084,7 @@ func configWithSeverityOverride(projectID string, severity *string) string {
 		severityOverride = fmt.Sprintf("severity_override = %[1]q", *severity)
 	}
 
-	x := fmt.Sprintf(`
+	return fmt.Sprintf(`
 		resource "mongodbatlas_alert_configuration" "test" {
 			project_id        = %[1]q
 			enabled           = true
@@ -1103,8 +1103,6 @@ func configWithSeverityOverride(projectID string, severity *string) string {
 			alert_configuration_id = mongodbatlas_alert_configuration.test.id
 		}
 		`, projectID, severityOverride)
-
-	return x
 }
 
 func TestAccConfigDSAlertConfiguration_withOutput(t *testing.T) {


### PR DESCRIPTION
## Description

CLOUDP-313016: add support for alertConfiguration.severityOverride attribute

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [x] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ x I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
