### PR TITLE
chore: Move CloseTokenSource call out of defer

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,6 @@ import (
 )
 
 func main() {
-	defer config.CloseTokenSource() // Revoke SA token when the plugin is exiting because Terraform command finished.
-
 	var debugMode bool
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
@@ -25,7 +23,8 @@ func main() {
 		provider.MuxProviderFactory(),
 		serveOpts...,
 	)
+	config.CloseTokenSource() // Revoke SA token when the plugin is exiting because Terraform command finished.
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Description

Move CloseTokenSource call out of defer.

This is an improvement so we can call Fatal (as it was before) if `tf6server.Serve` returns an error. We can't use `defer` because `os.Exit` in `Fatal` doesn't call deferred methods.


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
