### PR TITLE
feat: Add num_partitions field in mongodbatlas_search_index

### DIFF
--- a/.changelog/3982.txt
+++ b/.changelog/3982.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/mongodbatlas_search_index: Adds `num_partitions`
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_search_index: Adds `num_partitions`
+```
+
+```release-note:enhancement
+data-source/mongodbatlas_search_indexes: Adds `num_partitions`
+```

--- a/.changelog/3982.txt
+++ b/.changelog/3982.txt
@@ -1,11 +1,11 @@
 ```release-note:enhancement
-resource/mongodbatlas_search_index: Adds `num_partitions`
+resource/mongodbatlas_search_index: Adds the `num_partitions` attribute 
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_index: Adds `num_partitions`
+data-source/mongodbatlas_search_index: Adds the `num_partitions` attribute 
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_indexes: Adds `num_partitions`
+data-source/mongodbatlas_search_indexes: Adds the `num_partitions` attribute 
 ```

--- a/.changelog/3982.txt
+++ b/.changelog/3982.txt
@@ -1,11 +1,11 @@
 ```release-note:enhancement
-resource/mongodbatlas_search_index: Adds the `num_partitions` attribute 
+resource/mongodbatlas_search_index: Adds `num_partitions` attribute 
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_index: Adds the `num_partitions` attribute 
+data-source/mongodbatlas_search_index: Adds `num_partitions` attribute 
 ```
 
 ```release-note:enhancement
-data-source/mongodbatlas_search_indexes: Adds the `num_partitions` attribute 
+data-source/mongodbatlas_search_indexes: Adds `num_partitions` attribute 
 ```

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,6 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions, returns 0 if not set in the resource
+* `num_partitions` - Number of index partitions.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,6 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Note: When not set, the API returns nil for this field and Terraform displays it as 0 due to SDK v2 limitations with null values for integer types.
+* `num_partitions` - Number of index partitions, returns 0 if not set in the resource
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,6 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4].
+* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4]. Default value is 1.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,6 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - (Optional) Number of index partitions. Allowed values are [1, 2, 4].
+* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4].
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,5 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
+* `num_partitions` - (Optional) Number of index partitions. Allowed values are [1, 2, 4].
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_index.md
+++ b/docs/data-sources/search_index.md
@@ -46,6 +46,6 @@ data "mongodbatlas_search_index" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4]. Default value is 1.
+* `num_partitions` - Number of index partitions. Note: When not set, the API returns nil for this field and Terraform displays it as 0 due to SDK v2 limitations with null values for integer types.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -52,6 +52,6 @@ data "mongodbatlas_search_indexes" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4].
+* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4]. Default value is 1.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -52,6 +52,6 @@ data "mongodbatlas_search_indexes" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4]. Default value is 1.
+* `num_partitions` - Number of index partitions. Note: When not set, the API returns nil for this field and Terraform displays it as 0 due to SDK v2 limitations with null values for integer types.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -52,5 +52,6 @@ data "mongodbatlas_search_indexes" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
+* `num_partitions` - Number of index partitions. Allowed values are [1, 2, 4].
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -52,6 +52,6 @@ data "mongodbatlas_search_indexes" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions. Note: When not set, the API returns nil for this field and Terraform displays it as 0 due to SDK v2 limitations with null values for integer types.
+* `num_partitions` - Number of index partitions, returns 0 if not set in the resource
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/data-sources/search_indexes.md
+++ b/docs/data-sources/search_indexes.md
@@ -52,6 +52,6 @@ data "mongodbatlas_search_indexes" "test" {
 * `type_sets` - Set of type set definitions (when present). Each item includes:
   * `name` - Type set name.
   * `types` - JSON array string describing the types for the set.
-* `num_partitions` - Number of index partitions, returns 0 if not set in the resource
+* `num_partitions` - Number of index partitions.
 
 For more information see: [MongoDB Atlas API Reference.](https://docs.atlas.mongodb.com/atlas-search/) - [and MongoDB Atlas API - Search](https://docs.atlas.mongodb.com/reference/api/atlas-search/) Documentation for more information.

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -237,6 +237,8 @@ EOF
     EOF
   ```
 
+* `num_partitions` - (Optional) Number of index partitions. Allowed values are [1, 2, 4].
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/search_index.md
+++ b/docs/resources/search_index.md
@@ -237,7 +237,7 @@ EOF
     EOF
   ```
 
-* `num_partitions` - (Optional) Number of index partitions. Allowed values are [1, 2, 4].
+* `num_partitions` - (Optional) Number of index partitions. Allowed values are [1, 2, 4]. Default value is 1.
 
 ## Attributes Reference
 

--- a/internal/service/searchindex/data_source_search_index.go
+++ b/internal/service/searchindex/data_source_search_index.go
@@ -227,7 +227,7 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("error setting `stored_source` for search index (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("num_partitions", searchIndex.LatestDefinition.GetNumPartitions()); err != nil {
+	if err := d.Set("num_partitions", searchIndex.LatestDefinition.NumPartitions); err != nil {
 		return diag.Errorf("error setting `num_partitions` for search index (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/searchindex/data_source_search_index.go
+++ b/internal/service/searchindex/data_source_search_index.go
@@ -118,6 +118,10 @@ func returnSearchIndexDSSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"num_partitions": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
 	}
 }
 
@@ -221,6 +225,10 @@ func dataSourceMongoDBAtlasSearchIndexRead(ctx context.Context, d *schema.Resour
 	}
 	if err := d.Set("stored_source", strStoredSource); err != nil {
 		return diag.Errorf("error setting `stored_source` for search index (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("num_partitions", searchIndex.LatestDefinition.GetNumPartitions()); err != nil {
+		return diag.Errorf("error setting `num_partitions` for search index (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(conversion.EncodeStateID(map[string]string{

--- a/internal/service/searchindex/data_source_search_indexes.go
+++ b/internal/service/searchindex/data_source_search_indexes.go
@@ -102,6 +102,7 @@ func flattenSearchIndexes(searchIndexes []admin.SearchIndexResponse, projectID, 
 			"status":          searchIndexes[i].Status,
 			"synonyms":        flattenSearchIndexSynonyms(searchIndexes[i].LatestDefinition.GetSynonyms()),
 			"type":            searchIndexes[i].Type,
+			"num_partitions":  searchIndexes[i].LatestDefinition.NumPartitions,
 		}
 
 		if searchIndexes[i].LatestDefinition.Mappings != nil {

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -156,6 +156,10 @@ func returnSearchIndexSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"num_partitions": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
 	}
 }
 
@@ -269,11 +273,16 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			StoredSource:   searchRead.LatestDefinition.StoredSource,
 			Synonyms:       searchRead.LatestDefinition.Synonyms,
 			Fields:         searchRead.LatestDefinition.Fields,
+			NumPartitions:  searchRead.LatestDefinition.NumPartitions,
 		},
 	}
 
 	if d.HasChange("analyzer") {
 		searchIndex.Definition.Analyzer = conversion.StringPtr(d.Get("analyzer").(string))
+	}
+
+	if d.HasChange("num_partitions") {
+		searchIndex.Definition.NumPartitions = conversion.IntPtr(d.Get("num_partitions").(int))
 	}
 
 	if d.HasChange("search_analyzer") {
@@ -485,6 +494,10 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("error setting `stored_source` for search index (%s): %s", d.Id(), err)
 	}
 
+	if err := d.Set("num_partitions", searchIndex.LatestDefinition.GetNumPartitions()); err != nil {
+		return diag.Errorf("error setting `num_partitions` for search index (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -501,6 +514,7 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		Definition: &admin.BaseSearchIndexCreateRequestDefinition{
 			Analyzer:       conversion.StringPtr(d.Get("analyzer").(string)),
 			SearchAnalyzer: conversion.StringPtr(d.Get("search_analyzer").(string)),
+			NumPartitions:  conversion.IntPtr(d.Get("num_partitions").(int)),
 		},
 	}
 

--- a/internal/service/searchindex/resource_search_index.go
+++ b/internal/service/searchindex/resource_search_index.go
@@ -494,7 +494,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		return diag.Errorf("error setting `stored_source` for search index (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("num_partitions", searchIndex.LatestDefinition.GetNumPartitions()); err != nil {
+	if err := d.Set("num_partitions", searchIndex.LatestDefinition.NumPartitions); err != nil {
 		return diag.Errorf("error setting `num_partitions` for search index (%s): %s", d.Id(), err)
 	}
 

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -198,7 +198,7 @@ func TestAccSearchIndex_withNumPartitions(t *testing.T) {
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
 		indexName              = acc.RandomName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
@@ -224,7 +224,7 @@ func TestAccVectorSearchIndex_withNumPartitions(t *testing.T) {
 		projectID, clusterName = acc.ClusterNameExecution(t, true)
 		indexName              = acc.RandomName()
 	)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acc.PreCheckBasic(t) },
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		CheckDestroy:             acc.CheckDestroySearchIndex,
@@ -683,14 +683,13 @@ func checkVectorSearchWithNumPartitions(projectID, indexName, clusterName string
 
 	if numPartitions != nil {
 		checks = append(checks,
-			resource.TestCheckResourceAttr(resourceName, "num_partitions", fmt.Sprintf("%d", *numPartitions)),
-			resource.TestCheckResourceAttr(datasourceName, "num_partitions", fmt.Sprintf("%d", *numPartitions)),
+			resource.TestCheckResourceAttr(resourceName, "num_partitions", strconv.Itoa(*numPartitions)),
+			resource.TestCheckResourceAttr(datasourceName, "num_partitions", strconv.Itoa(*numPartitions)),
 		)
 	} else {
-		var ret int
 		checks = append(checks,
-			resource.TestCheckResourceAttr(resourceName, "num_partitions", strconv.Itoa(ret)),
-			resource.TestCheckResourceAttr(datasourceName, "num_partitions", strconv.Itoa(ret)),
+			resource.TestCheckResourceAttr(resourceName, "num_partitions", "0"),
+			resource.TestCheckResourceAttr(datasourceName, "num_partitions", "0"),
 		)
 	}
 
@@ -717,14 +716,13 @@ func checkSearchWithNumPartitions(projectID, indexName, clusterName string, numP
 
 	if numPartitions != nil {
 		checks = append(checks,
-			resource.TestCheckResourceAttr(resourceName, "num_partitions", fmt.Sprintf("%d", *numPartitions)),
-			resource.TestCheckResourceAttr(datasourceName, "num_partitions", fmt.Sprintf("%d", *numPartitions)),
+			resource.TestCheckResourceAttr(resourceName, "num_partitions", strconv.Itoa(*numPartitions)),
+			resource.TestCheckResourceAttr(datasourceName, "num_partitions", strconv.Itoa(*numPartitions)),
 		)
 	} else {
-		var ret int
 		checks = append(checks,
-			resource.TestCheckResourceAttr(resourceName, "num_partitions", strconv.Itoa(ret)),
-			resource.TestCheckResourceAttr(datasourceName, "num_partitions", strconv.Itoa(ret)),
+			resource.TestCheckResourceAttr(resourceName, "num_partitions", "0"),
+			resource.TestCheckResourceAttr(datasourceName, "num_partitions", "0"),
 		)
 	}
 	return checkAggr(projectID, clusterName, indexName, indexType, mappingsDynamic, checks...)

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -545,8 +545,8 @@ func configSearchWithNumPartitions(projectID, indexName, clusterName string, num
 	return fmt.Sprintf(`
 
 		resource "mongodbatlas_search_deployment" "test" {
-			project_id   = %[2]q
 			cluster_name = %[1]q
+			project_id   = %[2]q
 			specs = [
 				{
 					instance_size = "S20_HIGHCPU_NVME"

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -424,7 +424,7 @@ func configBasic(projectID, clusterName, indexName, indexType, storedSource stri
 		data "mongodbatlas_search_index" "data_index" {
 			cluster_name     = mongodbatlas_search_index.test.cluster_name
 			project_id       = mongodbatlas_search_index.test.project_id
-			index_id 				 = mongodbatlas_search_index.test.index_id
+			index_id         = mongodbatlas_search_index.test.index_id
 		}
 	`, clusterName, projectID, indexName, database, collection, searchAnalyzer, extra)
 }
@@ -461,7 +461,7 @@ func configWithMapping(projectID, indexName, clusterName string) string {
 		data "mongodbatlas_search_index" "data_index" {
 			cluster_name     = mongodbatlas_search_index.test.cluster_name
 			project_id       = mongodbatlas_search_index.test.project_id
-			index_id 				 = mongodbatlas_search_index.test.index_id
+			index_id         = mongodbatlas_search_index.test.index_id
 		}
 	`, clusterName, projectID, indexName, database, collection, searchAnalyzer, analyzersTF, mappingsFieldsTF)
 }
@@ -503,7 +503,7 @@ func configWithSynonyms(projectID, indexName, clusterName string, has bool) stri
 		data "mongodbatlas_search_index" "data_index" {
 			cluster_name     = mongodbatlas_search_index.test.cluster_name
 			project_id       = mongodbatlas_search_index.test.project_id
-			index_id 				 = mongodbatlas_search_index.test.index_id
+			index_id         = mongodbatlas_search_index.test.index_id
 		}
 	`, clusterName, projectID, indexName, database, collection, searchAnalyzer, synonymsStr)
 }
@@ -541,7 +541,7 @@ func configAdditional(projectID, indexName, clusterName, additional string) stri
 		data "mongodbatlas_search_index" "data_index" {
 			cluster_name     = mongodbatlas_search_index.test.cluster_name
 			project_id       = mongodbatlas_search_index.test.project_id
-			index_id 				 = mongodbatlas_search_index.test.index_id
+			index_id = mongodbatlas_search_index.test.index_id
 		}
 	`, clusterName, projectID, indexName, database, collection, searchAnalyzer, additional)
 }
@@ -598,7 +598,7 @@ func configVectorSearchWithNumPartitions(projectID, indexName, clusterName strin
 	}
 	return fmt.Sprintf(`
 
-			resource "mongodbatlas_search_deployment" "test" {
+		resource "mongodbatlas_search_deployment" "test" {
 			cluster_name = %[1]q
 			project_id   = %[2]q
 			specs = [
@@ -608,6 +608,7 @@ func configVectorSearchWithNumPartitions(projectID, indexName, clusterName strin
 				}
 			]
 		}
+
 		resource "mongodbatlas_search_index" "test" {
 			cluster_name     = %[1]q
 			project_id       = %[2]q
@@ -620,6 +621,8 @@ func configVectorSearchWithNumPartitions(projectID, indexName, clusterName strin
 			fields = <<-EOF
 	    %[7]s
 			EOF
+		
+		depends_on = [mongodbatlas_search_deployment.test]
 		}
 	
 		data "mongodbatlas_search_index" "data_index" {
@@ -636,6 +639,17 @@ func configSearchWithNumPartitions(projectID, indexName, clusterName string, num
 		numPartitionsLine = fmt.Sprintf("num_partitions   = %d", *numPartitions)
 	}
 	return fmt.Sprintf(`
+
+		resource "mongodbatlas_search_deployment" "test" {
+			cluster_name = %[1]q
+			project_id   = %[2]q
+			specs = [
+				{
+					instance_size = "S20_HIGHCPU_NVME"
+					node_count    = 2
+				}
+			]
+		}
 
 		resource "mongodbatlas_search_index" "test" {
 			cluster_name     = %[1]q

--- a/internal/service/searchindex/resource_search_index_test.go
+++ b/internal/service/searchindex/resource_search_index_test.go
@@ -564,7 +564,7 @@ func configSearchWithNumPartitions(projectID, indexName, clusterName string, num
 			analyzer         = "lucene.standard"
 			search_analyzer  = "lucene.standard"
 			mappings_dynamic = true
-			num_partitions 	 = %[6]d
+			num_partitions   = %[6]d
 			type             = "search"
 			
 			depends_on = [mongodbatlas_search_deployment.test]
@@ -573,7 +573,7 @@ func configSearchWithNumPartitions(projectID, indexName, clusterName string, num
 		data "mongodbatlas_search_index" "data_index" {
 			cluster_name     = mongodbatlas_search_index.test.cluster_name
 			project_id       = mongodbatlas_search_index.test.project_id
-			index_id 				 = mongodbatlas_search_index.test.index_id
+			index_id 		 = mongodbatlas_search_index.test.index_id
 		}
 	`, clusterName, projectID, indexName, database, collection, numPartitions)
 }


### PR DESCRIPTION
## Description

The numPartitions field for MongoDB Atlas Search Index exists in the API, but Terraform can't manage it yet. The API overwrites nested fields like definition.numPartitions entirely (similar to PUT), making partial updates via PATCH unsupported. For now, customers need to use the MongoDB Atlas UI to manage this field until Terraform adds support.

This PR is for the addition of the `num_partitions` field in `mongodbatlas_search_index`

Link to any related issue(s):  CLOUDP-365383

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
