### PR TITLE
chore: Handles cluster deletion error during regional outage simulation

### DIFF
--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -254,6 +254,10 @@ func removeClusters(ctx context.Context, t *testing.T, dryRun bool, client *admi
 		t.Logf("delete cluster %s", cName)
 		if !dryRun {
 			_, err = client.ClustersApi.DeleteCluster(ctx, projectID, cName).Execute()
+			if admin.IsErrorCode(err, "CANNOT_TERMINATE_CLUSTER_WITH_UNDERGOING_REGIONAL_OUTAGE_SIMULATION") {
+				t.Logf("cluster %s has ongoing region outage simulation, deleting it now", cName)
+				_, _, err = client.ClusterOutageSimulationApi.EndOutageSimulation(ctx, projectID, cName).Execute()
+			}
 			if admin.IsErrorCode(err, "CLUSTER_ALREADY_REQUESTED_DELETION") {
 				t.Logf("cluster %s already requested deletion", cName)
 				continue

--- a/internal/testutil/clean/org_clean_test.go
+++ b/internal/testutil/clean/org_clean_test.go
@@ -262,6 +262,7 @@ func removeClusters(ctx context.Context, t *testing.T, dryRun bool, client *admi
 					deleteFailures = append(deleteFailures, fmt.Sprintf("Unable to delete %s (cluster simulation stuck), might require manual action: %s", cName, err))
 					continue
 				}
+				_, err = client.ClustersApi.DeleteCluster(ctx, projectID, cName).Execute() // Retry deletion after ending outage simulation
 			}
 			if admin.IsErrorCode(err, "CLUSTER_ALREADY_REQUESTED_DELETION") {
 				t.Logf("cluster %s already requested deletion", cName)


### PR DESCRIPTION
## Description

Handles cluster deletion during regional outage simulation

Link to any related issue(s): [Failing cluster cleanup due to outage simulation in progress.](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/19216819079/job/54927522394#step:3:253)

Example error:
```
                Error:          Should be empty, but was [Unable to delete test-acc-tf-c-2271139291488278286 (cluster simulation stuck), might require manual action: https://cloud-dev.mongodb.com/api/atlas/v2/groups/6902b10fabf4374f32987fb9/clusters/test-acc-tf-c-2271139291488278286/outageSimulation DELETE: HTTP 400 Bad Request (Error code: "INVALID_CLUSTER_OUTAGE_SIMULATION_STATE") Detail: Invalid cluster outage simulation state: START_REQUESTED, expected state: SIMULATING. Reason: Bad Request. Params: [START_REQUESTED SIMULATING], BadRequestDetail: ]
                Test:           TestSingleProjectRemoval
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
