### PR TITLE
chore: Fix v1x tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -451,10 +451,7 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'true'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          # include TestV1xMigBackupRSCloudBackupSchedule_copySettings
-          ACCTEST_PACKAGES: |
-            ./internal/service/advancedcluster
-            ./internal/service/cloudbackupschedule
+          ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
   advanced_cluster_tpf_mig_from_tpf_preview:
@@ -481,7 +478,10 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'false'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: ./internal/service/advancedcluster
+          # Include TestV1xMigBackupRSCloudBackupSchedule_copySettings.
+          ACCTEST_PACKAGES: |
+            ./internal/service/advancedcluster
+            ./internal/service/cloudbackupschedule
         run: make testacc
 
   advanced_cluster_sa_mig:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -406,7 +406,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'false' || inputs.test_group == 'advanced_cluster' }} # TODO: TEMPORARY remove before merging
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -428,9 +428,10 @@ jobs:
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  advanced_cluster_tpf_mig_from_sdkv2: # TODO: TEMPORARY remove before merging
+  advanced_cluster_tpf_mig_from_sdkv2:
     needs: [ change-detection, get-provider-version ]
     # advanced_cluster v1.x versions don't support SA.
+    if: ${{ inputs.reduced_tests != true && inputs.use_sa != true && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -453,9 +454,10 @@ jobs:
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  advanced_cluster_tpf_mig_from_tpf_preview: # TODO: TEMPORARY remove before merging
+  advanced_cluster_tpf_mig_from_tpf_preview:
     needs: [ change-detection, get-provider-version ]
     # advanced_cluster v1.x versions don't support SA.
+    if: ${{ inputs.reduced_tests != true && inputs.use_sa != true && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -406,7 +406,7 @@ jobs:
 
   advanced_cluster:
     needs: [ change-detection, get-provider-version ]
-    if: ${{ needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster' }}
+    if: ${{ needs.change-detection.outputs.advanced_cluster == 'false' || inputs.test_group == 'advanced_cluster' }} # TODO: TEMPORARY remove before merging
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -428,10 +428,9 @@ jobs:
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  advanced_cluster_tpf_mig_from_sdkv2:
+  advanced_cluster_tpf_mig_from_sdkv2: # TODO: TEMPORARY remove before merging
     needs: [ change-detection, get-provider-version ]
     # advanced_cluster v1.x versions don't support SA.
-    if: ${{ inputs.reduced_tests != true && inputs.use_sa != true && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -454,10 +453,9 @@ jobs:
           ACCTEST_PACKAGES: ./internal/service/advancedcluster
         run: make testacc
 
-  advanced_cluster_tpf_mig_from_tpf_preview:
+  advanced_cluster_tpf_mig_from_tpf_preview: # TODO: TEMPORARY remove before merging
     needs: [ change-detection, get-provider-version ]
     # advanced_cluster v1.x versions don't support SA.
-    if: ${{ inputs.reduced_tests != true && inputs.use_sa != true && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -451,7 +451,10 @@ jobs:
           MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           MONGODB_ATLAS_TEST_SDKV2_TO_TPF: 'true'
           ACCTEST_REGEX_RUN: '^TestV1xMig'
-          ACCTEST_PACKAGES: ./internal/service/advancedcluster
+          # include TestV1xMigBackupRSCloudBackupSchedule_copySettings
+          ACCTEST_PACKAGES: |
+            ./internal/service/advancedcluster
+            ./internal/service/cloudbackupschedule
         run: make testacc
 
   advanced_cluster_tpf_mig_from_tpf_preview:
@@ -706,7 +709,6 @@ jobs:
         env:
           MONGODB_ATLAS_PROJECT_OWNER_ID: ${{ inputs.mongodb_atlas_project_owner_id }}
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          MONGODB_ATLAS_LAST_1X_VERSION: ${{ inputs.mongodb_atlas_last_1x_version }}
           AWS_REGION: ${{ vars.AWS_REGION_LOWERCASE }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -87,7 +87,8 @@ jobs:
           echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
           cat doc.repo.patch
           exit 1
-  call-acceptance-tests-workflow: # TODO: TEMPORARY remove before merging
+  call-acceptance-tests-workflow:
+    needs: [build, lint, shellcheck, unit-test, generate-doc-check]
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -87,8 +87,7 @@ jobs:
           echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
           cat doc.repo.patch
           exit 1
-  call-acceptance-tests-workflow:
-    needs: [build, lint, shellcheck, unit-test, generate-doc-check]
+  call-acceptance-tests-workflow: # TODO: TEMPORARY remove before merging
     secrets: inherit
     uses: ./.github/workflows/acceptance-tests.yml
     with:

--- a/internal/service/advancedcluster/resource_migration_v1x_test.go
+++ b/internal/service/advancedcluster/resource_migration_v1x_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
 )
 
-var versionBeforeTPFGARelease = os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
+var (
+	versionBeforeTPFGARelease = os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
+	isSDKv2                   = acc.IsTestSDKv2ToTPF()
+)
 
 func TestV1xMigClusterAdvancedClusterConfig_geoShardedNewSchema(t *testing.T) {
 	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
-	isSDKv2 := acc.IsTestSDKv2ToTPF()
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -122,10 +123,8 @@ func checkGeoShardedTransitionOldToNewSchema(isTPF, useNewSchema bool) resource.
 
 func TestV1xMigAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T) {
 	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
-	isSDKv2 := acc.IsTestSDKv2ToTPF()
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasicSleep(t, nil, projectID, clusterName); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -151,11 +150,8 @@ func TestV1xMigAdvancedCluster_oldToNewSchemaWithAutoscalingEnabled(t *testing.T
 
 func TestV1xMigAdvancedCluster_shardedNewSchema(t *testing.T) {
 	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
-	versionBeforeTPFGARelease := os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
-	isSDKv2 := acc.IsTestSDKv2ToTPF()
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -277,11 +273,8 @@ func checkShardedTransitionOldToNewSchema(isTPF, useNewSchema bool) resource.Tes
 
 func TestV1xMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.T) {
 	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 8)
-	versionBeforeTPFGARelease := os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
-	isSDKv2 := acc.IsTestSDKv2ToTPF()
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasic(t); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -305,14 +298,9 @@ func TestV1xMigAdvancedCluster_geoShardedMigrationFromOldToNewSchema(t *testing.
 }
 
 func TestV1xMigAdvancedCluster_replicaSetAWSProvider(t *testing.T) {
-	var (
-		projectID, clusterName    = acc.ProjectIDExecutionWithCluster(t, 6)
-		versionBeforeTPFGARelease = os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
-		isSDKv2                   = acc.IsTestSDKv2ToTPF()
-	)
-
+	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 6)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasicSleep(t, nil, projectID, clusterName); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
@@ -352,11 +340,9 @@ func TestV1xMigAdvancedCluster_replicaSetMultiCloud(t *testing.T) {
 	var (
 		orgID                    = os.Getenv("MONGODB_ATLAS_ORG_ID")
 		projectName, clusterName = acc.ProjectIDExecutionWithCluster(t, 6)
-		isSDKv2                  = acc.IsTestSDKv2ToTPF()
 	)
-
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acc.PreCheckBasic(t); mig.PreCheckLast1XVersion(t) },
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t) },
 		CheckDestroy: acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_test.go
@@ -1,7 +1,6 @@
 package cloudbackupschedule_test
 
 import (
-	"os"
 	"testing"
 
 	"go.mongodb.org/atlas-sdk/v20250312008/admin"
@@ -46,89 +45,6 @@ func TestMigBackupRSCloudBackupSchedule_basic(t *testing.T) {
 				),
 			},
 			mig.TestStepCheckEmptyPlan(config),
-		},
-	})
-}
-
-func TestMigBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
-	mig.SkipIfVersionBelow(t, "1.29.0") // version when advanced cluster TPF was introduced
-	var (
-		lastVersionRepSpecID = os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
-		clusterInfo          = acc.GetClusterInfo(t, &acc.ClusterRequest{
-			CloudBackup: true,
-			ReplicationSpecs: []acc.ReplicationSpecRequest{
-				{Region: "US_EAST_2"},
-			},
-			PitEnabled: true, // you cannot copy oplogs when pit is not enabled
-		})
-		clusterName                     = clusterInfo.Name
-		terraformStr                    = clusterInfo.TerraformStr
-		clusterResourceName             = clusterInfo.ResourceName
-		projectID                       = clusterInfo.ProjectID
-		copySettingsConfigWithRepSpecID = configCopySettings(terraformStr, projectID, clusterResourceName, false, true, &admin.DiskBackupSnapshotSchedule20240805{
-			ReferenceHourOfDay:    conversion.Pointer(3),
-			ReferenceMinuteOfHour: conversion.Pointer(45),
-			RestoreWindowDays:     conversion.Pointer(1),
-		})
-		copySettingsConfigWithZoneID = configCopySettings(terraformStr, projectID, clusterResourceName, false, false, &admin.DiskBackupSnapshotSchedule20240805{
-			ReferenceHourOfDay:    conversion.Pointer(3),
-			ReferenceMinuteOfHour: conversion.Pointer(45),
-			RestoreWindowDays:     conversion.Pointer(1),
-		})
-		checkMap = map[string]string{
-			"cluster_name":                             clusterName,
-			"reference_hour_of_day":                    "3",
-			"reference_minute_of_hour":                 "45",
-			"restore_window_days":                      "1",
-			"policy_item_hourly.#":                     "1",
-			"policy_item_daily.#":                      "1",
-			"policy_item_weekly.#":                     "1",
-			"policy_item_monthly.#":                    "1",
-			"policy_item_yearly.#":                     "1",
-			"policy_item_hourly.0.frequency_interval":  "1",
-			"policy_item_hourly.0.retention_unit":      "days",
-			"policy_item_hourly.0.retention_value":     "1",
-			"policy_item_daily.0.frequency_interval":   "1",
-			"policy_item_daily.0.retention_unit":       "days",
-			"policy_item_daily.0.retention_value":      "2",
-			"policy_item_weekly.0.frequency_interval":  "4",
-			"policy_item_weekly.0.retention_unit":      "weeks",
-			"policy_item_weekly.0.retention_value":     "3",
-			"policy_item_monthly.0.frequency_interval": "5",
-			"policy_item_monthly.0.retention_unit":     "months",
-			"policy_item_monthly.0.retention_value":    "4",
-			"policy_item_yearly.0.frequency_interval":  "1",
-			"policy_item_yearly.0.retention_unit":      "years",
-			"policy_item_yearly.0.retention_value":     "1",
-		}
-		copySettingsChecks = map[string]string{
-			"copy_settings.#":                    "1",
-			"copy_settings.0.cloud_provider":     "AWS",
-			"copy_settings.0.region_name":        "US_EAST_1",
-			"copy_settings.0.should_copy_oplogs": "true",
-		}
-	)
-
-	checksDefault := acc.AddAttrChecks(resourceName, []resource.TestCheckFunc{checkExists(resourceName)}, checkMap)
-	checksCreate := acc.AddAttrChecks(resourceName, checksDefault, copySettingsChecks)
-	checksCreateWithReplicationSpecID := acc.AddAttrSetChecks(resourceName, checksCreate, "copy_settings.0.replication_spec_id")
-	checksUpdateWithZoneID := acc.AddAttrSetChecks(resourceName, checksCreate, "copy_settings.0.zone_id")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { mig.PreCheckBasicSleep(t); mig.PreCheckOldPreviewEnv(t) },
-		CheckDestroy: checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: acc.ExternalProviders(lastVersionRepSpecID),
-				Config:            copySettingsConfigWithRepSpecID,
-				Check:             resource.ComposeAggregateTestCheckFunc(checksCreateWithReplicationSpecID...),
-			},
-			{
-				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-				Config:                   copySettingsConfigWithZoneID,
-				Check:                    resource.ComposeAggregateTestCheckFunc(checksUpdateWithZoneID...),
-			},
-			mig.TestStepCheckEmptyPlan(copySettingsConfigWithZoneID),
 		},
 	})
 }

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_v1x_test.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule_migration_v1x_test.go
@@ -1,0 +1,97 @@
+package cloudbackupschedule_test
+
+import (
+	"os"
+	"testing"
+
+	"go.mongodb.org/atlas-sdk/v20250312008/admin"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/mig"
+)
+
+func TestV1xMigBackupRSCloudBackupSchedule_copySettings(t *testing.T) {
+	mig.SkipIfVersionBelow(t, "1.29.0") // version when advanced cluster TPF was introduced
+	var (
+		lastVersionRepSpecID = os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION")
+		clusterInfo          = acc.GetClusterInfo(t, &acc.ClusterRequest{
+			CloudBackup: true,
+			ReplicationSpecs: []acc.ReplicationSpecRequest{
+				{Region: "US_EAST_2"},
+			},
+			PitEnabled: true, // you cannot copy oplogs when pit is not enabled
+		})
+		clusterName                     = clusterInfo.Name
+		terraformStr                    = clusterInfo.TerraformStr
+		clusterResourceName             = clusterInfo.ResourceName
+		projectID                       = clusterInfo.ProjectID
+		copySettingsConfigWithRepSpecID = configCopySettings(terraformStr, projectID, clusterResourceName, false, true, &admin.DiskBackupSnapshotSchedule20240805{
+			ReferenceHourOfDay:    conversion.Pointer(3),
+			ReferenceMinuteOfHour: conversion.Pointer(45),
+			RestoreWindowDays:     conversion.Pointer(1),
+		})
+		copySettingsConfigWithZoneID = configCopySettings(terraformStr, projectID, clusterResourceName, false, false, &admin.DiskBackupSnapshotSchedule20240805{
+			ReferenceHourOfDay:    conversion.Pointer(3),
+			ReferenceMinuteOfHour: conversion.Pointer(45),
+			RestoreWindowDays:     conversion.Pointer(1),
+		})
+		checkMap = map[string]string{
+			"cluster_name":                             clusterName,
+			"reference_hour_of_day":                    "3",
+			"reference_minute_of_hour":                 "45",
+			"restore_window_days":                      "1",
+			"policy_item_hourly.#":                     "1",
+			"policy_item_daily.#":                      "1",
+			"policy_item_weekly.#":                     "1",
+			"policy_item_monthly.#":                    "1",
+			"policy_item_yearly.#":                     "1",
+			"policy_item_hourly.0.frequency_interval":  "1",
+			"policy_item_hourly.0.retention_unit":      "days",
+			"policy_item_hourly.0.retention_value":     "1",
+			"policy_item_daily.0.frequency_interval":   "1",
+			"policy_item_daily.0.retention_unit":       "days",
+			"policy_item_daily.0.retention_value":      "2",
+			"policy_item_weekly.0.frequency_interval":  "4",
+			"policy_item_weekly.0.retention_unit":      "weeks",
+			"policy_item_weekly.0.retention_value":     "3",
+			"policy_item_monthly.0.frequency_interval": "5",
+			"policy_item_monthly.0.retention_unit":     "months",
+			"policy_item_monthly.0.retention_value":    "4",
+			"policy_item_yearly.0.frequency_interval":  "1",
+			"policy_item_yearly.0.retention_unit":      "years",
+			"policy_item_yearly.0.retention_value":     "1",
+		}
+		copySettingsChecks = map[string]string{
+			"copy_settings.#":                    "1",
+			"copy_settings.0.cloud_provider":     "AWS",
+			"copy_settings.0.region_name":        "US_EAST_1",
+			"copy_settings.0.should_copy_oplogs": "true",
+		}
+	)
+
+	checksDefault := acc.AddAttrChecks(resourceName, []resource.TestCheckFunc{checkExists(resourceName)}, checkMap)
+	checksCreate := acc.AddAttrChecks(resourceName, checksDefault, copySettingsChecks)
+	checksCreateWithReplicationSpecID := acc.AddAttrSetChecks(resourceName, checksCreate, "copy_settings.0.replication_spec_id")
+	checksUpdateWithZoneID := acc.AddAttrSetChecks(resourceName, checksCreate, "copy_settings.0.zone_id")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { mig.PreCheckLast1XVersionSleep(t); mig.PreCheckOldPreviewEnv(t) },
+		CheckDestroy: checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: acc.ExternalProviders(lastVersionRepSpecID),
+				Config:            copySettingsConfigWithRepSpecID,
+				Check:             resource.ComposeAggregateTestCheckFunc(checksCreateWithReplicationSpecID...),
+			},
+			{
+				ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+				Config:                   copySettingsConfigWithZoneID,
+				Check:                    resource.ComposeAggregateTestCheckFunc(checksUpdateWithZoneID...),
+			},
+			mig.TestStepCheckEmptyPlan(copySettingsConfigWithZoneID),
+		},
+	})
+}

--- a/internal/testutil/mig/pre_check.go
+++ b/internal/testutil/mig/pre_check.go
@@ -24,11 +24,13 @@ func PreCheckBasicSleep(tb testing.TB) func() {
 	}
 }
 
-func PreCheckLast1XVersion(tb testing.TB) {
+func PreCheckLast1XVersionSleep(tb testing.TB) {
 	tb.Helper()
 	if os.Getenv("MONGODB_ATLAS_LAST_1X_VERSION") == "" {
 		tb.Fatal("`MONGODB_ATLAS_LAST_1X_VERSION` must be set for this migration testing")
 	}
+	PreCheckBasic(tb)
+	acc.SerialSleep(tb)
 }
 
 func PreCheck(tb testing.TB) {


### PR DESCRIPTION
Fix v1x tests. Rename TestMigBackupRSCloudBackupSchedule_copySettings to TestV1xMigBackupRSCloudBackupSchedule_copySettings so it's run in `advanced_cluster_tpf_mig_from_sdkv2` test group.

In this way all v1x tests run in the same test group.

Before this PR it was run in the regular `backup` test group. For example the tests would fail for SA as v1.x providers don't support SA.

Example of advanced_cluster executions for [PAK](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/18983975900/job/54223281205) and [SA](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/18983993719/job/54223342219).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
