### PR TITLE
chore: Add support for typed nested sets in autogen

### DIFF
--- a/internal/common/autogen/customtypes/nested_set.go
+++ b/internal/common/autogen/customtypes/nested_set.go
@@ -1,0 +1,206 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+/*
+	Custom Nested Set type used in auto-generated code to enable the generic marshal/unmarshal operations to access nested attribute struct tags during conversion.
+	Custom types docs: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/custom
+
+	Usage:
+		- Schema definition:
+			"sample_nested_object_set": schema.SetNestedAttribute{
+				...
+				CustomType: customtypes.NewNestedSetType[TFSampleNestedObjectModel](ctx),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"string_attribute": schema.StringAttribute{...},
+					},
+				},
+			}
+
+		- TF Models:
+			type TFModel struct {
+				SampleNestedObjectSet customtypes.NestedSetValue[TFSampleNestedObjectModel] `tfsdk:"sample_nested_object_set"`
+				...
+			}
+
+			type TFSampleNestedObjectModel struct {
+				StringAttribute types.String `tfsdk:"string_attribute"`
+				...
+			}
+*/
+
+var (
+	_ basetypes.SetTypable    = NestedSetType[struct{}]{}
+	_ basetypes.SetValuable   = NestedSetValue[struct{}]{}
+	_ NestedSetValueInterface = NestedSetValue[struct{}]{}
+)
+
+type NestedSetType[T any] struct {
+	basetypes.SetType
+}
+
+func NewNestedSetType[T any](ctx context.Context) NestedSetType[T] {
+	elemType, diags := getElementType[T](ctx)
+	if diags.HasError() {
+		panic(fmt.Errorf("error creating NestedSetType: %v", diags))
+	}
+
+	result := NestedSetType[T]{
+		SetType: basetypes.SetType{ElemType: elemType},
+	}
+	return result
+}
+
+func (t NestedSetType[T]) Equal(o attr.Type) bool {
+	other, ok := o.(NestedSetType[T])
+	if !ok {
+		return false
+	}
+	return t.SetType.Equal(other.SetType)
+}
+
+func (NestedSetType[T]) String() string {
+	var t T
+	return fmt.Sprintf("NestedSetType[%T]", t)
+}
+
+func (t NestedSetType[T]) ValueFromSet(ctx context.Context, in basetypes.SetValue) (basetypes.SetValuable, diag.Diagnostics) {
+	if in.IsNull() {
+		return NewNestedSetValueNull[T](ctx), nil
+	}
+
+	if in.IsUnknown() {
+		return NewNestedSetValueUnknown[T](ctx), nil
+	}
+
+	elemType, diags := getElementType[T](ctx)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	baseSetValue, diags := basetypes.NewSetValue(elemType, in.Elements())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return NestedSetValue[T]{SetValue: baseSetValue}, nil
+}
+
+func (t NestedSetType[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.SetType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	setValue, ok := attrValue.(basetypes.SetValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	setValuable, diags := t.ValueFromSet(ctx, setValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting SetValue to SetValuable: %v", diags)
+	}
+
+	return setValuable, nil
+}
+
+func (t NestedSetType[T]) ValueType(_ context.Context) attr.Value {
+	return NestedSetValue[T]{}
+}
+
+type NestedSetValue[T any] struct {
+	basetypes.SetValue
+}
+
+type NestedSetValueInterface interface {
+	basetypes.SetValuable
+	NewNestedSetValue(ctx context.Context, value any) NestedSetValueInterface
+	NewNestedSetValueNull(ctx context.Context) NestedSetValueInterface
+	SlicePtrAsAny(ctx context.Context) (any, diag.Diagnostics)
+	NewEmptySlicePtr() any
+	Len() int
+}
+
+func (v NestedSetValue[T]) NewNestedSetValue(ctx context.Context, value any) NestedSetValueInterface {
+	return NewNestedSetValue[T](ctx, value)
+}
+
+func NewNestedSetValue[T any](ctx context.Context, value any) NestedSetValue[T] {
+	elemType, diags := getElementType[T](ctx)
+	if diags.HasError() {
+		panic(fmt.Errorf("error creating NestedSetValue: %v", diags))
+	}
+
+	newValue, diags := basetypes.NewSetValueFrom(ctx, elemType, value)
+	if diags.HasError() {
+		return NewNestedSetValueUnknown[T](ctx)
+	}
+
+	return NestedSetValue[T]{SetValue: newValue}
+}
+
+func (v NestedSetValue[T]) NewNestedSetValueNull(ctx context.Context) NestedSetValueInterface {
+	return NewNestedSetValueNull[T](ctx)
+}
+
+func NewNestedSetValueNull[T any](ctx context.Context) NestedSetValue[T] {
+	elemType, diags := getElementType[T](ctx)
+	if diags.HasError() {
+		panic(fmt.Errorf("error creating null NestedSetValue: %v", diags))
+	}
+	return NestedSetValue[T]{SetValue: basetypes.NewSetNull(elemType)}
+}
+
+func NewNestedSetValueUnknown[T any](ctx context.Context) NestedSetValue[T] {
+	elemType, diags := getElementType[T](ctx)
+	if diags.HasError() {
+		panic(fmt.Errorf("error creating unknown NestedSetValue: %v", diags))
+	}
+	return NestedSetValue[T]{SetValue: basetypes.NewSetUnknown(elemType)}
+}
+
+func (v NestedSetValue[T]) Equal(o attr.Value) bool {
+	other, ok := o.(NestedSetValue[T])
+	if !ok {
+		return false
+	}
+	return v.SetValue.Equal(other.SetValue)
+}
+
+func (v NestedSetValue[T]) Type(ctx context.Context) attr.Type {
+	return NewNestedSetType[T](ctx)
+}
+
+func (v NestedSetValue[T]) SlicePtrAsAny(ctx context.Context) (any, diag.Diagnostics) {
+	valuePtr := new([]T)
+
+	if v.IsNull() || v.IsUnknown() {
+		return valuePtr, nil
+	}
+
+	diags := v.ElementsAs(ctx, valuePtr, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return valuePtr, diags
+}
+
+func (v NestedSetValue[T]) NewEmptySlicePtr() any {
+	return new([]T)
+}
+
+func (v NestedSetValue[T]) Len() int {
+	return len(v.Elements())
+}

--- a/internal/common/autogen/unknown.go
+++ b/internal/common/autogen/unknown.go
@@ -72,6 +72,12 @@ func prepareAttr(value attr.Value) (attr.Value, error) {
 		}
 		// If known, no need to process each list item since unmarshal does not generate unknown attributes.
 		return v, nil
+	case customtypes.NestedSetValueInterface:
+		if v.IsUnknown() {
+			return v.NewNestedSetValueNull(ctx), nil
+		}
+		// If known, no need to process each set item since unmarshal does not generate unknown attributes.
+		return v, nil
 	}
 
 	if value.IsUnknown() { // unknown values are converted to null

--- a/internal/common/autogen/unknown_test.go
+++ b/internal/common/autogen/unknown_test.go
@@ -36,6 +36,7 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrCustomObject            customtypes.ObjectValue[modelCustomTypeTest] `tfsdk:"attr_custom_object"`
 		AttrCustomListUnknown       customtypes.ListValue[types.String]          `tfsdk:"attr_custom_list_string"`
 		AttrCustomNestedListUnknown customtypes.NestedListValue[modelEmptyTest]  `tfsdk:"attr_custom_nested_list_unknown"`
+		AttrCustomNestedSetUnknown  customtypes.NestedSetValue[modelEmptyTest]   `tfsdk:"attr_custom_nested_set_unknown"`
 	}
 
 	model := modelst{
@@ -89,6 +90,7 @@ func TestResolveUnknowns(t *testing.T) {
 			AttrMANYUpper:     types.Int64Unknown(),
 		}),
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueUnknown[modelEmptyTest](ctx),
+		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueUnknown[modelEmptyTest](ctx),
 		AttrCustomListUnknown:       customtypes.NewListValueUnknown[types.String](ctx),
 	}
 	modelExpected := modelst{
@@ -143,6 +145,7 @@ func TestResolveUnknowns(t *testing.T) {
 		}),
 		AttrCustomListUnknown:       customtypes.NewListValueNull[types.String](ctx),
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueNull[modelEmptyTest](ctx),
+		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueNull[modelEmptyTest](ctx),
 	}
 	require.NoError(t, autogen.ResolveUnknowns(&model))
 	assert.Equal(t, modelExpected, model)

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -96,6 +96,11 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomNestedListUnknownSent    customtypes.NestedListValue[modelCustomTypeTest] `tfsdk:"attr_custom_nested_list_unknown_sent"`
 		AttrSetString                      types.Set                                        `tfsdk:"attr_set_string"`
 		AttrSetObj                         types.Set                                        `tfsdk:"attr_set_obj"`
+		AttrCustomNestedSet                customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set"`
+		AttrCustomNestedSetNullNotSent     customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set_null_not_sent"`
+		AttrCustomNestedSetNullSent        customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set_null_sent"`
+		AttrCustomNestedSetUnknownNotSent  customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set_unknown_not_sent"`
+		AttrCustomNestedSetUnknownSent     customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set_unknown_sent"`
 		AttrListListString                 types.List                                       `tfsdk:"attr_list_list_string"`
 		AttrSetListObj                     types.Set                                        `tfsdk:"attr_set_list_obj"`
 		AttrListObjKnown                   types.List                                       `tfsdk:"attr_list_obj_known"`
@@ -151,8 +156,23 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomNestedListUnknownSent:    customtypes.NewNestedListValueUnknown[modelCustomTypeTest](ctx),
 		AttrSetString:                      types.SetUnknown(types.StringType),
 		AttrSetObj:                         types.SetUnknown(objTypeTest),
-		AttrListListString:                 types.ListUnknown(types.ListType{ElemType: types.StringType}),
-		AttrSetListObj:                     types.SetUnknown(types.ListType{ElemType: objTypeTest}),
+		AttrCustomNestedSet: customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			{
+				// these attribute values are irrelevant, they will be overwritten with JSON values
+				AttrString:    types.StringValue("different_string"),
+				AttrInt:       types.Int64Value(999),
+				AttrFloat:     types.Float64Unknown(),
+				AttrBool:      types.BoolUnknown(),
+				AttrNested:    customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
+				AttrMANYUpper: types.Int64Value(999),
+			},
+		}),
+		AttrCustomNestedSetNullNotSent:    customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetNullSent:       customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownNotSent: customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownSent:    customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
+		AttrListListString:                types.ListUnknown(types.ListType{ElemType: types.StringType}),
+		AttrSetListObj:                    types.SetUnknown(types.ListType{ElemType: objTypeTest}),
 		AttrListObjKnown: types.ListValueMust(objTypeTest, []attr.Value{
 			types.ObjectValueMust(objTypeTest.AttrTypes, map[string]attr.Value{
 				"attr_string": types.StringValue("val"),
@@ -276,6 +296,30 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 						"attrInt": 22,
 						"attrFloat": 22.2,		
 						"attrBool": true		
+					}
+				],
+				"attrCustomNestedSet": [
+					{
+						"attrString": "nestedSet1",
+						"attrInt": 1,
+						"attrFloat": 1.1,
+						"attrBool": true,
+						"attrNested": {},
+						"attrMANYUpper": 123
+					},
+					{
+						"attrString": "nestedSet2",
+						"attrInt": 2,
+						"attrFloat": 2.2,
+						"attrBool": false,
+						"attrNested": {},
+						"attrMANYUpper": 456
+					}
+				],
+				"attrCustomNestedSetNullSent": null,
+				"attrCustomNestedSetUnknownSent": [
+					{
+						"attrString": "unknownSetSent"
 					}
 				],
 				"attrListListString": [
@@ -484,6 +528,37 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 				"attr_float":  types.Float64Value(22.2),
 				"attr_bool":   types.BoolValue(true),
 			}),
+		}),
+		AttrCustomNestedSet: customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			{
+				AttrString:    types.StringValue("nestedSet1"),
+				AttrInt:       types.Int64Value(1),
+				AttrFloat:     types.Float64Value(1.1),
+				AttrBool:      types.BoolValue(true),
+				AttrNested:    customtypes.NewObjectValue[modelEmptyTest](ctx, modelEmptyTest{}),
+				AttrMANYUpper: types.Int64Value(123),
+			},
+			{
+				AttrString:    types.StringValue("nestedSet2"),
+				AttrInt:       types.Int64Value(2),
+				AttrFloat:     types.Float64Value(2.2),
+				AttrBool:      types.BoolValue(false),
+				AttrNested:    customtypes.NewObjectValue[modelEmptyTest](ctx, modelEmptyTest{}),
+				AttrMANYUpper: types.Int64Value(456),
+			},
+		}),
+		AttrCustomNestedSetNullNotSent:    customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetNullSent:       customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownNotSent: customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownSent: customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			{
+				AttrString:    types.StringValue("unknownSetSent"),
+				AttrInt:       types.Int64Null(),
+				AttrFloat:     types.Float64Null(),
+				AttrBool:      types.BoolNull(),
+				AttrNested:    customtypes.NewObjectValueNull[modelEmptyTest](ctx),
+				AttrMANYUpper: types.Int64Null(),
+			},
 		}),
 		AttrListListString: types.ListValueMust(types.ListType{ElemType: types.StringType}, []attr.Value{
 			types.ListValueMust(types.StringType, []attr.Value{

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -250,6 +250,7 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 							TFSchemaName:             "nested_set_array_attr",
 							TFModelName:              "NestedSetArrayAttr",
 							ComputedOptionalRequired: codespec.Computed,
+							CustomType:               codespec.NewCustomNestedSetType("NestedSetArrayAttr"),
 							SetNested: &codespec.SetNestedAttribute{
 								NestedObject: codespec.NestedAttributeObject{
 									Attributes: codespec.Attributes{

--- a/tools/codegen/codespec/attribute.go
+++ b/tools/codegen/codespec/attribute.go
@@ -192,6 +192,9 @@ func (s *APISpecSchema) buildArrayAttr(name, ancestorsName string, computability
 
 		if isNested && !isNestedEmpty {
 			if isSet {
+				if useCustomNestedTypes {
+					attr.CustomType = NewCustomNestedSetType(*nestedObjectName)
+				}
 				attr.SetNested = &SetNestedAttribute{NestedObject: *nestedObject}
 			} else {
 				if useCustomNestedTypes {

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -232,3 +232,11 @@ func NewCustomNestedListType(name string) *CustomType {
 		Schema:  fmt.Sprintf("customtypes.NewNestedListType[TF%sModel](ctx)", name),
 	}
 }
+
+func NewCustomNestedSetType(name string) *CustomType {
+	return &CustomType{
+		Package: CustomTypesPkg,
+		Model:   fmt.Sprintf("customtypes.NestedSetValue[TF%sModel]", name),
+		Schema:  fmt.Sprintf("customtypes.NewNestedSetType[TF%sModel](ctx)", name),
+	}
+}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -519,6 +519,7 @@ resources:
       path: /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}
       method: DELETE
     schema:
+      use_custom_nested_types: false
       overrides:
         secrets.secret:
           sensitive: true

--- a/tools/codegen/gofilegen/schema/schema_file_test.go
+++ b/tools/codegen/gofilegen/schema/schema_file_test.go
@@ -280,6 +280,18 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 								},
 							},
 						},
+						{
+							TFSchemaName:             "nested_set_attr",
+							TFModelName:              "NestedSetAttr",
+							Description:              admin.PtrString("nested set attribute"),
+							ComputedOptionalRequired: codespec.Optional,
+							CustomType:               codespec.NewCustomNestedSetType("NestedSetAttr"),
+							SetNested: &codespec.SetNestedAttribute{
+								NestedObject: codespec.NestedAttributeObject{
+									Attributes: []codespec.Attribute{intAttr},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/tools/codegen/gofilegen/schema/testdata/custom-types-attributes.golden.go
+++ b/tools/codegen/gofilegen/schema/testdata/custom-types-attributes.golden.go
@@ -70,6 +70,19 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
+			"nested_set_attr": schema.SetNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: "nested set attribute",
+				CustomType:          customtypes.NewNestedSetType[TFNestedSetAttrModel](ctx),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"int_attr": schema.Int64Attribute{
+							Required:            true,
+							MarkdownDescription: "int attribute",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -78,6 +91,7 @@ type TFModel struct {
 	NestedObjectAttr customtypes.ObjectValue[TFNestedObjectAttrModel]   `tfsdk:"nested_object_attr"`
 	StringListAttr   customtypes.ListValue[types.String]                `tfsdk:"string_list_attr"`
 	NestedListAttr   customtypes.NestedListValue[TFNestedListAttrModel] `tfsdk:"nested_list_attr"`
+	NestedSetAttr    customtypes.NestedSetValue[TFNestedSetAttrModel]   `tfsdk:"nested_set_attr"`
 }
 type TFNestedObjectAttrModel struct {
 	StringAttr          types.String                                                        `tfsdk:"string_attr"`
@@ -93,4 +107,7 @@ type TFNestedListAttrModel struct {
 }
 type TFNestedListAttrDoubleNestedListAttrModel struct {
 	StringAttr types.String `tfsdk:"string_attr"`
+}
+type TFNestedSetAttrModel struct {
+	IntAttr types.Int64 `tfsdk:"int_attr"`
 }


### PR DESCRIPTION
## Description

Adding a custom `NestedSet` terraform type for autogen usage.

Note that NestedSet supports nested objects but **not** Terraform attr types, e.g. `types.string`. These will be covered in the next PR (same as how it was done for lists).

Custom TF types docs: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/custom

Link to any related issue(s): CLOUDP-353170

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
