### PR TITLE
chore: Support configuration for update marshalling to send null for list/set types

### DIFF
--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -81,13 +81,15 @@ func marshalAttr(attrNameModel string, attrValModel reflect.Value, objJSON map[s
 		return err
 	}
 
-	if val == nil && isUpdate {
+	// Emit empty array for null list/set attributes unless explicit configuration with includeNullOnUpdate
+	if val == nil && isUpdate && !includeNullOnUpdate {
 		switch obj.(type) {
 		case customtypes.ListValueInterface, customtypes.NestedListValueInterface, customtypes.SetValueInterface, customtypes.NestedSetValueInterface:
-			val = []any{} // Send an empty array if it's a null root list or set
+			val = []any{}
 		}
 	}
 
+	// Emit value if non-nil, or emit null on update when configured by includeNullOnUpdate
 	if val != nil || (isUpdate && includeNullOnUpdate) {
 		objJSON[attrNameJSON] = val
 	}

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -157,27 +157,70 @@ func TestMarshalOmitJSONUpdate(t *testing.T) {
 	assert.JSONEq(t, expectedUpdate, string(update))
 }
 
-func TestMarshalUpdateNull(t *testing.T) {
+func TestMarshalUpdateAbsentAttrs(t *testing.T) {
+	type modelEmptyTest struct{}
+
 	model := struct {
-		AttrCustomList    customtypes.ListValue[types.String] `tfsdk:"attr_custom_list"`
-		AttrCustomSet     customtypes.SetValue[types.String]  `tfsdk:"attr_custom_set"`
-		AttrCustomMap     customtypes.MapValue[types.String]  `tfsdk:"attr_custom_map"`
-		AttrString        types.String                        `tfsdk:"attr_string"`
-		AttrIncludeString types.String                        `tfsdk:"attr_include_update" autogen:"includenullonupdate"`
+		AttrList                    customtypes.ListValue[types.String]         `tfsdk:"attr_list"`
+		AttrListIncludeNull         customtypes.ListValue[types.String]         `tfsdk:"attr_list_include_null" autogen:"includenullonupdate"`
+		AttrSet                     customtypes.SetValue[types.String]          `tfsdk:"attr_set"`
+		AttrSetIncludeNull          customtypes.SetValue[types.String]          `tfsdk:"attr_set_include_null" autogen:"includenullonupdate"`
+		AttrNestedList              customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list"`
+		AttrNestedListIncludeNull   customtypes.NestedListValue[modelEmptyTest] `tfsdk:"attr_nested_list_include_null" autogen:"includenullonupdate"`
+		AttrNestedSet               customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set"`
+		AttrNestedSetIncludeNull    customtypes.NestedSetValue[modelEmptyTest]  `tfsdk:"attr_nested_set_include_null" autogen:"includenullonupdate"`
+		AttrMap                     customtypes.MapValue[types.String]          `tfsdk:"attr_map"`
+		AttrMapIncludeNull          customtypes.MapValue[types.String]          `tfsdk:"attr_map_include_null" autogen:"includenullonupdate"`
+		AttrNestedMap               customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map"`
+		AttrNestedMapIncludeNull    customtypes.NestedMapValue[modelEmptyTest]  `tfsdk:"attr_nested_map_include_null" autogen:"includenullonupdate"`
+		AttrNestedObject            customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object"`
+		AttrNestedObjectIncludeNull customtypes.ObjectValue[modelEmptyTest]     `tfsdk:"attr_nested_object_include_null" autogen:"includenullonupdate"`
+		AttrString                  types.String                                `tfsdk:"attr_string"`
+		AttrStringIncludeNull       types.String                                `tfsdk:"attr_include_update" autogen:"includenullonupdate"`
+		AttrInt                     types.Int64                                 `tfsdk:"attr_int"`
+		AttrIntIncludeNull          types.Int64                                 `tfsdk:"attr_int_include_null" autogen:"includenullonupdate"`
+		AttrBool                    types.Bool                                  `tfsdk:"attr_bool"`
+		AttrBoolIncludeNull         types.Bool                                  `tfsdk:"attr_bool_include_null" autogen:"includenullonupdate"`
 	}{
-		AttrCustomList:    customtypes.NewListValueNull[types.String](t.Context()),
-		AttrCustomSet:     customtypes.NewSetValueNull[types.String](t.Context()),
-		AttrCustomMap:     customtypes.NewMapValueNull[types.String](t.Context()),
-		AttrString:        types.StringNull(),
-		AttrIncludeString: types.StringNull(),
+		AttrList:                    customtypes.NewListValueNull[types.String](t.Context()),
+		AttrListIncludeNull:         customtypes.NewListValueNull[types.String](t.Context()),
+		AttrSet:                     customtypes.NewSetValueNull[types.String](t.Context()),
+		AttrSetIncludeNull:          customtypes.NewSetValueNull[types.String](t.Context()),
+		AttrMap:                     customtypes.NewMapValueNull[types.String](t.Context()),
+		AttrMapIncludeNull:          customtypes.NewMapValueNull[types.String](t.Context()),
+		AttrNestedObject:            customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
+		AttrNestedList:              customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
+		AttrNestedListIncludeNull:   customtypes.NewNestedListValueNull[modelEmptyTest](t.Context()),
+		AttrNestedSet:               customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
+		AttrNestedSetIncludeNull:    customtypes.NewNestedSetValueNull[modelEmptyTest](t.Context()),
+		AttrNestedMap:               customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
+		AttrNestedMapIncludeNull:    customtypes.NewNestedMapValueNull[modelEmptyTest](t.Context()),
+		AttrNestedObjectIncludeNull: customtypes.NewObjectValueNull[modelEmptyTest](t.Context()),
+		AttrString:                  types.StringNull(),
+		AttrBool:                    types.BoolNull(),
+		AttrInt:                     types.Int64Null(),
+		AttrStringIncludeNull:       types.StringNull(),
+		AttrIntIncludeNull:          types.Int64Null(),
+		AttrBoolIncludeNull:         types.BoolNull(),
 	}
 	// null list and set root elements are sent as empty arrays in update.
 	// fields with includenullonupdate tag are included even when null during updates.
 	const expectedJSON = `
 		{
-			"attrCustomList": [],
-			"attrCustomSet": [],
-			"attrIncludeString": null
+			"attrList": [],
+			"attrListIncludeNull": null,
+			"attrSet": [],
+			"attrSetIncludeNull": null,
+			"attrNestedList": [],
+			"attrNestedListIncludeNull": null,
+			"attrNestedSet": [],
+			"attrNestedSetIncludeNull": null,
+			"attrMapIncludeNull": null,
+			"attrNestedMapIncludeNull": null,
+			"attrNestedObjectIncludeNull": null,
+			"attrStringIncludeNull": null,
+			"attrIntIncludeNull": null,
+			"attrBoolIncludeNull": null
 		}
 	`
 	raw, err := autogen.Marshal(&model, true)

--- a/internal/serviceapi/searchindexapi/resource_schema.go
+++ b/internal/serviceapi/searchindexapi/resource_schema.go
@@ -498,7 +498,7 @@ type TFDefinitionModel struct {
 	Analyzers      customtypes.NestedListValue[TFDefinitionAnalyzersModel] `tfsdk:"analyzers"`
 	Fields         customtypes.ListValue[jsontypes.Normalized]             `tfsdk:"fields"`
 	Synonyms       customtypes.NestedListValue[TFDefinitionSynonymsModel]  `tfsdk:"synonyms"`
-	TypeSets       customtypes.NestedListValue[TFDefinitionTypeSetsModel]  `tfsdk:"type_sets"`
+	TypeSets       customtypes.NestedListValue[TFDefinitionTypeSetsModel]  `tfsdk:"type_sets" autogen:"includenullonupdate"`
 	Analyzer       types.String                                            `tfsdk:"analyzer"`
 	Mappings       customtypes.ObjectValue[TFDefinitionMappingsModel]      `tfsdk:"mappings"`
 	SearchAnalyzer types.String                                            `tfsdk:"search_analyzer"`

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -79,11 +79,10 @@ func TestAccSearchIndexAPI_MappingWithAnalyzersUpdatedToEmptyAnalyzers(t *testin
 				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
 				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, true),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
-			// {
-			// 	Config: configWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
-			// 	Check:  checkWithMappingAndAnalyzer(projectID, clusterName, indexName, false),
-			// },
+			{
+				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
+				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
+			},
 		},
 	})
 }
@@ -102,11 +101,10 @@ func TestAccSearchIndexAPI_MappingsUpdatedToEmptyMapping(t *testing.T) {
 				Config: configFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
 				Check:  checkFieldMappingOptionalAnalyzers(projectID, clusterName, indexName, false),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
-			// {
-			// 	Config: configBasic(projectID, clusterName, indexName),
-			// 	Check:  checkBasic(projectID, clusterName, indexName),
-			// },
+			{
+				Config: configBasic(projectID, clusterName, indexName),
+				Check:  checkBasic(projectID, clusterName, indexName),
+			},
 		},
 	})
 }
@@ -129,11 +127,10 @@ func TestAccSearchIndexAPI_withTypeSets_ConfigurableDynamic(t *testing.T) {
 				Config: configWithTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, []string{`{"type":"string"}`, `{"type":"number"}`}),
 				Check:  checkTypeSets(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`, 2),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
-			// {
-			// 	Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
-			// 	Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, `{"typeSet":"ts_acc"}`),
-			// },
+			{
+				Config: configWithTypeSetsOmitted(projectID, clusterName, indexName, "true"),
+				Check:  checkTypeSetsOmitted(projectID, clusterName, indexName, "true"),
+			},
 		},
 	})
 }
@@ -170,11 +167,10 @@ func TestAccSearchIndexAPI_withStoredSourceBool(t *testing.T) {
 				Config: configWithStoredSourceBool(projectID, clusterName, indexName, false),
 				Check:  checkStoredSourceBool(projectID, clusterName, indexName, false),
 			},
-			// Currently fails due to Invalid definition: "typeSets" cannot be empty. CLOUDP-360429 to allow configuration for sending null instead of empty array which causes error.
-			// {
-			// 	Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
-			// 	Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
-			// },
+			{
+				Config: configWithStoredSourceBool(projectID, clusterName, indexName, true),
+				Check:  checkStoredSourceBool(projectID, clusterName, indexName, true),
+			},
 		},
 	})
 }
@@ -532,6 +528,25 @@ func configWithTypeSets(projectID, clusterName, indexName, dynamicJSON string, t
 	`, projectID, clusterName, indexName, database, collection, dynamicJSON, typesStr)
 }
 
+func configWithTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_search_index_api" "test" {
+			group_id        = %[1]q
+			cluster_name    = %[2]q
+			name            = %[3]q
+			database        = %[4]q
+			collection_name = %[5]q
+			type            = "search"
+
+			definition = {
+				mappings = {
+					dynamic = jsonencode(%[6]s)
+				}
+			}
+		}
+	`, projectID, clusterName, indexName, database, collection, dynamicJSON)
+}
+
 func checkAttrs(projectID, clusterName, indexName string) resource.TestCheckFunc {
 	attributes := map[string]string{
 		"group_id":        projectID,
@@ -600,5 +615,13 @@ func checkTypeSets(projectID, clusterName, indexName, dynamicJSON string, typeCo
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "1"),
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.name", "ts_acc"),
 		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.0.types.#", fmt.Sprintf("%d", typeCount)),
+	)
+}
+
+func checkTypeSetsOmitted(projectID, clusterName, indexName, dynamicJSON string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		checkAttrs(projectID, clusterName, indexName),
+		resource.TestCheckResourceAttrWith(resourceName, "latest_definition.mappings.dynamic", acc.JSONEquals(dynamicJSON)),
+		resource.TestCheckResourceAttr(resourceName, "latest_definition.type_sets.#", "0"),
 	)
 }

--- a/internal/serviceapi/searchindexapi/resource_test.go
+++ b/internal/serviceapi/searchindexapi/resource_test.go
@@ -36,7 +36,7 @@ func TestAccSearchIndexAPI_basic(t *testing.T) {
 				ImportStateIdFunc:                    importStateIDFunc(resourceName),
 				ImportStateVerifyIdentifierAttribute: "name",
 				// import experience is limited due to API not respecting: Fields defined in CREATE and UPDATE request schemas should be the same and should be present in response schema
-				// Current API defines index within `definition` property, however response doen not include `definition` and instead returns `latestDefinition`.
+				// Current API defines index within `definition` property, however response does not include `definition` and instead returns `latestDefinition`.
 				ImportStateVerifyIgnore: []string{"delete_on_create_timeout", "definition.%", "definition.mappings.%", "definition.mappings.dynamic"},
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -55,7 +55,7 @@ func TestAccSearchIndexAPI_withSynonymsUpdatedToEmpty(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             checkDestroy,
 		Steps: []resource.TestStep{
-			// configWithSynonyms requires a source collection to be setup in the database, creation reachs READY but does have an error.
+			// configWithSynonyms requires a source collection to be setup in the database, creation reaches READY but does have an error.
 			// Any follow up steps fail with an error unexpected state 'FAILED', wanted target 'READY, STEADY'.
 			{
 				Config: configWithSynonyms(projectID, clusterName, indexName, true),

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -658,6 +658,9 @@ resources:
     schema:
       aliases:
         indexId: indexID # path param name does not match the API response property
+      overrides:
+        definition.type_sets:
+          include_null_on_update: true # on update if an empty array is sent the index definition is rejected with error Invalid definition: "typeSets" cannot be empty. 
 
   # Update doesn't work because API defines incorrectly region and cloud_provider at root level in PATCH instead of inside data_process_region as in the other endpoints.
   # id should be Computed but is ignored because it's defined as _id which is not a legal name for a Terraform attribute as they can't start with an underscore.

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -283,7 +283,7 @@ schema:
                       computed_optional_required: optional
                       tf_schema_name: type_sets
                       tf_model_name: TypeSets
-                      req_body_usage: all_request_bodies
+                      req_body_usage: include_null_on_update
                       sensitive: false
                       create_only: false
           description: The index definition to update the search index to.


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-360429

### Context
We currently have a configuration `include_null_on_update` in our autogen tool that allows configuring specific properties to send null if there is no value present in the config (applies for update requests). This configuration however is not working for list and set types, for these types an empty array is always sent (default behaviour).

Sending null instead of empty array is a relevant use case for `type_sets` attribute in search index resource. Sending an empty array in all patch requests was leading to API validation errors in the PATCH request.

### Changes
- Change in marshalling logic to ensure `include_null_on_update` works for all attribute types.
- Update `search_index_api` with configuration for `type_sets`. Uncomment all update test steps which are now successful when sending `"typeSets": null` instead of `"typeSets": []`


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
