### PR TITLE
chore: Add support for typed sets in autogen

### DIFF
--- a/internal/common/autogen/customtypes/set.go
+++ b/internal/common/autogen/customtypes/set.go
@@ -1,0 +1,163 @@
+package customtypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+/*
+	Custom Set type used in auto-generated code to enable the generic marshal/unmarshal operations to access the elements' type during conversion.
+	Custom types docs: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/custom
+
+	Usage:
+		- Schema definition:
+			"sample_string_set": schema.SetAttribute{
+				...
+				CustomType: customtypes.NewSetType[basetypes.StringValue](ctx),
+				ElementType: types.StringType,
+			}
+
+		- TF Models:
+			type TFModel struct {
+				SampleStringSet customtypes.SetValue[basetypes.StringValue] `tfsdk:"sample_string_set"`
+				...
+			}
+*/
+
+var (
+	_ basetypes.SetTypable  = SetType[basetypes.StringValue]{}
+	_ basetypes.SetValuable = SetValue[basetypes.StringValue]{}
+	_ SetValueInterface     = SetValue[basetypes.StringValue]{}
+)
+
+type SetType[T attr.Value] struct {
+	basetypes.SetType
+}
+
+func NewSetType[T attr.Value](ctx context.Context) SetType[T] {
+	elemType := getElemType[T](ctx)
+	return SetType[T]{
+		SetType: basetypes.SetType{ElemType: elemType},
+	}
+}
+
+func (t SetType[T]) Equal(o attr.Type) bool {
+	other, ok := o.(SetType[T])
+	if !ok {
+		return false
+	}
+	return t.SetType.Equal(other.SetType)
+}
+
+func (SetType[T]) String() string {
+	var t T
+	return fmt.Sprintf("SetType[%T]", t)
+}
+
+func (t SetType[T]) ValueFromSet(ctx context.Context, in basetypes.SetValue) (basetypes.SetValuable, diag.Diagnostics) {
+	if in.IsNull() {
+		return NewSetValueNull[T](ctx), nil
+	}
+
+	if in.IsUnknown() {
+		return NewSetValueUnknown[T](ctx), nil
+	}
+
+	elemType := getElemType[T](ctx)
+	baseSetValue, diags := basetypes.NewSetValue(elemType, in.Elements())
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return SetValue[T]{SetValue: baseSetValue}, nil
+}
+
+func (t SetType[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.SetType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	setValue, ok := attrValue.(basetypes.SetValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	setValuable, diags := t.ValueFromSet(ctx, setValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting SetValue to SetValuable: %v", diags)
+	}
+
+	return setValuable, nil
+}
+
+func (t SetType[T]) ValueType(_ context.Context) attr.Value {
+	return SetValue[T]{}
+}
+
+type SetValue[T attr.Value] struct {
+	basetypes.SetValue
+}
+
+type SetValueInterface interface {
+	basetypes.SetValuable
+	NewSetValue(ctx context.Context, value []attr.Value) SetValueInterface
+	NewSetValueNull(ctx context.Context) SetValueInterface
+	ElementType(ctx context.Context) attr.Type
+	Elements() []attr.Value
+}
+
+func (v SetValue[T]) NewSetValue(ctx context.Context, value []attr.Value) SetValueInterface {
+	return NewSetValue[T](ctx, value)
+}
+
+func NewSetValue[T attr.Value](ctx context.Context, value []attr.Value) SetValue[T] {
+	elemType := getElemType[T](ctx)
+
+	setValue, diags := basetypes.NewSetValue(elemType, value)
+	if diags.HasError() {
+		return NewSetValueUnknown[T](ctx)
+	}
+
+	return SetValue[T]{SetValue: setValue}
+}
+
+func (v SetValue[T]) NewSetValueNull(ctx context.Context) SetValueInterface {
+	return NewSetValueNull[T](ctx)
+}
+
+func NewSetValueNull[T attr.Value](ctx context.Context) SetValue[T] {
+	elemType := getElemType[T](ctx)
+	return SetValue[T]{SetValue: basetypes.NewSetNull(elemType)}
+}
+
+func NewSetValueUnknown[T attr.Value](ctx context.Context) SetValue[T] {
+	elemType := getElemType[T](ctx)
+	return SetValue[T]{SetValue: basetypes.NewSetUnknown(elemType)}
+}
+
+func (v SetValue[T]) Equal(o attr.Value) bool {
+	other, ok := o.(SetValue[T])
+	if !ok {
+		return false
+	}
+	return v.SetValue.Equal(other.SetValue)
+}
+
+func (v SetValue[T]) Type(ctx context.Context) attr.Type {
+	return NewSetType[T](ctx)
+}
+
+func (v SetValue[T]) ElementType(ctx context.Context) attr.Type {
+	return getElemType[T](ctx)
+}
+
+func (v SetValue[T]) Elements() []attr.Value {
+	return v.SetValue.Elements()
+}

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -77,7 +77,8 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 
 	if val == nil && isUpdate {
 		switch obj.(type) {
-		case types.List, types.Set, customtypes.ListValueInterface, customtypes.NestedListValueInterface, customtypes.NestedSetValueInterface:
+		case types.List, customtypes.ListValueInterface, customtypes.NestedListValueInterface,
+			types.Set, customtypes.SetValueInterface, customtypes.NestedSetValueInterface:
 			val = []any{} // Send an empty array if it's a null root list or set
 		}
 	}
@@ -110,6 +111,8 @@ func getModelAttr(val attr.Value, isUpdate bool) (any, error) {
 	case customtypes.ListValueInterface:
 		return getListAttr(v.Elements(), isUpdate)
 	case types.Set:
+		return getListAttr(v.Elements(), isUpdate)
+	case customtypes.SetValueInterface:
 		return getListAttr(v.Elements(), isUpdate)
 	case jsontypes.Normalized:
 		var valueJSON any

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -127,6 +127,7 @@ func TestMarshalNestedAllTypes(t *testing.T) {
 		AttrCustomList customtypes.ListValue[types.String] `tfsdk:"attr_custom_list"`
 		AttrListObj    types.List                          `tfsdk:"attr_list_obj"`
 		AttrSetSimple  types.Set                           `tfsdk:"attr_set_simple"`
+		AttrCustomSet  customtypes.SetValue[types.String]  `tfsdk:"attr_custom_set"`
 		AttrSetObj     types.Set                           `tfsdk:"attr_set_obj"`
 		AttrMapSimple  types.Map                           `tfsdk:"attr_map_simple"`
 		AttrMapObj     types.Map                           `tfsdk:"attr_map_obj"`
@@ -136,6 +137,7 @@ func TestMarshalNestedAllTypes(t *testing.T) {
 		AttrCustomList: customtypes.NewListValue[types.String](t.Context(), []attr.Value{types.StringValue("val1"), types.StringValue("val2")}),
 		AttrListObj:    attrListObj,
 		AttrSetSimple:  types.SetValueMust(types.StringType, []attr.Value{types.StringValue("val11"), types.StringValue("val22")}),
+		AttrCustomSet:  customtypes.NewSetValue[types.String](t.Context(), []attr.Value{types.StringValue("val11"), types.StringValue("val22")}),
 		AttrSetObj:     attrSetObj,
 		AttrMapSimple: types.MapValueMust(types.StringType, map[string]attr.Value{
 			"keyOne": types.StringValue("val1"),
@@ -153,6 +155,7 @@ func TestMarshalNestedAllTypes(t *testing.T) {
 				{ "attrString": "str2", "attrInt": 2 }
 			],
 			"attrSetSimple": ["val11", "val22"],
+			"attrCustomSet": ["val11", "val22"],
 			"attrSetObj": [
 				{ "attrString": "str11", "attrInt": 11 },
 				{ "attrString": "str22", "attrInt": 22 }
@@ -264,6 +267,7 @@ func TestMarshalUpdateNull(t *testing.T) {
 		AttrList          types.List                          `tfsdk:"attr_list"`
 		AttrCustomList    customtypes.ListValue[types.String] `tfsdk:"attr_custom_list"`
 		AttrSet           types.Set                           `tfsdk:"attr_set"`
+		AttrCustomSet     customtypes.SetValue[types.String]  `tfsdk:"attr_custom_set"`
 		AttrString        types.String                        `tfsdk:"attr_string"`
 		AttrObj           types.Object                        `tfsdk:"attr_obj"`
 		AttrIncludeString types.String                        `tfsdk:"attr_include_update" autogen:"includenullonupdate"`
@@ -272,6 +276,7 @@ func TestMarshalUpdateNull(t *testing.T) {
 		AttrList:          types.ListNull(types.StringType),
 		AttrCustomList:    customtypes.NewListValueNull[types.String](t.Context()),
 		AttrSet:           types.SetNull(types.StringType),
+		AttrCustomSet:     customtypes.NewSetValueNull[types.String](t.Context()),
 		AttrString:        types.StringNull(),
 		AttrObj:           types.ObjectNull(objTypeTest.AttrTypes),
 		AttrIncludeString: types.StringNull(),
@@ -284,6 +289,7 @@ func TestMarshalUpdateNull(t *testing.T) {
 			"attrList": [],
 			"attrCustomList": [],
 			"attrSet": [],
+			"attrCustomSet": [],
 			"attrIncludeString": null,
 			"attrIncludeObj": null
 		}

--- a/internal/common/autogen/unknown.go
+++ b/internal/common/autogen/unknown.go
@@ -86,6 +86,12 @@ func prepareAttr(value attr.Value) (attr.Value, error) {
 		}
 
 		return v.NewNestedListValue(ctx, slicePtr), nil
+	case customtypes.SetValueInterface:
+		if v.IsUnknown() {
+			return v.NewSetValueNull(ctx), nil
+		}
+		// If known, no need to process each set item since unmarshal does not generate unknown attributes.
+		return v, nil
 	case customtypes.NestedSetValueInterface:
 		if v.IsUnknown() {
 			return v.NewNestedSetValueNull(ctx), nil

--- a/internal/common/autogen/unknown_test.go
+++ b/internal/common/autogen/unknown_test.go
@@ -35,6 +35,7 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrCustomObjectUnknown     customtypes.ObjectValue[modelEmptyTest]          `tfsdk:"attr_custom_object_unknown"`
 		AttrCustomObject            customtypes.ObjectValue[modelCustomTypeTest]     `tfsdk:"attr_custom_object"`
 		AttrCustomListUnknown       customtypes.ListValue[types.String]              `tfsdk:"attr_custom_list_string"`
+		AttrCustomSetUnknown        customtypes.SetValue[types.String]               `tfsdk:"attr_custom_set_string"`
 		AttrCustomNestedListUnknown customtypes.NestedListValue[modelEmptyTest]      `tfsdk:"attr_custom_nested_list_unknown"`
 		AttrCustomNestedSetUnknown  customtypes.NestedSetValue[modelEmptyTest]       `tfsdk:"attr_custom_nested_set_unknown"`
 		AttrCustomNestedList        customtypes.NestedListValue[modelCustomTypeTest] `tfsdk:"attr_custom_nested_list"`
@@ -94,6 +95,7 @@ func TestResolveUnknowns(t *testing.T) {
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueUnknown[modelEmptyTest](ctx),
 		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueUnknown[modelEmptyTest](ctx),
 		AttrCustomListUnknown:       customtypes.NewListValueUnknown[types.String](ctx),
+		AttrCustomSetUnknown:        customtypes.NewSetValueUnknown[types.String](ctx),
 		AttrCustomNestedList: customtypes.NewNestedListValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{
 			{
 				AttrKnownString:   types.StringValue("val1"),
@@ -158,6 +160,7 @@ func TestResolveUnknowns(t *testing.T) {
 			AttrMANYUpper:     types.Int64Null(),
 		}),
 		AttrCustomListUnknown:       customtypes.NewListValueNull[types.String](ctx),
+		AttrCustomSetUnknown:        customtypes.NewSetValueNull[types.String](ctx),
 		AttrCustomNestedListUnknown: customtypes.NewNestedListValueNull[modelEmptyTest](ctx),
 		AttrCustomNestedSetUnknown:  customtypes.NewNestedSetValueNull[modelEmptyTest](ctx),
 		AttrCustomNestedList: customtypes.NewNestedListValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -104,6 +104,7 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomNestedListUnknownNotSent customtypes.NestedListValue[modelCustomTypeTest] `tfsdk:"attr_custom_nested_list_unknown_not_sent"`
 		AttrCustomNestedListUnknownSent    customtypes.NestedListValue[modelCustomTypeTest] `tfsdk:"attr_custom_nested_list_unknown_sent"`
 		AttrSetString                      types.Set                                        `tfsdk:"attr_set_string"`
+		AttrCustomSetString                customtypes.SetValue[types.String]               `tfsdk:"attr_custom_set_string"`
 		AttrSetObj                         types.Set                                        `tfsdk:"attr_set_obj"`
 		AttrCustomNestedSet                customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set"`
 		AttrCustomNestedSetNullNotSent     customtypes.NestedSetValue[modelCustomTypeTest]  `tfsdk:"attr_custom_nested_set_null_not_sent"`
@@ -156,6 +157,7 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 		AttrCustomNestedListUnknownNotSent: customtypes.NewNestedListValueUnknown[modelCustomTypeTest](ctx),
 		AttrCustomNestedListUnknownSent:    customtypes.NewNestedListValueUnknown[modelCustomTypeTest](ctx),
 		AttrSetString:                      types.SetUnknown(types.StringType),
+		AttrCustomSetString:                customtypes.NewSetValueUnknown[types.String](ctx),
 		AttrSetObj:                         types.SetUnknown(objTypeTest),
 		AttrCustomNestedSet:                customtypes.NewNestedSetValue[modelCustomTypeTest](ctx, []modelCustomTypeTest{modelCustomTypeBasic}),
 		AttrCustomNestedSetNullNotSent:     customtypes.NewNestedSetValueNull[modelCustomTypeTest](ctx),
@@ -270,6 +272,10 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 					}
 				],
 				"attrSetString": [
+					"set1",
+					"set2"
+				],
+				"attrCustomSetString": [
 					"set1",
 					"set2"
 				],
@@ -501,6 +507,10 @@ func TestUnmarshalNestedAllTypes(t *testing.T) {
 			},
 		}),
 		AttrSetString: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("set1"),
+			types.StringValue("set2"),
+		}),
+		AttrCustomSetString: customtypes.NewSetValue[types.String](ctx, []attr.Value{
 			types.StringValue("set1"),
 			types.StringValue("set2"),
 		}),

--- a/internal/serviceapi/orgserviceaccountapi/resource_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
 )
 
@@ -38,6 +39,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"roles": schema.SetAttribute{
 				Required:            true,
 				MarkdownDescription: "A list of organization-level roles for the Service Account.",
+				CustomType:          customtypes.NewSetType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
 			"secret_expires_after_hours": schema.Int64Attribute{
@@ -48,6 +50,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"secrets": schema.SetNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "A list of secrets associated with the specified Service Account.",
+				CustomType:          customtypes.NewNestedSetType[TFSecretsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"created_at": schema.StringAttribute{
@@ -83,14 +86,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Roles                   types.Set    `tfsdk:"roles"`
-	Secrets                 types.Set    `tfsdk:"secrets" autogen:"omitjson"`
-	ClientId                types.String `tfsdk:"client_id" autogen:"omitjson"`
-	CreatedAt               types.String `tfsdk:"created_at" autogen:"omitjson"`
-	Description             types.String `tfsdk:"description"`
-	Name                    types.String `tfsdk:"name"`
-	OrgId                   types.String `tfsdk:"org_id" autogen:"omitjson"`
-	SecretExpiresAfterHours types.Int64  `tfsdk:"secret_expires_after_hours" autogen:"omitjsonupdate"`
+	Roles                   customtypes.SetValue[types.String]         `tfsdk:"roles"`
+	Secrets                 customtypes.NestedSetValue[TFSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
+	ClientId                types.String                               `tfsdk:"client_id" autogen:"omitjson"`
+	CreatedAt               types.String                               `tfsdk:"created_at" autogen:"omitjson"`
+	Description             types.String                               `tfsdk:"description"`
+	Name                    types.String                               `tfsdk:"name"`
+	OrgId                   types.String                               `tfsdk:"org_id" autogen:"omitjson"`
+	SecretExpiresAfterHours types.Int64                                `tfsdk:"secret_expires_after_hours" autogen:"omitjsonupdate"`
 }
 type TFSecretsModel struct {
 	CreatedAt         types.String `tfsdk:"created_at" autogen:"omitjson"`

--- a/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper_test.go
@@ -291,6 +291,7 @@ func TestConvertToProviderSpec_nested(t *testing.T) {
 							TFSchemaName:             "set_primitive_string_attr",
 							TFModelName:              "SetPrimitiveStringAttr",
 							ComputedOptionalRequired: codespec.Computed,
+							CustomType:               codespec.NewCustomSetType(codespec.String),
 							Set: &codespec.SetAttribute{
 								ElementType: codespec.String,
 							},
@@ -669,7 +670,7 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 							TFModelName:              "ListString",
 							ComputedOptionalRequired: codespec.Required,
 							// List overridden to set
-							// CustomType:   codespec.NewCustomSetType(codespec.String), // TODO uncomment once CustomSetType is supported - CLOUDP-353170
+							CustomType:   codespec.NewCustomSetType(codespec.String),
 							Set:          &codespec.SetAttribute{ElementType: codespec.String},
 							ReqBodyUsage: codespec.AllRequestBodies,
 						},
@@ -678,7 +679,7 @@ func TestConvertToProviderSpec_typeOverride(t *testing.T) {
 							TFModelName:              "SetString",
 							ComputedOptionalRequired: codespec.Required,
 							// Set overridden to list
-							// CustomType:   codespec.NewCustomListType(codespec.String), // TODO uncomment once CustomSetType is supported - CLOUDP-353170
+							CustomType:   codespec.NewCustomListType(codespec.String),
 							List:         &codespec.ListAttribute{ElementType: codespec.String},
 							ReqBodyUsage: codespec.AllRequestBodies,
 						},

--- a/tools/codegen/codespec/attribute.go
+++ b/tools/codegen/codespec/attribute.go
@@ -204,6 +204,9 @@ func (s *APISpecSchema) buildArrayAttr(name, ancestorsName string, computability
 			}
 		} else {
 			if isSet {
+				if useCustomNestedTypes {
+					attr.CustomType = NewCustomSetType(elemType)
+				}
 				attr.Set = &SetAttribute{ElementType: elemType}
 			} else {
 				if useCustomNestedTypes {

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -155,24 +155,18 @@ func applyTypeOverride(override *config.Override, attr *Attribute) {
 	switch *override.Type {
 	case config.Set:
 		if attr.List != nil {
-			attr.CustomType = nil
-			/* TODO revisit once CustomSetType is supported - CLOUDP-353170
 			if attr.CustomType != nil {
 				attr.CustomType = NewCustomSetType(attr.List.ElementType)
 			}
-			*/
-
 			attr.Set = &SetAttribute{ElementType: attr.List.ElementType}
 			attr.List = nil
 			return
 		}
 	case config.List:
 		if attr.Set != nil {
-			/* TODO uncomment once CustomSetType is supported - CLOUDP-353170
 			if attr.CustomType != nil {
 				attr.CustomType = NewCustomListType(attr.Set.ElementType)
 			}
-			*/
 			attr.List = &ListAttribute{ElementType: attr.Set.ElementType}
 			attr.Set = nil
 			return

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -233,6 +233,15 @@ func NewCustomNestedListType(name string) *CustomType {
 	}
 }
 
+func NewCustomSetType(elemType ElemType) *CustomType {
+	elemTypeStr := ElementTypeToModelString[elemType]
+	return &CustomType{
+		Package: CustomTypesPkg,
+		Model:   fmt.Sprintf("customtypes.SetValue[%s]", elemTypeStr),
+		Schema:  fmt.Sprintf("customtypes.NewSetType[%s](ctx)", elemTypeStr),
+	}
+}
+
 func NewCustomNestedSetType(name string) *CustomType {
 	return &CustomType{
 		Package: CustomTypesPkg,

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -517,7 +517,6 @@ resources:
       path: /api/atlas/v2/orgs/{orgId}/serviceAccounts/{clientId}
       method: DELETE
     schema:
-      use_custom_nested_types: false
       overrides:
         secrets.secret:
           sensitive: true

--- a/tools/codegen/gofilegen/schema/schema_file_test.go
+++ b/tools/codegen/gofilegen/schema/schema_file_test.go
@@ -281,6 +281,14 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 							},
 						},
 						{
+							TFSchemaName:             "string_set_attr",
+							TFModelName:              "StringSetAttr",
+							Description:              admin.PtrString("string set attribute"),
+							ComputedOptionalRequired: codespec.Optional,
+							CustomType:               codespec.NewCustomSetType(codespec.String),
+							Set:                      &codespec.SetAttribute{ElementType: codespec.String},
+						},
+						{
 							TFSchemaName:             "nested_set_attr",
 							TFModelName:              "NestedSetAttr",
 							Description:              admin.PtrString("nested set attribute"),

--- a/tools/codegen/gofilegen/schema/testdata/custom-types-attributes.golden.go
+++ b/tools/codegen/gofilegen/schema/testdata/custom-types-attributes.golden.go
@@ -70,6 +70,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					},
 				},
 			},
+			"string_set_attr": schema.SetAttribute{
+				Optional:            true,
+				MarkdownDescription: "string set attribute",
+				CustomType:          customtypes.NewSetType[types.String](ctx),
+				ElementType:         types.StringType,
+			},
 			"nested_set_attr": schema.SetNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: "nested set attribute",
@@ -91,6 +97,7 @@ type TFModel struct {
 	NestedObjectAttr customtypes.ObjectValue[TFNestedObjectAttrModel]   `tfsdk:"nested_object_attr"`
 	StringListAttr   customtypes.ListValue[types.String]                `tfsdk:"string_list_attr"`
 	NestedListAttr   customtypes.NestedListValue[TFNestedListAttrModel] `tfsdk:"nested_list_attr"`
+	StringSetAttr    customtypes.SetValue[types.String]                 `tfsdk:"string_set_attr"`
 	NestedSetAttr    customtypes.NestedSetValue[TFNestedSetAttrModel]   `tfsdk:"nested_set_attr"`
 }
 type TFNestedObjectAttrModel struct {

--- a/tools/codegen/models/org_service_account_api.yaml
+++ b/tools/codegen/models/org_service_account_api.yaml
@@ -44,6 +44,10 @@ schema:
         - set:
             element_type: 4
           description: A list of organization-level roles for the Service Account.
+          custom_type:
+            package: customtypes
+            model: customtypes.SetValue[types.String]
+            schema: customtypes.NewSetType[types.String](ctx)
           computed_optional_required: required
           tf_schema_name: roles
           tf_model_name: Roles
@@ -110,6 +114,10 @@ schema:
                       sensitive: true
                       create_only: false
           description: A list of secrets associated with the specified Service Account.
+          custom_type:
+            package: customtypes
+            model: customtypes.NestedSetValue[TFSecretsModel]
+            schema: customtypes.NewNestedSetType[TFSecretsModel](ctx)
           computed_optional_required: computed
           tf_schema_name: secrets
           tf_model_name: Secrets


### PR DESCRIPTION
## Description

Adding a custom Set terraform type for autogen usage following the work done at [#3819](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3819) which added a custom `NestedSet` type.

The new `customtypes.Set` type is used for Terraform attr types, e.g. `types.String`.

Now that we support custom sets:
- Enabled custom types for `org_service_account_api`
- Config overriden types (set <-> list) now work with custom types as well.

Custom TF types docs: https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/custom

Link to any related issue(s): CLOUDP-353170

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
