### PR TITLE
chore: Sensitive attributes unmarshaling

### DIFF
--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	tagKey                    = "autogen"
+	tagSensitive              = "sensitive"
 	tagValOmitJSON            = "omitjson"
 	tagValOmitJSONUpdate      = "omitjsonupdate"
 	tagValIncludeNullOnUpdate = "includenullonupdate"

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -62,10 +62,10 @@ func unmarshalAttr(attrNameJSON string, attrObjJSON any, valModel reflect.Value)
 		return fmt.Errorf("unmarshal trying to set non-Terraform attribute %s", attrNameModel)
 	}
 
-	if !oldVal.IsNull() && !oldVal.IsUnknown() {
-		structField, _ := valModel.Type().FieldByName(attrNameModel) // Always valid, checked above
-		if slices.Contains(strings.Split(structField.Tag.Get(tagKey), ","), tagSensitive) {
-			return nil // skip sensitive fields that are already set in the plan/state to avoid overwriting
+	if !oldVal.IsNull() && !oldVal.IsUnknown() { // Check if oldVal is a known value
+		structField, _ := valModel.Type().FieldByName(attrNameModel)                        // Always valid, checked above
+		if slices.Contains(strings.Split(structField.Tag.Get(tagKey), ","), tagSensitive) { // Field contains the "sensitive" tag
+			return nil // skip sensitive fields that are already set in the plan/state to avoid overwriting with redacted values
 		}
 	}
 


### PR DESCRIPTION
## Description

Handling `sensitive` attributes in autogen unmarshal.
If the attribute is known, the (redacted) value from the API response is ignored and the plan/state value is kept.
If the attribute is null or unknown, the (redacted) value from the API response is written to the plan/state.

Link to any related issue(s): CLOUDP-356401

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
