### PR TITLE
test: Moves resource_policy_api (autogen) tests to separate step with different org to avoid impacting other tests

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -306,7 +306,6 @@ jobs:
             - 'internal/serviceapi/orgserviceaccountapi/*.go'
             - 'internal/serviceapi/projectapi/*.go'
             - 'internal/serviceapi/projectsettingsapi/*.go'
-            - 'internal/serviceapi/resourcepolicyapi/*.go'
           autogen_slow:
             - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/clusterapi/*.go'
@@ -391,6 +390,7 @@ jobs:
             - 'internal/service/pushbasedlogexport/*.go'
           resource_policy:
             - 'internal/service/resourcepolicy/*.go'
+            - 'internal/serviceapi/resourcepolicyapi/*.go'
           search_deployment:
             - 'internal/service/searchdeployment/*.go'
           search_index:
@@ -655,7 +655,6 @@ jobs:
             ./internal/serviceapi/orgserviceaccountapi
             ./internal/serviceapi/projectapi
             ./internal/serviceapi/projectsettingsapi
-            ./internal/serviceapi/resourcepolicyapi
         run: make testacc
 
   autogen_slow:
@@ -1283,8 +1282,8 @@ jobs:
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
         with:
           terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false  
-      - name: Acceptance Tests
+          terraform_wrapper: false
+      - name: Acceptance Tests (Currated)
         env:
           MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
           MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
@@ -1294,6 +1293,20 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/resourcepolicy
         run: make testacc
+      - name: Enable autogen
+        run: make tools enable-autogen
+      - name: Acceptance Tests (Autogen)
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
+          MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
+          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/resourcepolicyapi
+        run: make testacc
+            
+            
   
   search_deployment:
     needs: [ change-detection, get-provider-version ]

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -625,6 +625,9 @@ jobs:
 
   autogen_fast:
     needs: [change-detection, get-provider-version]
+    # Avoids concurrent execution of resource policy tests to prevent race conditions on organization-level side effects of resource policies
+    concurrency:
+      group: ${{ github.repository }}-resource-policy-concurrency
     if: ${{ needs.change-detection.outputs.autogen_fast == 'true' || inputs.test_group == 'autogen' || inputs.test_group == 'autogen_fast' }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -1279,18 +1282,12 @@ jobs:
 
   resource_policy:
     needs: [ change-detection, get-provider-version ]
+    # Avoids concurrent execution of resource policy tests to prevent race conditions on organization-level side effects of resource policies
+    concurrency:
+      group: ${{ github.repository }}-resource-policy-concurrency
     if: ${{ needs.change-detection.outputs.resource_policy == 'true' || inputs.test_group == 'resource_policy' }}
     runs-on: ubuntu-latest
     permissions: {}
-    # Environment variables are set at job level and use dedicated resource policy credentials (mongodb_atlas_rp_*)
-    # instead of standard credentials due to organization-level side effects of resource policies
-    env:
-      MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
-      MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
-      MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
-      MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
-      MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
-      MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -1304,6 +1301,12 @@ jobs:
           terraform_wrapper: false
       - name: Acceptance Tests
         env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
+          MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
+          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/resourcepolicy
         run: make testacc
 

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -306,6 +306,7 @@ jobs:
             - 'internal/serviceapi/orgserviceaccountapi/*.go'
             - 'internal/serviceapi/projectapi/*.go'
             - 'internal/serviceapi/projectsettingsapi/*.go'
+            - 'internal/serviceapi/resourcepolicyapi/*.go'
           autogen_slow:
             - 'internal/common/autogen/*.go'
             - 'internal/serviceapi/clusterapi/*.go'
@@ -390,7 +391,6 @@ jobs:
             - 'internal/service/pushbasedlogexport/*.go'
           resource_policy:
             - 'internal/service/resourcepolicy/*.go'
-            - 'internal/serviceapi/resourcepolicyapi/*.go'
           search_deployment:
             - 'internal/service/searchdeployment/*.go'
           search_index:
@@ -655,6 +655,16 @@ jobs:
             ./internal/serviceapi/orgserviceaccountapi
             ./internal/serviceapi/projectapi
             ./internal/serviceapi/projectsettingsapi
+        run: make testacc
+      - name: Acceptance Tests (Resource Policy API)
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
+          MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
+          MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
+          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: ./internal/serviceapi/resourcepolicyapi
         run: make testacc
 
   autogen_slow:
@@ -1292,15 +1302,9 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
-      - name: Acceptance Tests (Curated)
+      - name: Acceptance Tests
         env:
           ACCTEST_PACKAGES: ./internal/service/resourcepolicy
-        run: make testacc
-      - name: Enable autogen
-        run: make tools enable-autogen
-      - name: Acceptance Tests (Autogen)
-        env:
-          ACCTEST_PACKAGES: ./internal/serviceapi/resourcepolicyapi
         run: make testacc
 
   search_deployment:

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -1272,6 +1272,15 @@ jobs:
     if: ${{ needs.change-detection.outputs.resource_policy == 'true' || inputs.test_group == 'resource_policy' }}
     runs-on: ubuntu-latest
     permissions: {}
+    # Environment variables are set at job level and use dedicated resource policy credentials (mongodb_atlas_rp_*)
+    # instead of standard credentials due to organization-level side effects of resource policies
+    env:
+      MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
+      MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
+      MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
+      MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
+      MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
+      MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
@@ -1285,24 +1294,12 @@ jobs:
           terraform_wrapper: false
       - name: Acceptance Tests (Currated)
         env:
-          MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
-          MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
-          MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
-          MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
-          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/service/resourcepolicy
         run: make testacc
       - name: Enable autogen
         run: make tools enable-autogen
       - name: Acceptance Tests (Autogen)
         env:
-          MONGODB_ATLAS_PUBLIC_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_public_key || '' }}
-          MONGODB_ATLAS_PRIVATE_KEY: ${{ inputs.use_sa != true && secrets.mongodb_atlas_rp_private_key || '' }}
-          MONGODB_ATLAS_CLIENT_ID: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_id || '' }}
-          MONGODB_ATLAS_CLIENT_SECRET: ${{ inputs.use_sa == true && secrets.mongodb_atlas_rp_client_secret || '' }}
-          MONGODB_ATLAS_ORG_ID: ${{ inputs.mongodb_atlas_rp_org_id }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: ./internal/serviceapi/resourcepolicyapi
         run: make testacc
             

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -1292,7 +1292,7 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
-      - name: Acceptance Tests (Currated)
+      - name: Acceptance Tests (Curated)
         env:
           ACCTEST_PACKAGES: ./internal/service/resourcepolicy
         run: make testacc
@@ -1302,9 +1302,7 @@ jobs:
         env:
           ACCTEST_PACKAGES: ./internal/serviceapi/resourcepolicyapi
         run: make testacc
-            
-            
-  
+
   search_deployment:
     needs: [ change-detection, get-provider-version ]
     if: ${{ needs.change-detection.outputs.search_deployment == 'true' || inputs.test_group == 'search_deployment' }}


### PR DESCRIPTION
## Description

Moves autogen group to the resource_policy  job to avoid impacting other tests

Fixes flaky tests in other groups by running autogen resource_policy tests in separate org

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
