### PR TITLE
fix: Changes `user_id` and `username` to be Optional and Computed in `mongodbatlas_cloud_user_org_assignment` data source

### DIFF
--- a/.changelog/3911.txt
+++ b/.changelog/3911.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/mongodbatlas_cloud_user_org_assignment: Changes `user_id` and `username` to be Optional and Computed
+```

--- a/internal/service/clouduserorgassignment/resource_test.go
+++ b/internal/service/clouduserorgassignment/resource_test.go
@@ -107,18 +107,6 @@ func dataSourceTestCase(t *testing.T) *resource.TestCase {
 				Check: resource.ComposeTestCheckFunc(
 					cloudUserOrgAssignmentChecks("data.mongodbatlas_cloud_user_org_assignment.by_username", orgID, username, "PENDING", roles),
 					cloudUserOrgAssignmentChecks("data.mongodbatlas_cloud_user_org_assignment.by_user_id", orgID, username, "PENDING", roles),
-					// Verify that when using username, user_id is computed and matches the resource
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_user_org_assignment.by_username", "user_id"),
-					resource.TestCheckResourceAttrPair(
-						"data.mongodbatlas_cloud_user_org_assignment.by_username", "user_id",
-						"mongodbatlas_cloud_user_org_assignment.test", "user_id",
-					),
-					// Verify that when using user_id, username is computed and matches the resource
-					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_user_org_assignment.by_user_id", "username"),
-					resource.TestCheckResourceAttrPair(
-						"data.mongodbatlas_cloud_user_org_assignment.by_user_id", "username",
-						"mongodbatlas_cloud_user_org_assignment.test", "username",
-					),
 				),
 			},
 		},
@@ -130,23 +118,43 @@ func testAccCloudUserOrgAssignmentWithDataSourceConfig(orgID, username string, r
 
 	return fmt.Sprintf(`
 resource "mongodbatlas_cloud_user_org_assignment" "test" {
-  org_id   = "%s"
-  username = "%s"
+  org_id   = %[1]q
+  username = %[2]q
   roles = {
-    org_roles = [%s]
+    org_roles = [%[3]s]
   }
 }
 
+# Query by username - user_id should be computed
 data "mongodbatlas_cloud_user_org_assignment" "by_username" {
-  org_id   = "%s"
+  org_id   = %[1]q
   username = mongodbatlas_cloud_user_org_assignment.test.username
 }
 
+# Query by user_id - username should be computed
 data "mongodbatlas_cloud_user_org_assignment" "by_user_id" {
-  org_id   = "%s"
+  org_id   = %[1]q
   user_id  = mongodbatlas_cloud_user_org_assignment.test.user_id
 }
-`, orgID, username, rolesStr, orgID, orgID)
+
+# The following resources verify that user_id is properly marked as Computed
+# When querying by username, user_id must be marked as "Computed: true" in the schema
+# so that Terraform knows its value will be available for use in other resources.
+# Without "Computed: true", Terraform will fail at plan time because it cannot validate
+# that user_id will be available as an input to the team assignment resource below, where user_id is required.
+#   - Without Computed: This test FAILS at plan time
+#   - With Computed: This test SUCCEEDS
+resource "mongodbatlas_team" "test" {
+  org_id = %[1]q
+  name   = "test-team"
+}
+
+resource "mongodbatlas_cloud_user_team_assignment" "test_team_assignment" {
+  org_id  = %[1]q
+  team_id = mongodbatlas_team.test.team_id
+  user_id = data.mongodbatlas_cloud_user_org_assignment.by_username.user_id
+}
+`, orgID, username, rolesStr)
 }
 
 func cloudUserOrgAssignmentChecks(resourceName, orgID, username, orgMembershipStatus string, roles []string) resource.TestCheckFunc {

--- a/internal/service/clouduserorgassignment/resource_test.go
+++ b/internal/service/clouduserorgassignment/resource_test.go
@@ -107,6 +107,18 @@ func dataSourceTestCase(t *testing.T) *resource.TestCase {
 				Check: resource.ComposeTestCheckFunc(
 					cloudUserOrgAssignmentChecks("data.mongodbatlas_cloud_user_org_assignment.by_username", orgID, username, "PENDING", roles),
 					cloudUserOrgAssignmentChecks("data.mongodbatlas_cloud_user_org_assignment.by_user_id", orgID, username, "PENDING", roles),
+					// Verify that when using username, user_id is computed and matches the resource
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_user_org_assignment.by_username", "user_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.mongodbatlas_cloud_user_org_assignment.by_username", "user_id",
+						"mongodbatlas_cloud_user_org_assignment.test", "user_id",
+					),
+					// Verify that when using user_id, username is computed and matches the resource
+					resource.TestCheckResourceAttrSet("data.mongodbatlas_cloud_user_org_assignment.by_user_id", "username"),
+					resource.TestCheckResourceAttrPair(
+						"data.mongodbatlas_cloud_user_org_assignment.by_user_id", "username",
+						"mongodbatlas_cloud_user_org_assignment.test", "username",
+					),
 				),
 			},
 		},

--- a/internal/service/clouduserorgassignment/schema.go
+++ b/internal/service/clouduserorgassignment/schema.go
@@ -2,8 +2,10 @@ package clouduserorgassignment
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -154,11 +156,19 @@ func dataSourceOverridenFields() map[string]dsschema.Attribute {
 	return map[string]dsschema.Attribute{
 		"user_id": dsschema.StringAttribute{
 			Optional:            true,
+			Computed:            true,
 			MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user.",
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.MatchRoot("username")),
+			},
 		},
 		"username": dsschema.StringAttribute{
 			Optional:            true,
+			Computed:            true,
 			MarkdownDescription: "Email address that represents the username of the MongoDB Cloud user.",
+			Validators: []validator.String{
+				stringvalidator.ExactlyOneOf(path.MatchRoot("user_id")),
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Description

Changes `user_id` and `username` to be Optional and Computed in `mongodbatlas_cloud_user_org_assignment` data source. Fixes https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3831

Link to any related issue(s): CLOUDP-356519

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
