### PR TITLE
test: Attempts fixing flaky TestAccProjectAPIKey_recreateWhenDeletedExternally

### DIFF
--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -187,7 +187,7 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 					if apiKeyID == "" {
 						t.Fatalf("API key ID not captured from previous step")
 					}
-					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
+					if _, err := acc.ConnV2().ProgrammaticAPIKeysApi.DeleteOrgApiKey(t.Context(), orgID, apiKeyID).Execute(); err != nil {
 						t.Fatalf("failed to manually delete API key resource: %s", err)
 					}
 					if err := waitForAPIKeyDeletionByID(orgID, apiKeyID, 2*time.Minute); err != nil {
@@ -249,21 +249,6 @@ func TestAccProjectAPIKey_invalidRole(t *testing.T) {
 			},
 		},
 	})
-}
-
-func deleteAPIKeyManually(orgID, descriptionPrefix string) error {
-	list, _, err := acc.ConnV2().ProgrammaticAPIKeysApi.ListOrgApiKeys(context.Background(), orgID).Execute()
-	if err != nil {
-		return err
-	}
-	for _, key := range list.GetResults() {
-		if strings.HasPrefix(key.GetDesc(), descriptionPrefix) {
-			if _, err := acc.ConnV2().ProgrammaticAPIKeysApi.DeleteOrgApiKey(context.Background(), orgID, key.GetId()).Execute(); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // waitForAPIKeyDeletionByID waits for API key deletion using GetOrgApiKey, the same method

--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -190,11 +190,9 @@ func TestAccProjectAPIKey_recreateWhenDeletedExternally(t *testing.T) {
 					if err := deleteAPIKeyManually(orgID, descriptionPrefix); err != nil {
 						t.Fatalf("failed to manually delete API key resource: %s", err)
 					}
-					if err := waitForAPIKeyDeletionByID(orgID, apiKeyID, 30*time.Second); err != nil {
+					if err := waitForAPIKeyDeletionByID(orgID, apiKeyID, 2*time.Minute); err != nil {
 						t.Fatalf("failed to verify API key deletion: %s", err)
 					}
-					// Additional delay to account for eventual consistency in Atlas API
-					time.Sleep(2 * time.Second)
 				},
 				Config:             config,
 				PlanOnly:           true,


### PR DESCRIPTION
## Description

The TestAccProjectAPIKey_recreateWhenDeletedExternally test was failing
intermittently (~60% failure rate) with "Expected a non-empty plan, but got
an empty refresh plan" error.
Use GetOrgApiKey for deletion verification to match provider Read operation,
fixing intermittent test failures caused by API eventual consistency.


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
