### PR TITLE
chore: Avoids accidental context.Background usage to support all analytics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
   settings:
     forbidigo:
       forbid:
-        - pattern: 'context\.Background\(\)'
+        - pattern: 'context\.Background'
           msg: 'Use of context.Background() is discouraged; use the ctx parameter instead to preserve analytics tracking'
     funlen:
       lines: 360
@@ -115,13 +115,7 @@ linters:
         text: "^hugeParam: req is heavy"
       - linters:
           - forbidigo
-        path: _test\.go$
-      - linters:
-          - forbidigo
-        path: tools/
-      - linters:
-          - forbidigo
-        path: internal/testutil/
+        path: '(_test\.go$|tools/|internal/(config|common|provider|testutil)/)'
       - path: schema\.go # exclude rules for schema files as it's auto-generated from OpenAPI spec
         text: var-naming|exceeds the maximum|regexpSimplify
       - path: (.+)\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - dogsled
     - errcheck
     - exhaustive
+    - forbidigo
     - funlen
     - gocritic
     - goprintffuncname
@@ -35,6 +36,10 @@ linters:
     - usestdlibvars
 
   settings:
+    forbidigo:
+      forbid:
+        - pattern: 'context\.Background\(\)'
+          msg: 'Use of context.Background() is discouraged; use the ctx parameter instead to preserve analytics tracking'
     funlen:
       lines: 360
       statements: 120
@@ -108,6 +113,15 @@ linters:
       - linters:
           - gocritic
         text: "^hugeParam: req is heavy"
+      - linters:
+          - forbidigo
+        path: _test\.go$
+      - linters:
+          - forbidigo
+        path: tools/
+      - linters:
+          - forbidigo
+        path: internal/testutil/
       - path: schema\.go # exclude rules for schema files as it's auto-generated from OpenAPI spec
         text: var-naming|exceeds the maximum|regexpSimplify
       - path: (.+)\.go$

--- a/internal/service/alertconfiguration/resource.go
+++ b/internal/service/alertconfiguration/resource.go
@@ -437,7 +437,7 @@ func (r *alertConfigurationRS) Read(ctx context.Context, req resource.ReadReques
 
 	ids := conversion.DecodeStateID(alertConfigState.ID.ValueString())
 
-	alert, getResp, err := connV2.AlertConfigurationsApi.GetAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID]).Execute()
+	alert, getResp, err := connV2.AlertConfigurationsApi.GetAlertConfig(ctx, ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID]).Execute()
 	if err != nil {
 		// deleted in the backend case
 		if validate.StatusNotFound(getResp) {
@@ -518,9 +518,9 @@ func (r *alertConfigurationRS) Update(ctx context.Context, req resource.UpdateRe
 		reflect.DeepEqual(apiReq, &admin.GroupAlertsConfig{Enabled: conversion.Pointer(false)}) {
 		// this code seems unreachable, as notifications are always being set
 		updatedAlertConfigResp, _, err = connV2.AlertConfigurationsApi.ToggleAlertConfig(
-			context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], &admin.AlertsToggle{Enabled: apiReq.Enabled}).Execute()
+			ctx, ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], &admin.AlertsToggle{Enabled: apiReq.Enabled}).Execute()
 	} else {
-		updatedAlertConfigResp, _, err = connV2.AlertConfigurationsApi.UpdateAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], apiReq).Execute()
+		updatedAlertConfigResp, _, err = connV2.AlertConfigurationsApi.UpdateAlertConfig(ctx, ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], apiReq).Execute()
 	}
 
 	if err != nil {

--- a/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/data_source_cloud_backup_schedule.go
@@ -257,7 +257,7 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	var copySettings []map[string]any
 	var err error
 
-	backupSchedule, _, err = connV2.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusterName).Execute()
+	backupSchedule, _, err = connV2.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		return diag.Errorf(errorSnapshotBackupScheduleRead, clusterName, err)
 	}

--- a/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
+++ b/internal/service/cloudbackupschedule/resource_cloud_backup_schedule.go
@@ -348,7 +348,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	var resp *http.Response
 	var err error
 
-	backupSchedule, resp, err = connV2.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusterName).Execute()
+	backupSchedule, resp, err = connV2.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusterName).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")
@@ -550,7 +550,7 @@ func cloudBackupScheduleCreateOrUpdate(ctx context.Context, connV2 *admin.APICli
 
 	req.Policies = getRequestPolicies(policiesItem, resp.GetPolicies())
 
-	_, _, err = connV2.CloudBackupsApi.UpdateBackupSchedule(context.Background(), projectID, clusterName, req).Execute()
+	_, _, err = connV2.CloudBackupsApi.UpdateBackupSchedule(ctx, projectID, clusterName, req).Execute()
 	if err != nil {
 		return err
 	}

--- a/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
+++ b/internal/service/cloudbackupsnapshotexportbucket/resource_cloud_backup_snapshot_export_bucket.go
@@ -239,7 +239,7 @@ func resourceRefresh(ctx context.Context, client *admin.APIClient, projectID, ex
 		clusters := clustersPaginated.GetResults()
 
 		for i := range clusters {
-			backupPolicy, _, err := client.CloudBackupsApi.GetBackupSchedule(context.Background(), projectID, clusters[i].GetName()).Execute()
+			backupPolicy, _, err := client.CloudBackupsApi.GetBackupSchedule(ctx, projectID, clusters[i].GetName()).Execute()
 			if err != nil {
 				continue
 			}

--- a/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup.go
+++ b/internal/service/cloudprovideraccess/resource_cloud_provider_access_setup.go
@@ -135,7 +135,7 @@ func resourceCloudProviderAccessSetupRead(ctx context.Context, d *schema.Resourc
 	projectID := ids["project_id"]
 	roleID := ids["id"]
 
-	role, resp, err := conn.CloudProviderAccessApi.GetCloudProviderAccess(context.Background(), projectID, roleID).Execute()
+	role, resp, err := conn.CloudProviderAccessApi.GetCloudProviderAccess(ctx, projectID, roleID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
+++ b/internal/service/customdnsconfigurationclusteraws/resource_custom_dns_configuration_cluster_aws.go
@@ -60,7 +60,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Id()
-	dnsResp, resp, err := connV2.AWSClustersDNSApi.GetAwsCustomDns(context.Background(), projectID).Execute()
+	dnsResp, resp, err := connV2.AWSClustersDNSApi.GetAwsCustomDns(ctx, projectID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/encryptionatrest/data_source.go
+++ b/internal/service/encryptionatrest/data_source.go
@@ -39,7 +39,7 @@ func (d *encryptionAtRestDS) Read(ctx context.Context, req datasource.ReadReques
 	connV2 := d.Client.AtlasV2
 	projectID := earConfig.ProjectID.ValueString()
 
-	encryptionResp, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
+	encryptionResp, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(ctx, projectID).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("error fetching resource", err.Error())
 		return

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -362,7 +362,7 @@ func (r *encryptionAtRestRS) Read(ctx context.Context, req resource.ReadRequest,
 
 	connV2 := r.Client.AtlasV2
 
-	encryptionResp, getResp, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
+	encryptionResp, getResp, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(ctx, projectID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(getResp) {
 			resp.State.RemoveResource(ctx)
@@ -408,7 +408,7 @@ func (r *encryptionAtRestRS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	projectID := encryptionAtRestState.ProjectID.ValueString()
-	atlasEncryptionAtRest, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
+	atlasEncryptionAtRest, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(ctx, projectID).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("error when getting encryption at rest resource during update", fmt.Sprintf(project.ErrorProjectRead, projectID, err.Error()))
 		return
@@ -441,7 +441,7 @@ func (r *encryptionAtRestRS) Delete(ctx context.Context, req resource.DeleteRequ
 	connV2 := r.Client.AtlasV2
 	projectID := encryptionAtRestState.ProjectID.ValueString()
 
-	_, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), projectID).Execute()
+	_, _, err := connV2.EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(ctx, projectID).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError("error when destroying resource", fmt.Sprintf(errorDeleteEncryptionAtRest, projectID, err.Error()))
 		return

--- a/internal/service/eventtrigger/data_source_event_triggers.go
+++ b/internal/service/eventtrigger/data_source_event_triggers.go
@@ -144,7 +144,7 @@ func PluralDataSource() *schema.Resource {
 }
 
 func dataSourceMongoDBAtlasEventTriggersRead(d *schema.ResourceData, meta any) error {
-	ctx := context.Background()
+	ctx := context.Background() //nolint:forbidigo // This SDKv2 data source doesn't use context-aware pattern (ReadContext)
 	conn, err := meta.(*config.MongoDBClient).Realm.Get(ctx)
 	if err != nil {
 		return err

--- a/internal/service/eventtrigger/resource_event_trigger.go
+++ b/internal/service/eventtrigger/resource_event_trigger.go
@@ -297,7 +297,7 @@ func resourceMongoDBAtlasEventTriggersCreate(ctx context.Context, d *schema.Reso
 
 	eventTriggerReq.Config = eventTriggerConfig
 
-	eventResp, _, err := conn.EventTriggers.Create(context.Background(), projectID, appID, eventTriggerReq)
+	eventResp, _, err := conn.EventTriggers.Create(ctx, projectID, appID, eventTriggerReq)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(errorEventTriggersCreate, projectID, err))
 	}

--- a/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider.go
+++ b/internal/service/federatedsettingsidentityprovider/resource_federated_settings_identity_provider.go
@@ -248,7 +248,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	federationSettingsID, idpID := DecodeIDs(d.Id())
 
-	existingIdentityProvider, _, err := connV2.FederatedAuthenticationApi.GetIdentityProvider(context.Background(), federationSettingsID, idpID).Execute()
+	existingIdentityProvider, _, err := connV2.FederatedAuthenticationApi.GetIdentityProvider(ctx, federationSettingsID, idpID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error retreiving federation settings identity provider (%s): %s", federationSettingsID, err))
 	}

--- a/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
+++ b/internal/service/federatedsettingsorgconfig/resource_federated_settings_connected_org.go
@@ -80,7 +80,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	federationSettingsID := ids["federation_settings_id"]
 	orgID := ids["org_id"]
 
-	federatedSettingsConnectedOrganization, resp, err := conn.FederatedAuthenticationApi.GetConnectedOrgConfig(context.Background(), federationSettingsID, orgID).Execute()
+	federatedSettingsConnectedOrganization, resp, err := conn.FederatedAuthenticationApi.GetConnectedOrgConfig(ctx, federationSettingsID, orgID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")
@@ -191,7 +191,7 @@ func resourceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 		return nil, err
 	}
 
-	_, _, err = conn.FederatedAuthenticationApi.GetConnectedOrgConfig(context.Background(), *federationSettingsID, *orgID).Execute()
+	_, _, err = conn.FederatedAuthenticationApi.GetConnectedOrgConfig(ctx, *federationSettingsID, *orgID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import Organization config (%s) in Federation settings (%s), error: %s", *orgID, *federationSettingsID, err)
 	}

--- a/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
+++ b/internal/service/federatedsettingsorgrolemapping/resource_federated_settings_org_role_mapping.go
@@ -79,7 +79,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	orgID := ids["org_id"]
 	roleMappingID := ids["role_mapping_id"]
 
-	federatedSettingsOrganizationRoleMapping, resp, err := conn.FederatedAuthenticationApi.GetRoleMapping(context.Background(), federationSettingsID, roleMappingID, orgID).Execute()
+	federatedSettingsOrganizationRoleMapping, resp, err := conn.FederatedAuthenticationApi.GetRoleMapping(ctx, federationSettingsID, roleMappingID, orgID).Execute()
 
 	if err != nil {
 		if validate.StatusNotFound(resp) {
@@ -157,7 +157,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	orgID := ids["org_id"]
 	roleMappingID := ids["role_mapping_id"]
 
-	federatedSettingsOrganizationRoleMappingUpdate, _, err := conn.FederatedAuthenticationApi.GetRoleMapping(context.Background(), federationSettingsID, roleMappingID, orgID).Execute()
+	federatedSettingsOrganizationRoleMappingUpdate, _, err := conn.FederatedAuthenticationApi.GetRoleMapping(ctx, federationSettingsID, roleMappingID, orgID).Execute()
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error retreiving federation settings connected organization (%s): %s", federationSettingsID, err))
 	}
@@ -201,7 +201,7 @@ func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) 
 		return nil, err
 	}
 
-	_, _, err = conn.FederatedAuthenticationApi.GetRoleMapping(context.Background(), *federationSettingsID, *roleMappingID, *orgID).Execute()
+	_, _, err = conn.FederatedAuthenticationApi.GetRoleMapping(ctx, *federationSettingsID, *roleMappingID, *orgID).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't import Role Mappings (%s) in Federation settings (%s), error: %s", *roleMappingID, *federationSettingsID, err)
 	}

--- a/internal/service/ldapconfiguration/resource_ldap_configuration.go
+++ b/internal/service/ldapconfiguration/resource_ldap_configuration.go
@@ -156,7 +156,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
-	resp, httpResp, err := connV2.LDAPConfigurationApi.GetUserSecurity(context.Background(), d.Id()).Execute()
+	resp, httpResp, err := connV2.LDAPConfigurationApi.GetUserSecurity(ctx, d.Id()).Execute()
 	if err != nil {
 		if validate.StatusNotFound(httpResp) {
 			d.SetId("")

--- a/internal/service/ldapverify/resource_ldap_verify.go
+++ b/internal/service/ldapverify/resource_ldap_verify.go
@@ -168,7 +168,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
 	requestID := ids["request_id"]
-	ldapResp, resp, err := connV2.LDAPConfigurationApi.GetUserSecurityVerify(context.Background(), projectID, requestID).Execute()
+	ldapResp, resp, err := connV2.LDAPConfigurationApi.GetUserSecurityVerify(ctx, projectID, requestID).Execute()
 	if err != nil || ldapResp == nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/maintenancewindow/resource_maintenance_window.go
+++ b/internal/service/maintenancewindow/resource_maintenance_window.go
@@ -162,7 +162,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	connV2 := meta.(*config.MongoDBClient).AtlasV2
 	projectID := d.Id()
 
-	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(context.Background(), projectID).Execute()
+	maintenanceWindow, resp, err := connV2.MaintenanceWindowsApi.GetMaintenanceWindow(ctx, projectID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/onlinearchive/resource.go
+++ b/internal/service/onlinearchive/resource.go
@@ -308,7 +308,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	projectID := ids["project_id"]
 	clusterName := ids["cluster_name"]
 
-	onlineArchive, resp, err := connV2.OnlineArchiveApi.GetOnlineArchive(context.Background(), projectID, archiveID, clusterName).Execute()
+	onlineArchive, resp, err := connV2.OnlineArchiveApi.GetOnlineArchive(ctx, projectID, archiveID, clusterName).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/privatelinkendpoint/resource.go
+++ b/internal/service/privatelinkendpoint/resource.go
@@ -171,7 +171,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	providerName := ids["provider_name"]
 	region := ids["region"]
 
-	privateEndpoint, resp, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpointService(context.Background(), projectID, providerName, privateLinkID).Execute()
+	privateEndpoint, resp, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpointService(ctx, projectID, providerName, privateLinkID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -234,7 +234,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	endpointServiceID := ids["endpoint_service_id"]
 	providerName := ids["provider_name"]
 
-	privateEndpoint, resp, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpoint(context.Background(), projectID, providerName, endpointServiceID, privateLinkID).Execute()
+	privateEndpoint, resp, err := connV2.PrivateEndpointServicesApi.GetPrivateEndpoint(ctx, projectID, providerName, endpointServiceID, privateLinkID).Execute()
 	if err != nil {
 		if validate.StatusNotFound(resp) {
 			d.SetId("")

--- a/internal/service/team/resource_team.go
+++ b/internal/service/team/resource_team.go
@@ -99,7 +99,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 	orgID := ids["org_id"]
 	teamID := ids["id"]
 
-	team, resp, err := connV2.TeamsApi.GetTeamById(context.Background(), orgID, teamID).Execute()
+	team, resp, err := connV2.TeamsApi.GetTeamById(ctx, orgID, teamID).Execute()
 
 	if err != nil {
 		if validate.StatusNotFound(resp) {
@@ -159,7 +159,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 		newUsernames := conversion.ExpandStringList(d.Get("usernames").(*schema.Set).List())
 
-		err = UpdateTeamUsers(connV2.TeamsApi, connV2.MongoDBCloudUsersApi, existingUsers, newUsernames, orgID, teamID)
+		err = UpdateTeamUsers(ctx, connV2.TeamsApi, connV2.MongoDBCloudUsersApi, existingUsers, newUsernames, orgID, teamID)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error when updating usernames in team: %s", err))
 		}

--- a/internal/service/team/update_user.go
+++ b/internal/service/team/update_user.go
@@ -6,8 +6,8 @@ import (
 	admin20241113 "go.mongodb.org/atlas-sdk/v20241113005/admin"
 )
 
-func UpdateTeamUsers(teamsAPI admin20241113.TeamsApi, usersAPI admin20241113.MongoDBCloudUsersApi, existingTeamUsers []admin20241113.CloudAppUser, newUsernames []string, orgID, teamID string) error {
-	validNewUsers, err := ValidateUsernames(usersAPI, newUsernames)
+func UpdateTeamUsers(ctx context.Context, teamsAPI admin20241113.TeamsApi, usersAPI admin20241113.MongoDBCloudUsersApi, existingTeamUsers []admin20241113.CloudAppUser, newUsernames []string, orgID, teamID string) error {
+	validNewUsers, err := ValidateUsernames(ctx, usersAPI, newUsernames)
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,7 @@ func UpdateTeamUsers(teamsAPI admin20241113.TeamsApi, usersAPI admin20241113.Mon
 	}
 	// save all users to add
 	if len(userToAddModels) > 0 {
-		_, _, err = teamsAPI.AddTeamUser(context.Background(), orgID, teamID, &userToAddModels).Execute()
+		_, _, err = teamsAPI.AddTeamUser(ctx, orgID, teamID, &userToAddModels).Execute()
 		if err != nil {
 			return err
 		}
@@ -32,7 +32,7 @@ func UpdateTeamUsers(teamsAPI admin20241113.TeamsApi, usersAPI admin20241113.Mon
 
 	for i := range usersToRemove {
 		// remove user from team
-		_, err := teamsAPI.RemoveTeamUser(context.Background(), orgID, teamID, usersToRemove[i]).Execute()
+		_, err := teamsAPI.RemoveTeamUser(ctx, orgID, teamID, usersToRemove[i]).Execute()
 		if err != nil {
 			return err
 		}
@@ -41,10 +41,10 @@ func UpdateTeamUsers(teamsAPI admin20241113.TeamsApi, usersAPI admin20241113.Mon
 	return nil
 }
 
-func ValidateUsernames(c admin20241113.MongoDBCloudUsersApi, usernames []string) ([]admin20241113.CloudAppUser, error) {
+func ValidateUsernames(ctx context.Context, c admin20241113.MongoDBCloudUsersApi, usernames []string) ([]admin20241113.CloudAppUser, error) {
 	var validUsers []admin20241113.CloudAppUser
 	for _, elem := range usernames {
-		userToAdd, _, err := c.GetUserByUsername(context.Background(), elem).Execute()
+		userToAdd, _, err := c.GetUserByUsername(ctx, elem).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/team/update_user_test.go
+++ b/internal/service/team/update_user_test.go
@@ -155,7 +155,7 @@ func TestUpdateTeamUsers(t *testing.T) {
 			mockTeamsAPI := mockadmin20241113.NewTeamsApi(t)
 			mockUsersAPI := mockadmin20241113.NewMongoDBCloudUsersApi(t)
 			testCase.mockFuncExpectations(mockTeamsAPI, mockUsersAPI)
-			testCase.expectError(t, team.UpdateTeamUsers(mockTeamsAPI, mockUsersAPI, testCase.existingTeamUsers.GetResults(), testCase.usernames, "orgID", "teamID"))
+			testCase.expectError(t, team.UpdateTeamUsers(t.Context(), mockTeamsAPI, mockUsersAPI, testCase.existingTeamUsers.GetResults(), testCase.usernames, "orgID", "teamID"))
 		})
 	}
 }


### PR DESCRIPTION
## Description

Adds forbidigo linter to golangci configuration to  discourage the use of context.Background() in favor of using the ctx parameter for better analytics tracking.

Link to any related issue(s): CLOUDP-359723

## Example errors:
- See also [job](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/19428698601/job/55582135065?pr=3888) after introducing the linter

```go
internal/service/alertconfiguration/resource.go:440:25: use of `connV2.AlertConfigurationsApi.GetAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID]).Execute` forbidden because "Use of context.Background() is discouraged; use the ctx parameter instead to preserve analytics tracking" (forbidigo)
        alert, getResp, err := connV2.AlertConfigurationsApi.GetAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID]).Execute()
                               ^
internal/service/alertconfiguration/resource.go:520:36: use of `connV2.AlertConfigurationsApi.ToggleAlertConfig(
        context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], &admin.AlertsToggle{Enabled: apiReq.Enabled}).Execute` forbidden because "Use of context.Background() is discouraged; use the ctx parameter instead to preserve analytics tracking" (forbidigo)
                updatedAlertConfigResp, _, err = connV2.AlertConfigurationsApi.ToggleAlertConfig(
                                                 ^
internal/service/alertconfiguration/resource.go:523:36: use of `connV2.AlertConfigurationsApi.UpdateAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], apiReq).Execute` forbidden because "Use of context.Background() is discouraged; use the ctx parameter instead to preserve analytics tracking" (forbidigo)
                updatedAlertConfigResp, _, err = connV2.AlertConfigurationsApi.UpdateAlertConfig(context.Background(), ids[EncodedIDKeyProjectID], ids[EncodedIDKeyAlertID], apiReq).Execute()
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
