### PR TITLE
chore: Support new `listasmap` autogen tag used for custom marshal/unmarshal of `tags` and `labels`

### DIFF
--- a/internal/common/autogen/list_as_map.go
+++ b/internal/common/autogen/list_as_map.go
@@ -2,7 +2,7 @@ package autogen
 
 import "slices"
 
-func modifyJSONFromListToMap(attrObjJSON any) any {
+func ModifyJSONFromListToMap(attrObjJSON any) any {
 	if attrObjJSON == nil {
 		return nil
 	}
@@ -45,7 +45,7 @@ func modifyJSONFromListToMap(attrObjJSON any) any {
 	return result
 }
 
-func modifyJSONFromMapToList(val any) any {
+func ModifyJSONFromMapToList(val any) any {
 	if val == nil {
 		return nil
 	}

--- a/internal/common/autogen/list_as_map.go
+++ b/internal/common/autogen/list_as_map.go
@@ -1,0 +1,80 @@
+package autogen
+
+import "slices"
+
+func modifyJSONFromListToMap(attrObjJSON any) any {
+	if attrObjJSON == nil {
+		return nil
+	}
+
+	list, ok := attrObjJSON.([]any)
+	if !ok {
+		// If it's not a list, leave it unchanged.
+		return attrObjJSON
+	}
+
+	// For an empty list, return an empty map.
+	if len(list) == 0 {
+		return map[string]any{}
+	}
+
+	result := make(map[string]any, len(list))
+	for _, item := range list {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			// If any element is not an object, fall back to original value.
+			return attrObjJSON
+		}
+
+		keyRaw, hasKey := obj["key"]
+		value, hasValue := obj["value"]
+		if !hasKey || !hasValue {
+			// Skip items without both key and value.
+			continue
+		}
+
+		key, ok := keyRaw.(string)
+		if !ok {
+			// Keys must be strings; skip otherwise.
+			continue
+		}
+
+		result[key] = value
+	}
+
+	return result
+}
+
+func modifyJSONFromMapToList(val any) any {
+	if val == nil {
+		return nil
+	}
+
+	obj, ok := val.(map[string]any)
+	if !ok {
+		// If it's not a map, leave it unchanged.
+		return val
+	}
+
+	// For an empty map, return an empty list.
+	if len(obj) == 0 {
+		return []any{}
+	}
+
+	// To ensure deterministic output (useful for tests), sort keys.
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	result := make([]any, 0, len(obj))
+	for _, k := range keys {
+		result = append(result, map[string]any{
+			"key":   k,
+			"value": obj[k],
+		})
+	}
+
+	return result
+}

--- a/internal/common/autogen/list_as_map_test.go
+++ b/internal/common/autogen/list_as_map_test.go
@@ -1,0 +1,78 @@
+package autogen_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModifyJSONFromListToMap(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		var input any
+		output := autogen.ModifyJSONFromListToMap(input)
+		assert.Nil(t, output)
+	})
+
+	t.Run("non list input returned as-is", func(t *testing.T) {
+		input := map[string]any{"foo": "bar"}
+		output := autogen.ModifyJSONFromListToMap(input)
+		assert.Equal(t, input, output)
+	})
+
+	t.Run("empty list returns empty map", func(t *testing.T) {
+		input := []any{}
+		output := autogen.ModifyJSONFromListToMap(input)
+		assert.Equal(t, map[string]any{}, output)
+	})
+
+	t.Run("list with key/value objects returns map", func(t *testing.T) {
+		input := []any{
+			map[string]any{"key": "key1", "value": "val1"},
+			map[string]any{"key": "key2", "value": 2},
+		}
+
+		output := autogen.ModifyJSONFromListToMap(input)
+
+		expected := map[string]any{
+			"key1": "val1",
+			"key2": 2,
+		}
+		assert.Equal(t, expected, output)
+	})
+}
+
+func TestModifyJSONFromMapToList(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		var input any
+		output := autogen.ModifyJSONFromMapToList(input)
+		assert.Nil(t, output)
+	})
+
+	t.Run("non map input returned as-is", func(t *testing.T) {
+		input := []any{"foo"}
+		output := autogen.ModifyJSONFromMapToList(input)
+		assert.Equal(t, input, output)
+	})
+
+	t.Run("empty map returns empty list", func(t *testing.T) {
+		input := map[string]any{}
+		output := autogen.ModifyJSONFromMapToList(input)
+		assert.Equal(t, []any{}, output)
+	})
+
+	t.Run("map with values returns list", func(t *testing.T) {
+		input := map[string]any{
+			"b": 2,
+			"a": "one",
+		}
+
+		output := autogen.ModifyJSONFromMapToList(input)
+
+		expected := []any{
+			map[string]any{"key": "a", "value": "one"},
+			map[string]any{"key": "b", "value": 2},
+		}
+		assert.Equal(t, expected, output)
+	})
+}

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -91,7 +91,7 @@ func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[st
 	// Emit value if non-nil, or emit null on update when configured by includeNullOnUpdate
 	if val != nil || (isUpdate && tags.IncludeNullOnUpdate) {
 		if tags.ListAsMap {
-			val = modifyJSONFromMapToList(val)
+			val = ModifyJSONFromMapToList(val)
 		}
 		objJSON[attrNameJSON] = val
 	}

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -5,23 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"slices"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/stringcase"
-)
-
-const (
-	tagKey                    = "autogen"
-	tagSensitive              = "sensitive"
-	tagValOmitJSON            = "omitjson"
-	tagValOmitJSONUpdate      = "omitjsonupdate"
-	tagValIncludeNullOnUpdate = "includenullonupdate"
-	tagAPIName                = "apiname" // e.g., apiname:"groupId" means JSON field is "groupId", used if the API name is different from the uncapitalized model name
 )
 
 // Marshal gets a Terraform model and marshals it into JSON (e.g. for an Atlas request).
@@ -54,35 +43,27 @@ func marshalAttrs(valModel reflect.Value, isUpdate bool) (map[string]any, error)
 	objJSON := make(map[string]any)
 	for i := range valModel.NumField() {
 		attrTypeModel := valModel.Type().Field(i)
-		tags := strings.Split(attrTypeModel.Tag.Get(tagKey), ",")
-		if slices.Contains(tags, tagValOmitJSON) {
+		tags := GetPropertyTags(&attrTypeModel)
+		if tags.OmitJSON {
 			continue // skip fields with tag `omitjson`
 		}
-		if isUpdate && slices.Contains(tags, tagValOmitJSONUpdate) {
+		if isUpdate && tags.OmitJSONUpdate {
 			continue // skip fields with tag `omitjsonupdate` if in update mode
 		}
-		attrNameModel := attrTypeModel.Name
-		// Check for apiname tag to get the actual JSON field name (for aliased attributes)
-		apiName := getAPINameFromTag(attrTypeModel.Tag, attrNameModel)
+		apiName := stringcase.Uncapitalize(attrTypeModel.Name)
+		// Override with apiname tag if present
+		if tags.APIName != nil {
+			apiName = *tags.APIName
+		}
 		attrValModel := valModel.Field(i)
-		includeNullOnUpdate := slices.Contains(tags, tagValIncludeNullOnUpdate)
-		if err := marshalAttr(apiName, attrValModel, objJSON, isUpdate, includeNullOnUpdate); err != nil {
+		if err := marshalAttr(apiName, attrValModel, objJSON, isUpdate, tags); err != nil {
 			return nil, err
 		}
 	}
 	return objJSON, nil
 }
 
-// getAPINameFromTag extracts the API name from the apiname tag if present (e.g., apiname:"groupId"),
-// otherwise returns the model name uncapitalized as the default JSON name.
-func getAPINameFromTag(structTag reflect.StructTag, modelName string) string {
-	if apiName := structTag.Get(tagAPIName); apiName != "" {
-		return apiName
-	}
-	return stringcase.Uncapitalize(modelName)
-}
-
-func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[string]any, isUpdate, includeNullOnUpdate bool) error {
+func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[string]any, isUpdate bool, tags PropertyTags) error {
 	obj, ok := attrValModel.Interface().(attr.Value)
 	if !ok {
 		panic("marshal expects only Terraform types in the model")
@@ -93,15 +74,20 @@ func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[st
 	}
 
 	// Emit empty array for null list/set attributes unless explicit configuration with includeNullOnUpdate
-	if val == nil && isUpdate && !includeNullOnUpdate {
+	if val == nil && isUpdate && !tags.IncludeNullOnUpdate {
 		switch obj.(type) {
 		case customtypes.ListValueInterface, customtypes.NestedListValueInterface, customtypes.SetValueInterface, customtypes.NestedSetValueInterface:
 			val = []any{}
+		case customtypes.MapValueInterface, customtypes.NestedMapValueInterface:
+			val = map[string]any{}
 		}
 	}
 
 	// Emit value if non-nil, or emit null on update when configured by includeNullOnUpdate
-	if val != nil || (isUpdate && includeNullOnUpdate) {
+	if val != nil || (isUpdate && tags.IncludeNullOnUpdate) {
+		if tags.ListAsMap {
+			val = modifyJSONFromMapToList(val)
+		}
 		objJSON[attrNameJSON] = val
 	}
 	return nil

--- a/internal/common/autogen/marshal.go
+++ b/internal/common/autogen/marshal.go
@@ -50,17 +50,22 @@ func marshalAttrs(valModel reflect.Value, isUpdate bool) (map[string]any, error)
 		if isUpdate && tags.OmitJSONUpdate {
 			continue // skip fields with tag `omitjsonupdate` if in update mode
 		}
-		apiName := stringcase.Uncapitalize(attrTypeModel.Name)
-		// Override with apiname tag if present
-		if tags.APIName != nil {
-			apiName = *tags.APIName
-		}
+		apiName := getAPINameFromTag(attrTypeModel.Name, tags)
 		attrValModel := valModel.Field(i)
 		if err := marshalAttr(apiName, attrValModel, objJSON, isUpdate, tags); err != nil {
 			return nil, err
 		}
 	}
 	return objJSON, nil
+}
+
+// getAPINameFromTag extracts the API name from the apiname tag if present (e.g., apiname:"groupId"),
+// otherwise returns the model name uncapitalized as the default JSON name.
+func getAPINameFromTag(modelName string, propertyTags PropertyTags) string {
+	if propertyTags.APIName != nil {
+		return *propertyTags.APIName
+	}
+	return stringcase.Uncapitalize(modelName)
 }
 
 func marshalAttr(attrNameJSON string, attrValModel reflect.Value, objJSON map[string]any, isUpdate bool, tags PropertyTags) error {

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -226,7 +226,7 @@ func TestMarshalUpdateAbsentAttrs(t *testing.T) {
 		AttrIntIncludeNull:          types.Int64Null(),
 		AttrBoolIncludeNull:         types.BoolNull(),
 	}
-	// null list and set root elements are sent as empty arrays in update.
+	// null list, set and map elements are sent with empty values in update.
 	// fields with includenullonupdate tag are included even when null during updates.
 	const expectedJSON = `
 		{
@@ -234,12 +234,14 @@ func TestMarshalUpdateAbsentAttrs(t *testing.T) {
 			"attrListIncludeNull": null,
 			"attrSet": [],
 			"attrSetIncludeNull": null,
+			"attrMap": {},
+			"attrMapIncludeNull": null,
+			"attrNestedMap": {},
+			"attrNestedMapIncludeNull": null,
 			"attrNestedList": [],
 			"attrNestedListIncludeNull": null,
 			"attrNestedSet": [],
 			"attrNestedSetIncludeNull": null,
-			"attrMapIncludeNull": null,
-			"attrNestedMapIncludeNull": null,
 			"attrNestedObjectIncludeNull": null,
 			"attrStringIncludeNull": null,
 			"attrIntIncludeNull": null,
@@ -646,6 +648,58 @@ func TestMarshalCustomTypeNestedMap(t *testing.T) {
 			"attrNestedMapEmpty": {}
 		}
 	`
+	rawUpdate, err := autogen.Marshal(&model, true)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedUpdateJSON, string(rawUpdate))
+}
+
+func TestMarshalListAsMap(t *testing.T) {
+	model := struct {
+		AttrListAsMapWithValues customtypes.MapValue[types.String] `tfsdk:"attr_list_as_map_with_values" autogen:"listasmap"`
+		AttrListAsMapEmpty      customtypes.MapValue[types.String] `tfsdk:"attr_list_as_map_empty" autogen:"listasmap"`
+		AttrListAsMapNull       customtypes.MapValue[types.String] `tfsdk:"attr_list_as_map_null" autogen:"listasmap"`
+	}{
+		AttrListAsMapWithValues: customtypes.NewMapValue[types.String](t.Context(), map[string]attr.Value{
+			"key1": types.StringValue("val1"),
+			"key2": types.StringValue("val2"),
+		}),
+		AttrListAsMapEmpty: customtypes.NewMapValue[types.String](t.Context(), map[string]attr.Value{}),
+		AttrListAsMapNull:  customtypes.NewMapValueNull[types.String](t.Context()),
+	}
+	const expectedCreateJSON = `
+		{ 
+			"attrListAsMapWithValues": [
+				{
+					"key": "key1",
+					"value": "val1"
+				},
+				{
+					"key": "key2",
+					"value": "val2"
+				}
+			],
+			"attrListAsMapEmpty": []
+		}
+	`
+	const expectedUpdateJSON = `
+		{ 
+			"attrListAsMapWithValues": [
+				{
+					"key": "key1",
+					"value": "val1"
+				},
+				{
+					"key": "key2",
+					"value": "val2"
+				}
+			],
+			"attrListAsMapEmpty": [],
+			"attrListAsMapNull": [],
+		}
+	`
+	rawCreate, err := autogen.Marshal(&model, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedCreateJSON, string(rawCreate))
 	rawUpdate, err := autogen.Marshal(&model, true)
 	require.NoError(t, err)
 	assert.JSONEq(t, expectedUpdateJSON, string(rawUpdate))

--- a/internal/common/autogen/marshal_test.go
+++ b/internal/common/autogen/marshal_test.go
@@ -645,6 +645,7 @@ func TestMarshalCustomTypeNestedMap(t *testing.T) {
 					}
 				}
 			},
+			"attrNestedMapNull": {},
 			"attrNestedMapEmpty": {}
 		}
 	`
@@ -694,7 +695,7 @@ func TestMarshalListAsMap(t *testing.T) {
 				}
 			],
 			"attrListAsMapEmpty": [],
-			"attrListAsMapNull": [],
+			"attrListAsMapNull": []
 		}
 	`
 	rawCreate, err := autogen.Marshal(&model, false)

--- a/internal/common/autogen/property_tags.go
+++ b/internal/common/autogen/property_tags.go
@@ -1,0 +1,41 @@
+package autogen
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+)
+
+const (
+	tagKey                    = "autogen"
+	tagSensitive              = "sensitive"
+	tagValOmitJSON            = "omitjson"
+	tagValOmitJSONUpdate      = "omitjsonupdate"
+	tagValIncludeNullOnUpdate = "includenullonupdate"
+	tagValListAsMap           = "listasmap"
+	tagAPIName                = "apiname" // e.g., apiname:"groupId" means JSON field is "groupId", used if the API name is different from the uncapitalized model name
+)
+
+type PropertyTags struct {
+	APIName             *string
+	Sensitive           bool
+	OmitJSON            bool
+	OmitJSONUpdate      bool
+	IncludeNullOnUpdate bool
+	ListAsMap           bool
+}
+
+func GetPropertyTags(field *reflect.StructField) PropertyTags {
+	tags := strings.Split(field.Tag.Get(tagKey), ",")
+	result := PropertyTags{
+		Sensitive:           slices.Contains(tags, tagSensitive),
+		OmitJSON:            slices.Contains(tags, tagValOmitJSON),
+		OmitJSONUpdate:      slices.Contains(tags, tagValOmitJSONUpdate),
+		IncludeNullOnUpdate: slices.Contains(tags, tagValIncludeNullOnUpdate),
+		ListAsMap:           slices.Contains(tags, tagValListAsMap),
+	}
+	if apiName := field.Tag.Get(tagAPIName); apiName != "" {
+		result.APIName = &apiName
+	}
+	return result
+}

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -50,8 +49,12 @@ func unmarshalAttrs(objJSON map[string]any, model any) error {
 			continue // skip fields that cannot be set
 		}
 
-		// Get the API name (JSON field name) for this model field
-		apiName := getAPINameFromTag(field.Tag, field.Name)
+		tags := GetPropertyTags(&field)
+		apiName := stringcase.Uncapitalize(field.Name)
+		// Override with apiname tag if present
+		if tags.APIName != nil {
+			apiName = *tags.APIName
+		}
 
 		// Look up the JSON property
 		attrObjJSON, ok := objJSON[apiName]
@@ -72,6 +75,7 @@ func unmarshalAttrs(objJSON map[string]any, model any) error {
 
 func unmarshalAttr(attrObjJSON any, fieldModel reflect.Value, structField *reflect.StructField) error {
 	attrNameModel := structField.Name
+	tags := GetPropertyTags(structField)
 
 	oldVal, ok := fieldModel.Interface().(attr.Value)
 	if !ok {
@@ -79,9 +83,13 @@ func unmarshalAttr(attrObjJSON any, fieldModel reflect.Value, structField *refle
 	}
 
 	if !oldVal.IsNull() && !oldVal.IsUnknown() { // Check if oldVal is a known value
-		if slices.Contains(strings.Split(structField.Tag.Get(tagKey), ","), tagSensitive) { // Field contains the "sensitive" tag
+		if tags.Sensitive {
 			return nil // skip sensitive fields that are already set in the plan/state to avoid overwriting with redacted values
 		}
+	}
+
+	if tags.ListAsMap {
+		attrObjJSON = modifyJSONFromListToMap(attrObjJSON)
 	}
 
 	valueType := oldVal.Type(context.Background())
@@ -184,6 +192,12 @@ func getObjectValueTFAttr(ctx context.Context, objJSON map[string]any, obj custo
 }
 
 func getMapValueTFAttr(ctx context.Context, mapJSON map[string]any, m customtypes.MapValueInterface) (attr.Value, error) {
+	if len(mapJSON) == 0 && len(m.Elements()) == 0 {
+		// Keep current map if both model and JSON maps are zero-len (empty or null) so config is preserved.
+		// It avoids inconsistent result after apply when user explicitly sets an empty map in config.
+		return m, nil
+	}
+
 	mapAttrs := make(map[string]attr.Value, len(mapJSON))
 	elemType := m.ElementType(ctx)
 
@@ -207,6 +221,13 @@ func getNestedMapValueTFAttr(ctx context.Context, mapJSON map[string]any, m cust
 	}
 
 	oldMapVal := reflect.ValueOf(oldMapPtr).Elem()
+	oldMapLen := oldMapVal.Len()
+
+	if len(mapJSON) == 0 && oldMapLen == 0 {
+		// Keep current map if both model and JSON map are zero-len (empty or null) so config is preserved.
+		// It avoids inconsistent result after apply when user explicitly sets an empty map in config.
+		return m, nil
+	}
 
 	mapPtr := m.NewEmptyMapPtr()
 	mapVal := reflect.ValueOf(mapPtr).Elem()

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -50,11 +50,7 @@ func unmarshalAttrs(objJSON map[string]any, model any) error {
 		}
 
 		tags := GetPropertyTags(&field)
-		apiName := stringcase.Uncapitalize(field.Name)
-		// Override with apiname tag if present
-		if tags.APIName != nil {
-			apiName = *tags.APIName
-		}
+		apiName := getAPINameFromTag(field.Name, tags)
 
 		// Look up the JSON property
 		attrObjJSON, ok := objJSON[apiName]

--- a/internal/common/autogen/unmarshal.go
+++ b/internal/common/autogen/unmarshal.go
@@ -85,7 +85,7 @@ func unmarshalAttr(attrObjJSON any, fieldModel reflect.Value, structField *refle
 	}
 
 	if tags.ListAsMap {
-		attrObjJSON = modifyJSONFromListToMap(attrObjJSON)
+		attrObjJSON = ModifyJSONFromListToMap(attrObjJSON)
 	}
 
 	valueType := oldVal.Type(context.Background())

--- a/internal/common/autogen/unmarshal_test.go
+++ b/internal/common/autogen/unmarshal_test.go
@@ -314,6 +314,7 @@ func TestUnmarshalCustomList(t *testing.T) {
 		AttrCustomNestedList               customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list"`
 		AttrCustomNestedListNullNotSent    customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_null_not_sent"`
 		AttrCustomNestedListNullSent       customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_null_sent"`
+		AttrCustomNestedListEmptySent      customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_empty_sent"`
 		AttrCustomNestedListUnknownNotSent customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_unknown_not_sent"`
 		AttrCustomNestedListUnknownSent    customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_unknown_sent"`
 		AttrCustomNestedListZeroInit       customtypes.NestedListValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_list_zero"`
@@ -341,6 +342,7 @@ func TestUnmarshalCustomList(t *testing.T) {
 		}),
 		AttrCustomNestedListNullNotSent:    customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListNullSent:       customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedListEmptySent:      customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListUnknownNotSent: customtypes.NewNestedListValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListUnknownSent:    customtypes.NewNestedListValueUnknown[unmarshalModelCustomType](ctx),
 	}
@@ -369,6 +371,7 @@ func TestUnmarshalCustomList(t *testing.T) {
 					}
 				],
 				"attrCustomNestedListNullSent": null,
+				"attrCustomNestedListEmptySent": [],
 				"attrCustomNestedListUnknownSent": [
 					{
 						"attrString": "unknownSent"
@@ -409,6 +412,7 @@ func TestUnmarshalCustomList(t *testing.T) {
 		}),
 		AttrCustomNestedListNullNotSent:    customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListNullSent:       customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedListEmptySent:      customtypes.NewNestedListValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListUnknownNotSent: customtypes.NewNestedListValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedListUnknownSent: customtypes.NewNestedListValue[unmarshalModelCustomType](ctx, []unmarshalModelCustomType{
 			{
@@ -444,6 +448,7 @@ func TestUnmarshalCustomSet(t *testing.T) {
 		AttrCustomNestedSet               customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set"`
 		AttrCustomNestedSetNullNotSent    customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_null_not_sent"`
 		AttrCustomNestedSetNullSent       customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_null_sent"`
+		AttrCustomNestedSetEmptySent      customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_empty_sent"`
 		AttrCustomNestedSetUnknownNotSent customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_unknown_not_sent"`
 		AttrCustomNestedSetUnknownSent    customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_unknown_sent"`
 		AttrCustomNestedSetZeroInit       customtypes.NestedSetValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_set_zero"`
@@ -461,6 +466,7 @@ func TestUnmarshalCustomSet(t *testing.T) {
 		}}),
 		AttrCustomNestedSetNullNotSent:    customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetNullSent:       customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedSetEmptySent:      customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetUnknownNotSent: customtypes.NewNestedSetValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetUnknownSent:    customtypes.NewNestedSetValueUnknown[unmarshalModelCustomType](ctx),
 	}
@@ -491,6 +497,7 @@ func TestUnmarshalCustomSet(t *testing.T) {
 					}
 				],
 				"attrCustomNestedSetNullSent": null,
+				"attrCustomNestedSetEmptySent": [],
 				"attrCustomNestedSetUnknownSent": [
 					{
 						"attrString": "unknownSetSent"
@@ -531,6 +538,7 @@ func TestUnmarshalCustomSet(t *testing.T) {
 		}),
 		AttrCustomNestedSetNullNotSent:    customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetNullSent:       customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedSetEmptySent:      customtypes.NewNestedSetValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetUnknownNotSent: customtypes.NewNestedSetValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedSetUnknownSent: customtypes.NewNestedSetValue[unmarshalModelCustomType](ctx, []unmarshalModelCustomType{
 			{
@@ -563,16 +571,19 @@ func TestUnmarshalCustomMap(t *testing.T) {
 
 	type modelst struct {
 		AttrCustomMapString               customtypes.MapValue[types.String]                   `tfsdk:"attr_custom_map_string"`
+		AttrCustomMapEmptySent            customtypes.MapValue[types.String]                   `tfsdk:"attr_custom_map_empty_sent"`
 		AttrCustomNestedMap               customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map"`
 		AttrCustomNestedMapNullNotSent    customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_null_not_sent"`
 		AttrCustomNestedMapNullSent       customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_null_sent"`
+		AttrCustomNestedMapEmptySent      customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_empty_sent"`
 		AttrCustomNestedMapUnknownNotSent customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_unknown_not_sent"`
 		AttrCustomNestedMapUnknownSent    customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_unknown_sent"`
 		AttrCustomNestedMapZeroInit       customtypes.NestedMapValue[unmarshalModelCustomType] `tfsdk:"attr_custom_nested_map_zero"`
 	}
 
 	model := modelst{
-		AttrCustomMapString: customtypes.NewMapValueUnknown[types.String](ctx),
+		AttrCustomMapString:    customtypes.NewMapValueUnknown[types.String](ctx),
+		AttrCustomMapEmptySent: customtypes.NewMapValueNull[types.String](ctx),
 		AttrCustomNestedMap: customtypes.NewNestedMapValue[unmarshalModelCustomType](ctx, map[string]unmarshalModelCustomType{
 			"keyOne": {
 				AttrString:    types.StringValue("different_string"),
@@ -593,6 +604,7 @@ func TestUnmarshalCustomMap(t *testing.T) {
 		}),
 		AttrCustomNestedMapNullNotSent:    customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapNullSent:       customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedMapEmptySent:      customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapUnknownNotSent: customtypes.NewNestedMapValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapUnknownSent:    customtypes.NewNestedMapValueUnknown[unmarshalModelCustomType](ctx),
 	}
@@ -604,6 +616,7 @@ func TestUnmarshalCustomMap(t *testing.T) {
 					"keyOne": "map1",
 					"KeyTwo": "map2"
 				},
+				"attrCustomMapEmptySent": {},
 				"attrCustomNestedMap": {
 					"keyOne": {
 						"attrString": "nestedMap1",
@@ -621,6 +634,7 @@ func TestUnmarshalCustomMap(t *testing.T) {
 					}
 				},
 				"attrCustomNestedMapNullSent": null,
+				"attrCustomNestedMapEmptySent": {},
 				"attrCustomNestedMapUnknownSent": {
 					"keyOne": {
 						"attrString": "unknownMapSent"
@@ -641,6 +655,7 @@ func TestUnmarshalCustomMap(t *testing.T) {
 			"keyOne": types.StringValue("map1"),
 			"KeyTwo": types.StringValue("map2"),
 		}),
+		AttrCustomMapEmptySent: customtypes.NewMapValueNull[types.String](ctx),
 		AttrCustomNestedMap: customtypes.NewNestedMapValue[unmarshalModelCustomType](ctx, map[string]unmarshalModelCustomType{
 			"keyOne": {
 				AttrString:    types.StringValue("nestedMap1"),
@@ -661,6 +676,7 @@ func TestUnmarshalCustomMap(t *testing.T) {
 		}),
 		AttrCustomNestedMapNullNotSent:    customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapNullSent:       customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
+		AttrCustomNestedMapEmptySent:      customtypes.NewNestedMapValueNull[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapUnknownNotSent: customtypes.NewNestedMapValueUnknown[unmarshalModelCustomType](ctx),
 		AttrCustomNestedMapUnknownSent: customtypes.NewNestedMapValue[unmarshalModelCustomType](ctx, map[string]unmarshalModelCustomType{
 			"keyOne": {
@@ -682,6 +698,48 @@ func TestUnmarshalCustomMap(t *testing.T) {
 				AttrMANYUpper: types.Int64Null(),
 			},
 		}),
+	}
+
+	require.NoError(t, autogen.Unmarshal([]byte(jsonResp), &model))
+	assert.Equal(t, modelExpected, model)
+}
+
+func TestUnmarshalListAsMap(t *testing.T) {
+	ctx := context.Background()
+
+	type modelst struct {
+		ListWithValues customtypes.MapValue[types.String] `tfsdk:"list_with_values" autogen:"listasmap"`
+		EmptyList      customtypes.MapValue[types.String] `tfsdk:"empty_list" autogen:"listasmap"`
+		NotSent        customtypes.MapValue[types.String] `tfsdk:"not_sent" autogen:"listasmap"`
+	}
+
+	model := modelst{
+		ListWithValues: customtypes.NewMapValueUnknown[types.String](ctx),
+		EmptyList:      customtypes.NewMapValueNull[types.String](ctx),
+		NotSent:        customtypes.NewMapValueNull[types.String](ctx),
+	}
+	const jsonResp = `
+		{
+			"listWithValues": [
+				{
+					"key": "key1",
+					"value": "value1"
+				},
+				{
+					"key": "key2",
+					"value": "value2"
+				}
+			],
+			"emptyList": []
+		}
+	`
+	modelExpected := modelst{
+		ListWithValues: customtypes.NewMapValue[types.String](ctx, map[string]attr.Value{
+			"key1": types.StringValue("value1"),
+			"key2": types.StringValue("value2"),
+		}),
+		EmptyList: customtypes.NewMapValueNull[types.String](ctx),
+		NotSent:   customtypes.NewMapValueNull[types.String](ctx),
 	}
 
 	require.NoError(t, autogen.Unmarshal([]byte(jsonResp), &model))


### PR DESCRIPTION
## Description

Link to any related issue(s): CLOUDP-363096

**Note**: Recommend reviewing https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4024 first as it provides context on when `listasmap` tag is defined and why it is needed.

### Changes in autogen marshal/unmarshal behavior

Marshal/unmarshal logic is enhanced to support new `listasmap` tag. This tags is used to identify Map attributes which map to a property in the API which is a list of objects (e.g. `[ { "key": "someKey", "value": "someValue"  } ]`).

This requires the following changes:

- Marshaling: A new step is added (if tag is present) **after** regular marshalling logic which transforms the resulting json object into an equivalent json array (`ModifyJSONFromMapToList`).
- Unmarshaling: A new step is added (if tag is present) **prior** to regular unmarshalling logic which transforms the input json array into an equivalent json object (`ModifyJSONFromListToMap`).

As tags and labels are now dependent on regular Map type marshaling and unmarshaling logic, it brought up 2 inconsistencies we had between how list and map types behave. These changes ensure `TestAccProjectAPI_basic` continue to work contemplating removal of tags:

- Handle unmarshalling of empty values in json response (`[]` or `{}`): For list type we had specific logic to ensure previous null representation is preserved (allowing for both absent attribute or attribute with explicit empty value). This is now added in map type as well.
- Handle marshalling of null value in TF model: For list type on update operation we explicitly send empty list to ensure API removes values. This is now added in map type as well.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
