### PR TITLE
chore: Remove schedule to update dev branches from master

### DIFF
--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -6,8 +6,6 @@ on:
       branches:
         description: 'Dev branch names to update from master'
         default: '["CLOUDP-313272-dev-effective-fields"]'
-  schedule:
-    - cron: "0 5 * * 1,4" # workflow runs every Monday and Thursday at 5 AM UTC
 concurrency:
   group: '${{ github.workflow }}'
   cancel-in-progress: false

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -6,8 +6,8 @@ on:
       branches:
         description: 'Dev branch names to update from master'
         default: '["CLOUDP-313272-dev-effective-fields"]'
-  schedule:
-    - cron: "0 5 * * 1,4" # workflow runs every Monday and Thursday at 5 AM UTC
+  # schedule:
+  #   - cron: "0 5 * * 1,4" # workflow runs every Monday and Thursday at 5 AM UTC
 concurrency:
   group: '${{ github.workflow }}'
   cancel-in-progress: false

--- a/.github/workflows/update-dev-branches.yml
+++ b/.github/workflows/update-dev-branches.yml
@@ -6,6 +6,8 @@ on:
       branches:
         description: 'Dev branch names to update from master'
         default: '["CLOUDP-313272-dev-effective-fields"]'
+  schedule:
+    - cron: "0 5 * * 1,4" # workflow runs every Monday and Thursday at 5 AM UTC
 concurrency:
   group: '${{ github.workflow }}'
   cancel-in-progress: false


### PR DESCRIPTION
## Description

Remove schedule to update dev branches from master, as work has finished in the effective fields dev branch.

Link to any related issue(s): CLOUDP-361037

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
