### PR TITLE
chore: Adds panic for deprecated SDKv2 resource operations

### DIFF
--- a/internal/config/resource_base.go
+++ b/internal/config/resource_base.go
@@ -26,6 +26,21 @@ type ImplementedResource interface {
 	GetName() string
 }
 
+/*
+Note: Unlike SDKv2 resources (see resource_base_sdkv2.go), we do NOT need panic checks for deprecated fields here.
+
+Why panic checks are NOT necessary for TPF resources:
+  - TPF uses interfaces with methods, not structs with fields. You cannot accidentally "set" a deprecated
+    field because there are no fields - only methods that must be implemented.
+  - Go's type system enforces interface implementation, preventing accidental use of deprecated signatures.
+  - Staticcheck CAN detect deprecated interface methods (unlike struct field assignments in SDKv2).
+
+Interface preservation:
+  - RSCommon embeds ImplementedResource, so all interfaces that ImplementedResource implements are preserved.
+  - Optional interfaces (ResourceWithModifyPlan, ResourceWithMoveState, etc.) are handled by checking
+    if the embedded resource implements them and delegating accordingly.
+  - If TPF adds new optional interfaces in the future, RSCommon will need to be updated to delegate to them.
+*/
 func AnalyticsResourceFunc(iResource resource.Resource) func() resource.Resource {
 	commonResource, ok := iResource.(ImplementedResource)
 	if !ok {

--- a/internal/config/resource_base_sdkv2.go
+++ b/internal/config/resource_base_sdkv2.go
@@ -13,16 +13,16 @@ func NewAnalyticsResourceSDKv2(d *schema.Resource, name string, isDataSource boo
 		log.Panicf("%s: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead", name)
 	}
 	if d.Update != nil {
-		log.Panicf("%s: Update is not supported for SDKv2 resources, it is deprecated, use UpdateContext instead or UpdateWithoutTimeout instead", name)
+		log.Panicf("%s: Update is not supported for SDKv2 resources, it is deprecated, use UpdateContext or UpdateWithoutTimeout instead", name)
 	}
 	if d.Delete != nil {
-		log.Panicf("%s: Delete is not supported for SDKv2 resources, it is deprecated, use DeleteContext instead or DeleteWithoutTimeout instead", name)
+		log.Panicf("%s: Delete is not supported for SDKv2 resources, it is deprecated, use DeleteContext or DeleteWithoutTimeout instead", name)
 	}
 	if d.Importer != nil && d.Importer.State != nil {
 		log.Panicf("%s: Importer.State is not supported for SDKv2 resources, it is deprecated, use Importer.StateContext instead", name)
 	}
 	if d.Create != nil {
-		log.Panicf("%s: Create is not supported for SDKv2 resources, it is deprecated, use CreateContext instead or CreateWithoutTimeout instead", name)
+		log.Panicf("%s: Create is not supported for SDKv2 resources, it is deprecated, use CreateContext or CreateWithoutTimeout instead", name)
 	}
 	analyticsResource := &AnalyticsResourceSDKv2{
 		resource:     d,

--- a/internal/config/resource_base_sdkv2.go
+++ b/internal/config/resource_base_sdkv2.go
@@ -9,6 +9,21 @@ import (
 )
 
 func NewAnalyticsResourceSDKv2(d *schema.Resource, name string, isDataSource bool) *schema.Resource {
+	if d.Read != nil {
+		log.Panicf("%s: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead", name)
+	}
+	if d.Update != nil {
+		log.Panicf("%s: Update is not supported for SDKv2 resources, it is deprecated, use UpdateContext instead or UpdateWithoutTimeout instead", name)
+	}
+	if d.Delete != nil {
+		log.Panicf("%s: Delete is not supported for SDKv2 resources, it is deprecated, use DeleteContext instead or DeleteWithoutTimeout instead", name)
+	}
+	if d.Importer != nil && d.Importer.State != nil {
+		log.Panicf("%s: Importer.State is not supported for SDKv2 resources, it is deprecated, use Importer.StateContext instead", name)
+	}
+	if d.Create != nil {
+		log.Panicf("%s: Create is not supported for SDKv2 resources, it is deprecated, use CreateContext instead or CreateWithoutTimeout instead", name)
+	}
 	analyticsResource := &AnalyticsResourceSDKv2{
 		resource:     d,
 		name:         name,


### PR DESCRIPTION
## Description

Added panic logs for unsupported operations (Read, Update, Delete, Importer.State, Create) in SDKv2 resources, advising users to use the corresponding Context or WithoutTimeout alternatives.

Example panic:
```
Running tool: /Users/espen.albert/.local/share/mise/installs/go/1.25.0/bin/go test -timeout 7200s -run ^TestAccControlPlaneIpAddressesDS_basic$ github.com/mongodb/terraform-provider-mongodbatlas/internal/service/controlplaneipaddresses -v -count=1

=== RUN   TestAccControlPlaneIpAddressesDS_basic
=== PAUSE TestAccControlPlaneIpAddressesDS_basic
=== CONT  TestAccControlPlaneIpAddressesDS_basic
2025-11-19T13:35:53.971Z [DEBUG] sdk.helper_resource: Starting TestCase: test_name=TestAccControlPlaneIpAddressesDS_basic
2025-11-19T13:35:53.971Z [DEBUG] sdk.helper_resource: Calling TestCase PreCheck: test_name=TestAccControlPlaneIpAddressesDS_basic
2025-11-19T13:35:53.971Z [DEBUG] sdk.helper_resource: Called TestCase PreCheck: test_name=TestAccControlPlaneIpAddressesDS_basic
2025-11-19T13:35:53.972Z [DEBUG] sdk.helper_resource: Found Terraform CLI: test_terraform_path=/Users/espen.albert/.local/share/mise/installs/terraform/1.12.1/terraform test_name=TestAccControlPlaneIpAddressesDS_basic
2025/11/19 13:35:54 mongodbatlas_event_triggers: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead
2025/11/19 13:35:54 mongodbatlas_event_triggers: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead
--- FAIL: TestAccControlPlaneIpAddressesDS_basic (0.20s)
panic: mongodbatlas_event_triggers: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead
        panic: mongodbatlas_event_triggers: Read is not supported for SDKv2 resources, it is deprecated, use ReadContext instead or ReadWithoutTimeout instead [recovered, repanicked]

goroutine 35 [running]:
testing.tRunner.func1.2({0x105d10160, 0x140000588c0})
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/testing/testing.go:1875 +0x31c
panic({0x105d10160?, 0x140000588c0?})
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/runtime/panic.go:783 +0x120
log.Panicf({0x10595f69f?, 0x1b?}, {0x1400051a070?, 0x0?, 0x7f?})
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/log/log.go:460 +0x70
github.com/mongodb/terraform-provider-mongodbatlas/internal/config.NewAnalyticsResourceSDKv2(0x1400027c900, {0x1058fb432, 0x1b}, 0x1)
        /Users/espen.albert/agentws/lz/code/provider/internal/config/resource_base_sdkv2.go:13 +0x68
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.getDataSourcesMap()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider_sdk2.go:248 +0x2c10
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.NewSdkV2Provider()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider_sdk2.go:132 +0x820
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.MuxProviderFactory()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider.go:349 +0x20
github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc.init.0.func1()
        /Users/espen.albert/agentws/lz/code/provider/internal/testutil/acc/factory.go:56 +0x1c
github.com/hashicorp/terraform-plugin-testing/helper/resource.runProviderCommand({0x1062fc8c0, 0x14000514360}, {0x106316200, 0x14000102fc0}, 0x140005300f0, 0x1400051f818, 0x1400051bc50)
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/plugin.go:402 +0x1660
github.com/hashicorp/terraform-plugin-testing/helper/resource.runNewTest.func1()
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/testing_new.go:70 +0x98
panic({0x105d10160?, 0x140000585c0?})
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/runtime/panic.go:783 +0x120
log.Panicf({0x10595f69f?, 0x1b?}, {0x1400051c090?, 0x0?, 0x7f?})
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/log/log.go:460 +0x70
github.com/mongodb/terraform-provider-mongodbatlas/internal/config.NewAnalyticsResourceSDKv2(0x140000e3900, {0x1058fb432, 0x1b}, 0x1)
        /Users/espen.albert/agentws/lz/code/provider/internal/config/resource_base_sdkv2.go:13 +0x68
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.getDataSourcesMap()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider_sdk2.go:248 +0x2c10
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.NewSdkV2Provider()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider_sdk2.go:132 +0x820
github.com/mongodb/terraform-provider-mongodbatlas/internal/provider.MuxProviderFactory()
        /Users/espen.albert/agentws/lz/code/provider/internal/provider/provider.go:349 +0x20
github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc.init.0.func1()
        /Users/espen.albert/agentws/lz/code/provider/internal/testutil/acc/factory.go:56 +0x1c
github.com/hashicorp/terraform-plugin-testing/helper/resource.runProviderCommand({0x1062fc8c0, 0x14000514360}, {0x106316200, 0x14000102fc0}, 0x140005300f0, 0x1400051f818, 0x1400051f8a0)
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/plugin.go:402 +0x1660
github.com/hashicorp/terraform-plugin-testing/helper/resource.runNewTest({0x1062fc8c0, 0x14000514360}, {0x106316200, 0x14000102fc0}, {0x0, 0x140003a9430, {0x0, 0x0, 0x0}, 0x0, ...}, ...)
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/testing_new.go:119 +0x4dc
github.com/hashicorp/terraform-plugin-testing/helper/resource.Test({0x106316200, 0x14000102fc0}, {0x0, 0x140003a9430, {0x0, 0x0, 0x0}, 0x0, 0x0, 0x140003c9d40, ...})
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/testing.go:979 +0x500
github.com/hashicorp/terraform-plugin-testing/helper/resource.ParallelTest({0x106316200, 0x14000102fc0}, {0x0, 0x140003a9430, {0x0, 0x0, 0x0}, 0x0, 0x0, 0x140003c9d40, ...})
        /Users/espen.albert/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.13.3/helper/resource/testing.go:880 +0x68
github.com/mongodb/terraform-provider-mongodbatlas/internal/service/controlplaneipaddresses_test.TestAccControlPlaneIpAddressesDS_basic(0x14000102fc0)
        /Users/espen.albert/agentws/lz/code/provider/internal/service/controlplaneipaddresses/data_source_test.go:12 +0x234
testing.tRunner(0x14000102fc0, 0x1062df830)
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
        /Users/espen.albert/.local/share/mise/installs/go/1.25.0/src/testing/testing.go:1997 +0x364
FAIL    github.com/mongodb/terraform-provider-mongodbatlas/internal/service/controlplaneipaddresses     1.436s
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
