### PR TITLE
feat: Add Configurable Dynamic Indexing for Atlas Search

### DIFF
--- a/.changelog/3867.txt
+++ b/.changelog/3867.txt
@@ -1,15 +1,15 @@
 ```release-note:enhancement
-resource/mongodbatlas_search_index: Add `type_sets` field to support Atlas Search configurable dynamic type sets.
+resource/mongodbatlas_search_index: Adds `type_sets` field to support Atlas Search configurable dynamic type sets
 ```
 
 ```release-note:enhancement
-resource/mongodbatlas_search_index: Add `mappings_dynamic_config` (mutually exclusive with `mappings_dynamic`) to support object form of `mappings.dynamic`.
+resource/mongodbatlas_search_index: Adds `mappings_dynamic_config` (mutually exclusive with `mappings_dynamic`) to support object form of `mappings.dynamic`
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_index: Expose `mappings_dynamic_config` and `type_sets`.
+data-source/mongodbatlas_search_index: Exposes `mappings_dynamic_config` and `type_sets`
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_indexes: Expose `mappings_dynamic_config` and `type_sets` per result.
+data-source/mongodbatlas_search_indexes: Exposes `mappings_dynamic_config` and `type_sets` per result
 ```

--- a/.changelog/3867.txt
+++ b/.changelog/3867.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+resource/mongodbatlas_search_index: Add `type_sets` field to support Atlas Search configurable dynamic type sets.
+```
+
+```release-note:enhancement
+resource/mongodbatlas_search_index: Add `mappings_dynamic_config` (mutually exclusive with `mappings_dynamic`) to support object form of `mappings.dynamic`.
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_search_index: Expose `mappings_dynamic_config` and `type_sets`.
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_search_indexes: Expose `mappings_dynamic_config` and `type_sets` per result.
+```

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -35,6 +35,7 @@ data "mongodbatlas_search_index" "test" {
 * `collection_name` - Name of the collection the index is on.
 * `database` - Name of the database the collection is in.
 * `mappings_dynamic` - Flag indicating whether the index uses dynamic or static mappings.
+* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)).
 * `mappings_fields` - Object containing one or more field specifications.
 * `search_analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when searching the index.
 * `synonyms` - 	Synonyms mapping definition to use in this index.
@@ -42,5 +43,8 @@ data "mongodbatlas_search_index" "test" {
 * `synonyms.#.source_collection` - Name of the source MongoDB collection for the synonyms.
 * `synonyms.#.analyzer` - Name of the [analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use with this synonym mapping. 
 * `stored_source` - String that can be "true" (store all fields), "false" (default, don't store any field), or a JSON string that contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see [Stored Source Fields](https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/).
+* `type_sets` - Set of type set definitions (when present). Each item includes:
+  * `name` - Type set name.
+  * `types` - JSON array string describing the types for the set.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -35,7 +35,7 @@ data "mongodbatlas_search_index" "test" {
 * `collection_name` - Name of the collection the index is on.
 * `database` - Name of the database the collection is in.
 * `mappings_dynamic` - Flag indicating whether the index uses dynamic or static mappings.
-* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)).
+* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)). Mutually exclusive with `mappings_dynamic`.
 * `mappings_fields` - Object containing one or more field specifications.
 * `search_analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when searching the index.
 * `synonyms` - 	Synonyms mapping definition to use in this index.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -41,6 +41,7 @@ data "mongodbatlas_search_indexes" "test" {
 * `collection_name` - (Required) Name of the collection the index is on.
 * `database` - (Required) Name of the database the collection is in.
 * `mappings_dynamic` - Flag indicating whether the index uses dynamic or static mappings.
+* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)).
 * `mappings_fields` - Object containing one or more field specifications.
 * `search_analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when searching the index.
 * `synonyms` - 	Synonyms mapping definition to use in this index.
@@ -48,5 +49,8 @@ data "mongodbatlas_search_indexes" "test" {
 * `synonyms.#.source_collection` - Name of the source MongoDB collection for the synonyms.
 * `synonyms.#.analyzer` - Name of the [analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use with this synonym mapping.
 * `stored_source` - String that can be "true" (store all fields), "false" (default, don't store any field), or a JSON string that contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see [Stored Source Fields](https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/).
+* `type_sets` - Set of type set definitions (when present). Each item includes:
+  * `name` - Type set name.
+  * `types` - JSON array string describing the types for the set.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -40,8 +40,8 @@ data "mongodbatlas_search_indexes" "test" {
 * `analyzers` - [Custom analyzers](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/custom/#std-label-custom-analyzers) to use in this index (this is an array of objects).
 * `collection_name` - (Required) Name of the collection the index is on.
 * `database` - (Required) Name of the database the collection is in.
-* `mappings_dynamic` - Flag indicating whether the index uses dynamic or static mappings.
-* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)).
+* `mappings_dynamic` - Flag indicating whether the index uses dynamic or static mappings. Mutually exclusive with `mappings_dynamic_config`.
+* `mappings_dynamic_config` - JSON object for `mappings.dynamic` when Atlas returns an object (Please see the documentation for [dynamic and static mappings](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#field-mapping-examples)). Mutually exclusive with `mappings_dynamic`.
 * `mappings_fields` - Object containing one or more field specifications.
 * `search_analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when searching the index.
 * `synonyms` - 	Synonyms mapping definition to use in this index.

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -217,7 +217,7 @@ EOF
     EOF
   ```
 
-* `mappings_dynamic_config` - (Optional) JSON object for `mappings.dynamic` when using configurable dynamic. Please note that this is mutually exclusive with `mappings_dynamic`, and should be use along with `type_sets`. See the MongoDB documentation for further information on [Static and Dynamic Mapping](https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings).
+* `mappings_dynamic_config` - (Optional) JSON object for `mappings.dynamic` when using configurable dynamic. Please note that this is mutually exclusive with `mappings_dynamic`. See the MongoDB documentation for further information on [Static and Dynamic Mapping](https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings).
 
 * `type_sets` - (Optional) One or more blocks defining configurable dynamic type sets. Atlas only persists/returns `typeSets` when `mappings.dynamic` is an object referencing a `typeSet` name.
   * `name` - (Required) Name of the type set.

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -217,7 +217,7 @@ EOF
     EOF
   ```
 
-* `mappings_dynamic_config` - (Optional) JSON object for `mappings.dynamic` when using configurable dynamic. Please note that this is mutually exclusive with `mappings_dynamic`. See the MongoDB documentation for further information on [Static and Dynamic Mapping](https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings).
+* `mappings_dynamic_config` - (Optional) JSON object for `mappings.dynamic` when using configurable dynamic. See the MongoDB documentation for further information on [Static and Dynamic Mapping](https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings). Mutually exclusive with `mappings_dynamic`.
 
 * `type_sets` - (Optional) One or more blocks defining configurable dynamic type sets. Atlas only persists/returns `typeSets` when `mappings.dynamic` is an object referencing a `typeSet` name.
   * `name` - (Required) Name of the type set.

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -179,7 +179,7 @@ EOF
 
 * `database` - (Required) Name of the database the collection is in.
 
-* `mappings_dynamic` - Indicates whether the search index uses dynamic or static mapping. For dynamic mapping, set the value to `true`. For static mapping, specify the fields to index using `mappings_fields`. Mutually exclusive with `mappings_dynamic_config`.
+* `mappings_dynamic` - Indicates whether the search index uses dynamic or static mapping. For default dynamic mapping, set the value to `true`. For static mapping, specify the fields to index using `mappings_fields`. Mutually exclusive with `mappings_dynamic_config`.
 
 * `mappings_fields` - attribute is required in search indexes when `mappings_dynamic` is false. This field needs to be a JSON string in order to be decoded correctly.
   ```terraform

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -113,6 +113,33 @@ EOF
 }
 ```
 
+### Configurable dynamic (typeSets + dynamic object)
+```terraform
+resource "mongodbatlas_search_index" "conf-dynamic" {
+  project_id      = "<PROJECT_ID>"
+  cluster_name    = "<CLUSTER_NAME>"
+  collection_name = "collection_test"
+  database        = "database_test"
+  name            = "conf-dynamic"
+  type            = "search"
+
+  # mappings.dynamic as an object referencing a type set
+  mappings_dynamic_config = <<-EOF
+  { "typeSet": "type_set_name" }
+  EOF
+
+  # Define the referenced type set
+  type_sets {
+    name  = "type_set_name"
+    types = <<-EOF
+    [
+      { "type": "string" }
+    ]
+    EOF
+  }
+}
+```
+
 ## Argument Reference
 
 * `type` - (Optional) Type of index: `search` or `vectorSearch`. Default type is `search`.
@@ -152,7 +179,7 @@ EOF
 
 * `database` - (Required) Name of the database the collection is in.
 
-* `mappings_dynamic` - Indicates whether the search index uses dynamic or static mapping. For dynamic mapping, set the value to `true`. For static mapping, specify the fields to index using `mappings_fields`
+* `mappings_dynamic` - Indicates whether the search index uses dynamic or static mapping. For dynamic mapping, set the value to `true`. For static mapping, specify the fields to index using `mappings_fields`. Mutually exclusive with `mappings_dynamic_config`.
 
 * `mappings_fields` - attribute is required in search indexes when `mappings_dynamic` is false. This field needs to be a JSON string in order to be decoded correctly.
   ```terraform
@@ -189,6 +216,12 @@ EOF
     }
     EOF
   ```
+
+* `mappings_dynamic_config` - (Optional) JSON object for `mappings.dynamic` when using configurable dynamic. Please note that this is mutually exclusive with `mappings_dynamic`, and should be use along with `type_sets`. See the MongoDB documentation for further information on [Static and Dynamic Mapping](https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#std-label-fts-field-mappings).
+
+* `type_sets` - (Optional) One or more blocks defining configurable dynamic type sets. Atlas only persists/returns `typeSets` when `mappings.dynamic` is an object referencing a `typeSet` name.
+  * `name` - (Required) Name of the type set.
+  * `types` - (Optional) JSON array describing the types.
 
 * `search_analyzer` - [Analyzer](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/#std-label-analyzers-ref) to use when searching the index. Defaults to [lucene.standard](https://docs.atlas.mongodb.com/reference/atlas-search/analyzers/standard/#std-label-ref-standard-analyzer)
 * `synonyms` - Synonyms mapping definition to use in this index.

--- a/internal/service/searchindex/data_source_search_index.go
+++ b/internal/service/searchindex/data_source_search_index.go
@@ -180,30 +180,8 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 	}
 
 	if searchIndex.LatestDefinition.Mappings != nil {
-		switch v := searchIndex.LatestDefinition.Mappings.GetDynamic().(type) {
-		case bool:
-			if err := d.Set("mappings_dynamic", v); err != nil {
-				return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
-			}
-		case map[string]any:
-			j, err := marshalSearchIndex(v)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			if err := d.Set("mappings_dynamic_config", j); err != nil {
-				return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
-			}
-		default:
-		}
-
-		if fields := searchIndex.LatestDefinition.Mappings.Fields; fields != nil && conversion.HasElementsSliceOrMap(*fields) {
-			searchIndexMappingFields, err := marshalSearchIndex(*fields)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			if err := d.Set("mappings_fields", searchIndexMappingFields); err != nil {
-				return diag.Errorf("error setting `mappings_fields` for for search index (%s): %s", d.Id(), err)
-			}
+		if diags := setMappingsAttributesFromDefinition(d, searchIndex.LatestDefinition.Mappings); diags != nil {
+			return diags
 		}
 	}
 

--- a/internal/service/searchindex/data_source_search_index.go
+++ b/internal/service/searchindex/data_source_search_index.go
@@ -58,6 +58,10 @@ func returnSearchIndexDSSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
+		"mappings_dynamic_config": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"mappings_fields": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -97,6 +101,22 @@ func returnSearchIndexDSSchema() map[string]*schema.Schema {
 		"stored_source": {
 			Type:     schema.TypeString,
 			Computed: true,
+		},
+		"type_sets": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"types": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -160,8 +180,20 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 	}
 
 	if searchIndex.LatestDefinition.Mappings != nil {
-		if err := d.Set("mappings_dynamic", searchIndex.LatestDefinition.Mappings.Dynamic); err != nil {
-			return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
+		switch v := searchIndex.LatestDefinition.Mappings.GetDynamic().(type) {
+		case bool:
+			if err := d.Set("mappings_dynamic", v); err != nil {
+				return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
+			}
+		case map[string]any:
+			j, err := marshalSearchIndex(v)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if err := d.Set("mappings_dynamic_config", j); err != nil {
+				return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
+			}
+		default:
 		}
 
 		if fields := searchIndex.LatestDefinition.Mappings.Fields; fields != nil && conversion.HasElementsSliceOrMap(*fields) {
@@ -183,6 +215,24 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 
 		if err := d.Set("fields", fieldsMarshaled); err != nil {
 			return diag.Errorf("error setting `fields` for for search index (%s): %s", d.Id(), err)
+		}
+	}
+
+	if typeSets := searchIndex.LatestDefinition.GetTypeSets(); len(typeSets) > 0 {
+		var flattened []map[string]any
+		for _, t := range typeSets {
+			entry := map[string]any{"name": t.Name}
+			if types := t.GetTypes(); len(types) > 0 {
+				j, err := marshalSearchIndex(types)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				entry["types"] = j
+			}
+			flattened = append(flattened, entry)
+		}
+		if err := d.Set("type_sets", flattened); err != nil {
+			return diag.Errorf("error setting `type_sets` for search index (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -62,16 +62,19 @@ func unmarshalSearchIndexMappingFields(str string) (map[string]any, diag.Diagnos
 	return fields, nil
 }
 
-func unmarshalSearchIndexFields(str string) ([]map[string]any, diag.Diagnostics) {
-	fields := []map[string]any{}
+func unmarshalJSONArrayForAttr(str, attr string) ([]map[string]any, diag.Diagnostics) {
+	arr := []map[string]any{}
 	if str == "" {
-		return fields, nil
+		return arr, nil
 	}
-	if err := json.Unmarshal([]byte(str), &fields); err != nil {
-		return nil, diag.Errorf("cannot unmarshal search index attribute `fields` because it has an incorrect format")
+	if err := json.Unmarshal([]byte(str), &arr); err != nil {
+		return nil, diag.Errorf("cannot unmarshal search index attribute `%s` because it has an incorrect format", attr)
 	}
+	return arr, nil
+}
 
-	return fields, nil
+func unmarshalSearchIndexFields(str string) ([]map[string]any, diag.Diagnostics) {
+	return unmarshalJSONArrayForAttr(str, "fields")
 }
 
 func UnmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyzer, diag.Diagnostics) {
@@ -103,7 +106,7 @@ func expandSearchIndexTypeSets(d *schema.ResourceData) ([]admin.SearchTypeSets, 
 		}
 
 		if s, ok := item["types"].(string); ok && s != "" {
-			arr, diags := unmarshalSearchIndexFields(s)
+			arr, diags := unmarshalJSONArrayForAttr(s, "type_sets.types")
 			if diags != nil {
 				return nil, diags
 			}

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -170,44 +168,11 @@ func canonicalizeJSONString(s string) string {
 	if err := json.Unmarshal([]byte(s), &v); err != nil {
 		return s
 	}
-	return canonicalizeJSONValue(v)
-}
-
-func canonicalizeJSONValue(v any) string {
-	switch t := v.(type) {
-	case map[string]any:
-		keys := make([]string, 0, len(t))
-		for k := range t {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		var b strings.Builder
-		b.WriteString("{")
-		for i, k := range keys {
-			if i > 0 {
-				b.WriteString(",")
-			}
-			b.WriteString(k)
-			b.WriteString(":")
-			b.WriteString(canonicalizeJSONValue(t[k]))
-		}
-		b.WriteString("}")
-		return b.String()
-	case []any:
-		var b strings.Builder
-		b.WriteString("[")
-		for i, el := range t {
-			if i > 0 {
-				b.WriteString(",")
-			}
-			b.WriteString(canonicalizeJSONValue(el))
-		}
-		b.WriteString("]")
-		return b.String()
-	default:
-		by, _ := json.Marshal(t)
-		return string(by)
+	by, err := json.Marshal(v)
+	if err != nil {
+		return s
 	}
+	return string(by)
 }
 
 func hashTypeSetElement(v interface{}) int {

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -209,3 +209,14 @@ func canonicalizeJSONValue(v any) string {
 		return string(by)
 	}
 }
+
+func hashTypeSetElement(v interface{}) int {
+	m := v.(map[string]interface{})
+	name := ""
+	if nv, ok := m["name"].(string); ok {
+		name = nv
+	}
+	typesStr, _ := m["types"].(string)
+	canon := canonicalizeJSONString(typesStr)
+	return schema.HashString(name + "|" + canon)
+}

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"

--- a/internal/service/searchindex/model_search_index.go
+++ b/internal/service/searchindex/model_search_index.go
@@ -85,6 +85,35 @@ func UnmarshalSearchIndexAnalyzersFields(str string) ([]admin.AtlasSearchAnalyze
 	return fields, nil
 }
 
+func expandSearchIndexTypeSets(d *schema.ResourceData) ([]admin.SearchTypeSets, diag.Diagnostics) {
+	var result []admin.SearchTypeSets
+
+	v, ok := d.GetOk("type_sets")
+	if !ok {
+		return result, nil
+	}
+
+	for _, raw := range v.(*schema.Set).List() {
+		item := raw.(map[string]any)
+
+		ts := admin.SearchTypeSets{
+			Name: item["name"].(string),
+		}
+
+		if s, ok := item["types"].(string); ok && s != "" {
+			arr, diags := unmarshalSearchIndexFields(s)
+			if diags != nil {
+				return nil, diags
+			}
+			ts.Types = conversion.ToAnySlicePointer(&arr)
+		}
+
+		result = append(result, ts)
+	}
+
+	return result, nil
+}
+
 func MarshalStoredSource(obj any) (string, error) {
 	if obj == nil {
 		return "", nil

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -169,9 +169,6 @@ func setMappingsAttributesFromDefinition(d *schema.ResourceData, mappings *admin
 		if err := d.Set("mappings_dynamic", v); err != nil {
 			return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
 		}
-		if err := d.Set("mappings_dynamic_config", ""); err != nil {
-			return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
-		}
 	case map[string]any:
 		j, err := marshalSearchIndex(v)
 		if err != nil {
@@ -179,9 +176,6 @@ func setMappingsAttributesFromDefinition(d *schema.ResourceData, mappings *admin
 		}
 		if err := d.Set("mappings_dynamic_config", j); err != nil {
 			return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
-		}
-		if err := d.Set("mappings_dynamic", nil); err != nil {
-			return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
 		}
 	default:
 		log.Printf("[DEBUG] search_index: unexpected mappings.dynamic type: %T", v)

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -141,16 +141,7 @@ func returnSearchIndexSchema() map[string]*schema.Schema {
 		"type_sets": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Set: func(v interface{}) int {
-				m := v.(map[string]interface{})
-				name := ""
-				if nv, ok := m["name"].(string); ok {
-					name = strings.ToLower(nv)
-				}
-				typesStr, _ := m["types"].(string)
-				canon := canonicalizeJSONString(typesStr)
-				return schema.HashString(name + "|" + canon)
-			},
+			Set:      hashTypeSetElement,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"name": {

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -414,7 +414,9 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			if err := d.Set("mappings_dynamic", v); err != nil {
 				return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
 			}
-			_ = d.Set("mappings_dynamic_config", "")
+			if err := d.Set("mappings_dynamic_config", ""); err != nil {
+				return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
+			}
 		case map[string]any:
 			j, err := marshalSearchIndex(v)
 			if err != nil {
@@ -423,8 +425,11 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			if err := d.Set("mappings_dynamic_config", j); err != nil {
 				return diag.Errorf("error setting `mappings_dynamic_config` for search index (%s): %s", d.Id(), err)
 			}
-			_ = d.Set("mappings_dynamic", nil)
+			if err := d.Set("mappings_dynamic", nil); err != nil {
+				return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
+			}
 		default:
+			log.Printf("[DEBUG] search_index: unexpected mappings.dynamic type: %T", v)
 		}
 
 		if fields := searchIndex.LatestDefinition.Mappings.Fields; fields != nil && conversion.HasElementsSliceOrMap(*fields) {

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -423,7 +423,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 			if err := d.Set("mappings_dynamic", v); err != nil {
 				return diag.Errorf("error setting `mappings_dynamic` for search index (%s): %s", d.Id(), err)
 			}
-		//	_ = d.Set("mappings_dynamic_config", "")
+			_ = d.Set("mappings_dynamic_config", "")
 		case map[string]any:
 			j, err := marshalSearchIndex(v)
 			if err != nil {

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -88,6 +88,10 @@ func TestAccSearchIndex_withTypeSets_ConfigurableDynamic(t *testing.T) {
 				Config: configWithTypeSets(projectID, clusterName, indexName, dynamicTypeSet, typeSetsJSONTwo),
 				Check:  resource.ComposeAggregateTestCheckFunc(checkExists(resourceName), checkTypeSetsConfigurableDynamic(typeSetsJSONTwo)),
 			},
+			{
+				Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, dynamicTypeSet),
+				Check:  resource.ComposeAggregateTestCheckFunc(checkExists(resourceName), checkTypeSetsOmittedConfigDynamic()),
+			},
 		},
 	})
 }
@@ -102,6 +106,15 @@ func checkTypeSetsConfigurableDynamic(typeSetsJSON string) resource.TestCheckFun
 		resource.TestCheckResourceAttr(datasourceName, "type_sets.#", "1"),
 		resource.TestCheckResourceAttr(datasourceName, "type_sets.0.name", "ts_acc"),
 		resource.TestCheckResourceAttrWith(datasourceName, "type_sets.0.types", acc.JSONEquals(typeSetsJSON)),
+	)
+}
+
+func checkTypeSetsOmittedConfigDynamic() resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrWith(resourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
+		resource.TestCheckResourceAttr(resourceName, "type_sets.#", "0"),
+		resource.TestCheckResourceAttrWith(datasourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
+		resource.TestCheckResourceAttr(datasourceName, "type_sets.#", "0"),
 	)
 }
 
@@ -688,4 +701,28 @@ func configWithTypeSets(projectID, clusterName, indexName, dynamicJSON, typeSets
             index_id         = mongodbatlas_search_index.test.index_id
         }
     `, clusterName, projectID, indexName, database, collection, dynamicJSON, typeSetsJSON)
+}
+
+func configWithTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) string {
+	return fmt.Sprintf(`
+        resource "mongodbatlas_search_index" "test" {
+            cluster_name     = %[1]q
+            project_id       = %[2]q
+            name             = %[3]q
+            database         = %[4]q
+            collection_name  = %[5]q
+
+            type = "search"
+
+            mappings_dynamic_config = <<-EOF
+            %[6]s
+            EOF
+        }
+
+        data "mongodbatlas_search_index" "data_index" {
+            cluster_name     = mongodbatlas_search_index.test.cluster_name
+            project_id       = mongodbatlas_search_index.test.project_id
+            index_id         = mongodbatlas_search_index.test.index_id
+        }
+    `, clusterName, projectID, indexName, database, collection, dynamicJSON)
 }

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -82,26 +82,27 @@ func TestAccSearchIndex_withTypeSets_ConfigurableDynamic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configWithTypeSets(projectID, clusterName, indexName, dynamicTypeSet, typeSetsJSONOne),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrWith(resourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
-					resource.TestCheckResourceAttr(resourceName, "type_sets.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "type_sets.0.name", "ts_acc"),
-					resource.TestCheckResourceAttrWith(resourceName, "type_sets.0.types", acc.JSONEquals(typeSetsJSONOne)),
-				),
+				Check:  resource.ComposeAggregateTestCheckFunc(checkExists(resourceName), checkTypeSetsConfigurableDynamic(typeSetsJSONOne)),
 			},
 			{
 				Config: configWithTypeSets(projectID, clusterName, indexName, dynamicTypeSet, typeSetsJSONTwo),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					checkExists(resourceName),
-					resource.TestCheckResourceAttrWith(resourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
-					resource.TestCheckResourceAttr(resourceName, "type_sets.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "type_sets.0.name", "ts_acc"),
-					resource.TestCheckResourceAttrWith(resourceName, "type_sets.0.types", acc.JSONEquals(typeSetsJSONTwo)),
-				),
+				Check:  resource.ComposeAggregateTestCheckFunc(checkExists(resourceName), checkTypeSetsConfigurableDynamic(typeSetsJSONTwo)),
 			},
 		},
 	})
+}
+
+func checkTypeSetsConfigurableDynamic(typeSetsJSON string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrWith(resourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
+		resource.TestCheckResourceAttr(resourceName, "type_sets.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "type_sets.0.name", "ts_acc"),
+		resource.TestCheckResourceAttrWith(resourceName, "type_sets.0.types", acc.JSONEquals(typeSetsJSON)),
+		resource.TestCheckResourceAttrWith(datasourceName, "mappings_dynamic_config", acc.JSONEquals(dynamicTypeSet)),
+		resource.TestCheckResourceAttr(datasourceName, "type_sets.#", "1"),
+		resource.TestCheckResourceAttr(datasourceName, "type_sets.0.name", "ts_acc"),
+		resource.TestCheckResourceAttrWith(datasourceName, "type_sets.0.types", acc.JSONEquals(typeSetsJSON)),
+	)
 }
 
 func TestAccSearchIndex_updatedToEmptySynonyms(t *testing.T) {


### PR DESCRIPTION
## Description

Add new fields to `mongodbatlas_searchindex` resource for dynamic index configuration:

- `mappings_dynamic_config`: Field added to model the object form of `mappings.dynamic` without breaking the existing boolean field. These fields are mutually exclusive and documentation has also been added to ensure that users are aware of this.
- `type_sets` field: Defines configurable dynamic type sets.

Link to any related issue(s): [CLOUDP-331577](https://jira.mongodb.org/browse/CLOUDP-331577)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [X] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [X] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
