### PR TITLE
chore: Support nested set and list override in autogen

### DIFF
--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -278,6 +278,14 @@ func applyTypeOverride(override *config.Override, attr *Attribute) error {
 			attr.List = nil
 			return nil
 		}
+		if attr.ListNested != nil {
+			if attr.CustomType != nil {
+				attr.CustomType = NewCustomNestedSetType(attr.TFModelName)
+			}
+			attr.SetNested = &SetNestedAttribute{NestedObject: attr.ListNested.NestedObject}
+			attr.ListNested = nil
+			return nil
+		}
 	case config.List:
 		if attr.Set != nil {
 			if attr.CustomType != nil {
@@ -285,6 +293,14 @@ func applyTypeOverride(override *config.Override, attr *Attribute) error {
 			}
 			attr.List = &ListAttribute{ElementType: attr.Set.ElementType}
 			attr.Set = nil
+			return nil
+		}
+		if attr.SetNested != nil {
+			if attr.CustomType != nil {
+				attr.CustomType = NewCustomNestedListType(attr.TFModelName)
+			}
+			attr.ListNested = &ListNestedAttribute{NestedObject: attr.SetNested.NestedObject}
+			attr.SetNested = nil
 			return nil
 		}
 	default:


### PR DESCRIPTION
## Description

We already support overrides between set <-> list. Adding support for nested set & list as well.

Link to any related issue(s): CLOUDP-368414

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
