### PR TITLE
chore: Replace prod SDK with preview SDK for private endpoint/endpoint service

### DIFF
--- a/internal/service/privatelinkendpoint/data_source.go
+++ b/internal/service/privatelinkendpoint/data_source.go
@@ -87,7 +87,8 @@ func DataSource() *schema.Resource {
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	projectID := d.Get("project_id").(string)
 	privateLinkID := conversion.GetEncodedID(d.Get("private_link_id").(string), "private_link_id")

--- a/internal/service/privatelinkendpoint/resource.go
+++ b/internal/service/privatelinkendpoint/resource.go
@@ -16,7 +16,9 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"go.mongodb.org/atlas-sdk/v20250312010/admin"
+
+	// TODO: update before merging to master:  "go.mongodb.org/atlas-sdk/v20250312010/admin"
+	"github.com/mongodb/atlas-sdk-go/admin"
 )
 
 const (
@@ -123,7 +125,8 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Get("project_id").(string)
 	providerName := d.Get("provider_name").(string)
 	region := d.Get("region").(string)
@@ -163,7 +166,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -239,7 +243,8 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	ids := conversion.DecodeStateID(d.Id())
 	privateLinkID := ids["private_link_id"]

--- a/internal/service/privatelinkendpointservice/data_source.go
+++ b/internal/service/privatelinkendpointservice/data_source.go
@@ -98,7 +98,8 @@ func DataSource() *schema.Resource {
 
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Get client connection.
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	projectID := d.Get("project_id").(string)
 	privateLinkID := conversion.GetEncodedID(d.Get("private_link_id").(string), "private_link_id")

--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -204,8 +204,9 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 
 	clusterConf := &retry.StateChangeConf{
-		Pending:    []string{"REPEATING", "PENDING"},
-		Target:     []string{"IDLE", "DELETED"},
+		Pending: []string{"REPEATING", "PENDING"},
+		Target:  []string{"IDLE", "DELETED"},
+		// TODO: update before merging to master: ResourceClusterListAdvancedRefreshFunc to advancedcluster.ResourceClusterListAdvancedRefreshFunc
 		Refresh:    ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: delayAndMinTimeout,
@@ -332,8 +333,9 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 
 		clusterConf := &retry.StateChangeConf{
-			Pending:    []string{"REPEATING", "PENDING"},
-			Target:     []string{"IDLE", "DELETED"},
+			Pending: []string{"REPEATING", "PENDING"},
+			Target:  []string{"IDLE", "DELETED"},
+			// TODO: update before merging to master: ResourceClusterListAdvancedRefreshFunc to advancedcluster.ResourceClusterListAdvancedRefreshFunc
 			Refresh:    ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: delayAndMinTimeout,
@@ -477,6 +479,7 @@ func flattenGCPEndpoints(apiObjects *[]admin.GCPConsumerForwardingRule) []any {
 	return tfList
 }
 
+// TODO: update before merging to master: delete ResourceClusterListAdvancedRefreshFunc and use advancedcluster.ResourceClusterListAdvancedRefreshFunc
 func ResourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, clustersAPI admin.ClustersApi) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		clusters, resp, err := clustersAPI.ListClusters(ctx, projectID).Execute()

--- a/internal/service/privatelinkendpointservice/resource.go
+++ b/internal/service/privatelinkendpointservice/resource.go
@@ -17,8 +17,9 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
-	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster"
-	"go.mongodb.org/atlas-sdk/v20250312010/admin"
+
+	// TODO: update before merging to master:  "go.mongodb.org/atlas-sdk/v20250312010/admin"
+	"github.com/mongodb/atlas-sdk-go/admin"
 )
 
 const (
@@ -145,7 +146,8 @@ func Resource() *schema.Resource {
 }
 
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 	projectID := d.Get("project_id").(string)
 	privateLinkID := conversion.GetEncodedID(d.Get("private_link_id").(string), "private_link_id")
 	providerName := d.Get("provider_name").(string)
@@ -204,7 +206,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	clusterConf := &retry.StateChangeConf{
 		Pending:    []string{"REPEATING", "PENDING"},
 		Target:     []string{"IDLE", "DELETED"},
-		Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
+		Refresh:    ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: delayAndMinTimeout,
 		Delay:      delayAndMinTimeout,
@@ -226,7 +228,8 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -298,7 +301,8 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 }
 
 func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	ids := conversion.DecodeStateID(d.Id())
 	projectID := ids["project_id"]
@@ -330,7 +334,7 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		clusterConf := &retry.StateChangeConf{
 			Pending:    []string{"REPEATING", "PENDING"},
 			Target:     []string{"IDLE", "DELETED"},
-			Refresh:    advancedcluster.ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
+			Refresh:    ResourceClusterListAdvancedRefreshFunc(ctx, projectID, connV2.ClustersApi),
 			Timeout:    d.Timeout(schema.TimeoutDelete),
 			MinTimeout: delayAndMinTimeout,
 			Delay:      delayAndMinTimeout,
@@ -346,7 +350,8 @@ func resourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.
 }
 
 func resourceImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	connV2 := meta.(*config.MongoDBClient).AtlasV2
+	// TODO: update before merging to master: connV2 := d.Client.AtlasV2
+	connV2 := meta.(*config.MongoDBClient).AtlasPreview
 
 	parts := strings.SplitN(d.Id(), "--", 4)
 	if len(parts) != 4 {
@@ -470,4 +475,36 @@ func flattenGCPEndpoints(apiObjects *[]admin.GCPConsumerForwardingRule) []any {
 	}
 
 	return tfList
+}
+
+func ResourceClusterListAdvancedRefreshFunc(ctx context.Context, projectID string, clustersAPI admin.ClustersApi) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		clusters, resp, err := clustersAPI.ListClusters(ctx, projectID).Execute()
+
+		if err != nil && strings.Contains(err.Error(), "reset by peer") {
+			return nil, "REPEATING", nil
+		}
+
+		if err != nil && clusters == nil && resp == nil {
+			return nil, "", err
+		}
+
+		if err != nil {
+			if validate.StatusNotFound(resp) {
+				return "", "DELETED", nil
+			}
+			if validate.StatusServiceUnavailable(resp) {
+				return "", "PENDING", nil
+			}
+			return nil, "", err
+		}
+
+		for i := range clusters.GetResults() {
+			cluster := clusters.GetResults()[i]
+			if cluster.GetStateName() != "IDLE" {
+				return cluster, "PENDING", nil
+			}
+		}
+		return clusters, "IDLE", nil
+	}
 }

--- a/internal/testutil/acc/privatelink_endpoint.go
+++ b/internal/testutil/acc/privatelink_endpoint.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/privatelinkendpoint"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312010/admin"
+
+	// TODO: update before merging to master: "go.mongodb.org/atlas-sdk/v20250312010/admin"
+	"github.com/mongodb/atlas-sdk-go/admin"
 )
 
 func createPrivateLinkEndpoint(tb testing.TB, projectID, providerName, region string) string {
@@ -19,10 +21,12 @@ func createPrivateLinkEndpoint(tb testing.TB, projectID, providerName, region st
 		Region:       region,
 	}
 
-	privateEndpoint, _, err := ConnV2().PrivateEndpointServicesApi.CreatePrivateEndpointService(tb.Context(), projectID, request).Execute()
+	// TODO: update before merging to master: ConnPreview to ConnV2
+	privateEndpoint, _, err := ConnPreview().PrivateEndpointServicesApi.CreatePrivateEndpointService(tb.Context(), projectID, request).Execute()
 	require.NoError(tb, err)
 
-	stateConf := privatelinkendpoint.CreateStateChangeConfig(tb.Context(), ConnV2(), projectID, providerName, privateEndpoint.GetId(), 1*time.Hour)
+	// TODO: update before merging to master: ConnPreview to ConnV2
+	stateConf := privatelinkendpoint.CreateStateChangeConfig(tb.Context(), ConnPreview(), projectID, providerName, privateEndpoint.GetId(), 1*time.Hour)
 	_, err = stateConf.WaitForStateContext(tb.Context())
 	require.NoError(tb, err, "Private link endpoint creation failed: %s, err: %s", privateEndpoint.GetId(), err)
 
@@ -30,12 +34,15 @@ func createPrivateLinkEndpoint(tb testing.TB, projectID, providerName, region st
 }
 
 func deletePrivateLinkEndpoint(projectID, providerName, privateLinkEndpointID string) {
-	_, err := ConnV2().PrivateEndpointServicesApi.DeletePrivateEndpointService(context.Background(), projectID, providerName, privateLinkEndpointID).Execute()
+	// TODO: update before merging to master: ConnPreview to ConnV2
+	_, err := ConnPreview().PrivateEndpointServicesApi.DeletePrivateEndpointService(context.Background(), projectID, providerName, privateLinkEndpointID).Execute()
 	if err != nil {
 		fmt.Printf("Failed to delete private link endpoint %s: %s\n", privateLinkEndpointID, err)
 		return
 	}
-	stateConf := privatelinkendpoint.DeleteStateChangeConfig(context.Background(), ConnV2(), projectID, providerName, privateLinkEndpointID, 1*time.Hour)
+
+	// TODO: update before merging to master: ConnPreview to ConnV2
+	stateConf := privatelinkendpoint.DeleteStateChangeConfig(context.Background(), ConnPreview(), projectID, providerName, privateLinkEndpointID, 1*time.Hour)
 	_, err = stateConf.WaitForStateContext(context.Background())
 	if err != nil {
 		fmt.Printf("Failed to delete private link endpoint %s: %s\n", privateLinkEndpointID, err)


### PR DESCRIPTION
## Description

This is a PR that will be reverted in the future, in order to work with the SDK preview for the implementation of GCP Port Based Routing API changes.

Link to any related issue(s): CLOUDP-363081


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
