### PR TITLE
fix: Sets default `interval_min` to 5 for alert configurations when not specified

### DIFF
--- a/.changelog/4021.txt
+++ b/.changelog/4021.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/mongodbatlas_alert_configuration: Sets default `interval_min` to 5 when not specified
+```

--- a/internal/service/alertconfiguration/model_test.go
+++ b/internal/service/alertconfiguration/model_test.go
@@ -561,3 +561,79 @@ func TestAlertConfigurationSdkToDSModelList(t *testing.T) {
 		})
 	}
 }
+
+func TestIntervalMinValue(t *testing.T) {
+	five := int64(5)
+	ten := int64(10)
+	zero := int64(0)
+	three := int64(3)
+
+	testCases := map[string]struct {
+		intervalMin    *int64
+		expectedResult *int
+		typeName       string
+	}{
+		"GROUP notification with nil interval_min defaults to 5": {
+			typeName:       "GROUP",
+			intervalMin:    nil,
+			expectedResult: admin.PtrInt(5),
+		},
+		"GROUP notification with interval_min=0 defaults to 5": {
+			typeName:       "GROUP",
+			intervalMin:    &zero,
+			expectedResult: admin.PtrInt(5),
+		},
+		"GROUP notification with interval_min=3 (less than min) defaults to 5": {
+			typeName:       "GROUP",
+			intervalMin:    &three,
+			expectedResult: admin.PtrInt(5),
+		},
+		"GROUP notification with interval_min=5 keeps value": {
+			typeName:       "GROUP",
+			intervalMin:    &five,
+			expectedResult: admin.PtrInt(5),
+		},
+		"GROUP notification with interval_min=10 keeps value": {
+			typeName:       "GROUP",
+			intervalMin:    &ten,
+			expectedResult: admin.PtrInt(10),
+		},
+		"ORG notification with nil interval_min defaults to 5": {
+			typeName:       "ORG",
+			intervalMin:    nil,
+			expectedResult: admin.PtrInt(5),
+		},
+		"EMAIL notification with nil interval_min defaults to 5": {
+			typeName:       "EMAIL",
+			intervalMin:    nil,
+			expectedResult: admin.PtrInt(5),
+		},
+		"PAGER_DUTY notification returns nil regardless of interval_min": {
+			typeName:       "PAGER_DUTY",
+			intervalMin:    &ten,
+			expectedResult: nil,
+		},
+		"pager_duty (lowercase) notification returns nil": {
+			typeName:       "pager_duty",
+			intervalMin:    &ten,
+			expectedResult: nil,
+		},
+		"OPS_GENIE notification returns nil regardless of interval_min": {
+			typeName:       "OPS_GENIE",
+			intervalMin:    &ten,
+			expectedResult: nil,
+		},
+		"VICTOR_OPS notification returns nil regardless of interval_min": {
+			typeName:       "VICTOR_OPS",
+			intervalMin:    &ten,
+			expectedResult: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := alertconfiguration.IntervalMinValue(tc.typeName, tc.intervalMin)
+			assert.Equal(t, tc.expectedResult, result, "intervalMinValue did not return expected result")
+		})
+	}
+}

--- a/internal/service/alertconfiguration/resource_test.go
+++ b/internal/service/alertconfiguration/resource_test.go
@@ -649,6 +649,40 @@ func TestAccConfigRSAlertConfiguration_withSeverityOverride(t *testing.T) {
 	})
 }
 
+// TestAccConfigRSAlertConfiguration_withoutIntervalMin reproduces the issue where default alerts
+// created by Atlas have interval_min=0 (or unset). When these alerts are imported via the data source
+// and then managed via Terraform, the generated HCL omits interval_min. During create/update,
+// the API rejects requests with NOTIFICATION_INTERVAL_OUT_OF_RANGE because interval_min must be >= 5.
+// This test mimics the scenario by creating an alert without interval_min specified.
+func TestAccConfigRSAlertConfiguration_withoutIntervalMin(t *testing.T) {
+	var (
+		projectID = acc.ProjectIDExecution(t)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// This test reproduces the issue where alerts imported from Atlas data source
+				// don't have interval_min set (because Atlas returns 0 for some default alerts).
+				// The API requires interval_min >= 5, so this should fail with current implementation.
+				// Once fixed, this test should pass and interval_min should default to 5.
+				Config: configWithoutIntervalMin(projectID, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "event_type", "NO_PRIMARY"),
+					resource.TestCheckResourceAttr(resourceName, "notification.#", "1"),
+					// After the fix, interval_min should be set to minimum value of 5
+					resource.TestCheckResourceAttr(resourceName, "notification.0.interval_min", "5"),
+				),
+			},
+		},
+	})
+}
+
 func checkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -1084,6 +1118,29 @@ func configWithPagerDutyAndIntervalMin(projectID, serviceKey string, enabled boo
 			}
 		}
 	`, projectID, serviceKey, enabled)
+}
+
+// configWithoutIntervalMin creates an alert configuration without specifying interval_min.
+// This mimics the HCL output from the data source when importing default Atlas alerts
+// that have interval_min=0 (which is omitted from the generated HCL).
+// The API requires interval_min >= 5, so this configuration will fail with
+// NOTIFICATION_INTERVAL_OUT_OF_RANGE unless the provider handles this case.
+func configWithoutIntervalMin(projectID string, enabled bool) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_alert_configuration" "test" {
+			project_id = %[1]q
+			enabled    = %[2]t
+			event_type = "NO_PRIMARY"
+
+			notification {
+				type_name     = "GROUP"
+				delay_min     = 0
+				sms_enabled   = false
+				email_enabled = true
+				roles         = ["GROUP_OWNER"]
+			}
+		}
+	`, projectID, enabled)
 }
 
 func configWithEmptyMetricThresholdConfig(projectID string, enabled bool) string {


### PR DESCRIPTION
## Description

Fixes an issue where importing default Atlas alerts via the data source and then managing them with Terraform would fail with `NOTIFICATION_INTERVAL_OUT_OF_RANGE` error.

Some default alerts created by Atlas have `interval_min=0`, but the API requires `interval_min >= 5` when updating. This fix ensures `interval_min` defaults to 5 when not specified or when the value is below the minimum.

### Changes

- Added `IntervalMinValue` function to default `interval_min` to 5 for notification types that support it
- PAGER_DUTY, OPS_GENIE, and VICTOR_OPS continue to not send `interval_min` (unchanged behavior)
- Added unit tests and acceptance test

Link to any related issue(s): CLOUDP-359588

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
