### PR TITLE
test: Adds delay to avoid flakiness in TestAccProjectAPIKey_recreateWhenDeletedExternally

### DIFF
--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -174,6 +175,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
 						t.Fatalf("failed to manually delete API key resource: %s", err)
 					}
+					time.Sleep(5 * time.Second) // avoid flaky test
 				},
 				Config:             config,
 				PlanOnly:           true,

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -175,7 +175,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
 						t.Fatalf("failed to manually delete API key resource: %s", err)
 					}
-					time.Sleep(5 * time.Second) // avoid flaky test
+					time.Sleep(5 * time.Second) // Avoid flaky empty plan error by ensuring the deletion is registered.
 				},
 				Config:             config,
 				PlanOnly:           true,


### PR DESCRIPTION
## Description

In the last two weeks we had 13/15 passing tests.
Today it failed, same error as 3 days ago:

```
2025-10-21T00:30:48.3856613Z === RUN   TestAccProjectAPIKey_recreateWhenDeletedExternally
2025-10-21T00:30:48.3861152Z === CONT  TestAccProjectAPIKey_recreateWhenDeletedExternally
2025-10-21T00:30:48.3871957Z === NAME  TestAccProjectAPIKey_recreateWhenDeletedExternally
2025-10-21T00:30:48.3872807Z     resource_project_api_key_test.go:163: Step 2/2 error: Expected a non-empty plan, but got an empty refresh plan
2025-10-21T00:30:48.3873390Z --- FAIL: TestAccProjectAPIKey_recreateWhenDeletedExternally (7.58s)
```

The test is relatively fast, so I expect the 5s sleep to have little downside.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
