### PR TITLE
fix: Skips `date_format` validation to allow all different formats

### DIFF
--- a/.changelog/3865.txt
+++ b/.changelog/3865.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/mongodbatlas_online_archive: Skips `date_format` validation to allow all different formats
+resource/mongodbatlas_online_archive: Removing incorrect validation for valid value `OBJECT_ID` in `date_format` field
 ```

--- a/.changelog/3865.txt
+++ b/.changelog/3865.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mongodbatlas_online_archive: Skips `date_format` validation to allow all different formats
+```

--- a/.changelog/3865.txt
+++ b/.changelog/3865.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-mongodbatlas_online_archive: Skips `date_format` validation to allow all different formats
+resource/mongodbatlas_online_archive: Skips `date_format` validation to allow all different formats
 ```

--- a/internal/service/onlinearchive/resource.go
+++ b/internal/service/onlinearchive/resource.go
@@ -87,10 +87,9 @@ func resourceSchema() map[string]*schema.Schema {
 						Optional: true,
 					},
 					"date_format": {
-						Type:         schema.TypeString,
-						Optional:     true,
-						Computed:     true, // api will set the default
-						ValidateFunc: validation.StringInSlice([]string{"ISODATE", "EPOCH_SECONDS", "EPOCH_MILLIS", "EPOCH_NANOSECONDS"}, false),
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true, // api will set the default
 					},
 					"expire_after_days": {
 						Type:     schema.TypeInt,

--- a/internal/testutil/acc/advanced_cluster.go
+++ b/internal/testutil/acc/advanced_cluster.go
@@ -71,6 +71,9 @@ func TestStepImportCluster(resourceName string, ignorePrefixFields ...string) re
 }
 
 func CheckDestroyCluster(s *terraform.State) error {
+	if ExistingClusterUsed() {
+		return nil
+	}
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mongodbatlas_cluster" && rs.Type != "mongodbatlas_advanced_cluster" {
 			continue


### PR DESCRIPTION
## Description

Skips `date_format` validation to allow all different formats

Link to any related issue(s): CLOUDP-357963 #3863

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
