### PR TITLE
chore: Use errors instead of ignorable warnings in autogen overrides

### DIFF
--- a/tools/codegen/codespec/api_to_provider_spec_mapper.go
+++ b/tools/codegen/codespec/api_to_provider_spec_mapper.go
@@ -134,7 +134,9 @@ func apiSpecResourceToCodeSpecModel(oasResource APISpecResource, resourceConfig 
 		Operations:  operations,
 	}
 
-	applyTransformationsWithConfigOpts(resourceConfig, resource)
+	if err := applyTransformationsWithConfigOpts(resourceConfig, resource); err != nil {
+		return nil, err
+	}
 
 	return resource, nil
 }


### PR DESCRIPTION
## Description

Removing warning logs from autogen override failures in favor of errors.
We want to fail autogen in these cases to catch issues/changes early.

Link to any related issue(s): CLOUDP-352318

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
