### PR TITLE
chore: Remove object type generation

### DIFF
--- a/internal/common/autogen/customtypes/common.go
+++ b/internal/common/autogen/customtypes/common.go
@@ -10,12 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-func getValueElementType[T attr.Value](ctx context.Context) attr.Type {
+func getValueType[T attr.Value](ctx context.Context) attr.Type {
 	var t T
 	return t.Type(ctx)
 }
 
-func getElementType[T any](ctx context.Context) (attr.Type, diag.Diagnostics) {
+func getNestedType[T any](ctx context.Context) (attr.Type, diag.Diagnostics) {
 	var t T
 	attrTypes, diags := valueToAttributeTypes(ctx, reflect.ValueOf(t))
 	if diags.HasError() {

--- a/internal/common/autogen/customtypes/list.go
+++ b/internal/common/autogen/customtypes/list.go
@@ -40,7 +40,7 @@ type ListType[T attr.Value] struct {
 }
 
 func NewListType[T attr.Value](ctx context.Context) ListType[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return ListType[T]{
 		ListType: basetypes.ListType{ElemType: elemType},
 	}
@@ -68,7 +68,7 @@ func (t ListType[T]) ValueFromList(ctx context.Context, in basetypes.ListValue) 
 		return NewListValueUnknown[T](ctx), nil
 	}
 
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	baseListValue, diags := basetypes.NewListValue(elemType, in.Elements())
 	if diags.HasError() {
 		return nil, diags
@@ -126,7 +126,7 @@ func (v ListValue[T]) NewListValue(ctx context.Context, value []attr.Value) List
 }
 
 func NewListValue[T attr.Value](ctx context.Context, value []attr.Value) ListValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 
 	listValue, diags := basetypes.NewListValue(elemType, value)
 	if diags.HasError() {
@@ -141,12 +141,12 @@ func (v ListValue[T]) NewListValueNull(ctx context.Context) ListValueInterface {
 }
 
 func NewListValueNull[T attr.Value](ctx context.Context) ListValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return ListValue[T]{ListValue: basetypes.NewListNull(elemType)}
 }
 
 func NewListValueUnknown[T attr.Value](ctx context.Context) ListValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return ListValue[T]{ListValue: basetypes.NewListUnknown(elemType)}
 }
 
@@ -163,7 +163,7 @@ func (v ListValue[T]) Type(ctx context.Context) attr.Type {
 }
 
 func (v ListValue[T]) ElementType(ctx context.Context) attr.Type {
-	return getValueElementType[T](ctx)
+	return getValueType[T](ctx)
 }
 
 func (v ListValue[T]) Elements() []attr.Value {

--- a/internal/common/autogen/customtypes/map.go
+++ b/internal/common/autogen/customtypes/map.go
@@ -40,7 +40,7 @@ type MapType[T attr.Value] struct {
 }
 
 func NewMapType[T attr.Value](ctx context.Context) MapType[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return MapType[T]{
 		MapType: basetypes.MapType{ElemType: elemType},
 	}
@@ -69,7 +69,7 @@ func (t MapType[T]) ValueFromMap(ctx context.Context, in basetypes.MapValue) (ba
 		return NewMapValueUnknown[T](ctx), nil
 	}
 
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	baseMapValue, diags := basetypes.NewMapValue(elemType, in.Elements())
 	if diags.HasError() {
 		return nil, diags
@@ -127,7 +127,7 @@ func (v MapValue[T]) NewMapValue(ctx context.Context, value map[string]attr.Valu
 }
 
 func NewMapValue[T attr.Value](ctx context.Context, value map[string]attr.Value) MapValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 
 	mapValue, diags := basetypes.NewMapValue(elemType, value)
 	if diags.HasError() {
@@ -142,12 +142,12 @@ func (v MapValue[T]) NewMapValueNull(ctx context.Context) MapValueInterface {
 }
 
 func NewMapValueNull[T attr.Value](ctx context.Context) MapValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return MapValue[T]{MapValue: basetypes.NewMapNull(elemType)}
 }
 
 func NewMapValueUnknown[T attr.Value](ctx context.Context) MapValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return MapValue[T]{MapValue: basetypes.NewMapUnknown(elemType)}
 }
 
@@ -164,7 +164,7 @@ func (v MapValue[T]) Type(ctx context.Context) attr.Type {
 }
 
 func (v MapValue[T]) ElementType(ctx context.Context) attr.Type {
-	return getValueElementType[T](ctx)
+	return getValueType[T](ctx)
 }
 
 func (v MapValue[T]) Elements() map[string]attr.Value {

--- a/internal/common/autogen/customtypes/nested_list.go
+++ b/internal/common/autogen/customtypes/nested_list.go
@@ -49,7 +49,7 @@ type NestedListType[T any] struct {
 }
 
 func NewNestedListType[T any](ctx context.Context) NestedListType[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedListType: %v", diags))
 	}
@@ -82,7 +82,7 @@ func (t NestedListType[T]) ValueFromList(ctx context.Context, in basetypes.ListV
 		return NewNestedListValueUnknown[T](ctx), nil
 	}
 
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -145,7 +145,7 @@ func (v NestedListValue[T]) NewNestedListValue(ctx context.Context, value any) N
 }
 
 func NewNestedListValue[T any](ctx context.Context, value any) NestedListValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedListValue: %v", diags))
 	}
@@ -163,7 +163,7 @@ func (v NestedListValue[T]) NewNestedListValueNull(ctx context.Context) NestedLi
 }
 
 func NewNestedListValueNull[T any](ctx context.Context) NestedListValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating null NestedListValue: %v", diags))
 	}
@@ -171,7 +171,7 @@ func NewNestedListValueNull[T any](ctx context.Context) NestedListValue[T] {
 }
 
 func NewNestedListValueUnknown[T any](ctx context.Context) NestedListValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating unknown NestedListValue: %v", diags))
 	}

--- a/internal/common/autogen/customtypes/nested_map.go
+++ b/internal/common/autogen/customtypes/nested_map.go
@@ -49,7 +49,7 @@ type NestedMapType[T any] struct {
 }
 
 func NewNestedMapType[T any](ctx context.Context) NestedMapType[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedMapType: %v", diags))
 	}
@@ -82,7 +82,7 @@ func (t NestedMapType[T]) ValueFromMap(ctx context.Context, in basetypes.MapValu
 		return NewNestedMapValueUnknown[T](ctx), nil
 	}
 
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -144,7 +144,7 @@ func (v NestedMapValue[T]) NewNestedMapValue(ctx context.Context, value any) Nes
 }
 
 func NewNestedMapValue[T any](ctx context.Context, value any) NestedMapValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedMapValue: %v", diags))
 	}
@@ -162,7 +162,7 @@ func (v NestedMapValue[T]) NewNestedMapValueNull(ctx context.Context) NestedMapV
 }
 
 func NewNestedMapValueNull[T any](ctx context.Context) NestedMapValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating null NestedMapValue: %v", diags))
 	}
@@ -170,7 +170,7 @@ func NewNestedMapValueNull[T any](ctx context.Context) NestedMapValue[T] {
 }
 
 func NewNestedMapValueUnknown[T any](ctx context.Context) NestedMapValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating unknown NestedMapValue: %v", diags))
 	}

--- a/internal/common/autogen/customtypes/nested_set.go
+++ b/internal/common/autogen/customtypes/nested_set.go
@@ -49,7 +49,7 @@ type NestedSetType[T any] struct {
 }
 
 func NewNestedSetType[T any](ctx context.Context) NestedSetType[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedSetType: %v", diags))
 	}
@@ -82,7 +82,7 @@ func (t NestedSetType[T]) ValueFromSet(ctx context.Context, in basetypes.SetValu
 		return NewNestedSetValueUnknown[T](ctx), nil
 	}
 
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -145,7 +145,7 @@ func (v NestedSetValue[T]) NewNestedSetValue(ctx context.Context, value any) Nes
 }
 
 func NewNestedSetValue[T any](ctx context.Context, value any) NestedSetValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating NestedSetValue: %v", diags))
 	}
@@ -163,7 +163,7 @@ func (v NestedSetValue[T]) NewNestedSetValueNull(ctx context.Context) NestedSetV
 }
 
 func NewNestedSetValueNull[T any](ctx context.Context) NestedSetValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating null NestedSetValue: %v", diags))
 	}
@@ -171,7 +171,7 @@ func NewNestedSetValueNull[T any](ctx context.Context) NestedSetValue[T] {
 }
 
 func NewNestedSetValueUnknown[T any](ctx context.Context) NestedSetValue[T] {
-	elemType, diags := getElementType[T](ctx)
+	elemType, diags := getNestedType[T](ctx)
 	if diags.HasError() {
 		panic(fmt.Errorf("error creating unknown NestedSetValue: %v", diags))
 	}

--- a/internal/common/autogen/customtypes/set.go
+++ b/internal/common/autogen/customtypes/set.go
@@ -40,7 +40,7 @@ type SetType[T attr.Value] struct {
 }
 
 func NewSetType[T attr.Value](ctx context.Context) SetType[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return SetType[T]{
 		SetType: basetypes.SetType{ElemType: elemType},
 	}
@@ -68,7 +68,7 @@ func (t SetType[T]) ValueFromSet(ctx context.Context, in basetypes.SetValue) (ba
 		return NewSetValueUnknown[T](ctx), nil
 	}
 
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	baseSetValue, diags := basetypes.NewSetValue(elemType, in.Elements())
 	if diags.HasError() {
 		return nil, diags
@@ -126,7 +126,7 @@ func (v SetValue[T]) NewSetValue(ctx context.Context, value []attr.Value) SetVal
 }
 
 func NewSetValue[T attr.Value](ctx context.Context, value []attr.Value) SetValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 
 	setValue, diags := basetypes.NewSetValue(elemType, value)
 	if diags.HasError() {
@@ -141,12 +141,12 @@ func (v SetValue[T]) NewSetValueNull(ctx context.Context) SetValueInterface {
 }
 
 func NewSetValueNull[T attr.Value](ctx context.Context) SetValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return SetValue[T]{SetValue: basetypes.NewSetNull(elemType)}
 }
 
 func NewSetValueUnknown[T attr.Value](ctx context.Context) SetValue[T] {
-	elemType := getValueElementType[T](ctx)
+	elemType := getValueType[T](ctx)
 	return SetValue[T]{SetValue: basetypes.NewSetUnknown(elemType)}
 }
 
@@ -163,7 +163,7 @@ func (v SetValue[T]) Type(ctx context.Context) attr.Type {
 }
 
 func (v SetValue[T]) ElementType(ctx context.Context) attr.Type {
-	return getValueElementType[T](ctx)
+	return getValueType[T](ctx)
 }
 
 func (v SetValue[T]) Elements() []attr.Value {

--- a/tools/codegen/gofilegen/schema/schema_file.go
+++ b/tools/codegen/gofilegen/schema/schema_file.go
@@ -7,9 +7,9 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/tools/codegen/gofilegen/codetemplate"
 )
 
-func GenerateGoCode(input *codespec.Resource, withObjTypes bool) []byte {
+func GenerateGoCode(input *codespec.Resource) []byte {
 	schemaAttrs := GenerateSchemaAttributes(input.Schema.Attributes)
-	models := GenerateTypedModels(input.Schema.Attributes, withObjTypes)
+	models := GenerateTypedModels(input.Schema.Attributes)
 
 	imports := []string{"github.com/hashicorp/terraform-plugin-framework/resource/schema"}
 	imports = append(imports, schemaAttrs.Imports...)

--- a/tools/codegen/gofilegen/schema/schema_file_test.go
+++ b/tools/codegen/gofilegen/schema/schema_file_test.go
@@ -45,7 +45,6 @@ func doubleCustomNestedListAttr(ancestorName string) codespec.Attribute {
 type schemaGenerationTestCase struct {
 	inputModel     codespec.Resource
 	goldenFileName string
-	withObjType    bool
 }
 
 //nolint:funlen // Long test data
@@ -118,7 +117,6 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 					},
 				},
 			},
-			withObjType:    true,
 			goldenFileName: "primitive-attributes",
 		},
 		"Custom type attributes": {
@@ -216,7 +214,6 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 					},
 				},
 			},
-			withObjType:    false,
 			goldenFileName: "custom-types-attributes",
 		},
 		"Timeout attribute": {
@@ -276,7 +273,6 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 					},
 				},
 			},
-			withObjType:    false,
 			goldenFileName: "multiple-nested-models-same-parent-attr-name",
 		},
 		"Plan modifiers using create only": {
@@ -412,14 +408,13 @@ func TestSchemaGenerationFromCodeSpec(t *testing.T) {
 					},
 				},
 			},
-			withObjType:    false,
 			goldenFileName: "plan-modifiers-create-only",
 		},
 	}
 
 	for testName, tc := range schemaGenFromCodeSpecTestCases {
 		t.Run(testName, func(t *testing.T) {
-			result := schema.GenerateGoCode(&tc.inputModel, tc.withObjType)
+			result := schema.GenerateGoCode(&tc.inputModel)
 			g := goldie.New(t, goldie.WithNameSuffix(".golden.go"))
 			g.Assert(t, tc.goldenFileName, result)
 		})

--- a/tools/codegen/main.go
+++ b/tools/codegen/main.go
@@ -77,7 +77,7 @@ func main() {
 
 		log.Printf("[INFO] Generating resource code: %s", resourceModel.Name)
 
-		schemaCode := schema.GenerateGoCode(resourceModel, false) // object types are not needed as part of fully generated resources
+		schemaCode := schema.GenerateGoCode(resourceModel)
 		schemaFilePath := fmt.Sprintf("internal/serviceapi/%s/resource_schema.go", resourceModel.Name.LowerCaseNoUnderscore())
 		if err := writeToFile(schemaFilePath, schemaCode); err != nil {
 			log.Fatalf("[ERROR] An error occurred when writing content to file: %v", err)


### PR DESCRIPTION
## Description

Removed object type generation from autogen.
As agreed offline, object types will not be needed since we took the custom types + reflection approach for conversion between TF schema and API json.

Renamed common customtype functions.

Link to any related issue(s): CLOUDP-352973

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
