### PR TITLE
fix: Fix `mongodbatlas_advanced_clusters` datasource when raises CLUSTER_NOT_FOUND error

### DIFF
--- a/.changelog/3995.txt
+++ b/.changelog/3995.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/mongodbatlas_advanced_clusters: Fixes datasource to handle CLUSTER_NOT_FOUND errors from List operation gracefully instead of failing
+```

--- a/internal/service/advancedcluster/plural_data_source.go
+++ b/internal/service/advancedcluster/plural_data_source.go
@@ -84,6 +84,7 @@ func (d *pluralDS) getBasicClusters(ctx context.Context, diags *diag.Diagnostics
 	})
 	if err != nil {
 		addListError(diags, projectID, err)
+		RemoveClusterNotFoundErrors(diags)
 		return nil
 	}
 	for i := range list {
@@ -101,6 +102,7 @@ func (d *pluralDS) getFlexClusters(ctx context.Context, diags *diag.Diagnostics,
 	listFlexClusters, err := flexcluster.ListFlexClusters(ctx, projectID, d.Client.AtlasV2.FlexClustersApi)
 	if err != nil {
 		addListError(diags, projectID, err)
+		RemoveClusterNotFoundErrors(diags)
 		return nil
 	}
 	for i := range *listFlexClusters {

--- a/internal/service/advancedcluster/plural_data_source.go
+++ b/internal/service/advancedcluster/plural_data_source.go
@@ -84,7 +84,7 @@ func (d *pluralDS) getBasicClusters(ctx context.Context, diags *diag.Diagnostics
 	})
 	if err != nil {
 		addListError(diags, projectID, err)
-		RemoveClusterNotFoundErrors(diags)
+		RemoveClusterNotFoundErrors(diags) // Needed until CLOUDP-366240 is done.
 		return nil
 	}
 	for i := range list {
@@ -102,7 +102,7 @@ func (d *pluralDS) getFlexClusters(ctx context.Context, diags *diag.Diagnostics,
 	listFlexClusters, err := flexcluster.ListFlexClusters(ctx, projectID, d.Client.AtlasV2.FlexClustersApi)
 	if err != nil {
 		addListError(diags, projectID, err)
-		RemoveClusterNotFoundErrors(diags)
+		RemoveClusterNotFoundErrors(diags) // Needed until CLOUDP-366240 is done.
 		return nil
 	}
 	for i := range *listFlexClusters {


### PR DESCRIPTION
## Description

Fix `mongodbatlas_advanced_clusters` datasource when raises `CLUSTER_NOT_FOUND` error. 

This fixes flaky test `TestAccMockableAdvancedCluster_tenantUpgrade`.


Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
