### PR TITLE
chore: Ensure any form of error in `Test Suite` execution results in slack notification

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -103,7 +103,8 @@ jobs:
   
   slack-notification:
     needs: [tests, variables, clean-after]
-    if: ${{ !cancelled() && needs.tests.result == 'failure' && needs.variables.outputs.send_notification == 'true' }}
+    # tests.result can have execution result of 'failure' or 'cancelled', independently of the test suite not being cancelled. For any form of error we want a notification.
+    if: ${{ !cancelled() && (needs.tests.result == 'failure' || needs.tests.result == 'cancelled') && needs.variables.outputs.send_notification == 'true' }}
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
## Description

[Today test execution](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/20321648924/job/58378587707) showcases that our `tests` can face job executions which end in a `cancelled` result (autogen_fast). This causes `needs.tests.result != 'failure'` and skips sending slack notifications.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
