### PR TITLE
chore: Invoke Delete operation if timeout in autogen

### DIFF
--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -73,7 +73,7 @@ func HandleCreate(ctx context.Context, req HandleCreateReq) {
 		return
 	}
 	errWait := handleWaitCreateUpdate(ctx, req.Wait, req.Client, req.Plan)
-	if errWait != nil && req.Wait != nil && req.DeleteCallParams != nil {
+	if errWait != nil && req.DeleteCallParams != nil {
 		// Handle timeout with cleanup if delete_on_create_timeout is enabled. Doesn't support Delete with StaticRequestBody.
 		errWait = cleanup.HandleCreateTimeout(req.DeleteOnCreateTimeout, errWait, func(ctxCleanup context.Context) error {
 			bodyResp, apiResp, err := callAPIWithoutBody(ctxCleanup, req.Client, req.DeleteCallParams)

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -205,7 +205,7 @@ func addError(d *diag.Diagnostics, opName, errSummary string, err error) {
 }
 
 // callAPIWithBody makes a request to the API with the given request body and returns the response body.
-// It is used for POST, PUT, PATCH, and DELETE with static content.
+// It is used for POST, PUT, PATCH and DELETE with static content.
 func callAPIWithBody(ctx context.Context, client *config.MongoDBClient, callParams *config.APICallParams, bodyReq []byte) ([]byte, *http.Response, error) {
 	apiResp, err := client.UntypedAPICall(ctx, callParams, bodyReq)
 	if err != nil {

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -155,7 +155,7 @@ func HandleUpdate(ctx context.Context, req HandleUpdateReq) {
 }
 
 type HandleDeleteReq struct {
-	Resp              *resource.DeleteResponse
+	Diags             *diag.Diagnostics
 	Client            *config.MongoDBClient
 	State             any
 	CallParams        *config.APICallParams
@@ -164,13 +164,12 @@ type HandleDeleteReq struct {
 }
 
 func HandleDelete(ctx context.Context, req HandleDeleteReq) {
-	d := &req.Resp.Diagnostics
 	if err := callDelete(ctx, &req); err != nil {
-		addError(d, opDelete, errCallingAPI, err)
+		addError(req.Diags, opDelete, errCallingAPI, err)
 		return
 	}
 	if errWait := handleWaitDelete(ctx, req.Wait, req.Client); errWait != nil {
-		addError(d, opDelete, errWaitingForChanges, errWait)
+		addError(req.Diags, opDelete, errWaitingForChanges, errWait)
 	}
 }
 

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -73,7 +73,7 @@ func HandleCreate(ctx context.Context, req HandleCreateReq) {
 		return
 	}
 	errWait := handleWaitCreateUpdate(ctx, req.Wait, req.Client, req.Plan)
-	if errWait != nil && req.DeleteCallParams != nil {
+	if req.DeleteCallParams != nil {
 		// Handle timeout with cleanup if delete_on_create_timeout is enabled. Doesn't support Delete with StaticRequestBody.
 		errWait = cleanup.HandleCreateTimeout(req.DeleteOnCreateTimeout, errWait, func(ctxCleanup context.Context) error {
 			bodyResp, apiResp, err := callAPIWithoutBody(ctxCleanup, req.Client, req.DeleteCallParams)

--- a/internal/common/autogen/handle_operations.go
+++ b/internal/common/autogen/handle_operations.go
@@ -40,11 +40,12 @@ type WaitReq struct {
 }
 
 type HandleCreateReq struct {
-	Resp       *resource.CreateResponse
-	Client     *config.MongoDBClient
-	Plan       any
-	CallParams *config.APICallParams
-	Wait       *WaitReq
+	Resp                  *resource.CreateResponse
+	Client                *config.MongoDBClient
+	Plan                  any
+	CallParams            *config.APICallParams
+	Wait                  *WaitReq
+	DeleteOnCreateTimeout bool
 }
 
 func HandleCreate(ctx context.Context, req HandleCreateReq) {

--- a/internal/serviceapi/auditingapi/resource.go
+++ b/internal/serviceapi/auditingapi/resource.go
@@ -5,6 +5,7 @@ package auditingapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -105,7 +106,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -126,14 +127,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
@@ -142,5 +143,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 		},
 		StaticRequestBody: `{"enabled": "false"}`,
 	}
-	return req
 }

--- a/internal/serviceapi/auditingapi/resource.go
+++ b/internal/serviceapi/auditingapi/resource.go
@@ -105,20 +105,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
-		PathParams:    pathParams,
-		Method:        "PATCH",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:              resp,
 		Client:            r.Client,
 		State:             &state,
-		CallParams:        &callParams,
+		CallParams:        deleteAPICallParams(&state),
 		StaticRequestBody: `{"enabled": "false"}`,
 	}
 	autogen.HandleDelete(ctx, reqHandle)
@@ -129,14 +120,26 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
+		"groupId": model.GroupId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId": model.GroupId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
+		PathParams:    pathParams,
+		Method:        "PATCH",
 	}
 }

--- a/internal/serviceapi/auditingapi/resource.go
+++ b/internal/serviceapi/auditingapi/resource.go
@@ -105,14 +105,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:              resp,
-		Client:            r.Client,
-		State:             &state,
-		CallParams:        deleteAPICallParams(&state),
-		StaticRequestBody: `{"enabled": "false"}`,
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -132,14 +126,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
-		PathParams:    pathParams,
-		Method:        "PATCH",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/auditLog",
+			PathParams:    pathParams,
+			Method:        "PATCH",
+		},
+		StaticRequestBody: `{"enabled": "false"}`,
 	}
+	return req
 }

--- a/internal/serviceapi/clusterapi/resource.go
+++ b/internal/serviceapi/clusterapi/resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -59,7 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
+		DeleteReq:             deleteRequest(r.Client, &plan, &resp.Diagnostics),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
@@ -137,12 +138,21 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	timeout, localDiags := state.Timeouts.Delete(ctx, 10800*time.Second)
-	resp.Diagnostics.Append(localDiags...)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
+	timeout, diags := state.Timeouts.Delete(ctx, 10800*time.Second)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty:     "stateName",
+		PendingStates:     []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING", "DELETING"},
+		TargetStates:      []string{"DELETED"},
+		Timeout:           timeout,
+		MinTimeoutSeconds: 60,
+		DelaySeconds:      30,
+		CallParams:        readAPICallParams(&state),
+	}
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -164,15 +174,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 		"name":    model.Name.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{name}",
@@ -180,16 +190,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	if timeout > 0 {
-		req.Wait = &autogen.WaitReq{
-			StateProperty:     "stateName",
-			PendingStates:     []string{"IDLE", "CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING", "DELETING"},
-			TargetStates:      []string{"DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 60,
-			DelaySeconds:      30,
-			CallParams:        readAPICallParams(model),
-		}
-	}
-	return req
 }

--- a/internal/serviceapi/clusterapi/resource.go
+++ b/internal/serviceapi/clusterapi/resource.go
@@ -55,10 +55,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 	reqHandle := autogen.HandleCreateReq{
-		Resp:       resp,
-		Client:     r.Client,
-		Plan:       &plan,
-		CallParams: &callParams,
+		Resp:                  resp,
+		Client:                r.Client,
+		Plan:                  &plan,
+		CallParams:            &callParams,
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
 			PendingStates:     []string{"CREATING", "UPDATING", "REPAIRING", "REPEATING", "PENDING", "DELETING"},

--- a/internal/serviceapi/clusterapi/resource_schema.go
+++ b/internal/serviceapi/clusterapi/resource_schema.go
@@ -607,6 +607,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional:            true,
 				MarkdownDescription: "Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify **mongoDBMajorVersion**.",
 			},
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+				PlanModifiers:       []planmodifier.Bool{customplanmodifier.CreateOnlyBoolWithDefault(true)},
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -621,14 +627,14 @@ type TFModel struct {
 	Tags                                          types.List     `tfsdk:"tags"`
 	ReplicationSpecs                              types.List     `tfsdk:"replication_specs"`
 	InternalClusterRole                           types.String   `tfsdk:"internal_cluster_role" autogen:"omitjson"`
-	MongoDBMajorVersion                           types.String   `tfsdk:"mongo_dbmajor_version"`
+	MongoDBVersion                                types.String   `tfsdk:"mongo_dbversion" autogen:"omitjson"`
 	ConfigServerManagementMode                    types.String   `tfsdk:"config_server_management_mode"`
 	ConfigServerType                              types.String   `tfsdk:"config_server_type" autogen:"omitjson"`
 	ConnectionStrings                             types.Object   `tfsdk:"connection_strings" autogen:"omitjson"`
 	CreateDate                                    types.String   `tfsdk:"create_date" autogen:"omitjson"`
 	DiskWarmingMode                               types.String   `tfsdk:"disk_warming_mode"`
 	EncryptionAtRestProvider                      types.String   `tfsdk:"encryption_at_rest_provider"`
-	FeatureCompatibilityVersion                   types.String   `tfsdk:"feature_compatibility_version" autogen:"omitjson"`
+	MongoDBMajorVersion                           types.String   `tfsdk:"mongo_dbmajor_version"`
 	FeatureCompatibilityVersionExpirationDate     types.String   `tfsdk:"feature_compatibility_version_expiration_date" autogen:"omitjson"`
 	Timeouts                                      timeouts.Value `tfsdk:"timeouts" autogen:"omitjson"`
 	GroupId                                       types.String   `tfsdk:"group_id" autogen:"omitjson"`
@@ -636,9 +642,9 @@ type TFModel struct {
 	AcceptDataRisksAndForceReplicaSetReconfig     types.String   `tfsdk:"accept_data_risks_and_force_replica_set_reconfig"`
 	ClusterType                                   types.String   `tfsdk:"cluster_type"`
 	BiConnector                                   types.Object   `tfsdk:"bi_connector"`
-	Name                                          types.String   `tfsdk:"name"`
-	MongoDBVersion                                types.String   `tfsdk:"mongo_dbversion" autogen:"omitjson"`
+	FeatureCompatibilityVersion                   types.String   `tfsdk:"feature_compatibility_version" autogen:"omitjson"`
 	MongoDBEmployeeAccessGrant                    types.Object   `tfsdk:"mongo_dbemployee_access_grant"`
+	Name                                          types.String   `tfsdk:"name"`
 	VersionReleaseSystem                          types.String   `tfsdk:"version_release_system"`
 	AdvancedConfiguration                         types.Object   `tfsdk:"advanced_configuration"`
 	StateName                                     types.String   `tfsdk:"state_name" autogen:"omitjson"`
@@ -650,6 +656,7 @@ type TFModel struct {
 	TerminationProtectionEnabled                  types.Bool     `tfsdk:"termination_protection_enabled"`
 	UseAwsTimeBasedSnapshotCopyForFastInitialSync types.Bool     `tfsdk:"use_aws_time_based_snapshot_copy_for_fast_initial_sync"`
 	Paused                                        types.Bool     `tfsdk:"paused"`
+	DeleteOnCreateTimeout                         types.Bool     `tfsdk:"delete_on_create_timeout" autogen:"omitjson"`
 	GlobalClusterSelfManagedSharding              types.Bool     `tfsdk:"global_cluster_self_managed_sharding"`
 }
 type TFAdvancedConfigurationModel struct {

--- a/internal/serviceapi/clusterapi/resource_test.go
+++ b/internal/serviceapi/clusterapi/resource_test.go
@@ -71,9 +71,9 @@ func TestAccClusterAPI_deleteOnCreateTimeout(t *testing.T) {
 }
 
 func configBasic(groupID, clusterName, instanceSize string, withTagsAndLabels, shortTimeout bool) string {
-	addtionalConfigStr := ""
+	additionalConfigStr := ""
 	if withTagsAndLabels {
-		addtionalConfigStr += `
+		additionalConfigStr += `
 			tags = [
 				{
 					key   = "tagKey"
@@ -93,7 +93,7 @@ func configBasic(groupID, clusterName, instanceSize string, withTagsAndLabels, s
 		`
 	}
 	if shortTimeout {
-		addtionalConfigStr += `
+		additionalConfigStr += `
 			timeouts = {
 				create = "10s"
 			}
@@ -117,7 +117,7 @@ func configBasic(groupID, clusterName, instanceSize string, withTagsAndLabels, s
 			}]
 			%[4]s
 		}
-	`, groupID, clusterName, instanceSize, addtionalConfigStr)
+	`, groupID, clusterName, instanceSize, additionalConfigStr)
 }
 
 func checkBasic(groupID, clusterName, instanceSize string) resource.TestCheckFunc {

--- a/internal/serviceapi/customdbroleapi/resource.go
+++ b/internal/serviceapi/customdbroleapi/resource.go
@@ -106,21 +106,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId":  state.GroupId.ValueString(),
-		"roleName": state.RoleName.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -130,15 +120,28 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId":  state.GroupId.ValueString(),
-		"roleName": state.RoleName.ValueString(),
+		"groupId":  model.GroupId.ValueString(),
+		"roleName": model.RoleName.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId":  model.GroupId.ValueString(),
+		"roleName": model.RoleName.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/customdbroleapi/resource.go
+++ b/internal/serviceapi/customdbroleapi/resource.go
@@ -106,13 +106,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -133,15 +128,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":  model.GroupId.ValueString(),
 		"roleName": model.RoleName.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/customdbroleapi/resource.go
+++ b/internal/serviceapi/customdbroleapi/resource.go
@@ -5,6 +5,7 @@ package customdbroleapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -106,7 +107,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -128,15 +129,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":  model.GroupId.ValueString(),
 		"roleName": model.RoleName.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}",
@@ -144,5 +145,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/databaseuserapi/resource.go
+++ b/internal/serviceapi/databaseuserapi/resource.go
@@ -5,6 +5,7 @@ package databaseuserapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -107,7 +108,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -130,16 +131,16 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":      model.GroupId.ValueString(),
 		"databaseName": model.DatabaseName.ValueString(),
 		"username":     model.Username.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
@@ -147,5 +148,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/databaseuserapi/resource.go
+++ b/internal/serviceapi/databaseuserapi/resource.go
@@ -107,22 +107,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId":      state.GroupId.ValueString(),
-		"databaseName": state.DatabaseName.ValueString(),
-		"username":     state.Username.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -132,16 +121,30 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId":      state.GroupId.ValueString(),
-		"databaseName": state.DatabaseName.ValueString(),
-		"username":     state.Username.ValueString(),
+		"groupId":      model.GroupId.ValueString(),
+		"databaseName": model.DatabaseName.ValueString(),
+		"username":     model.Username.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId":      model.GroupId.ValueString(),
+		"databaseName": model.DatabaseName.ValueString(),
+		"username":     model.Username.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/databaseuserapi/resource.go
+++ b/internal/serviceapi/databaseuserapi/resource.go
@@ -107,13 +107,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -135,16 +130,22 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":      model.GroupId.ValueString(),
 		"databaseName": model.DatabaseName.ValueString(),
 		"username":     model.Username.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/maintenancewindowapi/resource.go
+++ b/internal/serviceapi/maintenancewindowapi/resource.go
@@ -105,20 +105,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -128,14 +119,26 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
+		"groupId": model.GroupId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId": model.GroupId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/maintenancewindowapi/resource.go
+++ b/internal/serviceapi/maintenancewindowapi/resource.go
@@ -105,13 +105,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -131,14 +126,20 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/maintenancewindowapi/resource.go
+++ b/internal/serviceapi/maintenancewindowapi/resource.go
@@ -5,6 +5,7 @@ package maintenancewindowapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -105,7 +106,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -126,14 +127,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/maintenanceWindow",
@@ -141,5 +142,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/orgserviceaccountapi/resource.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource.go
@@ -106,13 +106,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -133,15 +128,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"orgId":    model.OrgId.ValueString(),
 		"clientId": model.ClientId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/orgserviceaccountapi/resource.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource.go
@@ -106,21 +106,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"orgId":    state.OrgId.ValueString(),
-		"clientId": state.ClientId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -130,15 +120,28 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"orgId":    state.OrgId.ValueString(),
-		"clientId": state.ClientId.ValueString(),
+		"orgId":    model.OrgId.ValueString(),
+		"clientId": model.ClientId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"orgId":    model.OrgId.ValueString(),
+		"clientId": model.ClientId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/orgserviceaccountapi/resource.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource.go
@@ -5,6 +5,7 @@ package orgserviceaccountapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -106,7 +107,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -128,15 +129,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"orgId":    model.OrgId.ValueString(),
 		"clientId": model.ClientId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}",
@@ -144,5 +145,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/projectapi/resource.go
+++ b/internal/serviceapi/projectapi/resource.go
@@ -103,13 +103,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -129,14 +124,20 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"id": model.Id.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{id}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{id}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/projectapi/resource.go
+++ b/internal/serviceapi/projectapi/resource.go
@@ -103,20 +103,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"id": state.Id.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{id}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -126,14 +117,26 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"id": state.Id.ValueString(),
+		"id": model.Id.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{id}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"id": model.Id.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{id}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/projectapi/resource.go
+++ b/internal/serviceapi/projectapi/resource.go
@@ -5,6 +5,7 @@ package projectapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -103,7 +104,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -124,14 +125,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"id": model.Id.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{id}",
@@ -139,5 +140,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/projectsettingsapi/resource.go
+++ b/internal/serviceapi/projectsettingsapi/resource.go
@@ -107,9 +107,9 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
+		"groupId": model.GroupId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/internal/serviceapi/pushbasedlogexportapi/resource.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource.go
@@ -55,10 +55,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 	reqHandle := autogen.HandleCreateReq{
-		Resp:       resp,
-		Client:     r.Client,
-		Plan:       &plan,
-		CallParams: &callParams,
+		Resp:                  resp,
+		Client:                r.Client,
+		Plan:                  &plan,
+		CallParams:            &callParams,
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"INITIATING", "BUCKET_VERIFIED"},

--- a/internal/serviceapi/pushbasedlogexportapi/resource.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource.go
@@ -59,6 +59,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
+		DeleteCallParams:      deleteAPICallParams(&plan),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -135,15 +136,6 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/pushBasedLogExport",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	timeout, localDiags := state.Timeouts.Delete(ctx, 900*time.Second)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
@@ -153,7 +145,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"ACTIVE", "INITIATING", "BUCKET_VERIFIED"},
@@ -172,14 +164,26 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
+		"groupId": model.GroupId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/pushBasedLogExport",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId": model.GroupId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/pushBasedLogExport",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/pushbasedlogexportapi/resource.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -59,7 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
+		DeleteReq:             deleteRequest(r.Client, &plan, &resp.Diagnostics),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -136,12 +137,21 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	timeout, localDiags := state.Timeouts.Delete(ctx, 900*time.Second)
-	resp.Diagnostics.Append(localDiags...)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
+	timeout, diags := state.Timeouts.Delete(ctx, 900*time.Second)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty:     "state",
+		PendingStates:     []string{"ACTIVE", "INITIATING", "BUCKET_VERIFIED"},
+		TargetStates:      []string{"UNCONFIGURED", "DELETED"},
+		Timeout:           timeout,
+		MinTimeoutSeconds: 60,
+		DelaySeconds:      10,
+		CallParams:        readAPICallParams(&state),
+	}
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -162,14 +172,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/pushBasedLogExport",
@@ -177,16 +187,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	if timeout > 0 {
-		req.Wait = &autogen.WaitReq{
-			StateProperty:     "state",
-			PendingStates:     []string{"ACTIVE", "INITIATING", "BUCKET_VERIFIED"},
-			TargetStates:      []string{"UNCONFIGURED", "DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 60,
-			DelaySeconds:      10,
-			CallParams:        readAPICallParams(model),
-		}
-	}
-	return req
 }

--- a/internal/serviceapi/pushbasedlogexportapi/resource_schema.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource_schema.go
@@ -40,6 +40,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Describes whether or not the feature is enabled and what status it is in.",
 			},
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+				PlanModifiers:       []planmodifier.Bool{customplanmodifier.CreateOnlyBoolWithDefault(true)},
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -50,11 +56,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	BucketName types.String   `tfsdk:"bucket_name"`
-	CreateDate types.String   `tfsdk:"create_date" autogen:"omitjson"`
-	GroupId    types.String   `tfsdk:"group_id" autogen:"omitjson"`
-	IamRoleId  types.String   `tfsdk:"iam_role_id"`
-	PrefixPath types.String   `tfsdk:"prefix_path"`
-	State      types.String   `tfsdk:"state" autogen:"omitjson"`
-	Timeouts   timeouts.Value `tfsdk:"timeouts" autogen:"omitjson"`
+	BucketName            types.String   `tfsdk:"bucket_name"`
+	CreateDate            types.String   `tfsdk:"create_date" autogen:"omitjson"`
+	GroupId               types.String   `tfsdk:"group_id" autogen:"omitjson"`
+	IamRoleId             types.String   `tfsdk:"iam_role_id"`
+	PrefixPath            types.String   `tfsdk:"prefix_path"`
+	State                 types.String   `tfsdk:"state" autogen:"omitjson"`
+	Timeouts              timeouts.Value `tfsdk:"timeouts" autogen:"omitjson"`
+	DeleteOnCreateTimeout types.Bool     `tfsdk:"delete_on_create_timeout" autogen:"omitjson"`
 }

--- a/internal/serviceapi/pushbasedlogexportapi/resource_test.go
+++ b/internal/serviceapi/pushbasedlogexportapi/resource_test.go
@@ -56,6 +56,7 @@ func basicTestCase(tb testing.TB) *resource.TestCase {
 				ImportState:                          true,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "group_id",
+				ImportStateVerifyIgnore:              []string{"delete_on_create_timeout"},
 			},
 		},
 	}

--- a/internal/serviceapi/resourcepolicyapi/resource.go
+++ b/internal/serviceapi/resourcepolicyapi/resource.go
@@ -5,6 +5,7 @@ package resourcepolicyapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -106,7 +107,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -128,15 +129,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"orgId": model.OrgId.ValueString(),
 		"id":    model.Id.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
@@ -144,5 +145,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/resourcepolicyapi/resource.go
+++ b/internal/serviceapi/resourcepolicyapi/resource.go
@@ -106,21 +106,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"orgId": state.OrgId.ValueString(),
-		"id":    state.Id.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -130,15 +120,28 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"orgId": state.OrgId.ValueString(),
-		"id":    state.Id.ValueString(),
+		"orgId": model.OrgId.ValueString(),
+		"id":    model.Id.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"orgId": model.OrgId.ValueString(),
+		"id":    model.Id.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/resourcepolicyapi/resource.go
+++ b/internal/serviceapi/resourcepolicyapi/resource.go
@@ -106,13 +106,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -133,15 +128,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"orgId": model.OrgId.ValueString(),
 		"id":    model.Id.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/orgs/{orgId}/resourcePolicies/{id}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/searchdeploymentapi/resource.go
+++ b/internal/serviceapi/searchdeploymentapi/resource.go
@@ -60,7 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteCallParams:      deleteAPICallParams(&plan),
+		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
@@ -143,22 +143,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-		Wait: &autogen.WaitReq{
-			StateProperty:     "stateName",
-			PendingStates:     []string{"IDLE", "UPDATING", "PAUSED"},
-			TargetStates:      []string{"DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 30,
-			DelaySeconds:      60,
-			CallParams:        readAPICallParams(&state),
-		},
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -179,15 +165,32 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":     model.GroupId.ValueString(),
 		"clusterName": model.ClusterName.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	if timeout > 0 {
+		req.Wait = &autogen.WaitReq{
+			StateProperty:     "stateName",
+			PendingStates:     []string{"IDLE", "UPDATING", "PAUSED"},
+			TargetStates:      []string{"DELETED"},
+			Timeout:           timeout,
+			MinTimeoutSeconds: 30,
+			DelaySeconds:      60,
+			CallParams:        readAPICallParams(model),
+		}
+	}
+	return req
 }

--- a/internal/serviceapi/searchdeploymentapi/resource.go
+++ b/internal/serviceapi/searchdeploymentapi/resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -60,7 +61,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
+		DeleteReq:             deleteRequest(r.Client, &plan, &resp.Diagnostics),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
@@ -138,12 +139,21 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	timeout, localDiags := state.Timeouts.Delete(ctx, 10800*time.Second)
-	resp.Diagnostics.Append(localDiags...)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
+	timeout, diags := state.Timeouts.Delete(ctx, 10800*time.Second)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty:     "stateName",
+		PendingStates:     []string{"IDLE", "UPDATING", "PAUSED"},
+		TargetStates:      []string{"DELETED"},
+		Timeout:           timeout,
+		MinTimeoutSeconds: 30,
+		DelaySeconds:      60,
+		CallParams:        readAPICallParams(&state),
+	}
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -165,15 +175,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId":     model.GroupId.ValueString(),
 		"clusterName": model.ClusterName.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
@@ -181,16 +191,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	if timeout > 0 {
-		req.Wait = &autogen.WaitReq{
-			StateProperty:     "stateName",
-			PendingStates:     []string{"IDLE", "UPDATING", "PAUSED"},
-			TargetStates:      []string{"DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 30,
-			DelaySeconds:      60,
-			CallParams:        readAPICallParams(model),
-		}
-	}
-	return req
 }

--- a/internal/serviceapi/searchdeploymentapi/resource.go
+++ b/internal/serviceapi/searchdeploymentapi/resource.go
@@ -60,6 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
+		DeleteCallParams:      deleteAPICallParams(&plan),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
@@ -137,16 +138,6 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId":     state.GroupId.ValueString(),
-		"clusterName": state.ClusterName.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	timeout, localDiags := state.Timeouts.Delete(ctx, 10800*time.Second)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
@@ -156,7 +147,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
 			PendingStates:     []string{"IDLE", "UPDATING", "PAUSED"},
@@ -175,15 +166,28 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId":     state.GroupId.ValueString(),
-		"clusterName": state.ClusterName.ValueString(),
+		"groupId":     model.GroupId.ValueString(),
+		"clusterName": model.ClusterName.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId":     model.GroupId.ValueString(),
+		"clusterName": model.ClusterName.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/searchdeploymentapi/resource.go
+++ b/internal/serviceapi/searchdeploymentapi/resource.go
@@ -56,10 +56,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 	reqHandle := autogen.HandleCreateReq{
-		Resp:       resp,
-		Client:     r.Client,
-		Plan:       &plan,
-		CallParams: &callParams,
+		Resp:                  resp,
+		Client:                r.Client,
+		Plan:                  &plan,
+		CallParams:            &callParams,
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "stateName",
 			PendingStates:     []string{"UPDATING", "PAUSED"},

--- a/internal/serviceapi/searchdeploymentapi/resource_schema.go
+++ b/internal/serviceapi/searchdeploymentapi/resource_schema.go
@@ -55,6 +55,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Computed:            true,
 				MarkdownDescription: "Human-readable label that indicates the current operating condition of this search deployment.",
 			},
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+				PlanModifiers:       []planmodifier.Bool{customplanmodifier.CreateOnlyBoolWithDefault(true)},
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -65,13 +71,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
+	Specs                    customtypes.NestedListValue[TFSpecsModel] `tfsdk:"specs"`
 	ClusterName              types.String                              `tfsdk:"cluster_name" autogen:"omitjson"`
 	EncryptionAtRestProvider types.String                              `tfsdk:"encryption_at_rest_provider" autogen:"omitjson"`
 	GroupId                  types.String                              `tfsdk:"group_id" autogen:"omitjson"`
 	Id                       types.String                              `tfsdk:"id" autogen:"omitjson"`
-	Specs                    customtypes.NestedListValue[TFSpecsModel] `tfsdk:"specs"`
 	StateName                types.String                              `tfsdk:"state_name" autogen:"omitjson"`
 	Timeouts                 timeouts.Value                            `tfsdk:"timeouts" autogen:"omitjson"`
+	DeleteOnCreateTimeout    types.Bool                                `tfsdk:"delete_on_create_timeout" autogen:"omitjson"`
 }
 type TFSpecsModel struct {
 	InstanceSize types.String `tfsdk:"instance_size"`

--- a/internal/serviceapi/searchdeploymentapi/resource_test.go
+++ b/internal/serviceapi/searchdeploymentapi/resource_test.go
@@ -31,11 +31,12 @@ func TestAccSearchDeploymentAPI_basic(t *testing.T) {
 			newSearchNodeTestStep(resourceID, orgID, projectName, clusterName, "S20_HIGHCPU_NVME", 3),
 			newSearchNodeTestStep(resourceID, orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
 			{
-				Config:            configBasic(orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
-				ResourceName:      resourceID,
-				ImportStateIdFunc: importStateIDFunc(resourceID),
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config:                  configBasic(orgID, projectName, clusterName, "S30_HIGHCPU_NVME", 4),
+				ResourceName:            resourceID,
+				ImportStateIdFunc:       importStateIDFunc(resourceID),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_on_create_timeout"},
 			},
 		},
 	})

--- a/internal/serviceapi/searchdeploymentapi/resource_test.go
+++ b/internal/serviceapi/searchdeploymentapi/resource_test.go
@@ -77,7 +77,7 @@ func configBasic(orgID, projectName, clusterName, instanceSize string, searchNod
 					node_count = %[3]d
 				}
 			]
-			timeouts = {     // TODO: timeouts are in the schema but are not used yet.
+			timeouts = {
 				create = "1h"
 				update = "30m"
 				delete = "10m"

--- a/internal/serviceapi/streaminstanceapi/resource.go
+++ b/internal/serviceapi/streaminstanceapi/resource.go
@@ -106,13 +106,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -133,15 +128,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 		"name":    model.Name.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	return req
 }

--- a/internal/serviceapi/streaminstanceapi/resource.go
+++ b/internal/serviceapi/streaminstanceapi/resource.go
@@ -5,6 +5,7 @@ package streaminstanceapi
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -106,7 +107,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -128,15 +129,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"groupId": model.GroupId.ValueString(),
 		"name":    model.Name.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
@@ -144,5 +145,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/internal/serviceapi/streaminstanceapi/resource.go
+++ b/internal/serviceapi/streaminstanceapi/resource.go
@@ -106,21 +106,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
-		"name":    state.Name.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -130,15 +120,28 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId": state.GroupId.ValueString(),
-		"name":    state.Name.ValueString(),
+		"groupId": model.GroupId.ValueString(),
+		"name":    model.Name.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId": model.GroupId.ValueString(),
+		"name":    model.Name.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{name}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/streamprocessorapi/resource.go
+++ b/internal/serviceapi/streamprocessorapi/resource.go
@@ -60,6 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
+		DeleteCallParams:      deleteAPICallParams(&plan),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -138,17 +139,6 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"groupId":    state.GroupId.ValueString(),
-		"tenantName": state.TenantName.ValueString(),
-		"name":       state.Name.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{name}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	timeout, localDiags := state.Timeouts.Delete(ctx, 300*time.Second)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
@@ -158,7 +148,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"INIT", "CREATING", "CREATED", "STARTED", "STOPPED"},
@@ -177,16 +167,30 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"groupId":    state.GroupId.ValueString(),
-		"tenantName": state.TenantName.ValueString(),
-		"name":       state.Name.ValueString(),
+		"groupId":    model.GroupId.ValueString(),
+		"tenantName": model.TenantName.ValueString(),
+		"name":       model.Name.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{name}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"groupId":    model.GroupId.ValueString(),
+		"tenantName": model.TenantName.ValueString(),
+		"name":       model.Name.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{name}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/internal/serviceapi/streamprocessorapi/resource.go
+++ b/internal/serviceapi/streamprocessorapi/resource.go
@@ -56,10 +56,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 	reqHandle := autogen.HandleCreateReq{
-		Resp:       resp,
-		Client:     r.Client,
-		Plan:       &plan,
-		CallParams: &callParams,
+		Resp:                  resp,
+		Client:                r.Client,
+		Plan:                  &plan,
+		CallParams:            &callParams,
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"INIT", "CREATING"},

--- a/internal/serviceapi/streamprocessorapi/resource_schema.go
+++ b/internal/serviceapi/streamprocessorapi/resource_schema.go
@@ -77,6 +77,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Human-readable label that identifies the stream instance.",
 				PlanModifiers:       []planmodifier.String{customplanmodifier.CreateOnly()},
 			},
+			"delete_on_create_timeout": schema.BoolAttribute{
+				Computed:            true,
+				Optional:            true,
+				MarkdownDescription: "Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.",
+				PlanModifiers:       []planmodifier.Bool{customplanmodifier.CreateOnlyBoolWithDefault(true)},
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
@@ -87,14 +93,15 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	GroupId    types.String                                `tfsdk:"group_id" autogen:"omitjson"`
-	Name       types.String                                `tfsdk:"name"`
-	Options    customtypes.ObjectValue[TFOptionsModel]     `tfsdk:"options"`
-	Pipeline   customtypes.ListValue[jsontypes.Normalized] `tfsdk:"pipeline"`
-	State      types.String                                `tfsdk:"state" autogen:"omitjson"`
-	Stats      jsontypes.Normalized                        `tfsdk:"stats" autogen:"omitjson"`
-	TenantName types.String                                `tfsdk:"tenant_name" autogen:"omitjson"`
-	Timeouts   timeouts.Value                              `tfsdk:"timeouts" autogen:"omitjson"`
+	Pipeline              customtypes.ListValue[jsontypes.Normalized] `tfsdk:"pipeline"`
+	GroupId               types.String                                `tfsdk:"group_id" autogen:"omitjson"`
+	Name                  types.String                                `tfsdk:"name"`
+	Options               customtypes.ObjectValue[TFOptionsModel]     `tfsdk:"options"`
+	State                 types.String                                `tfsdk:"state" autogen:"omitjson"`
+	Stats                 jsontypes.Normalized                        `tfsdk:"stats" autogen:"omitjson"`
+	TenantName            types.String                                `tfsdk:"tenant_name" autogen:"omitjson"`
+	Timeouts              timeouts.Value                              `tfsdk:"timeouts" autogen:"omitjson"`
+	DeleteOnCreateTimeout types.Bool                                  `tfsdk:"delete_on_create_timeout" autogen:"omitjson"`
 }
 type TFOptionsModel struct {
 	Dlq                  customtypes.ObjectValue[TFOptionsDlqModel] `tfsdk:"dlq"`

--- a/internal/serviceapi/streamprocessorapi/resource_test.go
+++ b/internal/serviceapi/streamprocessorapi/resource_test.go
@@ -61,7 +61,7 @@ func TestAccStreamProcessorAPI_basic(t *testing.T) {
 				ImportStateIdFunc:                    importStateIDFunc(resourceName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateVerifyIgnore:              []string{"stats"},
+				ImportStateVerifyIgnore:              []string{"stats", "delete_on_create_timeout"},
 				ImportStateVerifyIdentifierAttribute: "name", // id is not used because _id is returned in Atlas which is not a legal name for a Terraform attribute.
 			},
 			{

--- a/tools/codegen/codespec/config_test.go
+++ b/tools/codegen/codespec/config_test.go
@@ -3,6 +3,7 @@ package codespec_test
 import (
 	"testing"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
 	"github.com/stretchr/testify/assert"
 )
@@ -91,8 +92,6 @@ func TestApplyTimeoutTransformation(t *testing.T) {
 }
 
 func TestApplyDeleteOnCreateTimeoutTransformation(t *testing.T) {
-	defaultTrue := true
-
 	tests := map[string]struct {
 		inputOperations                codespec.APIOperations
 		shouldAddDeleteOnCreateTimeout bool
@@ -170,7 +169,7 @@ func TestApplyDeleteOnCreateTimeoutTransformation(t *testing.T) {
 				expectedAttr := codespec.Attribute{
 					TFSchemaName:             "delete_on_create_timeout",
 					TFModelName:              "DeleteOnCreateTimeout",
-					Bool:                     &codespec.BoolAttribute{Default: &defaultTrue},
+					Bool:                     &codespec.BoolAttribute{Default: conversion.Pointer(true)},
 					Description:              &description,
 					ReqBodyUsage:             codespec.OmitAlways,
 					CreateOnly:               true,

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -52,13 +52,13 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		PathParams: pathParams,
 		Method: "{{ .APIOperations.Create.HTTPMethod }}",
 	}
-	{{with .APIOperations.Create.Wait -}}
+	{{- with .APIOperations.Create.Wait }}
 	timeout, localDiags := plan.Timeouts.Create(ctx, {{ .TimeoutSeconds }}*time.Second)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	{{ end -}}
+	{{- end }}
 	reqHandle := autogen.HandleCreateReq {
 		Resp: resp,
 		Client: r.Client,
@@ -66,6 +66,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		CallParams: &callParams,
 		{{- with .APIOperations.Create.Wait }}
 		{{- if $.APIOperations.Delete }}
+		DeleteCallParams: deleteAPICallParams(&plan),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		{{- end }}
 		Wait: &autogen.WaitReq{
@@ -150,16 +151,6 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{ {{range .APIOperations.Delete.PathParams }}
-		"{{ .CamelCaseName }}": state.{{ .PascalCaseName }}.ValueString(),
-	{{- end }}
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath: "{{ .APIOperations.Delete.Path }}",
-		PathParams: pathParams,
-		Method: "{{ .APIOperations.Delete.HTTPMethod }}",
-	}
 	{{with .APIOperations.Delete.Wait -}}
 	timeout, localDiags := state.Timeouts.Delete(ctx, {{ .TimeoutSeconds }}*time.Second)
 	resp.Diagnostics.Append(localDiags...)
@@ -171,7 +162,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		Resp: resp,
 		Client: r.Client,
 		State: &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 		{{- if ne .APIOperations.Delete.StaticRequestBody "" }}
 		StaticRequestBody: `{{ .APIOperations.Delete.StaticRequestBody }}`,
 		{{ end }}
@@ -196,15 +187,30 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{ {{range .APIOperations.Read.PathParams }}
-		"{{ .CamelCaseName }}": state.{{ .PascalCaseName }}.ValueString(),
+		"{{ .CamelCaseName }}": model.{{ .PascalCaseName }}.ValueString(),
 	{{- end }}
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath: "{{ .APIOperations.Read.Path }}",
 		PathParams: pathParams,
-		Method: "{{ .APIOperations.Read.HTTPMethod }}",		
+		Method: "{{ .APIOperations.Read.HTTPMethod }}",
 	}
 }
+
+{{- with .APIOperations.Delete}}
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{ {{range .PathParams }}
+		"{{ .CamelCaseName }}": model.{{ .PascalCaseName }}.ValueString(),
+	{{- end }}
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath: "{{ .Path }}",
+		PathParams: pathParams,
+		Method: "{{ .HTTPMethod }}",
+	}
+}
+{{- end}}

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -8,6 +8,9 @@ import (
 	"time"
 	{{ end }}
 
+	{{if .APIOperations.Delete }}
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	{{ end -}}
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -66,7 +69,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		CallParams: &callParams,
 		{{- with .APIOperations.Create.Wait }}
 		{{- if $.APIOperations.Delete }}
-		DeleteReq: deleteRequest(r.Client, &plan, nil{{- with $.APIOperations.Delete.Wait }}, 0{{- end }}),
+		DeleteReq: deleteRequest(r.Client, &plan, &resp.Diagnostics),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		{{- end }}
 		Wait: &autogen.WaitReq{
@@ -151,14 +154,23 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	{{with .APIOperations.Delete.Wait -}}
-	timeout, localDiags := state.Timeouts.Delete(ctx, {{ .TimeoutSeconds }}*time.Second)
-	resp.Diagnostics.Append(localDiags...)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
+	{{- with .APIOperations.Delete.Wait }}
+	timeout, diags := state.Timeouts.Delete(ctx, {{ .TimeoutSeconds }}*time.Second)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	{{ end -}}
-	reqHandle := deleteRequest(r.Client, &state, resp{{- with .APIOperations.Delete.Wait }}, timeout{{- end }})
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty: "{{ .StateProperty }}",
+		PendingStates: []string{ {{range .PendingStates }}"{{ . }}", {{- end }} },
+		TargetStates: []string{ {{range .TargetStates }}"{{ . }}", {{- end }} },
+		Timeout: timeout,
+		MinTimeoutSeconds: {{ .MinTimeoutSeconds }},
+		DelaySeconds: {{ .DelaySeconds }},
+		CallParams: readAPICallParams(&state),
+	}
+	{{- end }}
 	autogen.HandleDelete(ctx, *reqHandle)
     {{- end }}
 }
@@ -182,15 +194,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 }
 
 {{with .APIOperations.Delete}}
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse{{- with .Wait }}, timeout time.Duration{{- end }}) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{ {{range .PathParams }}
 		"{{ .CamelCaseName }}": model.{{ .PascalCaseName }}.ValueString(),
 	{{- end }}
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp: resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State: model,
+		Diags: diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath: "{{ .Path }}",
@@ -201,19 +213,5 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 		StaticRequestBody: `{{ .StaticRequestBody }}`,
 		{{- end }}
 	}
-	{{- with .Wait }}
-	if timeout > 0 {
-		req.Wait = &autogen.WaitReq{
-			StateProperty: "{{ .StateProperty }}",
-			PendingStates: []string{ {{range .PendingStates }}"{{ . }}", {{- end }} },
-			TargetStates: []string{ {{range .TargetStates }}"{{ . }}", {{- end }} },
-			Timeout: timeout,
-			MinTimeoutSeconds: {{ .MinTimeoutSeconds }},
-			DelaySeconds: {{ .DelaySeconds }},
-			CallParams: readAPICallParams(model),
-		}
-	}
-	{{- end }}
-	return req
 }
 {{end}}

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -200,7 +200,7 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-{{- with .APIOperations.Delete}}
+{{with .APIOperations.Delete}}
 func deleteAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{ {{range .PathParams }}
 		"{{ .CamelCaseName }}": model.{{ .PascalCaseName }}.ValueString(),
@@ -213,4 +213,4 @@ func deleteAPICallParams(model *TFModel) *config.APICallParams {
 		Method: "{{ .HTTPMethod }}",
 	}
 }
-{{- end}}
+{{end}}

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -64,7 +64,10 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client: r.Client,
 		Plan: &plan,
 		CallParams: &callParams,
-		{{with .APIOperations.Create.Wait -}}
+		{{- with .APIOperations.Create.Wait }}
+		{{- if $.APIOperations.Delete }}
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
+		{{- end }}
 		Wait: &autogen.WaitReq{
 			StateProperty: "{{ .StateProperty }}",
 			PendingStates: []string{ {{range .PendingStates }}"{{ . }}", {{- end }} },

--- a/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/resource-file.go.tmpl
@@ -66,7 +66,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		CallParams: &callParams,
 		{{- with .APIOperations.Create.Wait }}
 		{{- if $.APIOperations.Delete }}
-		DeleteCallParams: deleteAPICallParams(&plan),
+		DeleteReq: deleteRequest(r.Client, &plan, nil{{- with $.APIOperations.Delete.Wait }}, 0{{- end }}),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		{{- end }}
 		Wait: &autogen.WaitReq{
@@ -158,27 +158,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		return
 	}
 	{{ end -}}
-	reqHandle := autogen.HandleDeleteReq {
-		Resp: resp,
-		Client: r.Client,
-		State: &state,
-		CallParams: deleteAPICallParams(&state),
-		{{- if ne .APIOperations.Delete.StaticRequestBody "" }}
-		StaticRequestBody: `{{ .APIOperations.Delete.StaticRequestBody }}`,
-		{{ end }}
-		{{with .APIOperations.Delete.Wait -}}
-		Wait: &autogen.WaitReq{
-			StateProperty: "{{ .StateProperty }}",
-			PendingStates: []string{ {{range .PendingStates }}"{{ . }}", {{- end }} },
-			TargetStates: []string{ {{range .TargetStates }}"{{ . }}", {{- end }} },
-			Timeout: timeout,
-			MinTimeoutSeconds: {{ .MinTimeoutSeconds }},
-			DelaySeconds: {{ .DelaySeconds }},
-			CallParams: readAPICallParams(&state),
-		},
-		{{ end }}
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp{{- with .APIOperations.Delete.Wait }}, timeout{{- end }})
+	autogen.HandleDelete(ctx, *reqHandle)
     {{- end }}
 }
 
@@ -201,16 +182,38 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 }
 
 {{with .APIOperations.Delete}}
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse{{- with .Wait }}, timeout time.Duration{{- end }}) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{ {{range .PathParams }}
 		"{{ .CamelCaseName }}": model.{{ .PascalCaseName }}.ValueString(),
 	{{- end }}
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath: "{{ .Path }}",
-		PathParams: pathParams,
-		Method: "{{ .HTTPMethod }}",
+	req := &autogen.HandleDeleteReq{
+		Resp: resp,
+		Client: client,
+		State: model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath: "{{ .Path }}",
+			PathParams: pathParams,
+			Method: "{{ .HTTPMethod }}",
+		},
+		{{- if ne .StaticRequestBody "" }}
+		StaticRequestBody: `{{ .StaticRequestBody }}`,
+		{{- end }}
 	}
+	{{- with .Wait }}
+	if timeout > 0 {
+		req.Wait = &autogen.WaitReq{
+			StateProperty: "{{ .StateProperty }}",
+			PendingStates: []string{ {{range .PendingStates }}"{{ . }}", {{- end }} },
+			TargetStates: []string{ {{range .TargetStates }}"{{ . }}", {{- end }} },
+			Timeout: timeout,
+			MinTimeoutSeconds: {{ .MinTimeoutSeconds }},
+			DelaySeconds: {{ .DelaySeconds }},
+			CallParams: readAPICallParams(model),
+		}
+	}
+	{{- end }}
+	return req
 }
 {{end}}

--- a/tools/codegen/gofilegen/codetemplate/schema-file.go.tmpl
+++ b/tools/codegen/gofilegen/codetemplate/schema-file.go.tmpl
@@ -11,8 +11,8 @@ import (
 
 func ResourceSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
-		Attributes: map[string]schema.Attribute{ 
-			{{ .SchemaAttributes }} 
+		Attributes: map[string]schema.Attribute{
+			{{ .SchemaAttributes }}
 		},
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -106,13 +106,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -132,15 +127,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 		Method:        "GET",
 	}
 }
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 		"roleName":  model.RoleName.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	return &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -106,21 +106,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
-		"roleName":  state.RoleName.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -130,15 +120,27 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
-		"roleName":  state.RoleName.ValueString(),
+		"projectId": model.ProjectId.ValueString(),
+		"roleName":  model.RoleName.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"projectId": model.ProjectId.ValueString(),
+		"roleName":  model.RoleName.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -133,7 +133,7 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 		"projectId": model.ProjectId.ValueString(),
 		"roleName":  model.RoleName.ValueString(),
 	}
-	return &autogen.HandleDeleteReq{
+	req := &autogen.HandleDeleteReq{
 		Resp:   resp,
 		Client: client,
 		State:  model,
@@ -144,4 +144,5 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
+	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/different-urls-with-path-params.golden.go
@@ -5,6 +5,7 @@ package testname
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -106,7 +107,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -128,15 +129,15 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 		"roleName":  model.RoleName.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/v1/testname/{projectId}/{roleName}",
@@ -144,5 +145,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/no-op-delete-operation.golden.go
@@ -107,9 +107,9 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
+		"projectId": model.ProjectId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,

--- a/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
@@ -105,14 +105,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:              resp,
-		Client:            r.Client,
-		State:             &state,
-		CallParams:        deleteAPICallParams(&state),
-		StaticRequestBody: `{"enabled": false}`,
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -131,14 +125,21 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 		Method:        "GET",
 	}
 }
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "PATCH",
+	return &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/v1/testname/{projectId}",
+			PathParams:    pathParams,
+			Method:        "PATCH",
+		},
+		StaticRequestBody: `{"enabled": false}`,
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
@@ -130,7 +130,7 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	return &autogen.HandleDeleteReq{
+	req := &autogen.HandleDeleteReq{
 		Resp:   resp,
 		Client: client,
 		State:  model,
@@ -142,4 +142,5 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 		},
 		StaticRequestBody: `{"enabled": false}`,
 	}
+	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
@@ -5,6 +5,7 @@ package testname
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -105,7 +106,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -126,14 +127,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/v1/testname/{projectId}",
@@ -142,5 +143,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 		},
 		StaticRequestBody: `{"enabled": false}`,
 	}
-	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/static-request-body-delete.golden.go
@@ -105,20 +105,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "PATCH",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:              resp,
 		Client:            r.Client,
 		State:             &state,
-		CallParams:        &callParams,
+		CallParams:        deleteAPICallParams(&state),
 		StaticRequestBody: `{"enabled": false}`,
 	}
 	autogen.HandleDelete(ctx, reqHandle)
@@ -129,14 +120,25 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
+		"projectId": model.ProjectId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/v1/testname/{projectId}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"projectId": model.ProjectId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/v1/testname/{projectId}",
+		PathParams:    pathParams,
+		Method:        "PATCH",
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -105,20 +105,11 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	reqHandle := autogen.HandleDeleteReq{
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 	}
 	autogen.HandleDelete(ctx, reqHandle)
 }
@@ -128,14 +119,25 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
+		"projectId": model.ProjectId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/v1/testname/{projectId}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"projectId": model.ProjectId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/v1/testname/{projectId}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -5,6 +5,7 @@ package testname
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -105,7 +106,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -126,14 +127,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/v1/testname/{projectId}",
@@ -141,5 +142,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -130,7 +130,7 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	return &autogen.HandleDeleteReq{
+	req := &autogen.HandleDeleteReq{
 		Resp:   resp,
 		Client: client,
 		State:  model,
@@ -141,4 +141,5 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
+	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/update-with-put.golden.go
@@ -105,13 +105,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -130,14 +125,20 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 		Method:        "GET",
 	}
 }
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	return &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/v1/testname/{projectId}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
 }

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
@@ -59,7 +60,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
+		DeleteReq:             deleteRequest(r.Client, &plan, &resp.Diagnostics),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -136,12 +137,21 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	timeout, localDiags := state.Timeouts.Delete(ctx, 300*time.Second)
-	resp.Diagnostics.Append(localDiags...)
+	reqHandle := deleteRequest(r.Client, &state, &resp.Diagnostics)
+	timeout, diags := state.Timeouts.Delete(ctx, 300*time.Second)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	reqHandle.Wait = &autogen.WaitReq{
+		StateProperty:     "state",
+		PendingStates:     []string{"PENDING"},
+		TargetStates:      []string{"UNCONFIGURED", "DELETED"},
+		Timeout:           timeout,
+		MinTimeoutSeconds: 60,
+		DelaySeconds:      10,
+		CallParams:        readAPICallParams(&state),
+	}
 	autogen.HandleDelete(ctx, *reqHandle)
 }
 
@@ -162,14 +172,14 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 	}
 }
 
-func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
+func deleteRequest(client *config.MongoDBClient, model *TFModel, diags *diag.Diagnostics) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	req := &autogen.HandleDeleteReq{
-		Resp:   resp,
+	return &autogen.HandleDeleteReq{
 		Client: client,
 		State:  model,
+		Diags:  diags,
 		CallParams: &config.APICallParams{
 			VersionHeader: apiVersionHeader,
 			RelativePath:  "/api/v1/testname/{projectId}",
@@ -177,16 +187,4 @@ func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.
 			Method:        "DELETE",
 		},
 	}
-	if timeout > 0 {
-		req.Wait = &autogen.WaitReq{
-			StateProperty:     "state",
-			PendingStates:     []string{"PENDING"},
-			TargetStates:      []string{"UNCONFIGURED", "DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 60,
-			DelaySeconds:      10,
-			CallParams:        readAPICallParams(model),
-		}
-	}
-	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -59,7 +59,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteReq:             deleteRequest(r.Client, &plan, nil),
+		DeleteReq:             deleteRequest(r.Client, &plan, nil, 0),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -55,10 +55,11 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		return
 	}
 	reqHandle := autogen.HandleCreateReq{
-		Resp:       resp,
-		Client:     r.Client,
-		Plan:       &plan,
-		CallParams: &callParams,
+		Resp:                  resp,
+		Client:                r.Client,
+		Plan:                  &plan,
+		CallParams:            &callParams,
+		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"INITIATING"},

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -59,7 +59,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
-		DeleteCallParams:      deleteAPICallParams(&plan),
+		DeleteReq:             deleteRequest(r.Client, &plan, nil),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -141,22 +141,8 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	reqHandle := autogen.HandleDeleteReq{
-		Resp:       resp,
-		Client:     r.Client,
-		State:      &state,
-		CallParams: deleteAPICallParams(&state),
-		Wait: &autogen.WaitReq{
-			StateProperty:     "state",
-			PendingStates:     []string{"PENDING"},
-			TargetStates:      []string{"UNCONFIGURED", "DELETED"},
-			Timeout:           timeout,
-			MinTimeoutSeconds: 60,
-			DelaySeconds:      10,
-			CallParams:        readAPICallParams(&state),
-		},
-	}
-	autogen.HandleDelete(ctx, reqHandle)
+	reqHandle := deleteRequest(r.Client, &state, resp, timeout)
+	autogen.HandleDelete(ctx, *reqHandle)
 }
 
 func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -175,14 +161,32 @@ func readAPICallParams(model *TFModel) *config.APICallParams {
 		Method:        "GET",
 	}
 }
-func deleteAPICallParams(model *TFModel) *config.APICallParams {
+
+func deleteRequest(client *config.MongoDBClient, model *TFModel, resp *resource.DeleteResponse, timeout time.Duration) *autogen.HandleDeleteReq {
 	pathParams := map[string]string{
 		"projectId": model.ProjectId.ValueString(),
 	}
-	return &config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
+	req := &autogen.HandleDeleteReq{
+		Resp:   resp,
+		Client: client,
+		State:  model,
+		CallParams: &config.APICallParams{
+			VersionHeader: apiVersionHeader,
+			RelativePath:  "/api/v1/testname/{projectId}",
+			PathParams:    pathParams,
+			Method:        "DELETE",
+		},
 	}
+	if timeout > 0 {
+		req.Wait = &autogen.WaitReq{
+			StateProperty:     "state",
+			PendingStates:     []string{"PENDING"},
+			TargetStates:      []string{"UNCONFIGURED", "DELETED"},
+			Timeout:           timeout,
+			MinTimeoutSeconds: 60,
+			DelaySeconds:      10,
+			CallParams:        readAPICallParams(model),
+		}
+	}
+	return req
 }

--- a/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
+++ b/tools/codegen/gofilegen/resource/testdata/wait-configuration.golden.go
@@ -59,6 +59,7 @@ func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resou
 		Client:                r.Client,
 		Plan:                  &plan,
 		CallParams:            &callParams,
+		DeleteCallParams:      deleteAPICallParams(&plan),
 		DeleteOnCreateTimeout: plan.DeleteOnCreateTimeout.ValueBool(),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
@@ -135,15 +136,6 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
-	}
-	callParams := config.APICallParams{
-		VersionHeader: apiVersionHeader,
-		RelativePath:  "/api/v1/testname/{projectId}",
-		PathParams:    pathParams,
-		Method:        "DELETE",
-	}
 	timeout, localDiags := state.Timeouts.Delete(ctx, 300*time.Second)
 	resp.Diagnostics.Append(localDiags...)
 	if resp.Diagnostics.HasError() {
@@ -153,7 +145,7 @@ func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resou
 		Resp:       resp,
 		Client:     r.Client,
 		State:      &state,
-		CallParams: &callParams,
+		CallParams: deleteAPICallParams(&state),
 		Wait: &autogen.WaitReq{
 			StateProperty:     "state",
 			PendingStates:     []string{"PENDING"},
@@ -172,14 +164,25 @@ func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, r
 	autogen.HandleImport(ctx, idAttributes, req, resp)
 }
 
-func readAPICallParams(state *TFModel) *config.APICallParams {
+func readAPICallParams(model *TFModel) *config.APICallParams {
 	pathParams := map[string]string{
-		"projectId": state.ProjectId.ValueString(),
+		"projectId": model.ProjectId.ValueString(),
 	}
 	return &config.APICallParams{
 		VersionHeader: apiVersionHeader,
 		RelativePath:  "/api/v1/testname/{projectId}",
 		PathParams:    pathParams,
 		Method:        "GET",
+	}
+}
+func deleteAPICallParams(model *TFModel) *config.APICallParams {
+	pathParams := map[string]string{
+		"projectId": model.ProjectId.ValueString(),
+	}
+	return &config.APICallParams{
+		VersionHeader: apiVersionHeader,
+		RelativePath:  "/api/v1/testname/{projectId}",
+		PathParams:    pathParams,
+		Method:        "DELETE",
 	}
 }

--- a/tools/codegen/gofilegen/schema/schema_attribute.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute.go
@@ -153,7 +153,7 @@ func commonProperties(attr *codespec.Attribute, planModifierType string) []CodeS
 			Imports: imports,
 		})
 	}
-	if attr.CreateOnly {
+	if attr.CreateOnly { // As of now this is the only property which implies defining plan modifiers.
 		planModifierImports := []string{
 			"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier",
 			"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier",

--- a/tools/codegen/gofilegen/schema/schema_attribute.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute.go
@@ -153,13 +153,21 @@ func commonProperties(attr *codespec.Attribute, planModifierType string) []CodeS
 			Imports: imports,
 		})
 	}
-	if attr.CreateOnly { // as of now this is the only property which implies defining plan modifiers
+	if attr.CreateOnly {
+		planModifierImports := []string{
+			"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier",
+			"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier",
+		}
+		code := fmt.Sprintf("PlanModifiers: []%s{customplanmodifier.CreateOnly()}", planModifierType)
+
+		// For bool attributes with create-only and default value, use CreateOnlyBoolWithDefault
+		if attr.Bool != nil && attr.Bool.Default != nil {
+			code = fmt.Sprintf("PlanModifiers: []%s{customplanmodifier.CreateOnlyBoolWithDefault(%t)}", planModifierType, *attr.Bool.Default)
+		}
+
 		result = append(result, CodeStatement{
-			Code: fmt.Sprintf("PlanModifiers: []%s{customplanmodifier.CreateOnly()}", planModifierType),
-			Imports: []string{
-				"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier",
-				"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier",
-			},
+			Code:    code,
+			Imports: planModifierImports,
 		})
 	}
 	return result

--- a/tools/codegen/gofilegen/schema/schema_attribute_test.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute_test.go
@@ -1,0 +1,119 @@
+package schema_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/codespec"
+	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/gofilegen/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateSchemaAttributes_CreateOnly(t *testing.T) {
+	tests := map[string]struct {
+		attribute       codespec.Attribute
+		hasPlanModifier bool
+	}{
+		"No create_only - no plan modifiers": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_string",
+				TFModelName:              "TestString",
+				String:                   &codespec.StringAttribute{},
+				ComputedOptionalRequired: codespec.Optional,
+				CreateOnly:               false,
+			},
+			hasPlanModifier: false,
+		},
+		"String attribute with create_only - uses CreateOnly()": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_string",
+				TFModelName:              "TestString",
+				String:                   &codespec.StringAttribute{},
+				ComputedOptionalRequired: codespec.Optional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"Bool attribute with create_only but no default - uses CreateOnly()": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_bool",
+				TFModelName:              "TestBool",
+				Bool:                     &codespec.BoolAttribute{},
+				ComputedOptionalRequired: codespec.Optional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"Bool attribute with create_only and default true - uses CreateOnlyBoolWithDefault(true)": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_bool",
+				TFModelName:              "TestBool",
+				Bool:                     &codespec.BoolAttribute{Default: conversion.Pointer(true)},
+				ComputedOptionalRequired: codespec.ComputedOptional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"Bool attribute with create_only and default false - uses CreateOnlyBoolWithDefault(false)": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_bool",
+				TFModelName:              "TestBool",
+				Bool:                     &codespec.BoolAttribute{Default: conversion.Pointer(false)},
+				ComputedOptionalRequired: codespec.ComputedOptional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"Int64 attribute with create_only - uses CreateOnly()": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_int",
+				TFModelName:              "TestInt",
+				Int64:                    &codespec.Int64Attribute{},
+				ComputedOptionalRequired: codespec.Optional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"Computed attribute with create_only - uses CreateOnly() (model is enforced)": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_computed",
+				TFModelName:              "TestComputed",
+				String:                   &codespec.StringAttribute{},
+				ComputedOptionalRequired: codespec.Computed,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+		"ComputedOptional attribute with create_only - uses CreateOnly()": {
+			attribute: codespec.Attribute{
+				TFSchemaName:             "test_computed_optional",
+				TFModelName:              "TestComputedOptional",
+				String:                   &codespec.StringAttribute{},
+				ComputedOptionalRequired: codespec.ComputedOptional,
+				CreateOnly:               true,
+			},
+			hasPlanModifier: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := schema.GenerateSchemaAttributes([]codespec.Attribute{tc.attribute})
+			code := result.Code
+			if !tc.hasPlanModifier {
+				assert.NotContains(t, code, "PlanModifiers:")
+				return
+			}
+			assert.Contains(t, code, "PlanModifiers:")
+			if tc.attribute.Bool != nil && tc.attribute.Bool.Default != nil {
+				expected := fmt.Sprintf("customplanmodifier.CreateOnlyBoolWithDefault(%t)", *tc.attribute.Bool.Default)
+				assert.Contains(t, code, expected)
+				return
+			}
+			if tc.attribute.CreateOnly {
+				assert.Contains(t, code, "customplanmodifier.CreateOnly()")
+			}
+		})
+	}
+}

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -1153,6 +1153,15 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+        - bool:
+            default: true
+          description: Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
+          computed_optional_required: computed_optional
+          tf_schema_name: delete_on_create_timeout
+          tf_model_name: DeleteOnCreateTimeout
+          req_body_usage: omit_always
+          sensitive: false
+          create_only: true
         - timeouts:
             configurable_timeouts:
                 - create

--- a/tools/codegen/models/push_based_log_export_api.yaml
+++ b/tools/codegen/models/push_based_log_export_api.yaml
@@ -52,6 +52,15 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: false
+        - bool:
+            default: true
+          description: Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
+          computed_optional_required: computed_optional
+          tf_schema_name: delete_on_create_timeout
+          tf_model_name: DeleteOnCreateTimeout
+          req_body_usage: omit_always
+          sensitive: false
+          create_only: true
         - timeouts:
             configurable_timeouts:
                 - create

--- a/tools/codegen/models/search_deployment_api.yaml
+++ b/tools/codegen/models/search_deployment_api.yaml
@@ -77,6 +77,15 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: false
+        - bool:
+            default: true
+          description: Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
+          computed_optional_required: computed_optional
+          tf_schema_name: delete_on_create_timeout
+          tf_model_name: DeleteOnCreateTimeout
+          req_body_usage: omit_always
+          sensitive: false
+          create_only: true
         - timeouts:
             configurable_timeouts:
                 - create

--- a/tools/codegen/models/stream_processor_api.yaml
+++ b/tools/codegen/models/stream_processor_api.yaml
@@ -121,6 +121,15 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: true
+        - bool:
+            default: true
+          description: Indicates whether to delete the resource being created if a timeout is reached when waiting for completion. When set to `true` and timeout occurs, it triggers the deletion and returns immediately without waiting for deletion to complete. When set to `false`, the timeout will not trigger resource deletion. If you suspect a transient error when the value is `true`, wait before retrying to allow resource deletion to finish. Default is `true`.
+          computed_optional_required: computed_optional
+          tf_schema_name: delete_on_create_timeout
+          tf_model_name: DeleteOnCreateTimeout
+          req_body_usage: omit_always
+          sensitive: false
+          create_only: true
         - timeouts:
             configurable_timeouts:
                 - create


### PR DESCRIPTION
## Description

Invoke Delete operation if timeout in autogen.
- Follows same pattern for `delete_on_create_timeout` as in manual resources.
- Create uses HandleDeleteReq so it has all delete functionality (empty or static request body)

Link to any related issue(s): CLOUDP-352323

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Example of error:
<img width="706" height="182" alt="err" src="https://github.com/user-attachments/assets/50f7a36c-3491-45b8-b4f6-6922836771ed" />
