### PR TITLE
chore: Change `mongodbatlas_stream_privatelink_endpoint` timeout to 60m

### DIFF
--- a/.changelog/3857.txt
+++ b/.changelog/3857.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/mongodbatlas_stream_privatelink_endpoint: Changes timeout from 20m to 1h
+```

--- a/internal/service/streamprivatelinkendpoint/state_transition.go
+++ b/internal/service/streamprivatelinkendpoint/state_transition.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultTimeout    = 20 * time.Minute // The amount of time to wait before timeout
+	defaultTimeout    = 60 * time.Minute // The amount of time to wait before timeout
 	defaultMinTimeout = 30 * time.Second // Smallest time to wait before refreshes
 )
 


### PR DESCRIPTION
## Description

Change `mongodbatlas_stream_privatelink_endpoint` timeout to 60m.

This is to help with this issue until user-defined timeouts are implemented: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3851

Link to any related issue(s): CLOUDP-357221

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
