### PR TITLE
feat: Adds max tier size attribute to stream workspace resource and datasource

### DIFF
--- a/.changelog/3871.txt
+++ b/.changelog/3871.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+data-source/mongodbatlas_stream_workspace: Adds the `max_tier_size` attribute 
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_stream_workspaces: Adds the `max_tier_size` attribute 
+```
+
+```release-note:enhancement
+resource/mongodbatlas_stream_workspace: Adds the `max_tier_size` attribute 
+```

--- a/docs/resources/stream_workspace.md
+++ b/docs/resources/stream_workspace.md
@@ -59,7 +59,8 @@ resource "mongodbatlas_stream_workspace" "example" {
 
 ### Stream Config
 
-* `tier` - (Required) Selected tier for the Stream Instance. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/creategroupstreamworkspace) describes the valid values.
+* `max_tier_size` - (Optional) Max tier size for the Stream Workspace. Configures Memory / VCPU allowances.
+* `tier` - (Optional) Selected tier for the Stream Workspace. Configures Memory / VCPU allowances. The [MongoDB Atlas API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Streams/operation/creategroupstreamworkspace) describes the valid values.
 
 
 ## Attributes Reference

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -61,7 +61,7 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 	}
 	var streamConfig = types.ObjectNull(StreamConfigObjectType.AttrTypes)
 	apiStreamConfig := apiResp.StreamConfig
-	if apiStreamConfig != nil && (apiStreamConfig.Tier != nil || apiStreamConfig.MaxTierSize != nil) {
+	if apiStreamConfig != nil {
 		returnedStreamConfig, diagsStreamConfig := types.ObjectValueFrom(ctx, StreamConfigObjectType.AttrTypes, TFInstanceStreamConfigSpecModel{
 			MaxTierSize: types.StringPointerValue(apiStreamConfig.MaxTierSize),
 			Tier:        types.StringPointerValue(apiStreamConfig.Tier),

--- a/internal/service/streaminstance/model_stream_instance.go
+++ b/internal/service/streaminstance/model_stream_instance.go
@@ -61,9 +61,10 @@ func NewTFStreamInstance(ctx context.Context, apiResp *admin.StreamsTenant) (*TF
 	}
 	var streamConfig = types.ObjectNull(StreamConfigObjectType.AttrTypes)
 	apiStreamConfig := apiResp.StreamConfig
-	if apiStreamConfig != nil && apiStreamConfig.Tier != nil {
+	if apiStreamConfig != nil && (apiStreamConfig.Tier != nil || apiStreamConfig.MaxTierSize != nil) {
 		returnedStreamConfig, diagsStreamConfig := types.ObjectValueFrom(ctx, StreamConfigObjectType.AttrTypes, TFInstanceStreamConfigSpecModel{
-			Tier: types.StringPointerValue(apiStreamConfig.Tier),
+			MaxTierSize: types.StringPointerValue(apiStreamConfig.MaxTierSize),
+			Tier:        types.StringPointerValue(apiStreamConfig.Tier),
 		})
 		streamConfig = returnedStreamConfig
 		diags.Append(diagsStreamConfig...)

--- a/internal/service/streaminstance/model_stream_instance_test.go
+++ b/internal/service/streaminstance/model_stream_instance_test.go
@@ -278,8 +278,7 @@ func tfRegionObject(t *testing.T, cloudProvider, region string) types.Object {
 func tfStreamConfigObject(t *testing.T, tier string) types.Object {
 	t.Helper()
 	streamConfig, diags := types.ObjectValueFrom(t.Context(), streaminstance.StreamConfigObjectType.AttrTypes, streaminstance.TFInstanceStreamConfigSpecModel{
-		MaxTierSize: types.StringNull(), // Set to null for test cases that don't specify it
-		Tier:        types.StringValue(tier),
+		Tier: types.StringValue(tier),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data process region model: %s", diags.Errors()[0].Summary())

--- a/internal/service/streaminstance/model_stream_instance_test.go
+++ b/internal/service/streaminstance/model_stream_instance_test.go
@@ -278,7 +278,8 @@ func tfRegionObject(t *testing.T, cloudProvider, region string) types.Object {
 func tfStreamConfigObject(t *testing.T, tier string) types.Object {
 	t.Helper()
 	streamConfig, diags := types.ObjectValueFrom(t.Context(), streaminstance.StreamConfigObjectType.AttrTypes, streaminstance.TFInstanceStreamConfigSpecModel{
-		Tier: types.StringValue(tier),
+		MaxTierSize: types.StringNull(), // Set to null for test cases that don't specify it
+		Tier:        types.StringValue(tier),
 	})
 	if diags.HasError() {
 		t.Errorf("failed to create terraform data process region model: %s", diags.Errors()[0].Summary())

--- a/internal/service/streaminstance/resource_schema.go
+++ b/internal/service/streaminstance/resource_schema.go
@@ -50,6 +50,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional: true,
 				Computed: true,
 				Attributes: map[string]schema.Attribute{
+					"max_tier_size": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
 					"tier": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
@@ -75,7 +79,8 @@ type TFInstanceProcessRegionSpecModel struct {
 }
 
 type TFInstanceStreamConfigSpecModel struct {
-	Tier types.String `tfsdk:"tier"`
+	MaxTierSize types.String `tfsdk:"max_tier_size"`
+	Tier        types.String `tfsdk:"tier"`
 }
 
 var ProcessRegionObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
@@ -84,5 +89,6 @@ var ProcessRegionObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
 }}
 
 var StreamConfigObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
-	"tier": types.StringType,
+	"max_tier_size": types.StringType,
+	"tier":          types.StringType,
 }}

--- a/internal/service/streamworkspace/data_source_test.go
+++ b/internal/service/streamworkspace/data_source_test.go
@@ -29,7 +29,8 @@ func TestAccStreamsWorkspaceDS_basic(t *testing.T) {
 				Config: streamsWorkspaceDataSourceConfig(projectID, workspaceName, region, cloudProvider),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					streamsWorkspaceAttributeChecks(dataSourceName, workspaceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(dataSourceName, "stream_config.tier", "SP30"),
+					resource.TestCheckResourceAttr(dataSourceName, "stream_config.max_tier_size", "SP30"),
+					resource.TestCheckResourceAttr(dataSourceName, "stream_config.tier", "SP10"),
 				),
 			},
 		},

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -3,7 +3,9 @@ package streamworkspace
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streaminstance"
 	"go.mongodb.org/atlas-sdk/v20250312009/admin"
@@ -28,9 +30,23 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 		if diags := plan.StreamConfig.As(ctx, streamConfig, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}
+		var maxTierSize *string
+		if !streamConfig.MaxTierSize.IsNull() && !streamConfig.MaxTierSize.IsUnknown() {
+			value := streamConfig.MaxTierSize.ValueString()
+			if value != "" {
+				maxTierSize = &value
+			}
+		}
+		var tier *string
+		if !streamConfig.Tier.IsNull() && !streamConfig.Tier.IsUnknown() {
+			value := streamConfig.Tier.ValueString()
+			if value != "" {
+				tier = &value
+			}
+		}
 		streamTenant.StreamConfig = &admin.StreamConfig{
-			MaxTierSize: streamConfig.MaxTierSize.ValueStringPointer(),
-			Tier:        streamConfig.Tier.ValueStringPointer(),
+			MaxTierSize: maxTierSize,
+			Tier:        tier,
 		}
 	}
 	return streamTenant, nil
@@ -55,6 +71,26 @@ func (m *TFModel) FromInstanceModel(instanceModel *streaminstance.TFStreamInstan
 	m.WorkspaceName = instanceModel.InstanceName
 	m.ProjectID = instanceModel.ProjectID
 	m.DataProcessRegion = instanceModel.DataProcessRegion
-	m.StreamConfig = instanceModel.StreamConfig
+	if instanceModel.StreamConfig.IsNull() {
+		m.StreamConfig = types.ObjectNull(map[string]attr.Type{
+			"max_tier_size": types.StringType,
+			"tier":          types.StringType,
+		})
+	} else {
+		instanceStreamConfigAttrs := instanceModel.StreamConfig.Attributes()
+		tierValue := instanceStreamConfigAttrs["tier"]
+
+		workspaceStreamConfig, _ := types.ObjectValue(
+			map[string]attr.Type{
+				"max_tier_size": types.StringType,
+				"tier":          types.StringType,
+			},
+			map[string]attr.Value{
+				"max_tier_size": types.StringNull(),
+				"tier":          tierValue,
+			},
+		)
+		m.StreamConfig = workspaceStreamConfig
+	}
 	m.Hostnames = instanceModel.Hostnames
 }

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -29,7 +29,8 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 			return nil, diags
 		}
 		streamTenant.StreamConfig = &admin.StreamConfig{
-			Tier: streamConfig.Tier.ValueStringPointer(),
+			MaxTierSize: streamConfig.MaxTierSize.ValueStringPointer(),
+			Tier:        streamConfig.Tier.ValueStringPointer(),
 		}
 	}
 	return streamTenant, nil

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -32,17 +32,12 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 		}
 		var maxTierSize *string
 		if !streamConfig.MaxTierSize.IsNull() && !streamConfig.MaxTierSize.IsUnknown() {
-			value := streamConfig.MaxTierSize.ValueString()
-			if value != "" {
-				maxTierSize = &value
-			}
+			maxTierSize = streamConfig.MaxTierSize.ValueStringPointer()
 		}
+
 		var tier *string
 		if !streamConfig.Tier.IsNull() && !streamConfig.Tier.IsUnknown() {
-			value := streamConfig.Tier.ValueString()
-			if value != "" {
-				tier = &value
-			}
+			tier = streamConfig.Tier.ValueStringPointer()
 		}
 		streamTenant.StreamConfig = &admin.StreamConfig{
 			MaxTierSize: maxTierSize,

--- a/internal/service/streamworkspace/model.go
+++ b/internal/service/streamworkspace/model.go
@@ -31,12 +31,12 @@ func newStreamWorkspaceCreateReq(ctx context.Context, plan *TFModel) (*admin.Str
 			return nil, diags
 		}
 		var maxTierSize *string
-		if !streamConfig.MaxTierSize.IsNull() && !streamConfig.MaxTierSize.IsUnknown() {
+		if streamConfig.MaxTierSize.ValueString() != "" {
 			maxTierSize = streamConfig.MaxTierSize.ValueStringPointer()
 		}
 
 		var tier *string
-		if !streamConfig.Tier.IsNull() && !streamConfig.Tier.IsUnknown() {
+		if streamConfig.Tier.ValueString() != "" {
 			tier = streamConfig.Tier.ValueStringPointer()
 		}
 		streamTenant.StreamConfig = &admin.StreamConfig{

--- a/internal/service/streamworkspace/move_state.go
+++ b/internal/service/streamworkspace/move_state.go
@@ -108,9 +108,11 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 			tier := schemafunc.GetAttrFromStateObj[string](configObj, "tier")
 
 			objValue, diags := types.ObjectValue(map[string]attr.Type{
-				"tier": types.StringType,
+				"max_tier_size": types.StringType,
+				"tier":          types.StringType,
 			}, map[string]attr.Value{
-				"tier": types.StringPointerValue(tier),
+				"max_tier_size": types.StringNull(),
+				"tier":          types.StringPointerValue(tier),
 			})
 			if !diags.HasError() {
 				model.StreamConfig = objValue
@@ -119,7 +121,8 @@ func stateMover(ctx context.Context, req resource.MoveStateRequest, resp *resour
 	}
 	if model.StreamConfig.IsNull() {
 		model.StreamConfig = types.ObjectNull(map[string]attr.Type{
-			"tier": types.StringType,
+			"max_tier_size": types.StringType,
+			"tier":          types.StringType,
 		})
 	}
 

--- a/internal/service/streamworkspace/plural_data_source_test.go
+++ b/internal/service/streamworkspace/plural_data_source_test.go
@@ -22,6 +22,8 @@ func TestAccStreamsWorkspacesDS_basic(t *testing.T) {
 		resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_process_region.region"),
 		resource.TestCheckResourceAttrSet(dataSourceName, "results.0.data_process_region.cloud_provider"),
 		resource.TestCheckResourceAttrSet(dataSourceName, "results.0.hostnames.#"),
+		resource.TestCheckResourceAttr(dataSourceName, "results.0.stream_config.max_tier_size", "SP30"),
+		resource.TestCheckResourceAttr(dataSourceName, "results.0.stream_config.tier", "SP10"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -46,6 +46,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				Optional: true,
 				Computed: true,
 				Attributes: map[string]schema.Attribute{
+					"max_tier_size": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
 					"tier": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
@@ -71,5 +75,6 @@ type TFWorkspaceProcessRegionSpecModel struct {
 }
 
 type TFWorkspaceStreamConfigModel struct {
-	Tier types.String `tfsdk:"tier"`
+	MaxTierSize types.String `tfsdk:"max_tier_size"`
+	Tier        types.String `tfsdk:"tier"`
 }

--- a/internal/service/streamworkspace/resource_schema.go
+++ b/internal/service/streamworkspace/resource_schema.go
@@ -49,6 +49,9 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 					"max_tier_size": schema.StringAttribute{
 						Optional: true,
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"tier": schema.StringAttribute{
 						Optional: true,

--- a/internal/service/streamworkspace/resource_test.go
+++ b/internal/service/streamworkspace/resource_test.go
@@ -25,7 +25,8 @@ func TestAccStreamWorkspaceRS_basic(t *testing.T) {
 				Config: streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.max_tier_size", "SP30"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
 				),
 			},
 			{
@@ -50,10 +51,11 @@ func TestAccStreamWorkspaceRS_withStreamConfig(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyStreamInstance, // Reuse the same destroy check
 		Steps: []resource.TestStep{
 			{
-				Config: streamsWorkspaceConfigWithStreamConfig(projectID, workspaceName, region, cloudProvider),
+				Config: streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					streamsWorkspaceAttributeChecks(resourceName, workspaceName, region, cloudProvider),
-					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP30"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.max_tier_size", "SP30"),
+					resource.TestCheckResourceAttr(resourceName, "stream_config.tier", "SP10"),
 				),
 			},
 		},
@@ -109,21 +111,9 @@ func streamsWorkspaceConfig(projectID, workspaceName, region, cloudProvider stri
 				region = %[3]q
 				cloud_provider = %[4]q
 			}
-		}
-	`, projectID, workspaceName, region, cloudProvider)
-}
-
-func streamsWorkspaceConfigWithStreamConfig(projectID, workspaceName, region, cloudProvider string) string {
-	return fmt.Sprintf(`
-		resource "mongodbatlas_stream_workspace" "test" {
-			project_id = %[1]q
-			workspace_name = %[2]q
-			data_process_region = {
-				region = %[3]q
-				cloud_provider = %[4]q
-			}
 			stream_config = {
-				tier = "SP30"
+				max_tier_size = "SP30"
+				tier = "SP10"
 			}
 		}
 	`, projectID, workspaceName, region, cloudProvider)


### PR DESCRIPTION
## Description

 adds the `max_tier_size` attribute to the stream_workspace rs and ds as well as the stream_workspaces ds. Not implemented for stream_instance to encourage customers to move to a non-deprecated feature. Due to our conversion logic, there are currently maxTierSize references in the stream instance models but that is not populated for the deprecated stream_instance rs and ds. We have a follow-up to explore refactoring the mapping logic

Link to any related issue(s): CLOUDP-358363

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
