### PR TITLE
refactor: Adds invalid update error for delete_on_create_timeout for sdkv2

### DIFF
--- a/internal/common/cleanup/handle_timeout.go
+++ b/internal/common/cleanup/handle_timeout.go
@@ -3,7 +3,6 @@ package cleanup
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -15,7 +14,8 @@ import (
 )
 
 const (
-	CleanupWarning = "Failed to create resource. Will run cleanup due to the operation timing out"
+	CleanupWarning                           = "Failed to create resource. Will run cleanup due to the operation timing out"
+	DeleteOnCreateTimeoutInvalidErrorMessage = "delete_on_create_timeout cannot be updated or set after import, remove it from the configuration"
 )
 
 // HandleCreateTimeout helps to implement Create in long-running operations.
@@ -128,7 +128,7 @@ func DeleteOnCreateTimeoutInvalidUpdate(resource resourceInterface) string {
 		return ""
 	}
 	if _, exists := resource.GetOkExists("delete_on_create_timeout"); exists {
-		return fmt.Sprintf("%s cannot be updated or set after import, remove it from the configuration", "delete_on_create_timeout")
+		return DeleteOnCreateTimeoutInvalidErrorMessage
 	}
 	return ""
 }

--- a/internal/common/cleanup/handle_timeout.go
+++ b/internal/common/cleanup/handle_timeout.go
@@ -113,12 +113,17 @@ func ResolveDeleteOnCreateTimeout(deleteOnCreateTimeout types.Bool) bool {
 	return deleteOnCreateTimeout.ValueBool()
 }
 
-type ResourceInterface interface {
-	GetOkExists(key string) (interface{}, bool)
+type resourceInterface interface {
+	GetOkExists(key string) (any, bool)
 	HasChange(key string) bool
 }
 
-func DeleteOnCreateTimeoutInvalidUpdate(resource ResourceInterface) string {
+// DeleteOnCreateTimeoutInvalidUpdate returns an error if the `delete_on_create_timeout` attribute has been updated to true/false
+// This use case differs slightly from the behavior of TPF customplanmodifier.CreateOnlyBoolWithDefault:
+// - from a given value (true/false) --> `null`.
+// This TPF implementation keeps the state value (UseStateForUnknown behavior).
+// This will set the state value to null (Optional-only attribute).
+func DeleteOnCreateTimeoutInvalidUpdate(resource resourceInterface) string {
 	if !resource.HasChange("delete_on_create_timeout") {
 		return ""
 	}

--- a/internal/common/cleanup/handle_timeout.go
+++ b/internal/common/cleanup/handle_timeout.go
@@ -3,6 +3,7 @@ package cleanup
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -110,4 +111,19 @@ func ResolveDeleteOnCreateTimeout(deleteOnCreateTimeout types.Bool) bool {
 	}
 	// Otherwise use the explicit value
 	return deleteOnCreateTimeout.ValueBool()
+}
+
+type ResourceInterface interface {
+	GetOkExists(key string) (interface{}, bool)
+	HasChange(key string) bool
+}
+
+func DeleteOnCreateTimeoutInvalidUpdate(resource ResourceInterface) string {
+	if !resource.HasChange("delete_on_create_timeout") {
+		return ""
+	}
+	if _, exists := resource.GetOkExists("delete_on_create_timeout"); exists {
+		return fmt.Sprintf("%s cannot be updated or set after import, remove it from the configuration", "delete_on_create_timeout")
+	}
+	return ""
 }

--- a/internal/common/cleanup/handle_timeout.go
+++ b/internal/common/cleanup/handle_timeout.go
@@ -121,8 +121,8 @@ type resourceInterface interface {
 // DeleteOnCreateTimeoutInvalidUpdate returns an error if the `delete_on_create_timeout` attribute has been updated to true/false
 // This use case differs slightly from the behavior of TPF customplanmodifier.CreateOnlyBoolWithDefault:
 // - from a given value (true/false) --> `null`.
-// This TPF implementation keeps the state value (UseStateForUnknown behavior).
-// This will set the state value to null (Optional-only attribute).
+// While the TPF implementation keeps the state value (UseStateForUnknown behavior),
+// The SDKv2 implementation will set the state value to null (Optional-only attribute).
 func DeleteOnCreateTimeoutInvalidUpdate(resource resourceInterface) string {
 	if !resource.HasChange("delete_on_create_timeout") {
 		return ""

--- a/internal/common/cleanup/handle_timeout_test.go
+++ b/internal/common/cleanup/handle_timeout_test.go
@@ -90,8 +90,8 @@ func TestReplaceContextDeadlineExceededDiags(t *testing.T) {
 }
 
 type mockResource struct {
-	values  map[string]interface{}
-	changes map[string]bool
+	values    map[string]interface{}
+	isChanged bool
 }
 
 func (m *mockResource) GetOkExists(key string) (interface{}, bool) {
@@ -100,14 +100,14 @@ func (m *mockResource) GetOkExists(key string) (interface{}, bool) {
 }
 
 func (m *mockResource) HasChange(key string) bool {
-	return m.changes[key]
+	return m.isChanged
 }
 
 func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 	t.Run("No change in delete_on_create_timeout returns empty string", func(t *testing.T) {
 		resource := &mockResource{
-			values:  map[string]interface{}{},
-			changes: map[string]bool{"delete_on_create_timeout": false},
+			values:    map[string]interface{}{},
+			isChanged: false,
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
@@ -116,8 +116,8 @@ func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 
 	t.Run("Change detected but field doesn't exist returns empty string", func(t *testing.T) {
 		resource := &mockResource{
-			values:  map[string]interface{}{},
-			changes: map[string]bool{"delete_on_create_timeout": true},
+			values:    map[string]interface{}{},
+			isChanged: true,
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
@@ -126,8 +126,8 @@ func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 
 	t.Run("Change detected and field exists returns error message", func(t *testing.T) {
 		resource := &mockResource{
-			values:  map[string]interface{}{"delete_on_create_timeout": true},
-			changes: map[string]bool{"delete_on_create_timeout": true},
+			values:    map[string]interface{}{"delete_on_create_timeout": true},
+			isChanged: true,
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
@@ -137,8 +137,8 @@ func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 
 	t.Run("Change detected with false value still returns error message", func(t *testing.T) {
 		resource := &mockResource{
-			values:  map[string]interface{}{"delete_on_create_timeout": false},
-			changes: map[string]bool{"delete_on_create_timeout": true},
+			values:    map[string]interface{}{"delete_on_create_timeout": false},
+			isChanged: true,
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)

--- a/internal/common/cleanup/handle_timeout_test.go
+++ b/internal/common/cleanup/handle_timeout_test.go
@@ -88,3 +88,61 @@ func TestReplaceContextDeadlineExceededDiags(t *testing.T) {
 		assert.Equal(t, expectedDetails[i], diag.Detail(), "Detail at index %d should match", i)
 	}
 }
+
+type mockResource struct {
+	values  map[string]interface{}
+	changes map[string]bool
+}
+
+func (m *mockResource) GetOkExists(key string) (interface{}, bool) {
+	value, exists := m.values[key]
+	return value, exists
+}
+
+func (m *mockResource) HasChange(key string) bool {
+	return m.changes[key]
+}
+
+func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
+	t.Run("No change in delete_on_create_timeout returns empty string", func(t *testing.T) {
+		resource := &mockResource{
+			values:  map[string]interface{}{},
+			changes: map[string]bool{"delete_on_create_timeout": false},
+		}
+
+		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
+		assert.Empty(t, result)
+	})
+
+	t.Run("Change detected but field doesn't exist returns empty string", func(t *testing.T) {
+		resource := &mockResource{
+			values:  map[string]interface{}{},
+			changes: map[string]bool{"delete_on_create_timeout": true},
+		}
+
+		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
+		assert.Empty(t, result)
+	})
+
+	t.Run("Change detected and field exists returns error message", func(t *testing.T) {
+		resource := &mockResource{
+			values:  map[string]interface{}{"delete_on_create_timeout": true},
+			changes: map[string]bool{"delete_on_create_timeout": true},
+		}
+
+		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
+		expectedMessage := "delete_on_create_timeout cannot be updated or set after import, remove it from the configuration"
+		assert.Equal(t, expectedMessage, result)
+	})
+
+	t.Run("Change detected with false value still returns error message", func(t *testing.T) {
+		resource := &mockResource{
+			values:  map[string]interface{}{"delete_on_create_timeout": false},
+			changes: map[string]bool{"delete_on_create_timeout": true},
+		}
+
+		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
+		expectedMessage := "delete_on_create_timeout cannot be updated or set after import, remove it from the configuration"
+		assert.Equal(t, expectedMessage, result)
+	})
+}

--- a/internal/common/cleanup/handle_timeout_test.go
+++ b/internal/common/cleanup/handle_timeout_test.go
@@ -131,7 +131,7 @@ func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
-		expectedMessage := "delete_on_create_timeout cannot be updated or set after import, remove it from the configuration"
+		expectedMessage := cleanup.DeleteOnCreateTimeoutInvalidErrorMessage
 		assert.Equal(t, expectedMessage, result)
 	})
 
@@ -142,7 +142,7 @@ func TestDeleteOnCreateTimeoutInvalidUpdate(t *testing.T) {
 		}
 
 		result := cleanup.DeleteOnCreateTimeoutInvalidUpdate(resource)
-		expectedMessage := "delete_on_create_timeout cannot be updated or set after import, remove it from the configuration"
+		expectedMessage := cleanup.DeleteOnCreateTimeoutInvalidErrorMessage
 		assert.Equal(t, expectedMessage, result)
 	})
 }

--- a/internal/service/networkpeering/resource.go
+++ b/internal/service/networkpeering/resource.go
@@ -448,6 +448,9 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	peerID := ids["peer_id"]
+	if invalidUpdate := cleanup.DeleteOnCreateTimeoutInvalidUpdate(d); invalidUpdate != "" {
+		return diag.FromErr(errors.New(invalidUpdate))
+	}
 
 	peer := &admin.BaseNetworkPeeringConnectionSettings{
 		ProviderName: conversion.StringPtr(ids["provider_name"]),

--- a/internal/service/networkpeering/resource_test.go
+++ b/internal/service/networkpeering/resource_test.go
@@ -255,7 +255,7 @@ func basicAWSTestCase(t *testing.T) *resource.TestCase {
 				ImportStateIdFunc:       importStateIDFunc(resourceName),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"accepter_region_name", "container_id"},
+				ImportStateVerifyIgnore: []string{"accepter_region_name", "container_id", "delete_on_create_timeout"},
 			},
 		},
 	}

--- a/internal/service/networkpeering/resource_test.go
+++ b/internal/service/networkpeering/resource_test.go
@@ -222,8 +222,8 @@ func TestAccNetworkNetworkPeering_timeouts(t *testing.T) {
 	})
 }
 
-func basicAWSTestCase(t *testing.T) *resource.TestCase {
-	t.Helper()
+func basicAWSTestCase(tb testing.TB) *resource.TestCase {
+	tb.Helper()
 	var (
 		orgID           = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		vpcID           = os.Getenv("AWS_VPC_ID")
@@ -238,7 +238,7 @@ func basicAWSTestCase(t *testing.T) *resource.TestCase {
 	checks := commonChecksAWS(vpcID, providerName, awsAccountID, vpcCIDRBlock, peerRegion)
 
 	return &resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckPeeringEnvAWS(t) },
+		PreCheck:                 func() { acc.PreCheckPeeringEnvAWS(tb) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroyNetworkPeering,
 		Steps: []resource.TestStep{
@@ -247,7 +247,7 @@ func basicAWSTestCase(t *testing.T) *resource.TestCase {
 				Check:  resource.ComposeAggregateTestCheckFunc(checks...),
 			},
 			{
-				Config:      acc.ConfigAddResourceStr(t, config, resourceName, "delete_on_create_timeout = true"),
+				Config:      acc.ConfigAddResourceStr(tb, config, resourceName, "delete_on_create_timeout = true"),
 				ExpectError: regexp.MustCompile(cleanup.DeleteOnCreateTimeoutInvalidErrorMessage),
 			},
 			{

--- a/internal/service/onlinearchive/resource.go
+++ b/internal/service/onlinearchive/resource.go
@@ -439,6 +439,9 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	atlasID := ids["archive_id"]
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
+	if invalidUpdate := cleanup.DeleteOnCreateTimeoutInvalidUpdate(d); invalidUpdate != "" {
+		return diag.FromErr(errors.New(invalidUpdate))
+	}
 
 	if dataProcessRegionHasChange := d.HasChange("data_process_region"); dataProcessRegionHasChange {
 		return diag.FromErr(fmt.Errorf("error updating Mongo Online Archive id: %s, data_process_region can't be modified", atlasID))

--- a/internal/testutil/acc/config_formatter.go
+++ b/internal/testutil/acc/config_formatter.go
@@ -16,21 +16,21 @@ import (
 )
 
 // ConfigAddResourceStr is useful when you need to add one or more attributes to a resource block.
-func ConfigAddResourceStr(t *testing.T, hclConfig, resourceID, extraResourceStr string) string {
-	t.Helper()
+func ConfigAddResourceStr(tb testing.TB, hclConfig, resourceID, extraResourceStr string) string {
+	tb.Helper()
 	resourceParts := strings.Split(resourceID, ".")
 	if len(resourceParts) != 2 {
-		t.Fatalf("resourceID must be in the format <type>.<name>, got %s", resourceID)
+		tb.Fatalf("resourceID must be in the format <type>.<name>, got %s", resourceID)
 	}
 	resourceType := resourceParts[0]
 	resourceName := resourceParts[1]
 	resourceBlockDef := fmt.Sprintf("resource %q %q {", resourceType, resourceName)
 	if !strings.Contains(hclConfig, resourceBlockDef) {
-		t.Fatalf("resource block %q not found in config: %s", resourceBlockDef, hclConfig)
+		tb.Fatalf("resource block %q not found in config: %s", resourceBlockDef, hclConfig)
 	}
 	resourceBlockDefWithExtraResourceStr := fmt.Sprintf("%s\n%s\n", resourceBlockDef, extraResourceStr)
 	hclConfigModified := strings.Replace(hclConfig, resourceBlockDef, resourceBlockDefWithExtraResourceStr, 1)
-	return localHcl.PrettyHCL(t, hclConfigModified)
+	return localHcl.PrettyHCL(tb, hclConfigModified)
 }
 
 func FormatToHCLMap(m map[string]string, indent, varName string) string {

--- a/internal/testutil/hcl/common.go
+++ b/internal/testutil/hcl/common.go
@@ -69,11 +69,11 @@ func AddAttributes(t *testing.T, body *hclsyntax.Body, ret map[string]cty.Value)
 	}
 }
 
-func PrettyHCL(t *testing.T, content string) string {
-	t.Helper()
+func PrettyHCL(tb testing.TB, content string) string {
+	tb.Helper()
 	builder := strings.Builder{}
-	fmt := getTF().Format(t.Context(), io.NopCloser(strings.NewReader(content)), &builder)
-	require.NoError(t, fmt)
+	fmt := getTF().Format(tb.Context(), io.NopCloser(strings.NewReader(content)), &builder)
+	require.NoError(tb, fmt)
 	formatted := builder.String()
 	return formatted
 }


### PR DESCRIPTION
## Description

Adds invalid update error for delete_on_create_timeout for sdkv2

Link to any related issue(s): CLOUDP-343190

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
