### PR TITLE
chore: Add custom plan modifier for RequestOnlyRequiredOnCreate Attribute

### DIFF
--- a/internal/common/customplanmodifier/request_only_required_create.go
+++ b/internal/common/customplanmodifier/request_only_required_create.go
@@ -1,0 +1,118 @@
+package customplanmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequestOnlyRequiredOnCreate returns a plan modifier that fails planning if the value is
+// missing (null/unknown) during create (i.e., when state is null), but allows omission on read/import.
+func RequestOnlyRequiredOnCreate() RequestOnlyRequiredOnCreateModifier {
+	return &requestOnlyRequiredOnCreateAttributePlanModifier{}
+}
+
+// Single interface so the modifier can be applied to any attribute type.
+type RequestOnlyRequiredOnCreateModifier interface {
+	planmodifier.String
+	planmodifier.Bool
+	planmodifier.Int64
+	planmodifier.Float64
+	planmodifier.Number
+	planmodifier.List
+	planmodifier.Map
+	planmodifier.Set
+	planmodifier.Object
+}
+
+type requestOnlyRequiredOnCreateAttributePlanModifier struct{}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) Description(ctx context.Context) string {
+	return m.MarkdownDescription(ctx)
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Ensures that create operations fail when attempting to create a resource with a missing required attribute."
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyFloat64(ctx context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyNumber(ctx context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}
+
+func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", req.Path),
+			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+		)
+	}
+}

--- a/internal/common/customplanmodifier/request_only_required_create.go
+++ b/internal/common/customplanmodifier/request_only_required_create.go
@@ -120,14 +120,14 @@ func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyObject(ctx 
 	)
 }
 
-// validateRequestOnlyRequiredOnCreate checks that an attribute has a known, non-null
+// validateRequestOnlyRequiredOnCreate checks that an attribute has a non-null
 // value during create and adds an error if it does not.
 func validateRequestOnlyRequiredOnCreate(isCreate bool, planValue attr.Value, attrPath path.Path, diagnostics *diag.Diagnostics) {
 	if !isCreate {
 		return
 	}
 
-	if planValue.IsNull() || planValue.IsUnknown() {
+	if planValue.IsNull() {
 		diagnostics.AddError(
 			fmt.Sprintf("%s is required when creating this resource", attrPath),
 			fmt.Sprintf("Provide a value for %s during resource creation.", attrPath),

--- a/internal/common/customplanmodifier/request_only_required_create.go
+++ b/internal/common/customplanmodifier/request_only_required_create.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -37,82 +40,97 @@ func (m *requestOnlyRequiredOnCreateAttributePlanModifier) MarkdownDescription(c
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyFloat64(ctx context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyNumber(ctx context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
-		)
-	}
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
 }
 
 func (m *requestOnlyRequiredOnCreateAttributePlanModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
-	if isCreate(&req.State) && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
-		resp.Diagnostics.AddError(
-			fmt.Sprintf("%s is required when creating this resource", req.Path),
-			fmt.Sprintf("Provide a value for %s during resource creation.", req.Path),
+	validateRequestOnlyRequiredOnCreate(
+		isCreate(&req.State),
+		req.PlanValue,
+		req.Path,
+		&resp.Diagnostics,
+	)
+}
+
+// validateRequestOnlyRequiredOnCreate checks that an attribute has a known, non-null
+// value during create and adds an error if it does not.
+func validateRequestOnlyRequiredOnCreate(isCreate bool, planValue attr.Value, attrPath path.Path, diagnostics *diag.Diagnostics) {
+	if !isCreate {
+		return
+	}
+
+	if planValue.IsNull() || planValue.IsUnknown() {
+		diagnostics.AddError(
+			fmt.Sprintf("%s is required when creating this resource", attrPath),
+			fmt.Sprintf("Provide a value for %s during resource creation.", attrPath),
 		)
 	}
 }

--- a/internal/serviceapi/orgserviceaccountapi/resource_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource_schema.go
@@ -45,7 +45,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"secret_expires_after_hours": schema.Int64Attribute{
 				Optional:            true,
 				MarkdownDescription: "The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.",
-				PlanModifiers:       []planmodifier.Int64{customplanmodifier.CreateOnly()},
+				PlanModifiers:       []planmodifier.Int64{customplanmodifier.CreateOnly(), customplanmodifier.RequestOnlyRequiredOnCreate()},
 			},
 			"secrets": schema.SetNestedAttribute{
 				Computed:            true,

--- a/internal/serviceapi/orgserviceaccountsecretapi/resource_schema.go
+++ b/internal/serviceapi/orgserviceaccountsecretapi/resource_schema.go
@@ -52,7 +52,7 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"secret_expires_after_hours": schema.Int64Attribute{
 				Optional:            true,
 				MarkdownDescription: "The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.",
-				PlanModifiers:       []planmodifier.Int64{customplanmodifier.CreateOnly()},
+				PlanModifiers:       []planmodifier.Int64{customplanmodifier.CreateOnly(), customplanmodifier.RequestOnlyRequiredOnCreate()},
 			},
 		},
 	}

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -88,7 +88,7 @@ var transformations = []AttributeTransformation{
 	aliasTransformation,
 	overridesTransformation,
 	createOnlyTransformation,
-	requiredOnCreateInputOnlyTransformation,
+	requestOnlyRequiredOnCreateTransformation,
 }
 
 var dataSourceTransformations = []AttributeTransformation{
@@ -223,7 +223,7 @@ func createOnlyTransformation(attr *Attribute, _ *attrPaths, _ config.SchemaOpti
 	return nil
 }
 
-func requiredOnCreateInputOnlyTransformation(attr *Attribute, _ *attrPaths, _ config.SchemaOptions) error {
+func requestOnlyRequiredOnCreateTransformation(attr *Attribute, _ *attrPaths, _ config.SchemaOptions) error {
 	if attr.ComputedOptionalRequired == Required && attr.ReqBodyUsage == OmitInUpdateBody && !attr.PresentInAnyResponse {
 		attr.RequestOnlyRequiredOnCreate = true
 		attr.ComputedOptionalRequired = Optional

--- a/tools/codegen/gofilegen/schema/schema_attribute_test.go
+++ b/tools/codegen/gofilegen/schema/schema_attribute_test.go
@@ -117,9 +117,7 @@ func TestGenerateSchemaAttributes_CreateOnly(t *testing.T) {
 		})
 	}
 }
-
 func TestGenerateSchemaAttributes_RequestOnlyRequiredOnCreate(t *testing.T) {
-
 	tests := map[string]struct {
 		attribute       codespec.Attribute
 		hasPlanModifier bool
@@ -160,5 +158,4 @@ func TestGenerateSchemaAttributes_RequestOnlyRequiredOnCreate(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
## Description

This PR addresses the following: 
1. Follow-up from PR #3972, where due to a renaming decision on attribute `requestOnlyRequiredOnCreate`, the transformation step function naming needs to match for consistency purposes. 
2. Addition of new custom plan modifier `RequestOnlyRequiredOnCreateModifier`, which adds validation when trying to create a resource with an attribute marked as `RequestOnlyRequiredOnCreate = true`, an error message will be shown. 
3. This implementation allows to perform `import` without having to apply an additional step, improving the user experience. 

Link to any related issue(s): [CLOUDP-363710](https://jira.mongodb.org/browse/CLOUDP-363710)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Behaviour of `CreateOnly` attribute is preserved, where the attribute is required on creation, but when tried to be updated in the configuration, a validation error message will be shown. 
