### PR TITLE
chore: Support merging of response custom nested list elements into plan/state

### DIFF
--- a/internal/common/autogen/unknown_test.go
+++ b/internal/common/autogen/unknown_test.go
@@ -24,19 +24,21 @@ func TestResolveUnknowns(t *testing.T) {
 	}
 
 	type modelst struct {
-		AttrStringUnknown           types.String                                 `tfsdk:"attr_string_unknown"`
-		AttrObjectUnknown           types.Object                                 `tfsdk:"attr_object_unknown"`
-		AttrListUnknown             types.List                                   `tfsdk:"attr_list_unknown"`
-		AttrObject                  types.Object                                 `tfsdk:"attr_object"`
-		AttrListString              types.List                                   `tfsdk:"attr_list_string"`
-		AttrSetString               types.Set                                    `tfsdk:"attr_set_string"`
-		AttrListObjObj              types.List                                   `tfsdk:"attr_list_obj_obj"`
-		AttrMapUnknown              types.Map                                    `tfsdk:"attr_map_unknown"`
-		AttrCustomObjectUnknown     customtypes.ObjectValue[modelEmptyTest]      `tfsdk:"attr_custom_object_unknown"`
-		AttrCustomObject            customtypes.ObjectValue[modelCustomTypeTest] `tfsdk:"attr_custom_object"`
-		AttrCustomListUnknown       customtypes.ListValue[types.String]          `tfsdk:"attr_custom_list_string"`
-		AttrCustomNestedListUnknown customtypes.NestedListValue[modelEmptyTest]  `tfsdk:"attr_custom_nested_list_unknown"`
-		AttrCustomNestedSetUnknown  customtypes.NestedSetValue[modelEmptyTest]   `tfsdk:"attr_custom_nested_set_unknown"`
+		AttrStringUnknown           types.String                                     `tfsdk:"attr_string_unknown"`
+		AttrObjectUnknown           types.Object                                     `tfsdk:"attr_object_unknown"`
+		AttrListUnknown             types.List                                       `tfsdk:"attr_list_unknown"`
+		AttrObject                  types.Object                                     `tfsdk:"attr_object"`
+		AttrListString              types.List                                       `tfsdk:"attr_list_string"`
+		AttrSetString               types.Set                                        `tfsdk:"attr_set_string"`
+		AttrListObjObj              types.List                                       `tfsdk:"attr_list_obj_obj"`
+		AttrMapUnknown              types.Map                                        `tfsdk:"attr_map_unknown"`
+		AttrCustomObjectUnknown     customtypes.ObjectValue[modelEmptyTest]          `tfsdk:"attr_custom_object_unknown"`
+		AttrCustomObject            customtypes.ObjectValue[modelCustomTypeTest]     `tfsdk:"attr_custom_object"`
+		AttrCustomListUnknown       customtypes.ListValue[types.String]              `tfsdk:"attr_custom_list_string"`
+		AttrCustomNestedListUnknown customtypes.NestedListValue[modelEmptyTest]      `tfsdk:"attr_custom_nested_list_unknown"`
+		AttrCustomNestedSetUnknown  customtypes.NestedSetValue[modelEmptyTest]       `tfsdk:"attr_custom_nested_set_unknown"`
+		AttrCustomNestedList        customtypes.NestedListValue[modelCustomTypeTest] `tfsdk:"attr_custom_nested_list"`
+		AttrCustomNestedSet         customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set"`
 	}
 
 	model := modelst{
@@ -92,6 +94,18 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueUnknown[modelEmptyTest](ctx),
 		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueUnknown[modelEmptyTest](ctx),
 		AttrCustomListUnknown:       customtypes.NewListValueUnknown[types.String](ctx),
+		AttrCustomNestedList: customtypes.NewNestedListValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			{
+				AttrKnownString:   types.StringValue("val1"),
+				AttrUnknownObject: customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
+				AttrMANYUpper:     types.Int64Unknown(),
+			},
+			{
+				AttrKnownString:   types.StringUnknown(),
+				AttrUnknownObject: customtypes.NewObjectValue[modelEmptyTest](ctx, modelEmptyTest{}),
+				AttrMANYUpper:     types.Int64Value(2),
+			},
+		}),
 	}
 	modelExpected := modelst{
 		AttrStringUnknown: types.StringNull(),
@@ -146,6 +160,18 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrCustomListUnknown:       customtypes.NewListValueNull[types.String](ctx),
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueNull[modelEmptyTest](ctx),
 		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueNull[modelEmptyTest](ctx),
+		AttrCustomNestedList: customtypes.NewNestedListValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			{
+				AttrKnownString:   types.StringValue("val1"),
+				AttrUnknownObject: customtypes.NewObjectValueNull[modelEmptyTest](ctx),
+				AttrMANYUpper:     types.Int64Null(),
+			},
+			{
+				AttrKnownString:   types.StringNull(),
+				AttrUnknownObject: customtypes.NewObjectValue[modelEmptyTest](ctx, modelEmptyTest{}),
+				AttrMANYUpper:     types.Int64Value(2),
+			},
+		}),
 	}
 	require.NoError(t, autogen.ResolveUnknowns(&model))
 	assert.Equal(t, modelExpected, model)

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -73,6 +73,15 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrMANYUpper types.Int64                             `tfsdk:"attr_many_upper"`
 	}
 
+	modelCustomTypeBasic := modelCustomTypeTest{
+		AttrString:    types.StringValue("different_string"),
+		AttrInt:       types.Int64Value(999),
+		AttrFloat:     types.Float64Unknown(),
+		AttrBool:      types.BoolUnknown(),
+		AttrNested:    customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
+		AttrMANYUpper: types.Int64Value(999),
+	}
+
 	type modelst struct {
 		AttrObj                            types.Object                                     `tfsdk:"attr_obj"`
 		AttrObjNullNotSent                 types.Object                                     `tfsdk:"attr_obj_null_not_sent"`
@@ -117,20 +126,12 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 			"attr_float":  types.Float64Unknown(), // can even be null
 			"attr_bool":   types.BoolUnknown(),    // can even be unknown
 		}),
-		AttrObjNullNotSent:    types.ObjectNull(objTypeTest.AttrTypes),
-		AttrObjNullSent:       types.ObjectNull(objTypeTest.AttrTypes),
-		AttrObjUnknownNotSent: types.ObjectUnknown(objTypeTest.AttrTypes), // unknown values are changed to null
-		AttrObjUnknownSent:    types.ObjectUnknown(objTypeTest.AttrTypes),
-		AttrObjParent:         types.ObjectNull(objTypeParentTest.AttrTypes),
-		AttrCustomObj: customtypes.NewObjectValue[modelCustomTypeTest](ctx, modelCustomTypeTest{
-			// these attribute values are irrelevant, they will be overwritten with JSON values
-			AttrString:    types.StringValue("different_string"),
-			AttrInt:       types.Int64Value(999),
-			AttrFloat:     types.Float64Unknown(), // can even be unknown
-			AttrBool:      types.BoolUnknown(),    // can even be unknown
-			AttrNested:    customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
-			AttrMANYUpper: types.Int64Value(999),
-		}),
+		AttrObjNullNotSent:          types.ObjectNull(objTypeTest.AttrTypes),
+		AttrObjNullSent:             types.ObjectNull(objTypeTest.AttrTypes),
+		AttrObjUnknownNotSent:       types.ObjectUnknown(objTypeTest.AttrTypes), // unknown values are changed to null
+		AttrObjUnknownSent:          types.ObjectUnknown(objTypeTest.AttrTypes),
+		AttrObjParent:               types.ObjectNull(objTypeParentTest.AttrTypes),
+		AttrCustomObj:               customtypes.NewObjectValue[modelCustomTypeTest](ctx, modelCustomTypeBasic),
 		AttrCustomObjNullNotSent:    customtypes.NewObjectValueNull[modelCustomTypeTest](ctx),
 		AttrCustomObjNullSent:       customtypes.NewObjectValueNull[modelCustomTypeTest](ctx),
 		AttrCustomObjUnknownNotSent: customtypes.NewObjectValueUnknown[modelCustomTypeTest](ctx), // unknown values are changed to null
@@ -140,10 +141,10 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomListString:        customtypes.NewListValueUnknown[types.String](ctx),
 		AttrListObj:                 types.ListUnknown(objTypeTest),
 		AttrCustomNestedList: customtypes.NewNestedListValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
+			modelCustomTypeBasic,
 			{
-				// these attribute values are irrelevant, they will be overwritten with JSON values
-				AttrString:    types.StringValue("different_string"),
-				AttrInt:       types.Int64Value(999),
+				AttrString:    types.StringValue("existing not overwritten"),
+				AttrInt:       types.Int64Unknown(),
 				AttrFloat:     types.Float64Unknown(),
 				AttrBool:      types.BoolUnknown(),
 				AttrNested:    customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
@@ -156,23 +157,13 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomNestedListUnknownSent:    customtypes.NewNestedListValueUnknown[modelCustomTypeTest](ctx),
 		AttrSetString:                      types.SetUnknown(types.StringType),
 		AttrSetObj:                         types.SetUnknown(objTypeTest),
-		AttrCustomNestedSet: customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
-			{
-				// these attribute values are irrelevant, they will be overwritten with JSON values
-				AttrString:    types.StringValue("different_string"),
-				AttrInt:       types.Int64Value(999),
-				AttrFloat:     types.Float64Unknown(),
-				AttrBool:      types.BoolUnknown(),
-				AttrNested:    customtypes.NewObjectValueUnknown[modelEmptyTest](ctx),
-				AttrMANYUpper: types.Int64Value(999),
-			},
-		}),
-		AttrCustomNestedSetNullNotSent:    customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
-		AttrCustomNestedSetNullSent:       customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
-		AttrCustomNestedSetUnknownNotSent: customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
-		AttrCustomNestedSetUnknownSent:    customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
-		AttrListListString:                types.ListUnknown(types.ListType{ElemType: types.StringType}),
-		AttrSetListObj:                    types.SetUnknown(types.ListType{ElemType: objTypeTest}),
+		AttrCustomNestedSet:                customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{modelCustomTypeBasic}),
+		AttrCustomNestedSetNullNotSent:     customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetNullSent:        customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownNotSent:  customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
+		AttrCustomNestedSetUnknownSent:     customtypes.NewNestedSetValueUnknown[modelCustomTypeTest](ctx),
+		AttrListListString:                 types.ListUnknown(types.ListType{ElemType: types.StringType}),
+		AttrSetListObj:                     types.SetUnknown(types.ListType{ElemType: objTypeTest}),
 		AttrListObjKnown: types.ListValueMust(objTypeTest, []attr.Value{
 			types.ObjectValueMust(objTypeTest.AttrTypes, map[string]attr.Value{
 				"attr_string": types.StringValue("val"),
@@ -266,8 +257,6 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 						"attrMANYUpper": 123
 					},
 					{
-						"attrString": "nestedList2",
-						"attrInt": 2,
 						"attrFloat": 2.2,
 						"attrBool": false,
 						"attrNested": {},
@@ -490,8 +479,8 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 				AttrMANYUpper: types.Int64Value(123),
 			},
 			{
-				AttrString:    types.StringValue("nestedList2"),
-				AttrInt:       types.Int64Value(2),
+				AttrString:    types.StringValue("existing not overwritten"),
+				AttrInt:       types.Int64Unknown(),
 				AttrFloat:     types.Float64Value(2.2),
 				AttrBool:      types.BoolValue(false),
 				AttrNested:    customtypes.NewObjectValue[modelEmptyTest](ctx, modelEmptyTest{}),

--- a/internal/serviceapi/customdbroleapi/resource_schema.go
+++ b/internal/serviceapi/customdbroleapi/resource_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
@@ -17,6 +18,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"actions": schema.ListNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "List of the individual privilege actions that the role grants.",
+				CustomType:          customtypes.NewNestedListType[TFActionsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"action": schema.StringAttribute{
@@ -26,6 +28,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 						"resources": schema.ListNestedAttribute{
 							Optional:            true,
 							MarkdownDescription: "List of resources on which you grant the action.",
+							CustomType:          customtypes.NewNestedListType[TFActionsResourcesModel](ctx),
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"cluster": schema.BoolAttribute{
@@ -54,6 +57,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"inherited_roles": schema.SetNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "List of the built-in roles that this custom role inherits.",
+				CustomType:          customtypes.NewNestedSetType[TFInheritedRolesModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"db": schema.StringAttribute{
@@ -77,14 +81,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Actions        types.List   `tfsdk:"actions"`
-	GroupId        types.String `tfsdk:"group_id" autogen:"omitjson"`
-	InheritedRoles types.Set    `tfsdk:"inherited_roles"`
-	RoleName       types.String `tfsdk:"role_name" autogen:"omitjsonupdate"`
+	Actions        customtypes.NestedListValue[TFActionsModel]       `tfsdk:"actions"`
+	GroupId        types.String                                      `tfsdk:"group_id" autogen:"omitjson"`
+	InheritedRoles customtypes.NestedSetValue[TFInheritedRolesModel] `tfsdk:"inherited_roles"`
+	RoleName       types.String                                      `tfsdk:"role_name" autogen:"omitjsonupdate"`
 }
 type TFActionsModel struct {
-	Action    types.String `tfsdk:"action"`
-	Resources types.List   `tfsdk:"resources"`
+	Action    types.String                                         `tfsdk:"action"`
+	Resources customtypes.NestedListValue[TFActionsResourcesModel] `tfsdk:"resources"`
 }
 type TFActionsResourcesModel struct {
 	Collection types.String `tfsdk:"collection"`

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -231,8 +231,6 @@ resources:
       path: /api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}
       method: DELETE
     version_header: application/vnd.atlas.2023-01-01+json
-    schema:
-      use_custom_nested_types: false
 
   database_user_api:
     read:

--- a/tools/codegen/models/custom_db_role_api.yaml
+++ b/tools/codegen/models/custom_db_role_api.yaml
@@ -40,6 +40,10 @@ schema:
                                   sensitive: false
                                   create_only: false
                       description: List of resources on which you grant the action.
+                      custom_type:
+                        package: customtypes
+                        model: customtypes.NestedListValue[TFActionsResourcesModel]
+                        schema: customtypes.NewNestedListType[TFActionsResourcesModel](ctx)
                       computed_optional_required: optional
                       tf_schema_name: resources
                       tf_model_name: Resources
@@ -47,6 +51,10 @@ schema:
                       sensitive: false
                       create_only: false
           description: List of the individual privilege actions that the role grants.
+          custom_type:
+            package: customtypes
+            model: customtypes.NestedListValue[TFActionsModel]
+            schema: customtypes.NewNestedListType[TFActionsModel](ctx)
           computed_optional_required: optional
           tf_schema_name: actions
           tf_model_name: Actions
@@ -84,6 +92,10 @@ schema:
                       sensitive: false
                       create_only: false
           description: List of the built-in roles that this custom role inherits.
+          custom_type:
+            package: customtypes
+            model: customtypes.NestedSetValue[TFInheritedRolesModel]
+            schema: customtypes.NewNestedSetType[TFInheritedRolesModel](ctx)
           computed_optional_required: optional
           tf_schema_name: inherited_roles
           tf_model_name: InheritedRoles


### PR DESCRIPTION
## Description

Merging API response custom nested lists into the plan/state nested list based on element order. 
This is similar to how the handwritten code works and how the non-custom nested list behaves in autogen.

Note that for custom sets, we still do not perform the merge as we cannot make the assumption that the order of elements in the plan/state and the API response is the same.

Enabling usage of custom types in `custom_db_role_api` which was previously disabled due to this missing behavior. Specifically, when `actions[#].resources[#].cluster` is set to `false` in the plan, the [API](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupcustomdbrolerole) does not return the `false` value back. Without the merging behavior, it creates an inconsistency. 

Link to any related issue(s): CLOUDP-353170

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
