### PR TITLE
chore: Adding acceptance tests for autogenerated search index resource

### DIFF
--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -423,6 +423,7 @@ func checkWithMapping(projectID, indexName, clusterName string) resource.TestChe
 	return checkAggr(projectID, clusterName, indexName, indexType, mappingsDynamic, checks...)
 }
 
+// Note: configWithSynonyms requires a synonyms source collection to be setup in the database (not being done in the test), current configuration returns successful creation but eventually reaches an error state.
 func configWithSynonyms(projectID, indexName, clusterName string, has bool) string {
 	var synonymsStr string
 	if has {

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -43,24 +43,6 @@ func TestAccSearchIndexAPI_basic(t *testing.T) {
 	})
 }
 
-func TestAccSearchIndexAPI_withMappingAndAnalyzer(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName, true),
-				Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName, true),
-			},
-		},
-	})
-}
-
 func TestAccSearchIndexAPI_withSynonymsUpdatedToEmpty(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
@@ -77,15 +59,11 @@ func TestAccSearchIndexAPI_withSynonymsUpdatedToEmpty(t *testing.T) {
 				Config: configWithSynonyms(projectID, clusterName, indexName, true),
 				Check:  checkWithSynonyms(projectID, clusterName, indexName, true),
 			},
-			// {
-			// 	Config: configWithSynonyms(projectID, clusterName, indexName, false),
-			// 	Check:  checkWithSynonyms(projectID, clusterName, indexName, false),
-			// },
 		},
 	})
 }
 
-func TestAccSearchIndexAPI_updatedToEmptyAnalyzers(t *testing.T) {
+func TestAccSearchIndexAPI_MappingWithAnalyzersUpdatedToEmptyAnalyzers(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
 		indexName              = acc.RandomName()
@@ -96,10 +74,10 @@ func TestAccSearchIndexAPI_updatedToEmptyAnalyzers(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName, true),
-				Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName, true),
+				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
+				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) types
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
 			// {
 			// 	Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
 			// 	Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
@@ -108,7 +86,75 @@ func TestAccSearchIndexAPI_updatedToEmptyAnalyzers(t *testing.T) {
 	})
 }
 
-func TestAccSearchIndexAPI_withStoredSourceFalse(t *testing.T) {
+func TestAccSearchIndexAPI_MappingsUpdatedToEmptyMapping(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
+				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
+			},
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
+			// {
+			// 	Config: configBasic(projectID, clusterName, indexName),
+			// 	Check:  checkBasic(projectID, clusterName, indexName),
+			// },
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withTypeSets_ConfigurableDynamic(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`}),
+				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 1),
+			},
+			{
+				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`, `{"type":"number"}`}),
+				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 2),
+			},
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
+			// {
+			// 	Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
+			// 	Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
+			// },
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withVector(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configVector(projectID, clusterName, indexName),
+				Check:  checkVector(projectID, clusterName, indexName),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceBool(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
 		indexName              = acc.RandomName()
@@ -122,21 +168,8 @@ func TestAccSearchIndexAPI_withStoredSourceFalse(t *testing.T) {
 				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
 				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
 			},
-		},
-	})
-}
-
-func TestAccSearchIndexAPI_withStoredSourceTrue(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
 			{
+				// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
 				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
 				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
 			},
@@ -157,24 +190,6 @@ func TestAccSearchIndexAPI_withStoredSourceInclude(t *testing.T) {
 			{
 				Config: configWithStoredSourceJSON(projectID, clusterName, indexName, `{"include":["include1","include2"]}`),
 				Check:  checkStoredSourceJSON(projectID, clusterName, indexName, `{"include":["include1","include2"]}`),
-			},
-		},
-	})
-}
-
-func TestAccSearchIndexAPI_withStoredSourceExclude(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithStoredSourceJSON(projectID, clusterName, indexName, `{"exclude":["exclude1","exclude2"]}`),
-				Check:  checkStoredSourceJSON(projectID, clusterName, indexName, `{"exclude":["exclude1","exclude2"]}`),
 			},
 		},
 	})
@@ -224,50 +239,6 @@ func TestAccSearchIndexAPI_withStoredSourceUpdateSearchType(t *testing.T) {
 	})
 }
 
-func TestAccSearchIndexAPI_withVector(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configVector(projectID, clusterName, indexName),
-				Check:  checkVector(projectID, clusterName, indexName),
-			},
-		},
-	})
-}
-
-func TestAccSearchIndexAPI_withTypeSets_ConfigurableDynamic(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`}),
-				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 1),
-			},
-			{
-				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`, `{"type":"number"}`}),
-				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 2),
-			},
-			{
-				Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
-				Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
-			},
-		},
-	})
-}
-
 func configBasic(projectID, clusterName, indexName string) string {
 	return fmt.Sprintf(`
 		resource "mongodbatlas_search_index_api" "test" {
@@ -286,7 +257,7 @@ func configBasic(projectID, clusterName, indexName string) string {
 	`, projectID, clusterName, indexName, database, collection)
 }
 
-func configWithMappingAndAnalyzer(projectID, clusterName, indexName string, includeAnalyzers bool) string {
+func configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName string, includeAnalyzers bool) string {
 	var analyzers string
 	if includeAnalyzers {
 		analyzers = `
@@ -377,7 +348,7 @@ func checkBasic(projectID, clusterName, indexName string) resource.TestCheckFunc
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func checkWithMappingAndAnalyzer(projectID, clusterName, indexName string, expectAnalyzers bool) resource.TestCheckFunc {
+func checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName string, expectAnalyzers bool) resource.TestCheckFunc {
 	checks := []resource.TestCheckFunc{
 		checkBasic(projectID, clusterName, indexName),
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.mappings.dynamic", "false"),
@@ -585,29 +556,6 @@ func configWithTypeSets(projectID, clusterName, indexName, dynamicJSON string, t
 	`, projectID, clusterName, indexName, database, collection, dynamicJSON, typesStr)
 }
 
-func configWithTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) string {
-	return fmt.Sprintf(`
-		resource "mongodbatlas_search_index_api" "test" {
-			group_id        = %[1]q
-			cluster_name    = %[2]q
-			name            = %[3]q
-			database        = %[4]q
-			collection_name = %[5]q
-			type            = "search"
-
-			definition = {
-				mappings = {
-					dynamic = jsonencode(%[6]s)
-				}
-			}
-		}
-	`, projectID, clusterName, indexName, database, collection, dynamicJSON)
-}
-
-// ---------------------------
-// Check helpers
-// ---------------------------
-
 func checkAttrs(projectID, clusterName, indexName string) resource.TestCheckFunc {
 	attributes := map[string]string{
 		"group_id":        projectID,
@@ -676,13 +624,5 @@ func checkTypeSets(projectID, clusterName, indexName, dynamicJSON string, typeCo
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "1"),
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.name", "ts_acc"),
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.types.#", fmt.Sprintf("%d", typeCount)),
-	)
-}
-
-func checkTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		checkAttrs(projectID, clusterName, indexName),
-		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.mappings.dynamic", acc.JSONEquals(dynamicJSON)),
-		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "0"),
 	)
 }

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -43,7 +43,7 @@ func TestAccSearchIndexAPI_basic(t *testing.T) {
 	})
 }
 
-func TestAccSearchIndexAPI_withMappingsFields(t *testing.T) {
+func TestAccSearchIndexAPI_withMappingAndAnalyzer(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
 		indexName              = acc.RandomName()
@@ -54,14 +54,215 @@ func TestAccSearchIndexAPI_withMappingsFields(t *testing.T) {
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: configWithMappingsFields(projectID, clusterName, indexName, true),
-				Check:  checkWithMappingsFields(projectID, clusterName, indexName, true),
+				Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName),
+				Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName),
 			},
-			// TODO: revise update behavior as part of CLOUDP-352324
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withSynonymsUpdatedToEmpty(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			// configWithSynonyms requires a source collection to be setup in the database, creation reachs READY but does have an error.
+			// Any follow up steps fail with an error unexpected state 'FAILED', wanted target 'READY, STEADY'.
+			{
+				Config: configWithSynonyms(projectID, clusterName, indexName, true),
+				Check:  checkWithSynonyms(projectID, clusterName, indexName, true),
+			},
 			// {
-			// 	Config: configWithMappingsFields(projectID, clusterName, indexName, false),
-			// 	Check:  checkWithMappingsFields(projectID, clusterName, indexName, false),
-			// },
+			// 	Config: configWithSynonyms(projectID, clusterName, indexName, false),
+			// 	Check:  checkWithSynonyms(projectID, clusterName, indexName, false),
+			// },	
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_updatedToEmptyAnalyzers(t *testing.T) {
+	// var (
+	// 	projectID, clusterName = acc.ClusterNameExecution(t, true)
+	// 	indexName              = acc.RandomName()
+	// )
+	// resource.ParallelTest(t, resource.TestCase{
+	// 	PreCheck:                 func() { acc.PreCheckBasic(t) },
+	// 	ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+	// 	CheckDestroy:             checkDestroy,
+	// 	// Steps: []resource.TestStep{
+	// 	// 	{
+	// 	// 		Config: configWithAnalyzers(projectID, clusterName, indexName),
+	// 	// 		Check:  checkWithAnalyzers(projectID, clusterName, indexName, true),
+	// 	// 	},
+	// 	// 	{
+	// 	// 		Config: configBasic(projectID, clusterName, indexName),
+	// 	// 		Check:  checkWithAnalyzers(projectID, clusterName, indexName, false),
+	// 	// 	},
+	// 	// },
+	// })
+}
+
+func TestAccSearchIndexAPI_withStoredSourceFalse(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceTrue(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceInclude(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceJSON(projectID, clusterName, indexName, `{"include":["include1","include2"]}`),
+				Check:  checkStoredSourceJSON(projectID, clusterName, indexName, `{"include":["include1","include2"]}`),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceExclude(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceJSON(projectID, clusterName, indexName, `{"exclude":["exclude1","exclude2"]}`),
+				Check:  checkStoredSourceJSON(projectID, clusterName, indexName, `{"exclude":["exclude1","exclude2"]}`),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceUpdateEmptyType(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
+			},
+			{
+				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withStoredSourceUpdateSearchType(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithStoredSourceBoolAndType(projectID, clusterName, indexName, "search", false),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
+			},
+			{
+				Config: configWithStoredSourceBoolAndType(projectID, clusterName, indexName, "search", true),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withVector(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configVector(projectID, clusterName, indexName),
+				Check:  checkVector(projectID, clusterName, indexName),
+			},
+		},
+	})
+}
+
+func TestAccSearchIndexAPI_withTypeSets_ConfigurableDynamic(t *testing.T) {
+	var (
+		projectID, clusterName = acc.ClusterNameExecution(t, true)
+		indexName              = acc.RandomName()
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`}),
+				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 1),
+			},
+			{
+				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`, `{"type":"number"}`}),
+				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 2),
+			},
+			{
+				Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
+				Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
+			},
 		},
 	})
 }
@@ -84,41 +285,7 @@ func configBasic(projectID, clusterName, indexName string) string {
 	`, projectID, clusterName, indexName, database, collection)
 }
 
-func configWithMappingsFields(projectID, clusterName, indexName string, with bool) string {
-	var fields string
-	if with {
-		fields = `
-                fields = {
-                    address = jsonencode({
-                        type = "document"
-                        fields = {
-                            city = {
-                                type = "string"
-                                analyzer = "lucene.simple"
-                                ignoreAbove = 255
-                            }
-                            state = {
-                                type = "string"
-                                analyzer = "lucene.english"
-                            }
-                        }
-                    })
-                    company = jsonencode({
-                        type = "string"
-                        analyzer = "lucene.whitespace"
-                        multi = {
-                            mySecondaryAnalyzer = {
-                                type = "string"
-                                analyzer = "lucene.french"
-                            }
-                        }
-                    })
-                    employees = jsonencode({
-                        type = "string"
-                        analyzer = "lucene.standard"
-                    })
-                }`
-	}
+func configWithMappingAndAnalyzer(projectID, clusterName, indexName string) string {
 	return fmt.Sprintf(`
         resource "mongodbatlas_search_index_api" "test" {
             group_id        = %[1]q
@@ -129,22 +296,72 @@ func configWithMappingsFields(projectID, clusterName, indexName string, with boo
 
             definition = {
                 mappings = {
-                    dynamic = jsonencode(true)
-                    %[6]s
+                    dynamic = jsonencode(false)
+                    fields = {
+						address = jsonencode({
+							type = "document"
+							fields = {
+								city = {
+									type = "string"
+									analyzer = "lucene.simple"
+									ignoreAbove = 255
+								}
+								state = {
+									type = "string"
+									analyzer = "lucene.english"
+								}
+							}
+						})
+						company = jsonencode({
+							type = "string"
+							analyzer = "lucene.whitespace"
+							multi = {
+								mySecondaryAnalyzer = {
+									type = "string"
+									analyzer = "lucene.french"
+								}
+							}
+						})
+						employees = jsonencode({
+							type = "string"
+							analyzer = "lucene.standard"
+						})
+                	}
                 }
+				analyzer = "index_analyzer_test_name"
+				analyzers = [{
+					name = "index_analyzer_test_name"
+					char_filters = [
+						jsonencode({
+							type     = "mapping"
+							mappings = {"\\\\"="/"}
+						})
+					]
+					tokenizer = {
+						type   = jsonencode("nGram")
+						minGram = 2
+						maxGram = 5
+					}
+					token_filters = [
+						jsonencode({
+							type = "length"
+							min  = 20
+							max  = 33
+						})
+					]
+				}]
             }
         }
-    `, projectID, clusterName, indexName, database, collection, fields)
+    `, projectID, clusterName, indexName, database, collection)
 }
 
 func checkBasic(projectID, clusterName, indexName string) resource.TestCheckFunc {
 	attributes := map[string]string{
-		"group_id":                           projectID,
-		"cluster_name":                       clusterName,
-		"name":                               indexName,
-		"database":                           database,
-		"collection_name":                    collection,
-		"latest_definition.mappings.dynamic": "true",
+		"group_id":        projectID,
+		"cluster_name":    clusterName,
+		"name":            indexName,
+		"database":        database,
+		"collection_name": collection,
 	}
 	checks := []resource.TestCheckFunc{
 		checkExists(resourceName),
@@ -154,14 +371,13 @@ func checkBasic(projectID, clusterName, indexName string) resource.TestCheckFunc
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func checkWithMappingsFields(projectID, clusterName, indexName string, has bool) resource.TestCheckFunc {
-	count := "0"
-	if has {
-		count = "3"
-	}
+func checkWithMappingAndAnalyzer(projectID, clusterName, indexName string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		checkBasic(projectID, clusterName, indexName),
-		resource.TestCheckResourceAttr(resourceName, "latest_definition.mappings.fields.%", count),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.mappings.dynamic", "false"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.mappings.fields.%", "3"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.analyzers.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.analyzer", "index_analyzer_test_name"),
 	)
 }
 
@@ -217,4 +433,245 @@ func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 		}
 		return fmt.Sprintf("%s/%s/%s", groupID, clusterName, indexID), nil
 	}
+}
+
+func configWithSynonyms(projectID, clusterName, indexName string, with bool) string {
+	var synonyms string
+	if with {
+		synonyms = fmt.Sprintf(`
+				synonyms = [{
+					analyzer = "lucene.simple"
+					name     = "synonym_test"
+					source = {
+						collection = %q
+					}
+				}]`, collection)
+	} else {
+		synonyms = "synonyms = []"
+	}
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			definition = {
+				search_analyzer = "lucene.standard"
+				mappings = {
+					dynamic = jsonencode(true)
+					fields = {}
+				}
+				%[6]s
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, synonyms)
+}
+
+func configWithStoredSourceBool(projectID, clusterName, indexName string, val bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+
+			definition = {
+				mappings = { dynamic = jsonencode(true) }
+				stored_source = jsonencode(%[6]t)
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, val)
+}
+
+func configWithStoredSourceBoolAndType(projectID, clusterName, indexName, indexType string, val bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			type            = %q
+
+			definition = {
+				mappings = { dynamic = jsonencode(true) }
+				stored_source = jsonencode(%[7]t)
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, indexType, val)
+}
+
+func configWithStoredSourceJSON(projectID, clusterName, indexName, json string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+
+			definition = {
+				mappings = { dynamic = jsonencode(true) }
+				stored_source = jsonencode(%[6]s)
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, json)
+}
+
+func configVector(projectID, clusterName, indexName string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			type            = "vectorSearch"
+
+			definition = {
+				fields = [
+					jsonencode({
+						type          = "vector"
+						path          = "plot_embedding"
+						numDimensions = 1536
+						similarity    = "euclidean"
+					})
+				]
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection)
+}
+
+func configWithTypeSets(projectID, clusterName, indexName, dynamicJSON string, types []string) string {
+	var typesStr string
+	for i, t := range types {
+		if i > 0 {
+			typesStr += ","
+		}
+		typesStr += fmt.Sprintf("jsonencode(%s)", t)
+	}
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			type            = "search"
+
+			definition = {
+				mappings = {
+					dynamic = jsonencode(%[6]s)
+				}
+				type_sets = [{
+					name  = "ts_acc"
+					types = [%[7]s]
+				}]
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, dynamicJSON, typesStr)
+}
+
+func configWithTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			type            = "search"
+
+			definition = {
+				mappings = {
+					dynamic = jsonencode(%[6]s)
+				}
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, dynamicJSON)
+}
+
+// ---------------------------
+// Check helpers
+// ---------------------------
+
+func checkAttrs(projectID, clusterName, indexName string) resource.TestCheckFunc {
+	attributes := map[string]string{
+		"group_id":        projectID,
+		"cluster_name":    clusterName,
+		"name":            indexName,
+		"database":        database,
+		"collection_name": collection,
+	}
+	checks := []resource.TestCheckFunc{
+		checkExists(resourceName),
+	}
+	checks = acc.AddAttrChecks(resourceName, checks, attributes)
+	checks = acc.AddAttrSetChecks(resourceName, checks, "index_id")
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkWithSynonyms(projectID, clusterName, indexName string, has bool) resource.TestCheckFunc {
+	count := "0"
+	extra := []resource.TestCheckFunc{}
+	if has {
+		count = "1"
+		extra = []resource.TestCheckFunc{
+			resource.TestCheckResourceAttr(resourceName, "latest_definition.synonyms.0.analyzer", "lucene.simple"),
+			resource.TestCheckResourceAttr(resourceName, "latest_definition.synonyms.0.name", "synonym_test"),
+			resource.TestCheckResourceAttr(resourceName, "latest_definition.synonyms.0.source.collection", collection),
+		}
+	}
+	checks := []resource.TestCheckFunc{
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.synonyms.#", count),
+	}
+	checks = append(checks, extra...)
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkStoredSourceBool(projectID, clusterName, indexName string, val bool) resource.TestCheckFunc {
+	boolJSON := "false"
+	if val {
+		boolJSON = "true"
+	}
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.stored_source", acc.JSONEquals(boolJSON)),
+	)
+}
+
+func checkStoredSourceJSON(projectID, clusterName, indexName, json string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.stored_source", acc.JSONEquals(json)),
+	)
+}
+
+func checkVector(projectID, clusterName, indexName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttr(resourceName, "type", "vectorSearch"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.fields.#", "1"),
+	)
+}
+
+func checkTypeSets(projectID, clusterName, indexName, dynamicJSON string, typeCount int) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.mappings.dynamic", acc.JSONEquals(dynamicJSON)),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.name", "ts_acc"),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.types.#", fmt.Sprintf("%d", typeCount)),
+	)
+}
+
+func checkTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.mappings.dynamic", acc.JSONEquals(dynamicJSON)),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "0"),
+	)
 }

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -35,7 +35,7 @@ func TestAccSearchIndexAPI_basic(t *testing.T) {
 				ResourceName:                         resourceName,
 				ImportStateIdFunc:                    importStateIDFunc(resourceName),
 				ImportStateVerifyIdentifierAttribute: "name",
-				// import experience is limited due to IPA not respecting: Fields defined in CREATE and UPDATE request schemas should be the same and should be present in response schema
+				// import experience is limited due to API not respecting: Fields defined in CREATE and UPDATE request schemas should be the same and should be present in response schema
 				// Current API defines index within `definition` property, however response doen not include `definition` and instead returns `latestDefinition`.
 				ImportStateVerifyIgnore: []string{"delete_on_create_timeout", "definition.%", "definition.mappings.%", "definition.mappings.dynamic"},
 				ImportState:             true,
@@ -79,7 +79,7 @@ func TestAccSearchIndexAPI_MappingWithAnalyzersUpdatedToEmptyAnalyzers(t *testin
 				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
 				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
 			// {
 			// 	Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
 			// 	Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
@@ -102,7 +102,7 @@ func TestAccSearchIndexAPI_MappingsUpdatedToEmptyMapping(t *testing.T) {
 				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
 				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
 			// {
 			// 	Config: configBasic(projectID, clusterName, indexName),
 			// 	Check:  checkBasic(projectID, clusterName, indexName),
@@ -129,7 +129,7 @@ func TestAccSearchIndexAPI_withTypeSets_ConfigurableDynamic(t *testing.T) {
 				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`, `{"type":"number"}`}),
 				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 2),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
 			// {
 			// 	Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
 			// 	Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
@@ -170,11 +170,11 @@ func TestAccSearchIndexAPI_withStoredSourceBool(t *testing.T) {
 				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
 				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
 			},
-			{
-				// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP to allow configuration for sending null in list (and other) properties which are not defined
-				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
-				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
-			},
+			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
+			// {
+			// 	Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
+			// 	Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
+			// },
 		},
 	})
 }
@@ -197,28 +197,6 @@ func TestAccSearchIndexAPI_withStoredSourceInclude(t *testing.T) {
 	})
 }
 
-func TestAccSearchIndexAPI_withStoredSourceUpdateEmptyType(t *testing.T) {
-	var (
-		projectID, clusterName = acc.ClusterNameExecution(t, true)
-		indexName              = acc.RandomName()
-	)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acc.PreCheckBasic(t) },
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             checkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
-				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
-			},
-			{
-				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
-				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
-			},
-		},
-	})
-}
-
 func TestAccSearchIndexAPI_withStoredSourceUpdateSearchType(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
@@ -232,10 +210,6 @@ func TestAccSearchIndexAPI_withStoredSourceUpdateSearchType(t *testing.T) {
 			{
 				Config: configWithStoredSourceBoolAndType(projectID, clusterName, indexName, "search", false),
 				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
-			},
-			{
-				Config: configWithStoredSourceBoolAndType(projectID, clusterName, indexName, "search", true),
-				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
 			},
 		},
 	})

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -35,9 +35,11 @@ func TestAccSearchIndexAPI_basic(t *testing.T) {
 				ResourceName:                         resourceName,
 				ImportStateIdFunc:                    importStateIDFunc(resourceName),
 				ImportStateVerifyIdentifierAttribute: "name",
-				ImportStateVerifyIgnore:              []string{"delete_on_create_timeout", "definition.%", "definition.mappings.%", "definition.mappings.dynamic"},
-				ImportState:                          true,
-				ImportStateVerify:                    true,
+				// import experience is limited due to IPA not respecting: Fields defined in CREATE and UPDATE request schemas should be the same and should be present in response schema
+				// Current API defines index within `definition` property, however response doen not include `definition` and instead returns `latestDefinition`.
+				ImportStateVerifyIgnore: []string{"delete_on_create_timeout", "definition.%", "definition.mappings.%", "definition.mappings.dynamic"},
+				ImportState:             true,
+				ImportStateVerify:       true,
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-352324

Adds acceptance tests capturing same create/update scenarios as in our existing search_index resource.

### Findings from API

The API has an uncommon approach in which property defined in request for defining the search index (`definition`) is not present in the response. Separate `latestDefinition` property is returned in the response with the index definition. This is not respecting the recommendation in https://mongodb.github.io/ipa/127 (Fields defined in CREATE and UPDATE request schemas should be the same and should be present in response schema). While the resource is "usable" the UX is impacted as there is no drift detection for `defintion` attribute and import requires doing an apply to store `definition` in the state.

```
-- REQUEST POST /api/atlas/v2/groups/688352869c0da273e13426a6/clusters/Cluster0/search/indexes
{
 "collectionName": "listingsAndReviews",
 "database": "sample_airbnb",
 "definition": {
  "mappings": {
   "dynamic": true
  }
 },
 "name": "test-acc-tf-2355194429236818437"
}

-- RESPONSE 
{
 "collectionName": "listingsAndReviews",
 "database": "sample_airbnb",
 "indexID": "691da35f4938dd1e70f77643",
 "latestDefinition": {
  "mappings": {
   "dynamic": true
  }
 },
 "name": "test-acc-tf-2355194429236818437",
 "status": "PENDING"
}
```

### Followup on autogeneration side

In several update test cases an error was encountered due to a specific property (`typeSets`). As of now our default behaviour is that for collection types if the attribute is not defined we send an empty array in the request. This specific property returns a validation if set to empty, and only allows defining array with elements or sending `null`. CLOUDP-360429  (followup PR) will enhance our configuration so we can define for this specific attribute that null must be sent when the attribute is absent (instead of empty array).

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
