### PR TITLE
refactor: Uses delete_on_create_timeout with default=true support across TPF resources

### DIFF
--- a/internal/common/cleanup/handle_timeout.go
+++ b/internal/common/cleanup/handle_timeout.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/constant"
 )
@@ -99,15 +98,4 @@ func ResolveTimeout(ctx context.Context, t *timeouts.Value, operationName string
 		timeoutDuration = constant.DefaultTimeout
 	}
 	return timeoutDuration
-}
-
-// ResolveDeleteOnCreateTimeout returns true if delete_on_create_timeout should be enabled.
-// Default behavior is true when not explicitly set to false.
-func ResolveDeleteOnCreateTimeout(deleteOnCreateTimeout types.Bool) bool {
-	// If null or unknown, default to true
-	if deleteOnCreateTimeout.IsNull() || deleteOnCreateTimeout.IsUnknown() {
-		return true
-	}
-	// Otherwise use the explicit value
-	return deleteOnCreateTimeout.ValueBool()
 }

--- a/internal/service/advancedcluster/resource.go
+++ b/internal/service/advancedcluster/resource.go
@@ -135,7 +135,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 	isFlex := IsFlex(latestReq.ReplicationSpecs)
 	projectID, clusterName := waitParams.ProjectID, waitParams.ClusterName
 	clusterDetailStr := fmt.Sprintf("Cluster name %s (project_id=%s).", clusterName, projectID)
-	if cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout) {
+	if plan.DeleteOnCreateTimeout.ValueBool() {
 		var deferCall func()
 		ctx, deferCall = cleanup.OnTimeout(
 			ctx, waitParams.Timeout, diags.AddWarning, clusterDetailStr, DeleteClusterNoWait(r.Client, projectID, clusterName, isFlex),

--- a/internal/service/advancedcluster/schema.go
+++ b/internal/service/advancedcluster/schema.go
@@ -135,7 +135,11 @@ func resourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.",
 			},
 			"delete_on_create_timeout": schema.BoolAttribute{
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.CreateOnlyBoolWithDefault(true),
+				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},
 			"encryption_at_rest_provider": schema.StringAttribute{

--- a/internal/service/encryptionatrestprivateendpoint/resource.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource.go
@@ -70,7 +70,7 @@ func (r *encryptionAtRestPrivateEndpointRS) Create(ctx context.Context, req reso
 	}
 
 	finalResp, err := waitStateTransition(ctx, projectID, cloudProvider, createResp.GetId(), connV2.EncryptionAtRestUsingCustomerKeyManagementApi, createTimeout)
-	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(earPrivateEndpointPlan.DeleteOnCreateTimeout), err, func(ctxCleanup context.Context) error {
+	err = cleanup.HandleCreateTimeout(earPrivateEndpointPlan.DeleteOnCreateTimeout.ValueBool(), err, func(ctxCleanup context.Context) error {
 		cleanResp, cleanErr := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.RequestPrivateEndpointDeletion(ctxCleanup, projectID, cloudProvider, createResp.GetId()).Execute()
 		if validate.StatusNotFound(cleanResp) {
 			return nil

--- a/internal/service/encryptionatrestprivateendpoint/resource_schema.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_schema.go
@@ -46,9 +46,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Delete: true,
 			}),
 			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Bool{
-					customplanmodifier.CreateOnly(),
+					customplanmodifier.CreateOnlyBoolWithDefault(true),
 				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},

--- a/internal/service/encryptionatrestprivateendpoint/resource_test.go
+++ b/internal/service/encryptionatrestprivateendpoint/resource_test.go
@@ -28,6 +28,17 @@ const (
 	earResourceName      = "mongodbatlas_encryption_at_rest.test"
 )
 
+func importStep(config string) resource.TestStep {
+	return resource.TestStep{
+		Config:                  config,
+		ResourceName:            resourceName,
+		ImportStateIdFunc:       importStateIDFunc(resourceName),
+		ImportState:             true,
+		ImportStateVerify:       true,
+		ImportStateVerifyIgnore: []string{"delete_on_create_timeout"},
+	}
+}
+
 func TestAccEncryptionAtRestPrivateEndpoint_Azure_basic(t *testing.T) {
 	resource.Test(t, *basicTestCaseAzure(t))
 }
@@ -106,13 +117,7 @@ func basicTestCaseAzure(tb testing.TB) *resource.TestCase {
 				Config: configAzureBasic(projectID, azureKeyVault, region, false),
 				Check:  checkBasic(projectID, *azureKeyVault.AzureEnvironment, region, false),
 			},
-			{
-				Config:            configAzureBasic(projectID, azureKeyVault, region, false),
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			importStep(configAzureBasic(projectID, azureKeyVault, region, false)),
 		},
 	}
 }
@@ -209,13 +214,7 @@ func basicTestCaseAWS(tb testing.TB) *resource.TestCase {
 				Config: configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKmsPrivateNetworking),
 				Check:  checkBasic(projectID, "AWS", region, true),
 			},
-			{
-				Config:            configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms),
-				ResourceName:      resourceName,
-				ImportStateIdFunc: importStateIDFunc(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			importStep(configAWSBasic(projectID, awsIAMRoleName, awsIAMRolePolicyName, &awsKms)),
 		},
 	}
 }

--- a/internal/service/pushbasedlogexport/resource.go
+++ b/internal/service/pushbasedlogexport/resource.go
@@ -76,7 +76,7 @@ func (r *pushBasedLogExportRS) Create(ctx context.Context, req resource.CreateRe
 	logExportConfigResp, err := WaitStateTransition(ctx, projectID, connV2.PushBasedLogExportApi,
 		retryTimeConfig(timeout, minTimeoutCreateUpdate))
 
-	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(tfPlan.DeleteOnCreateTimeout), err, func(ctx context.Context) error {
+	err = cleanup.HandleCreateTimeout(tfPlan.DeleteOnCreateTimeout.ValueBool(), err, func(ctx context.Context) error {
 		cleanResp, cleanErr := connV2.PushBasedLogExportApi.DeleteLogExport(ctx, projectID).Execute()
 		if validate.StatusNotFound(cleanResp) {
 			return nil

--- a/internal/service/pushbasedlogexport/resource_schema.go
+++ b/internal/service/pushbasedlogexport/resource_schema.go
@@ -57,9 +57,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Delete: true,
 			}),
 			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Bool{
-					customplanmodifier.CreateOnly(),
+					customplanmodifier.CreateOnlyBoolWithDefault(true),
 				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},

--- a/internal/service/pushbasedlogexport/resource_test.go
+++ b/internal/service/pushbasedlogexport/resource_test.go
@@ -58,6 +58,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "project_id",
+				ImportStateVerifyIgnore:              []string{"delete_on_create_timeout"},
 			},
 		},
 	}

--- a/internal/service/searchdeployment/resource.go
+++ b/internal/service/searchdeployment/resource.go
@@ -74,7 +74,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 
 	deploymentResp, err := WaitSearchNodeStateTransition(ctx, projectID, clusterName, connV2.AtlasSearchApi,
 		RetryTimeConfig(createTimeout, minTimeoutCreateUpdate))
-	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout), err, func(ctxCleanup context.Context) error {
+	err = cleanup.HandleCreateTimeout(plan.DeleteOnCreateTimeout.ValueBool(), err, func(ctxCleanup context.Context) error {
 		_, err := connV2.AtlasSearchApi.DeleteClusterSearchDeployment(ctxCleanup, projectID, clusterName).Execute()
 		return err
 	})

--- a/internal/service/searchdeployment/resource_schema.go
+++ b/internal/service/searchdeployment/resource_schema.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
 func ResourceSchema(ctx context.Context) schema.Schema {
@@ -68,7 +69,11 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:    true,
 			},
 			"delete_on_create_timeout": schema.BoolAttribute{
-				Optional:            true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.Bool{
+					customplanmodifier.CreateOnlyBoolWithDefault(true),
+				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},
 			"encryption_at_rest_provider": schema.StringAttribute{

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -21,13 +21,13 @@ const (
 	dataSourceID = "data.mongodbatlas_search_deployment.test"
 )
 
-func importStep(tfConfig string) resource.TestStep {
+func importStep() resource.TestStep {
 	return resource.TestStep{
-		Config:            tfConfig,
-		ResourceName:      resourceID,
-		ImportStateIdFunc: importStateIDFunc(resourceID),
-		ImportState:       true,
-		ImportStateVerify: true,
+		ResourceName:            resourceID,
+		ImportStateIdFunc:       importStateIDFunc(resourceID),
+		ImportState:             true,
+		ImportStateVerify:       true,
+		ImportStateVerifyIgnore: []string{"delete_on_create_timeout"},
 	}
 }
 func TestAccSearchDeployment_basic(t *testing.T) {
@@ -48,9 +48,7 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 				Config: updateStepNoWait,
 				Check:  updateStep.Check,
 			},
-			// Changes: skip_wait_on_update true -> null
-			updateStep,
-			importStep(updateStep.Config),
+			importStep(),
 		},
 	})
 }
@@ -119,7 +117,7 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceID, "timeouts.create"),
 				),
 			},
-			importStep(configWithTimeout("")),
+			importStep(),
 		},
 	})
 }

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -107,13 +107,13 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 				),
 			},
 			{
-				Config: configWithTimeout(timeoutsStrLongFalse),
-				Check:  resource.TestCheckResourceAttr(resourceID, "delete_on_create_timeout", "false"),
+				Config:      configWithTimeout(timeoutsStrLongFalse),
+				ExpectError: regexp.MustCompile("delete_on_create_timeout cannot be updated or set after import .*"),
 			},
 			{
 				Config: configWithTimeout(""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceID, "delete_on_create_timeout"),
+					resource.TestCheckResourceAttrSet(resourceID, "delete_on_create_timeout"), // Will keep value from state
 					resource.TestCheckNoResourceAttr(resourceID, "timeouts.create"),
 				),
 			},

--- a/internal/service/searchdeployment/resource_test.go
+++ b/internal/service/searchdeployment/resource_test.go
@@ -48,6 +48,9 @@ func TestAccSearchDeployment_basic(t *testing.T) {
 				Config: updateStepNoWait,
 				Check:  updateStep.Check,
 			},
+			// skip_wait_on_update = false again, and wait for stable state_name
+			updateStep,
+
 			importStep(),
 		},
 	})
@@ -108,7 +111,7 @@ func TestAccSearchDeployment_timeoutTest(t *testing.T) {
 			},
 			{
 				Config:      configWithTimeout(timeoutsStrLongFalse),
-				ExpectError: regexp.MustCompile("delete_on_create_timeout cannot be updated or set after import .*"),
+				ExpectError: regexp.MustCompile("delete_on_create_timeout cannot be updated or set after import.*"),
 			},
 			{
 				Config: configWithTimeout(""),

--- a/internal/service/streamprocessor/resource.go
+++ b/internal/service/streamprocessor/resource.go
@@ -94,7 +94,7 @@ func (r *streamProcessorRS) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	streamProcessorResp, err := WaitStateTransitionWithTimeout(ctx, streamProcessorParams, connV2.StreamsApi, []string{InitiatingState, CreatingState}, []string{CreatedState}, createTimeout)
-	err = cleanup.HandleCreateTimeout(cleanup.ResolveDeleteOnCreateTimeout(plan.DeleteOnCreateTimeout), err, func(ctxCleanup context.Context) error {
+	err = cleanup.HandleCreateTimeout(plan.DeleteOnCreateTimeout.ValueBool(), err, func(ctxCleanup context.Context) error {
 		_, err := connV2.StreamsApi.DeleteStreamProcessor(ctxCleanup, projectID, workspaceOrInstanceName, processorName).Execute()
 		if err != nil {
 			return err

--- a/internal/service/streamprocessor/resource_schema.go
+++ b/internal/service/streamprocessor/resource_schema.go
@@ -99,9 +99,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Create: true,
 			}),
 			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Bool{
-					customplanmodifier.CreateOnly(),
+					customplanmodifier.CreateOnlyBoolWithDefault(true),
 				},
 				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
 			},

--- a/internal/service/streamprocessor/resource_test.go
+++ b/internal/service/streamprocessor/resource_test.go
@@ -39,6 +39,16 @@ var (
 	testLogDestConfig    = connectionConfig{connectionType: connTypeTestLog, pipelineStepIsSource: false}
 )
 
+func importStep() resource.TestStep {
+	return resource.TestStep{
+		ResourceName:            resourceName,
+		ImportStateIdFunc:       importStateIDFunc(resourceName),
+		ImportState:             true,
+		ImportStateVerify:       true,
+		ImportStateVerifyIgnore: []string{"delete_on_create_timeout", "stats"},
+	}
+}
+
 func TestAccStreamProcessor_basic(t *testing.T) {
 	resource.ParallelTest(t, *basicTestCase(t))
 }
@@ -66,13 +76,7 @@ func basicTestCase(t *testing.T) *resource.TestCase {
 				Check:             composeStreamProcessorChecks(projectID, workspaceName, processorName, streamprocessor.StartedState, true, false),
 				ConfigStateChecks: pluralConfigStateChecks(processorName, streamprocessor.StartedState, workspaceName, true, false),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stats"},
-			},
+			importStep(),
 		}}
 }
 
@@ -150,13 +154,7 @@ func TestAccStreamProcessor_withOptions(t *testing.T) {
 				Check:             composeStreamProcessorChecks(projectID, workspaceName, processorName, streamprocessor.CreatedState, false, true),
 				ConfigStateChecks: pluralConfigStateChecks(processorName, streamprocessor.CreatedState, workspaceName, false, true),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportStateIdFunc:       importStateIDFunc(resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"stats"},
-			},
+			importStep(),
 		}})
 }
 


### PR DESCRIPTION
## Description

Uses delete_on_create_timeout with default=true support across TPF resources

Link to any related issue(s): CLOUDP-343190

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
