### PR TITLE
test: Fixes `TestAccEventTriggerDSPlural_realmClientWorks` failing test

### DIFF
--- a/internal/service/eventtrigger/data_source_event_triggers.go
+++ b/internal/service/eventtrigger/data_source_event_triggers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -13,7 +14,7 @@ import (
 
 func PluralDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMongoDBAtlasEventTriggersRead,
+		ReadContext: dataSourceMongoDBAtlasEventTriggersRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:         schema.TypeString,
@@ -143,11 +144,13 @@ func PluralDataSource() *schema.Resource {
 	}
 }
 
-func dataSourceMongoDBAtlasEventTriggersRead(d *schema.ResourceData, meta any) error {
-	ctx := context.Background()
+func dataSourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn, err := meta.(*config.MongoDBClient).Realm.Get(ctx)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+	if conn == nil {
+		return diag.FromErr(fmt.Errorf("realm client connection is nil"))
 	}
 
 	projectID := d.Get("project_id").(string)
@@ -155,11 +158,11 @@ func dataSourceMongoDBAtlasEventTriggersRead(d *schema.ResourceData, meta any) e
 
 	eventTriggers, _, err := conn.EventTriggers.List(ctx, projectID, appID)
 	if err != nil {
-		return fmt.Errorf("error getting event triggers information: %s", err)
+		return diag.FromErr(fmt.Errorf("error getting event triggers information: %w", err))
 	}
 
 	if err := d.Set("results", flattenEventTriggers(eventTriggers)); err != nil {
-		return fmt.Errorf("error setting `result` for event triggers: %s", err)
+		return diag.FromErr(fmt.Errorf("error setting `result` for event triggers: %s", err))
 	}
 
 	d.SetId(id.UniqueId())

--- a/internal/service/eventtrigger/data_source_event_triggers.go
+++ b/internal/service/eventtrigger/data_source_event_triggers.go
@@ -162,7 +162,7 @@ func dataSourceMongoDBAtlasEventTriggersRead(ctx context.Context, d *schema.Reso
 	}
 
 	if err := d.Set("results", flattenEventTriggers(eventTriggers)); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting `result` for event triggers: %s", err))
+		return diag.FromErr(fmt.Errorf("error setting `results` for event triggers: %w", err))
 	}
 
 	d.SetId(id.UniqueId())


### PR DESCRIPTION
## Description

Fixes a panic in `TestAccEventTriggerDSPlural_realmClientWorks` by updating the `mongodbatlas_event_triggers` data source to use `ReadContext` instead of `Read`. This aligns the implementation to be like in other plural data sources

## Changes

- Switched from `Read` to `ReadContext` in the plural data source resource definition
- Updated `dataSourceMongoDBAtlasEventTriggersRead` to:
  - Accept `context.Context` as the first parameter
  - Return `diag.Diagnostics` instead of `error`
  - Use `diag.FromErr()` for error handling
- Added nil check for Realm client connection
- Removed `context.Background()` call (context is now passed as parameter)

## Reason

The data source used the legacy `Read` function signature (returns `error`), which caused a nil pointer dereference panic in the Terraform SDK when the test ran. Other plural data sources in the codebase (e.g., `data_source_clusters.go`) use `ReadContext`, which is the correct pattern for SDK v2 data sources.

## Impact

- Fixes the panic in `TestAccEventTriggerDSPlural_realmClientWorks`
- Aligns the implementation with other plural data sources
- No breaking changes; the data source behavior remains the same

The test now runs without panicking. Any remaining failures are due to authentication/credentials, not code issues.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
