### PR TITLE
chore: Remove raw values from unmarshal errors

### DIFF
--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -693,28 +693,28 @@ func TestUnmarshalErrors(t *testing.T) {
 		errorStr     string
 	}{
 		"response ints are not converted to model strings": {
-			errorStr:     "unmarshal of attribute attr expects type StringType but got Number with value: 1",
+			errorStr:     "unmarshal of attribute attr expects type StringType but got Number",
 			responseJSON: `{"attr": 123}`,
 			model: &struct {
 				Attr types.String
 			}{},
 		},
 		"response strings are not converted to model ints": {
-			errorStr:     "unmarshal of attribute attr expects type Int64Type but got String with value: hello",
+			errorStr:     "unmarshal of attribute attr expects type Int64Type but got String",
 			responseJSON: `{"attr": "hello"}`,
 			model: &struct {
 				Attr types.Int64
 			}{},
 		},
 		"response strings are not converted to model bools": {
-			errorStr:     "unmarshal of attribute attr expects type BoolType but got String with value: true",
+			errorStr:     "unmarshal of attribute attr expects type BoolType but got String",
 			responseJSON: `{"attr": "true"}`,
 			model: &struct {
 				Attr types.Bool
 			}{},
 		},
 		"response bools are not converted to model string": {
-			errorStr:     "unmarshal of attribute attr expects type StringType but got Bool with value: true",
+			errorStr:     "unmarshal of attribute attr expects type StringType but got Bool",
 			responseJSON: `{"attr": true}`,
 			model: &struct {
 				Attr types.String
@@ -728,7 +728,7 @@ func TestUnmarshalErrors(t *testing.T) {
 			}{},
 		},
 		"model attr types in objects must match JSON types - string": {
-			errorStr:     "unmarshal of attribute attr_string expects type StringType but got Number with value: 1",
+			errorStr:     "unmarshal of attribute attr_string expects type StringType but got Number",
 			responseJSON: `{ "attrObj": { "attrString": 1 } }`,
 			model: &struct {
 				AttrObj customtypes.ObjectValue[testNestedObject] `tfsdk:"attr_obj"`
@@ -737,7 +737,7 @@ func TestUnmarshalErrors(t *testing.T) {
 			},
 		},
 		"model attr types in objects must match JSON types - bool": {
-			errorStr:     "unmarshal of attribute attr_bool expects type BoolType but got String with value: not a bool",
+			errorStr:     "unmarshal of attribute attr_bool expects type BoolType but got String",
 			responseJSON: `{ "attrObj": { "attrBool": "not a bool" } }`,
 			model: &struct {
 				AttrObj customtypes.ObjectValue[testNestedObject] `tfsdk:"attr_obj"`
@@ -746,7 +746,7 @@ func TestUnmarshalErrors(t *testing.T) {
 			},
 		},
 		"model attr types in objects must match JSON types - int": {
-			errorStr:     "unmarshal of attribute attr_int expects type Int64Type but got String with value: not an int",
+			errorStr:     "unmarshal of attribute attr_int expects type Int64Type but got String",
 			responseJSON: `{ "attrObj": { "attrInt": "not an int" } }`,
 			model: &struct {
 				AttrObj customtypes.ObjectValue[testNestedObject] `tfsdk:"attr_obj"`
@@ -755,7 +755,7 @@ func TestUnmarshalErrors(t *testing.T) {
 			},
 		},
 		"model attr types in objects must match JSON types - float": {
-			errorStr:     "unmarshal of attribute attr_float expects type Float64Type but got String with value: not an int",
+			errorStr:     "unmarshal of attribute attr_float expects type Float64Type but got String",
 			responseJSON: `{ "attrObj": { "attrFloat": "not an int" } }`,
 			model: &struct {
 				AttrObj customtypes.ObjectValue[testNestedObject] `tfsdk:"attr_obj"`


### PR DESCRIPTION
## Description

Remove raw values returned from the API from unmashal errors

Link to any related issue(s): CLOUDP-355316

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
