### PR TITLE
chore: Adds provider_meta support to all data sources

### DIFF
--- a/internal/config/datasource_base.go
+++ b/internal/config/datasource_base.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ImplementedDataSource interface {
+	datasource.DataSourceWithConfigure
+	GetName() string
+	SetClient(*MongoDBClient)
+}
+
+func AnalyticsDataSourceFunc(iDataSource datasource.DataSource) func() datasource.DataSource {
+	commonDataSource, ok := iDataSource.(ImplementedDataSource)
+	if !ok {
+		panic(fmt.Sprintf("data source %T didn't comply with the ImplementedDataSource interface", iDataSource))
+	}
+	return func() datasource.DataSource {
+		return analyticsDataSource(commonDataSource)
+	}
+}
+
+// DSCommon is used as an embedded struct for all framework data sources. Implements the following plugin-framework defined functions:
+// - Metadata
+// - Configure
+// Client is left empty and populated by the framework when envoking Configure method.
+// DataSourceName must be defined when creating an instance of a data source.
+//
+// When used as a wrapper (ImplementedDataSource is set), it intercepts Read to add analytics tracking.
+// When embedded in a data source struct, the data source's own Read method is used.
+type DSCommon struct {
+	ImplementedDataSource // Set when used as a wrapper, nil when embedded
+	Client                *MongoDBClient
+	DataSourceName        string
+}
+
+func (d *DSCommon) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, d.DataSourceName)
+}
+
+func (d *DSCommon) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	if d.ImplementedDataSource != nil {
+		// When used as a wrapper, delegate to the wrapped data source
+		d.ImplementedDataSource.Schema(ctx, req, resp)
+	}
+	// When embedded, the data source's own Schema method is used
+}
+
+func (d *DSCommon) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, err := configureClient(req.ProviderData)
+	if err != nil {
+		resp.Diagnostics.AddError(errorConfigureSummary, err.Error())
+		return
+	}
+	d.Client = client
+	// If used as a wrapper, set the client on the wrapped data source
+	if d.ImplementedDataSource != nil {
+		d.ImplementedDataSource.SetClient(client)
+	}
+}
+
+// Read intercepts the Read operation when DSCommon is used as a wrapper to add analytics tracking.
+// When DSCommon is embedded, this method is not used (the data source's own Read method is called).
+func (d *DSCommon) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.ImplementedDataSource == nil {
+		// This shouldn't happen, but if DSCommon is embedded, the data source's Read is used instead
+		return
+	}
+	extra := asUserAgentExtraFromProviderMeta(ctx, d.DataSourceName, UserAgentOperationValueRead, true, req.ProviderMeta)
+	ctx = AddUserAgentExtra(ctx, extra)
+	d.ImplementedDataSource.Read(ctx, req, resp)
+}
+
+func (d *DSCommon) GetName() string {
+	return d.DataSourceName
+}
+
+func (d *DSCommon) SetClient(client *MongoDBClient) {
+	d.Client = client
+}
+
+func configureClient(providerData any) (*MongoDBClient, error) {
+	if providerData == nil {
+		return nil, nil
+	}
+
+	if client, ok := providerData.(*MongoDBClient); ok {
+		return client, nil
+	}
+
+	return nil, fmt.Errorf(errorConfigure, providerData)
+}
+
+// analyticsDataSource wraps an ImplementedDataSource with DSCommon to add analytics tracking.
+// We cannot return iDataSource directly because we need to intercept the Read operation
+// to inject provider_meta information into the context before calling the actual data source method.
+func analyticsDataSource(iDataSource ImplementedDataSource) datasource.DataSource {
+	return &DSCommon{
+		DataSourceName:        iDataSource.GetName(),
+		ImplementedDataSource: iDataSource,
+	}
+}
+
+// asUserAgentExtraFromProviderMeta extracts UserAgentExtra from provider_meta.
+// This is a shared function used by both resources and data sources.
+func asUserAgentExtraFromProviderMeta(ctx context.Context, name, reqOperation string, isDataSource bool, reqProviderMeta tfsdk.Config) UserAgentExtra {
+	var meta ProviderMeta
+	var nameValue string
+	if isDataSource {
+		nameValue = userAgentNameValueDataSource(name)
+	} else {
+		nameValue = userAgentNameValue(name)
+	}
+	uaExtra := UserAgentExtra{
+		Name:      nameValue,
+		Operation: reqOperation,
+	}
+	if reqProviderMeta.Raw.IsNull() {
+		return uaExtra
+	}
+	diags := reqProviderMeta.Get(ctx, &meta)
+	if diags.HasError() {
+		return uaExtra
+	}
+
+	extrasLen := len(meta.UserAgentExtra.Elements())
+	userExtras := make(map[string]types.String, extrasLen)
+	diags.Append(meta.UserAgentExtra.ElementsAs(ctx, &userExtras, false)...)
+	if diags.HasError() {
+		return uaExtra
+	}
+	userExtrasString := make(map[string]string, extrasLen)
+	for k, v := range userExtras {
+		userExtrasString[k] = v.ValueString()
+	}
+	return uaExtra.Combine(UserAgentExtra{
+		Extras:        userExtrasString,
+		ModuleName:    meta.ModuleName.ValueString(),
+		ModuleVersion: meta.ModuleVersion.ValueString(),
+	})
+}

--- a/internal/config/user_agent.go
+++ b/internal/config/user_agent.go
@@ -33,6 +33,9 @@ type UserAgentExtra struct {
 	ModuleVersion string
 }
 
+func userAgentNameValueDataSource(name string) string {
+	return "data." + userAgentNameValue(name)
+}
 func userAgentNameValue(name string) string {
 	return strings.TrimPrefix(name, "mongodbatlas_")
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -299,7 +299,11 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 		advancedcluster.DataSource,
 		advancedcluster.PluralDataSource,
 	}
-	return dataSources
+	analyticsDataSources := []func() datasource.DataSource{}
+	for _, dataSourceFunc := range dataSources {
+		analyticsDataSources = append(analyticsDataSources, config.AnalyticsDataSourceFunc(dataSourceFunc()))
+	}
+	return analyticsDataSources
 }
 
 func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resource {

--- a/internal/provider/provider_sdk2.go
+++ b/internal/provider/provider_sdk2.go
@@ -243,7 +243,11 @@ func getDataSourcesMap() map[string]*schema.Resource {
 		"mongodbatlas_shared_tier_snapshot":                                         sharedtier.DataSourceSnapshot(),
 		"mongodbatlas_shared_tier_snapshots":                                        sharedtier.PluralDataSourceSnapshot(),
 	}
-	return dataSourcesMap
+	analyticsMap := map[string]*schema.Resource{}
+	for name, dataSource := range dataSourcesMap {
+		analyticsMap[name] = config.NewAnalyticsResourceSDKv2(dataSource, name, true)
+	}
+	return analyticsMap
 }
 
 func getResourcesMap() map[string]*schema.Resource {
@@ -292,7 +296,7 @@ func getResourcesMap() map[string]*schema.Resource {
 	}
 	analyticsMap := map[string]*schema.Resource{}
 	for name, resource := range resourcesMap {
-		analyticsMap[name] = config.NewAnalyticsResourceSDKv2(resource, name)
+		analyticsMap[name] = config.NewAnalyticsResourceSDKv2(resource, name, false)
 	}
 	return analyticsMap
 }


### PR DESCRIPTION
## Description

Adds provider_meta support to all data sources (TPF and SDKv2) for module usage tracking via User-Agent headers. Follows the same pattern as resources (PR #3618).

- Created datasource_base.go for data source analytics in TPF
- Added SetClient() method pattern matching resources
- Shared asUserAgentExtraFromProviderMeta() between resources and data sources

Link to any related issue(s): CLOUDP-340210

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
