### PR TITLE
chore: Fix TestAccConfigDSAtlasUser_ByUsername and TestAccProjectAPIKey_recreateWhenDeletedExternally

### DIFF
--- a/internal/service/atlasuser/data_source_atlas_user_test.go
+++ b/internal/service/atlasuser/data_source_atlas_user_test.go
@@ -65,7 +65,8 @@ func dataSourceChecksForUser(dataSourceName, attrPrefix string, user *admin20241
 		resource.TestCheckResourceAttr(dataSourceName, fmt.Sprintf("%smobile_number", attrPrefix), user.MobileNumber),
 		resource.TestCheckResourceAttr(dataSourceName, fmt.Sprintf("%scountry", attrPrefix), user.Country),
 		resource.TestCheckResourceAttr(dataSourceName, fmt.Sprintf("%screated_at", attrPrefix), *conversion.TimePtrToStringPtr(user.CreatedAt)),
-		resource.TestCheckResourceAttr(dataSourceName, fmt.Sprintf("%steam_ids.#", attrPrefix), fmt.Sprintf("%d", len(*user.TeamIds))),
+		// team_ids count validation is flexible as team membership can change during test execution.
+		resource.TestCheckResourceAttrWith(dataSourceName, fmt.Sprintf("%steam_ids.#", attrPrefix), acc.IntGreatThan(0)),
 		resource.TestCheckResourceAttr(dataSourceName, fmt.Sprintf("%slinks.#", attrPrefix), fmt.Sprintf("%d", len(*user.Links))),
 		// for assertion of roles the values of `user.Roles` must not be used as it has the risk of flaky executions. CLOUDP-220377
 		resource.TestCheckResourceAttrWith(dataSourceName, fmt.Sprintf("%sroles.#", attrPrefix), acc.IntGreatThan(0)),


### PR DESCRIPTION
Fix TestAccConfigDSAtlasUser_ByUsername and TestAccProjectAPIKey_recreateWhenDeletedExternally.

These are flaky tests, e.g. of failing execution [here](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/19109915877/job/54604795198?pr=3849)


```
  data_source_atlas_user_test.go:44: Step 1/1 error: Check failed: Check 9/12 error: data.mongodbatlas_atlas_user.test: Attribute 'team_ids.#' expected "13", got "14"
--- FAIL: TestAccConfigDSAtlasUser_ByUsername (0.87s)

NAME  TestAccProjectAPIKey_recreateWhenDeletedExternally
    resource_project_api_key_test.go:164: Step 2/2 error: Expected a non-empty plan, but got an empty refresh plan
--- FAIL: TestAccProjectAPIKey_recreateWhenDeletedExternally (15.65s)
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
