### PR TITLE
chore: Avoids adding duplicate resources when enabling autogenerated resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ access-token-revoke: ## Revoke an OAuth2 access token. Usage: make access-token-
 enable-autogen: ## Enable use of autogen resources in the provider
 	$(eval filename := ./internal/provider/provider.go)
 	$(eval resources := $(shell ls -d internal/serviceapi/*/ | xargs -n1 basename))
-	$(foreach resource,$(resources),make add-lines filename=${filename} find="project.Resource," add="$(resource).Resource,\n";)
+	$(foreach resource,$(resources),make add-lines-if-missing filename=${filename} resource=${resource};)
 	goimports -w ${filename}
 
 .PHONY: delete-lines ${filename} ${delete}
@@ -237,6 +237,12 @@ add-lines:
 	rm -f file.tmp
 	sed 's/${find}/${add}${find}/' "${filename}" > "file.tmp"
 	mv file.tmp ${filename}
+
+.PHONY: add-lines-if-missing ${filename} ${resource}
+add-lines-if-missing:
+	@if ! grep -q "${resource}.Resource," "${filename}" 2>/dev/null; then \
+		make add-lines filename=${filename} find="project.Resource," add="${resource}.Resource,\n"; \
+	fi
 
 .PHONY: change-lines ${filename} ${find} ${new}
 change-lines:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,23 +47,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamworkspace"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/teamprojectassignment"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/alertconfigurationapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/auditingapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusterapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusteroldapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/customdbroleapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/databaseuserapi"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/logintegration"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/maintenancewindowapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/orgserviceaccountapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectsettingsapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/pushbasedlogexportapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/resourcepolicyapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchdeploymentapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchindexapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streaminstanceapi"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamprocessorapi"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 )
 
@@ -328,22 +312,6 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 
 func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
-		alertconfigurationapi.Resource,
-		auditingapi.Resource,
-		clusterapi.Resource,
-		clusteroldapi.Resource,
-		customdbroleapi.Resource,
-		databaseuserapi.Resource,
-		maintenancewindowapi.Resource,
-		orgserviceaccountapi.Resource,
-		projectapi.Resource,
-		projectsettingsapi.Resource,
-		pushbasedlogexportapi.Resource,
-		resourcepolicyapi.Resource,
-		searchdeploymentapi.Resource,
-		searchindexapi.Resource,
-		streaminstanceapi.Resource,
-		streamprocessorapi.Resource,
 		project.Resource,
 		logintegration.Resource,
 		encryptionatrest.Resource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,23 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamworkspace"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/teamprojectassignment"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/alertconfigurationapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/auditingapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusterapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/clusteroldapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/customdbroleapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/databaseuserapi"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/logintegration"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/maintenancewindowapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/orgserviceaccountapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/projectsettingsapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/pushbasedlogexportapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/resourcepolicyapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchdeploymentapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/searchindexapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streaminstanceapi"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/streamprocessorapi"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 )
 
@@ -312,6 +328,22 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 
 func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
+		alertconfigurationapi.Resource,
+		auditingapi.Resource,
+		clusterapi.Resource,
+		clusteroldapi.Resource,
+		customdbroleapi.Resource,
+		databaseuserapi.Resource,
+		maintenancewindowapi.Resource,
+		orgserviceaccountapi.Resource,
+		projectapi.Resource,
+		projectsettingsapi.Resource,
+		pushbasedlogexportapi.Resource,
+		resourcepolicyapi.Resource,
+		searchdeploymentapi.Resource,
+		searchindexapi.Resource,
+		streaminstanceapi.Resource,
+		streamprocessorapi.Resource,
 		project.Resource,
 		logintegration.Resource,
 		encryptionatrest.Resource,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,6 +47,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamprocessor"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamworkspace"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/teamprojectassignment"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/serviceapi/logintegration"
 	"github.com/mongodb/terraform-provider-mongodbatlas/version"
 )
 
@@ -312,6 +313,7 @@ func (p *MongodbtlasProvider) DataSources(context.Context) []func() datasource.D
 func (p *MongodbtlasProvider) Resources(context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
 		project.Resource,
+		logintegration.Resource,
 		encryptionatrest.Resource,
 		databaseuser.Resource,
 		alertconfiguration.Resource,


### PR DESCRIPTION
## Description

Avoids adding duplicate resources when enabling autogenerated resources. Once we want to configure the resource into the provider, we need to add it manually, but we will now avoid duplicating the resource when running `make enable-autogen`.

You can see the result of running `make enable-autogen` command in [1f7d169](https://github.com/mongodb/terraform-provider-mongodbatlas/pull/3945/commits/1f7d169a370c9d9bb5ed0a82ed6a0d78e94ff7fe) 

Link to any related issue(s): CLOUDP-361989

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
