### PR TITLE
chore: Remove the advanced_cluster_sa_mig job

### DIFF
--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -213,8 +213,8 @@ env:
   ACCTEST_TIMEOUT: ${{ vars.ACCTEST_TIMEOUT }}
   # If the name (regex) of the test is set, only that test is run.
   # Only Migration tests are run when a specific previous provider version is set.
-  # When using Service Account, migration tests are run in dedicated jobs using access tokens to avoid token creation limit issues.
-  # Currently dedicated jobs are: config_sa_mig (fast tests) and advanced_cluster_sa_mig (most important resource), more can be added as needed.
+  # When using Service Account, migration tests are run in dedicated jobs using access tokens (max duration of 1hr) to avoid token creation limit issues.
+  # Currently dedicated jobs are: config_sa_mig (fast tests), more can be added as needed.
   # This is because each migration test creates a new SA token in the test first step as the previous provider runs externally (equivalent to running a Terraform command).
   ACCTEST_REGEX_RUN: ${{ inputs.test_name || inputs.use_sa == true && '^TestAcc' || inputs.provider_version == '' && '^Test(Acc|Mig)' || '^TestMig' }}
   MONGODB_ATLAS_BASE_URL: ${{ inputs.mongodb_atlas_base_url }}
@@ -486,39 +486,6 @@ jobs:
             ./internal/service/advancedcluster
             ./internal/service/cloudbackupschedule
         run: make testacc
-
-  advanced_cluster_sa_mig:
-    needs: [ change-detection, get-provider-version ]
-    if: ${{ inputs.use_sa == true && inputs.reduced_tests != true && (needs.change-detection.outputs.advanced_cluster == 'true' || inputs.test_group == 'advanced_cluster') }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
-      - id: create-token
-        run: make access-token-create
-      - name: Migration Tests with Access Token
-        env:
-          MONGODB_ATLAS_PUBLIC_KEY: ""
-          MONGODB_ATLAS_PRIVATE_KEY: ""
-          MONGODB_ATLAS_CLIENT_ID: ""
-          MONGODB_ATLAS_CLIENT_SECRET: ""
-          MONGODB_ATLAS_ACCESS_TOKEN: ${{ steps.create-token.outputs.access_token }}
-          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
-          HTTP_MOCKER_CAPTURE: 'true'
-          ACCTEST_REGEX_RUN: '^TestMig'
-          ACCTEST_PACKAGES: ./internal/service/advancedcluster
-        run: make testacc
-      - name: Revoke token
-        run: make access-token-revoke token="${{ steps.create-token.outputs.access_token }}"
 
   assume_role:
     needs: [ change-detection, get-provider-version ]


### PR DESCRIPTION
## Description

Service Account tests using access tokens get unauthorized errors after 1 hour (see [example](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/19721252856/job/56504214993)). The oauth2 token duration is 1 hour.

Removing the `advanced_cluster_sa_mig` tests. `config_sa_mig` already provides enough coverage for access tokens.

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
