### PR TITLE
chore: Uses production API spec and SDK

### DIFF
--- a/internal/serviceapi/alertconfigurationapi/data_source_schema.go
+++ b/internal/serviceapi/alertconfigurationapi/data_source_schema.go
@@ -63,7 +63,7 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"operator": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Comparison operator to apply when checking the current metric value against **matcher[n].value**.",
+							MarkdownDescription: "Comparison operator to apply when checking the current metric value against **matcher[n].value**. The `REGEX` operator only supports inclusive matches. Use the `NOT_CONTAINS` operator to exclude values.",
 						},
 						"value": dsschema.StringAttribute{
 							Computed:            true,
@@ -213,12 +213,12 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 						},
 						"webhook_secret": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Authentication secret for a webhook-based alert.\n\nAtlas returns this value if you set `\"notifications.[n].typeName\" :\"WEBHOOK\"` and either:\n* You set `notification.[n].webhookSecret` to a non-empty string\n* You set a default webhookSecret either on the Integrations page, or with the [Integrations API](#tag/Third-Party-Service-Integrations/operation/createIntegration)\n\n**NOTE**: When you view or edit the alert for a webhook notification, the secret appears completely redacted.",
+							MarkdownDescription: "Authentication secret for a webhook-based alert.\n\nAtlas returns this value if you set `\"notifications.[n].typeName\" :\"WEBHOOK\"` and either:\n* You set `notification.[n].webhookSecret` to a non-empty string\n* You set a default webhookSecret either on the Integrations page, or with the Integrations API\n\n**NOTE**: When you view or edit the alert for a webhook notification, the secret appears completely redacted.",
 							Sensitive:           true,
 						},
 						"webhook_url": dsschema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "Target URL for a webhook-based alert.\n\nAtlas returns this value if you set `\"notifications.[n].typeName\" :\"WEBHOOK\"` and either:\n* You set `notification.[n].webhookURL` to a non-empty string\n* You set a default webhookUrl either on the [Integrations](https://www.mongodb.com/docs/atlas/tutorial/third-party-service-integrations/#std-label-third-party-integrations) page, or with the [Integrations API](#tag/Third-Party-Service-Integrations/operation/createIntegration)\n\n**NOTE**: When you view or edit the alert for a Webhook URL notification, the URL appears partially redacted.",
+							MarkdownDescription: "Target URL for a webhook-based alert.\n\nAtlas returns this value if you set `\"notifications.[n].typeName\" :\"WEBHOOK\"` and either:\n* You set `notification.[n].webhookURL` to a non-empty string\n* You set a default webhookUrl either on the Integrations page, or with the Integrations API\n\n**NOTE**: When you view or edit the alert for a Webhook URL notification, the URL appears partially redacted.",
 						},
 					},
 				},

--- a/internal/serviceapi/logintegration/resource_test.go
+++ b/internal/serviceapi/logintegration/resource_test.go
@@ -233,7 +233,7 @@ func checkDestroy(state *terraform.State) error {
 	}
 	for _, rs := range state.RootModule().Resources {
 		if rs.Type == "mongodbatlas_push_based_log_export_api" {
-			_, _, err := acc.ConnPreview().PushBasedLogExportApi.GetGroupLogIntegration(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"]).Execute() // TODO: CLOUDP-362256 change to ConnV2() once API is in production
+			_, _, err := acc.ConnV2().PushBasedLogExportApi.GetGroupLogIntegration(context.Background(), rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"]).Execute()
 			if err == nil {
 				return fmt.Errorf("push-based log export for project_id %s with id %s still exists", rs.Primary.Attributes["project_id"], rs.Primary.Attributes["id"])
 			}

--- a/scripts/generate-autogen-api-spec.sh
+++ b/scripts/generate-autogen-api-spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_SPEC_URL="${SOURCE_SPEC_URL:-https://raw.githubusercontent.com/mongodb/openapi/dev/openapi/v2.yaml}" # TODO: CLOUDP-362256 change to main branch once API is in production
+SOURCE_SPEC_URL="${SOURCE_SPEC_URL:-https://raw.githubusercontent.com/mongodb/openapi/main/openapi/v2.yaml}"
 SPEC_PATH="tools/codegen/atlasapispec/raw-multi-version-api-spec.yml"
 FLATTENED_SPEC_PATH="tools/codegen/atlasapispec/multi-version-api-spec.flattened.yml"
 

--- a/tools/codegen/models/alert_configuration_api.yaml
+++ b/tools/codegen/models/alert_configuration_api.yaml
@@ -860,7 +860,7 @@ data_sources:
                           present_in_any_response: false
                           request_only_required_on_create: false
                         - string: {}
-                          description: Comparison operator to apply when checking the current metric value against **matcher[n].value**.
+                          description: Comparison operator to apply when checking the current metric value against **matcher[n].value**. The `REGEX` operator only supports inclusive matches. Use the `NOT_CONTAINS` operator to exclude values.
                           computed_optional_required: computed
                           tf_schema_name: operator
                           tf_model_name: Operator
@@ -1330,7 +1330,7 @@ data_sources:
 
                             Atlas returns this value if you set `"notifications.[n].typeName" :"WEBHOOK"` and either:
                             * You set `notification.[n].webhookSecret` to a non-empty string
-                            * You set a default webhookSecret either on the Integrations page, or with the [Integrations API](#tag/Third-Party-Service-Integrations/operation/createIntegration)
+                            * You set a default webhookSecret either on the Integrations page, or with the Integrations API
 
                             **NOTE**: When you view or edit the alert for a webhook notification, the secret appears completely redacted.
                           computed_optional_required: computed
@@ -1348,7 +1348,7 @@ data_sources:
 
                             Atlas returns this value if you set `"notifications.[n].typeName" :"WEBHOOK"` and either:
                             * You set `notification.[n].webhookURL` to a non-empty string
-                            * You set a default webhookUrl either on the [Integrations](https://www.mongodb.com/docs/atlas/tutorial/third-party-service-integrations/#std-label-third-party-integrations) page, or with the [Integrations API](#tag/Third-Party-Service-Integrations/operation/createIntegration)
+                            * You set a default webhookUrl either on the Integrations page, or with the Integrations API
 
                             **NOTE**: When you view or edit the alert for a Webhook URL notification, the URL appears partially redacted.
                           computed_optional_required: computed

--- a/tools/codegen/models/log_integration.yaml
+++ b/tools/codegen/models/log_integration.yaml
@@ -10,6 +10,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: |-
             Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
@@ -22,6 +24,8 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: true
+          present_in_any_response: false
+          request_only_required_on_create: false
         - string: {}
           description: Unique 24-hexadecimal digit string that identifies the AWS IAM role that MongoDB Cloud uses to access your S3 bucket.
           computed_optional_required: required
@@ -31,6 +35,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: Unique 24-character hexadecimal digit string that identifies the log integration configuration.
           computed_optional_required: computed
@@ -40,6 +46,8 @@ schema:
           req_body_usage: omit_always
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: AWS KMS key ID or ARN for server-side encryption (optional). If not provided, uses bucket default encryption settings.
           computed_optional_required: optional
@@ -49,6 +57,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - set:
             element_type: 4
           description: 'Array of log types to export to S3. Valid values: MONGOD, MONGOS, MONGOD_AUDIT, MONGOS_AUDIT.'
@@ -63,6 +73,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: S3 directory path prefix where the log files will be stored. MongoDB Cloud will add further sub-directories based on the log type.
           computed_optional_required: required
@@ -72,6 +84,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
         - string: {}
           description: Human-readable label that identifies the service to which you want to integrate with MongoDB Cloud. The value must match the log integration type.
           computed_optional_required: required
@@ -81,6 +95,8 @@ schema:
           req_body_usage: all_request_bodies
           sensitive: false
           create_only: false
+          present_in_any_response: true
+          request_only_required_on_create: false
 operations:
     delete:
         http_method: DELETE


### PR DESCRIPTION
## Description

Feature is now in prod, so we can now:
- use production API Spec
- use production SDK 

Link to any related issue(s): CLOUDP-362256

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
