### PR TITLE
chore: Support nested set and list override in autogen

### DIFF
--- a/internal/serviceapi/orgserviceaccountapi/data_source_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/data_source_schema.go
@@ -40,10 +40,10 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 				CustomType:          customtypes.NewSetType[types.String](ctx),
 				ElementType:         types.StringType,
 			},
-			"secrets": dsschema.SetNestedAttribute{
+			"secrets": dsschema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "A list of secrets associated with the specified Service Account.",
-				CustomType:          customtypes.NewNestedSetType[TFDSSecretsModel](ctx),
+				CustomType:          customtypes.NewNestedListType[TFDSSecretsModel](ctx),
 				NestedObject: dsschema.NestedAttributeObject{
 					Attributes: map[string]dsschema.Attribute{
 						"created_at": dsschema.StringAttribute{
@@ -79,13 +79,13 @@ func DataSourceSchema(ctx context.Context) dsschema.Schema {
 }
 
 type TFDSModel struct {
-	ClientId    types.String                                 `tfsdk:"client_id" autogen:"omitjson"`
-	CreatedAt   types.String                                 `tfsdk:"created_at" autogen:"omitjson"`
-	Description types.String                                 `tfsdk:"description" autogen:"omitjson"`
-	Name        types.String                                 `tfsdk:"name" autogen:"omitjson"`
-	OrgId       types.String                                 `tfsdk:"org_id" autogen:"omitjson"`
-	Roles       customtypes.SetValue[types.String]           `tfsdk:"roles" autogen:"omitjson"`
-	Secrets     customtypes.NestedSetValue[TFDSSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
+	ClientId    types.String                                  `tfsdk:"client_id" autogen:"omitjson"`
+	CreatedAt   types.String                                  `tfsdk:"created_at" autogen:"omitjson"`
+	Description types.String                                  `tfsdk:"description" autogen:"omitjson"`
+	Name        types.String                                  `tfsdk:"name" autogen:"omitjson"`
+	OrgId       types.String                                  `tfsdk:"org_id" autogen:"omitjson"`
+	Roles       customtypes.SetValue[types.String]            `tfsdk:"roles" autogen:"omitjson"`
+	Secrets     customtypes.NestedListValue[TFDSSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
 }
 type TFDSSecretsModel struct {
 	CreatedAt         types.String `tfsdk:"created_at" autogen:"omitjson"`

--- a/internal/serviceapi/orgserviceaccountapi/plural_data_source_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/plural_data_source_schema.go
@@ -46,10 +46,10 @@ func PluralDataSourceSchema(ctx context.Context) dsschema.Schema {
 							CustomType:          customtypes.NewSetType[types.String](ctx),
 							ElementType:         types.StringType,
 						},
-						"secrets": dsschema.SetNestedAttribute{
+						"secrets": dsschema.ListNestedAttribute{
 							Computed:            true,
 							MarkdownDescription: "A list of secrets associated with the specified Service Account.",
-							CustomType:          customtypes.NewNestedSetType[TFPluralDSResultsSecretsModel](ctx),
+							CustomType:          customtypes.NewNestedListType[TFPluralDSResultsSecretsModel](ctx),
 							NestedObject: dsschema.NestedAttributeObject{
 								Attributes: map[string]dsschema.Attribute{
 									"created_at": dsschema.StringAttribute{
@@ -92,12 +92,12 @@ type TFPluralDSModel struct {
 	Results customtypes.NestedListValue[TFPluralDSResultsModel] `tfsdk:"results" autogen:"omitjson"`
 }
 type TFPluralDSResultsModel struct {
-	ClientId    types.String                                              `tfsdk:"client_id" autogen:"omitjson"`
-	CreatedAt   types.String                                              `tfsdk:"created_at" autogen:"omitjson"`
-	Description types.String                                              `tfsdk:"description" autogen:"omitjson"`
-	Name        types.String                                              `tfsdk:"name" autogen:"omitjson"`
-	Roles       customtypes.SetValue[types.String]                        `tfsdk:"roles" autogen:"omitjson"`
-	Secrets     customtypes.NestedSetValue[TFPluralDSResultsSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
+	ClientId    types.String                                               `tfsdk:"client_id" autogen:"omitjson"`
+	CreatedAt   types.String                                               `tfsdk:"created_at" autogen:"omitjson"`
+	Description types.String                                               `tfsdk:"description" autogen:"omitjson"`
+	Name        types.String                                               `tfsdk:"name" autogen:"omitjson"`
+	Roles       customtypes.SetValue[types.String]                         `tfsdk:"roles" autogen:"omitjson"`
+	Secrets     customtypes.NestedListValue[TFPluralDSResultsSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
 }
 type TFPluralDSResultsSecretsModel struct {
 	CreatedAt         types.String `tfsdk:"created_at" autogen:"omitjson"`

--- a/internal/serviceapi/orgserviceaccountapi/resource_schema.go
+++ b/internal/serviceapi/orgserviceaccountapi/resource_schema.go
@@ -47,10 +47,10 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings.",
 				PlanModifiers:       []planmodifier.Int64{customplanmodifier.CreateOnly(), customplanmodifier.RequestOnlyRequiredOnCreate()},
 			},
-			"secrets": schema.SetNestedAttribute{
+			"secrets": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "A list of secrets associated with the specified Service Account.",
-				CustomType:          customtypes.NewNestedSetType[TFSecretsModel](ctx),
+				CustomType:          customtypes.NewNestedListType[TFSecretsModel](ctx),
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"created_at": schema.StringAttribute{
@@ -86,14 +86,14 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 }
 
 type TFModel struct {
-	Roles                   customtypes.SetValue[types.String]         `tfsdk:"roles"`
-	Secrets                 customtypes.NestedSetValue[TFSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
-	ClientId                types.String                               `tfsdk:"client_id" autogen:"omitjson"`
-	CreatedAt               types.String                               `tfsdk:"created_at" autogen:"omitjson"`
-	Description             types.String                               `tfsdk:"description"`
-	Name                    types.String                               `tfsdk:"name"`
-	OrgId                   types.String                               `tfsdk:"org_id" autogen:"omitjson"`
-	SecretExpiresAfterHours types.Int64                                `tfsdk:"secret_expires_after_hours" autogen:"omitjsonupdate"`
+	Roles                   customtypes.SetValue[types.String]          `tfsdk:"roles"`
+	Secrets                 customtypes.NestedListValue[TFSecretsModel] `tfsdk:"secrets" autogen:"omitjson"`
+	ClientId                types.String                                `tfsdk:"client_id" autogen:"omitjson"`
+	CreatedAt               types.String                                `tfsdk:"created_at" autogen:"omitjson"`
+	Description             types.String                                `tfsdk:"description"`
+	Name                    types.String                                `tfsdk:"name"`
+	OrgId                   types.String                                `tfsdk:"org_id" autogen:"omitjson"`
+	SecretExpiresAfterHours types.Int64                                 `tfsdk:"secret_expires_after_hours" autogen:"omitjsonupdate"`
 }
 type TFSecretsModel struct {
 	CreatedAt         types.String `tfsdk:"created_at" autogen:"omitjson"`

--- a/tools/codegen/codespec/config.go
+++ b/tools/codegen/codespec/config.go
@@ -278,6 +278,14 @@ func applyTypeOverride(override *config.Override, attr *Attribute) error {
 			attr.List = nil
 			return nil
 		}
+		if attr.ListNested != nil {
+			if attr.CustomType != nil {
+				attr.CustomType = NewCustomNestedSetType(attr.CustomType.Name)
+			}
+			attr.SetNested = &SetNestedAttribute{NestedObject: attr.ListNested.NestedObject}
+			attr.ListNested = nil
+			return nil
+		}
 	case config.List:
 		if attr.Set != nil {
 			if attr.CustomType != nil {
@@ -285,6 +293,14 @@ func applyTypeOverride(override *config.Override, attr *Attribute) error {
 			}
 			attr.List = &ListAttribute{ElementType: attr.Set.ElementType}
 			attr.Set = nil
+			return nil
+		}
+		if attr.SetNested != nil {
+			if attr.CustomType != nil {
+				attr.CustomType = NewCustomNestedListType(attr.CustomType.Name)
+			}
+			attr.ListNested = &ListNestedAttribute{NestedObject: attr.SetNested.NestedObject}
+			attr.SetNested = nil
 			return nil
 		}
 	default:

--- a/tools/codegen/codespec/model.go
+++ b/tools/codegen/codespec/model.go
@@ -222,6 +222,7 @@ const (
 
 type CustomType struct {
 	Package CustomTypePackage `yaml:"package"`
+	Name    string            `yaml:"name,omitempty"` // Nested object name without the "TF" & "Model" prefix and suffix. Used for type overrides.
 	Model   string            `yaml:"model"`
 	Schema  string            `yaml:"schema"`
 }
@@ -235,6 +236,7 @@ var CustomTypeJSONVar = CustomType{
 func NewCustomObjectType(name string) *CustomType {
 	return &CustomType{
 		Package: CustomTypesPkg,
+		Name:    name,
 		Model:   fmt.Sprintf("customtypes.ObjectValue[TF%sModel]", name),
 		Schema:  fmt.Sprintf("customtypes.NewObjectType[TF%sModel](ctx)", name),
 	}
@@ -252,6 +254,7 @@ func NewCustomListType(elemType ElemType) *CustomType {
 func NewCustomNestedListType(name string) *CustomType {
 	return &CustomType{
 		Package: CustomTypesPkg,
+		Name:    name,
 		Model:   fmt.Sprintf("customtypes.NestedListValue[TF%sModel]", name),
 		Schema:  fmt.Sprintf("customtypes.NewNestedListType[TF%sModel](ctx)", name),
 	}
@@ -269,6 +272,7 @@ func NewCustomSetType(elemType ElemType) *CustomType {
 func NewCustomNestedSetType(name string) *CustomType {
 	return &CustomType{
 		Package: CustomTypesPkg,
+		Name:    name,
 		Model:   fmt.Sprintf("customtypes.NestedSetValue[TF%sModel]", name),
 		Schema:  fmt.Sprintf("customtypes.NewNestedSetType[TF%sModel](ctx)", name),
 	}

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -760,6 +760,8 @@ resources:
       method: DELETE
     schema:
       overrides:
+        secrets:
+          type: list
         secrets.secret:
           sensitive: true
         roles:
@@ -771,6 +773,8 @@ resources:
         method: GET
       schema:
         overrides:
+          secrets:
+            type: list
           secrets.secret:
             sensitive: true
         ignores: ["links"]

--- a/tools/codegen/models/alert_configuration_api.yaml
+++ b/tools/codegen/models/alert_configuration_api.yaml
@@ -102,6 +102,7 @@ schema:
           description: List of rules that determine whether MongoDB Cloud checks an object for the alert configuration.
           custom_type:
             package: customtypes
+            name: Matchers
             model: customtypes.NestedListValue[TFMatchersModel]
             schema: customtypes.NewNestedListType[TFMatchersModel](ctx)
           computed_optional_required: optional
@@ -175,6 +176,7 @@ schema:
           description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics about the serverless database.
           custom_type:
             package: customtypes
+            name: MetricThreshold
             model: customtypes.ObjectValue[TFMetricThresholdModel]
             schema: customtypes.NewObjectType[TFMetricThresholdModel](ctx)
           computed_optional_required: optional
@@ -581,6 +583,7 @@ schema:
           description: List that contains the targets that MongoDB Cloud sends notifications.
           custom_type:
             package: customtypes
+            name: Notifications
             model: customtypes.NestedListValue[TFNotificationsModel]
             schema: customtypes.NewNestedListType[TFNotificationsModel](ctx)
           computed_optional_required: optional
@@ -665,6 +668,7 @@ schema:
           description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics in stream processors.
           custom_type:
             package: customtypes
+            name: Threshold
             model: customtypes.ObjectValue[TFThresholdModel]
             schema: customtypes.NewObjectType[TFThresholdModel](ctx)
           computed_optional_required: optional
@@ -806,6 +810,7 @@ data_sources:
               description: List of rules that determine whether MongoDB Cloud checks an object for the alert configuration.
               custom_type:
                 package: customtypes
+                name: Matchers
                 model: customtypes.NestedListValue[TFMatchersModel]
                 schema: customtypes.NewNestedListType[TFMatchersModel](ctx)
               computed_optional_required: computed
@@ -879,6 +884,7 @@ data_sources:
               description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics about the serverless database.
               custom_type:
                 package: customtypes
+                name: MetricThreshold
                 model: customtypes.ObjectValue[TFMetricThresholdModel]
                 schema: customtypes.NewObjectType[TFMetricThresholdModel](ctx)
               computed_optional_required: computed
@@ -1285,6 +1291,7 @@ data_sources:
               description: List that contains the targets that MongoDB Cloud sends notifications.
               custom_type:
                 package: customtypes
+                name: Notifications
                 model: customtypes.NestedListValue[TFNotificationsModel]
                 schema: customtypes.NewNestedListType[TFNotificationsModel](ctx)
               computed_optional_required: computed
@@ -1369,6 +1376,7 @@ data_sources:
               description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics in stream processors.
               custom_type:
                 package: customtypes
+                name: Threshold
                 model: customtypes.ObjectValue[TFThresholdModel]
                 schema: customtypes.NewObjectType[TFThresholdModel](ctx)
               computed_optional_required: computed
@@ -1508,6 +1516,7 @@ data_sources:
                           description: List of rules that determine whether MongoDB Cloud checks an object for the alert configuration.
                           custom_type:
                             package: customtypes
+                            name: ResultsMatchers
                             model: customtypes.NestedListValue[TFResultsMatchersModel]
                             schema: customtypes.NewNestedListType[TFResultsMatchersModel](ctx)
                           computed_optional_required: computed
@@ -1581,6 +1590,7 @@ data_sources:
                           description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics about the serverless database.
                           custom_type:
                             package: customtypes
+                            name: ResultsMetricThreshold
                             model: customtypes.ObjectValue[TFResultsMetricThresholdModel]
                             schema: customtypes.NewObjectType[TFResultsMetricThresholdModel](ctx)
                           computed_optional_required: computed
@@ -1987,6 +1997,7 @@ data_sources:
                           description: List that contains the targets that MongoDB Cloud sends notifications.
                           custom_type:
                             package: customtypes
+                            name: ResultsNotifications
                             model: customtypes.NestedListValue[TFResultsNotificationsModel]
                             schema: customtypes.NewNestedListType[TFResultsNotificationsModel](ctx)
                           computed_optional_required: computed
@@ -2071,6 +2082,7 @@ data_sources:
                           description: Threshold for the metric that, when exceeded, triggers an alert. The metric threshold pertains to event types which reflects changes of measurements and metrics in stream processors.
                           custom_type:
                             package: customtypes
+                            name: ResultsThreshold
                             model: customtypes.ObjectValue[TFResultsThresholdModel]
                             schema: customtypes.NewObjectType[TFResultsThresholdModel](ctx)
                           computed_optional_required: computed
@@ -2096,6 +2108,7 @@ data_sources:
               description: List of returned documents that MongoDB Cloud provides when completing this request.
               custom_type:
                 package: customtypes
+                name: Results
                 model: customtypes.NestedListValue[TFResultsModel]
                 schema: customtypes.NewNestedListType[TFResultsModel](ctx)
               computed_optional_required: computed

--- a/tools/codegen/models/cluster_api.yaml
+++ b/tools/codegen/models/cluster_api.yaml
@@ -75,6 +75,7 @@ schema:
           description: Group of settings that configures a subset of the advanced configuration details.
           custom_type:
             package: customtypes
+            name: AdvancedConfiguration
             model: customtypes.ObjectValue[TFAdvancedConfigurationModel]
             schema: customtypes.NewObjectType[TFAdvancedConfigurationModel](ctx)
           computed_optional_required: computed_optional
@@ -126,6 +127,7 @@ schema:
           description: Settings needed to configure the MongoDB Connector for Business Intelligence for this cluster.
           custom_type:
             package: customtypes
+            name: BiConnector
             model: customtypes.ObjectValue[TFBiConnectorModel]
             schema: customtypes.NewObjectType[TFBiConnectorModel](ctx)
           computed_optional_required: computed_optional
@@ -275,6 +277,7 @@ schema:
                                   description: List that contains the private endpoints through which you connect to MongoDB Cloud when you use **connectionStrings.privateEndpoint[n].connectionString** or **connectionStrings.privateEndpoint[n].srvConnectionString**.
                                   custom_type:
                                     package: customtypes
+                                    name: ConnectionStringsPrivateEndpointEndpoints
                                     model: customtypes.NestedListValue[TFConnectionStringsPrivateEndpointEndpointsModel]
                                     schema: customtypes.NewNestedListType[TFConnectionStringsPrivateEndpointEndpointsModel](ctx)
                                   computed_optional_required: computed
@@ -322,6 +325,7 @@ schema:
                       description: List of private endpoint-aware connection strings that you can use to connect to this cluster through a private endpoint. This parameter returns only if you deployed a private endpoint to all regions to which you deployed this clusters' nodes.
                       custom_type:
                         package: customtypes
+                        name: ConnectionStringsPrivateEndpoint
                         model: customtypes.NestedListValue[TFConnectionStringsPrivateEndpointModel]
                         schema: customtypes.NewNestedListType[TFConnectionStringsPrivateEndpointModel](ctx)
                       computed_optional_required: computed
@@ -369,6 +373,7 @@ schema:
           description: Collection of Uniform Resource Locators that point to the MongoDB database.
           custom_type:
             package: customtypes
+            name: ConnectionStrings
             model: customtypes.ObjectValue[TFConnectionStringsModel]
             schema: customtypes.NewObjectType[TFConnectionStringsModel](ctx)
           computed_optional_required: computed
@@ -539,6 +544,7 @@ schema:
           description: MongoDB employee granted access level and expiration for a cluster.
           custom_type:
             package: customtypes
+            name: MongoDBEmployeeAccessGrant
             model: customtypes.ObjectValue[TFMongoDBEmployeeAccessGrantModel]
             schema: customtypes.NewObjectType[TFMongoDBEmployeeAccessGrantModel](ctx)
           computed_optional_required: optional
@@ -716,6 +722,7 @@ schema:
                                               description: Options that determine how this cluster handles CPU scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAnalyticsAutoScalingCompute
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel](ctx)
                                               computed_optional_required: optional
@@ -744,6 +751,7 @@ schema:
                                               description: Setting that enables disk auto-scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGB
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGBModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGBModel](ctx)
                                               computed_optional_required: optional
@@ -758,6 +766,7 @@ schema:
                                   description: Options that determine how this cluster handles resource scaling.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx)
                                   computed_optional_required: optional
@@ -839,6 +848,7 @@ schema:
                                   description: The current hardware specifications for read only nodes in the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAnalyticsSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx)
                                   computed_optional_required: computed_optional
@@ -907,6 +917,7 @@ schema:
                                               description: Options that determine how this cluster handles CPU scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAutoScalingCompute
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingComputeModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingComputeModel](ctx)
                                               computed_optional_required: computed_optional
@@ -935,6 +946,7 @@ schema:
                                               description: Setting that enables disk auto-scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAutoScalingDiskGB
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingDiskGBModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingDiskGBModel](ctx)
                                               computed_optional_required: computed_optional
@@ -949,6 +961,7 @@ schema:
                                   description: Options that determine how this cluster handles resource scaling.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAutoScaling
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx)
                                   computed_optional_required: computed_optional
@@ -1041,6 +1054,7 @@ schema:
                                   description: The current hardware specifications for read only nodes in the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsEffectiveAnalyticsSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveAnalyticsSpecsModel](ctx)
                                   computed_optional_required: computed
@@ -1122,6 +1136,7 @@ schema:
                                   description: The current hardware specifications for read only nodes in the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsEffectiveElectableSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsEffectiveElectableSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveElectableSpecsModel](ctx)
                                   computed_optional_required: computed
@@ -1203,6 +1218,7 @@ schema:
                                   description: The current hardware specifications for read only nodes in the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsEffectiveReadOnlySpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsEffectiveReadOnlySpecsModel](ctx)
                                   computed_optional_required: computed
@@ -1295,6 +1311,7 @@ schema:
                                   description: Hardware specifications for all electable nodes deployed in the region. Electable nodes can become the primary and can enable local reads. If you don't specify this option, MongoDB Cloud deploys no electable nodes to the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsElectableSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsElectableSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsElectableSpecsModel](ctx)
                                   computed_optional_required: optional
@@ -1401,6 +1418,7 @@ schema:
                                   description: The current hardware specifications for read only nodes in the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsReadOnlySpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsReadOnlySpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx)
                                   computed_optional_required: computed_optional
@@ -1431,6 +1449,7 @@ schema:
                         If you set `"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize" : "M30"`, set `"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize" : `"M30"` if you have electable nodes and `"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize" : `"M30"` if you have read-only nodes.
                       custom_type:
                         package: customtypes
+                        name: ReplicationSpecsRegionConfigs
                         model: customtypes.NestedListValue[TFReplicationSpecsRegionConfigsModel]
                         schema: customtypes.NewNestedListType[TFReplicationSpecsRegionConfigsModel](ctx)
                       computed_optional_required: optional
@@ -1467,6 +1486,7 @@ schema:
           description: List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.
           custom_type:
             package: customtypes
+            name: ReplicationSpecs
             model: customtypes.NestedListValue[TFReplicationSpecsModel]
             schema: customtypes.NewNestedListType[TFReplicationSpecsModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/cluster_old_api.yaml
+++ b/tools/codegen/models/cluster_old_api.yaml
@@ -76,6 +76,7 @@ schema:
           description: Group of settings that configures a subset of the advanced configuration details.
           custom_type:
             package: customtypes
+            name: AdvancedConfiguration
             model: customtypes.ObjectValue[TFAdvancedConfigurationModel]
             schema: customtypes.NewObjectType[TFAdvancedConfigurationModel](ctx)
           computed_optional_required: computed_optional
@@ -127,6 +128,7 @@ schema:
           description: Settings needed to configure the MongoDB Connector for Business Intelligence for this cluster.
           custom_type:
             package: customtypes
+            name: BiConnector
             model: customtypes.ObjectValue[TFBiConnectorModel]
             schema: customtypes.NewObjectType[TFBiConnectorModel](ctx)
           computed_optional_required: computed_optional
@@ -276,6 +278,7 @@ schema:
                                   description: List that contains the private endpoints through which you connect to MongoDB Cloud when you use **connectionStrings.privateEndpoint[n].connectionString** or **connectionStrings.privateEndpoint[n].srvConnectionString**.
                                   custom_type:
                                     package: customtypes
+                                    name: ConnectionStringsPrivateEndpointEndpoints
                                     model: customtypes.NestedListValue[TFConnectionStringsPrivateEndpointEndpointsModel]
                                     schema: customtypes.NewNestedListType[TFConnectionStringsPrivateEndpointEndpointsModel](ctx)
                                   computed_optional_required: computed
@@ -323,6 +326,7 @@ schema:
                       description: List of private endpoint-aware connection strings that you can use to connect to this cluster through a private endpoint. This parameter returns only if you deployed a private endpoint to all regions to which you deployed this clusters' nodes.
                       custom_type:
                         package: customtypes
+                        name: ConnectionStringsPrivateEndpoint
                         model: customtypes.NestedListValue[TFConnectionStringsPrivateEndpointModel]
                         schema: customtypes.NewNestedListType[TFConnectionStringsPrivateEndpointModel](ctx)
                       computed_optional_required: computed
@@ -370,6 +374,7 @@ schema:
           description: Collection of Uniform Resource Locators that point to the MongoDB database.
           custom_type:
             package: customtypes
+            name: ConnectionStrings
             model: customtypes.ObjectValue[TFConnectionStringsModel]
             schema: customtypes.NewObjectType[TFConnectionStringsModel](ctx)
           computed_optional_required: computed
@@ -540,6 +545,7 @@ schema:
           description: MongoDB employee granted access level and expiration for a cluster.
           custom_type:
             package: customtypes
+            name: MongoDBEmployeeAccessGrant
             model: customtypes.ObjectValue[TFMongoDBEmployeeAccessGrantModel]
             schema: customtypes.NewObjectType[TFMongoDBEmployeeAccessGrantModel](ctx)
           computed_optional_required: optional
@@ -718,6 +724,7 @@ schema:
                                               description: Options that determine how this cluster handles CPU scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAnalyticsAutoScalingCompute
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingComputeModel](ctx)
                                               computed_optional_required: optional
@@ -746,6 +753,7 @@ schema:
                                               description: Setting that enables disk auto-scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGB
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGBModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingDiskGBModel](ctx)
                                               computed_optional_required: optional
@@ -760,6 +768,7 @@ schema:
                                   description: Options that determine how this cluster handles resource scaling.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAnalyticsAutoScaling
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsAutoScalingModel](ctx)
                                   computed_optional_required: optional
@@ -830,6 +839,7 @@ schema:
                                   description: Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads.If you don't specify this parameter, no read-only nodes are deployed to the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAnalyticsSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAnalyticsSpecsModel](ctx)
                                   computed_optional_required: computed_optional
@@ -898,6 +908,7 @@ schema:
                                               description: Options that determine how this cluster handles CPU scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAutoScalingCompute
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingComputeModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingComputeModel](ctx)
                                               computed_optional_required: computed_optional
@@ -926,6 +937,7 @@ schema:
                                               description: Setting that enables disk auto-scaling.
                                               custom_type:
                                                 package: customtypes
+                                                name: ReplicationSpecsRegionConfigsAutoScalingDiskGB
                                                 model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingDiskGBModel]
                                                 schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingDiskGBModel](ctx)
                                               computed_optional_required: computed_optional
@@ -940,6 +952,7 @@ schema:
                                   description: Options that determine how this cluster handles resource scaling.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsAutoScaling
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsAutoScalingModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsAutoScalingModel](ctx)
                                   computed_optional_required: computed_optional
@@ -1032,6 +1045,7 @@ schema:
                                   description: Hardware specifications for all electable nodes deployed in the region. Electable nodes can become the primary and can enable local reads. If you don't specify this option, MongoDB Cloud deploys no electable nodes to the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsElectableSpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsElectableSpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsElectableSpecsModel](ctx)
                                   computed_optional_required: optional
@@ -1127,6 +1141,7 @@ schema:
                                   description: Hardware specifications for read-only nodes in the region. Read-only nodes can never become the primary member, but can enable local reads.If you don't specify this parameter, no read-only nodes are deployed to the region.
                                   custom_type:
                                     package: customtypes
+                                    name: ReplicationSpecsRegionConfigsReadOnlySpecs
                                     model: customtypes.ObjectValue[TFReplicationSpecsRegionConfigsReadOnlySpecsModel]
                                     schema: customtypes.NewObjectType[TFReplicationSpecsRegionConfigsReadOnlySpecsModel](ctx)
                                   computed_optional_required: computed_optional
@@ -1157,6 +1172,7 @@ schema:
                         If you set `"replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize" : "M30"`, set `"replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize" : `"M30"` if you have electable nodes and `"replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize" : `"M30"` if you have read-only nodes.
                       custom_type:
                         package: customtypes
+                        name: ReplicationSpecsRegionConfigs
                         model: customtypes.NestedListValue[TFReplicationSpecsRegionConfigsModel]
                         schema: customtypes.NewNestedListType[TFReplicationSpecsRegionConfigsModel](ctx)
                       computed_optional_required: optional
@@ -1193,6 +1209,7 @@ schema:
           description: List of settings that configure your cluster regions. For Global Clusters, each object in the array represents a zone where your clusters nodes deploy. For non-Global sharded clusters and replica sets, this array has one object representing where your clusters nodes deploy.
           custom_type:
             package: customtypes
+            name: ReplicationSpecs
             model: customtypes.NestedListValue[TFReplicationSpecsModel]
             schema: customtypes.NewNestedListType[TFReplicationSpecsModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/control_plane_ip_addresses_api.yaml
+++ b/tools/codegen/models/control_plane_ip_addresses_api.yaml
@@ -58,6 +58,7 @@ data_sources:
               description: List of inbound IP addresses to the Atlas control plane, categorized by cloud provider. If your application allows outbound HTTP requests only to specific IP addresses, you must allow access to the following IP addresses so that your API requests can reach the Atlas control plane.
               custom_type:
                 package: customtypes
+                name: Inbound
                 model: customtypes.ObjectValue[TFInboundModel]
                 schema: customtypes.NewObjectType[TFInboundModel](ctx)
               computed_optional_required: computed
@@ -123,6 +124,7 @@ data_sources:
               description: List of outbound IP addresses from the Atlas control plane, categorized by cloud provider. If your network allows inbound HTTP requests only from specific IP addresses, you must allow access from the following IP addresses so that Atlas can communicate with your webhooks and KMS.
               custom_type:
                 package: customtypes
+                name: Outbound
                 model: customtypes.ObjectValue[TFOutboundModel]
                 schema: customtypes.NewObjectType[TFOutboundModel](ctx)
               computed_optional_required: computed

--- a/tools/codegen/models/custom_db_role_api.yaml
+++ b/tools/codegen/models/custom_db_role_api.yaml
@@ -54,6 +54,7 @@ schema:
                       description: List of resources on which you grant the action.
                       custom_type:
                         package: customtypes
+                        name: ActionsResources
                         model: customtypes.NestedListValue[TFActionsResourcesModel]
                         schema: customtypes.NewNestedListType[TFActionsResourcesModel](ctx)
                       computed_optional_required: optional
@@ -68,6 +69,7 @@ schema:
           description: List of the individual privilege actions that the role grants.
           custom_type:
             package: customtypes
+            name: Actions
             model: customtypes.NestedListValue[TFActionsModel]
             schema: customtypes.NewNestedListType[TFActionsModel](ctx)
           computed_optional_required: optional
@@ -121,6 +123,7 @@ schema:
           description: List of the built-in roles that this custom role inherits.
           custom_type:
             package: customtypes
+            name: InheritedRoles
             model: customtypes.NestedSetValue[TFInheritedRolesModel]
             schema: customtypes.NewNestedSetType[TFInheritedRolesModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/database_user_api.yaml
+++ b/tools/codegen/models/database_user_api.yaml
@@ -152,6 +152,7 @@ schema:
           description: List that provides the pairings of one role with one applicable database.
           custom_type:
             package: customtypes
+            name: Roles
             model: customtypes.NestedListValue[TFRolesModel]
             schema: customtypes.NewNestedListType[TFRolesModel](ctx)
           computed_optional_required: optional
@@ -191,6 +192,7 @@ schema:
           description: List that contains clusters, MongoDB Atlas Data Lakes, and MongoDB Atlas Streams Workspaces that this database user can access. If omitted, MongoDB Cloud grants the database user access to all the clusters, MongoDB Atlas Data Lakes, and MongoDB Atlas Streams Workspaces in the project.
           custom_type:
             package: customtypes
+            name: Scopes
             model: customtypes.NestedListValue[TFScopesModel]
             schema: customtypes.NewNestedListType[TFScopesModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/maintenance_window_api.yaml
+++ b/tools/codegen/models/maintenance_window_api.yaml
@@ -96,6 +96,7 @@ schema:
           description: Defines the a window where maintenance will not begin within.
           custom_type:
             package: customtypes
+            name: ProtectedHours
             model: customtypes.ObjectValue[TFProtectedHoursModel]
             schema: customtypes.NewObjectType[TFProtectedHoursModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/org_service_account_api.yaml
+++ b/tools/codegen/models/org_service_account_api.yaml
@@ -83,7 +83,7 @@ schema:
           create_only: true
           present_in_any_response: false
           request_only_required_on_create: true
-        - set_nested:
+        - list_nested:
             nested_object:
                 attributes:
                     - string: {}
@@ -155,8 +155,9 @@ schema:
           description: A list of secrets associated with the specified Service Account.
           custom_type:
             package: customtypes
-            model: customtypes.NestedSetValue[TFSecretsModel]
-            schema: customtypes.NewNestedSetType[TFSecretsModel](ctx)
+            name: Secrets
+            model: customtypes.NestedListValue[TFSecretsModel]
+            schema: customtypes.NewNestedListType[TFSecretsModel](ctx)
           computed_optional_required: computed
           tf_schema_name: secrets
           tf_model_name: Secrets
@@ -255,7 +256,7 @@ data_sources:
               create_only: false
               present_in_any_response: false
               request_only_required_on_create: false
-            - set_nested:
+            - list_nested:
                 nested_object:
                     attributes:
                         - string: {}
@@ -327,8 +328,9 @@ data_sources:
               description: A list of secrets associated with the specified Service Account.
               custom_type:
                 package: customtypes
-                model: customtypes.NestedSetValue[TFSecretsModel]
-                schema: customtypes.NewNestedSetType[TFSecretsModel](ctx)
+                name: Secrets
+                model: customtypes.NestedListValue[TFSecretsModel]
+                schema: customtypes.NewNestedListType[TFSecretsModel](ctx)
               computed_optional_required: computed
               tf_schema_name: secrets
               tf_model_name: Secrets
@@ -414,7 +416,7 @@ data_sources:
                           create_only: false
                           present_in_any_response: false
                           request_only_required_on_create: false
-                        - set_nested:
+                        - list_nested:
                             nested_object:
                                 attributes:
                                     - string: {}
@@ -486,8 +488,9 @@ data_sources:
                           description: A list of secrets associated with the specified Service Account.
                           custom_type:
                             package: customtypes
-                            model: customtypes.NestedSetValue[TFResultsSecretsModel]
-                            schema: customtypes.NewNestedSetType[TFResultsSecretsModel](ctx)
+                            name: ResultsSecrets
+                            model: customtypes.NestedListValue[TFResultsSecretsModel]
+                            schema: customtypes.NewNestedListType[TFResultsSecretsModel](ctx)
                           computed_optional_required: computed
                           tf_schema_name: secrets
                           tf_model_name: Secrets
@@ -500,6 +503,7 @@ data_sources:
               description: List of returned documents that MongoDB Cloud provides when completing this request.
               custom_type:
                 package: customtypes
+                name: Results
                 model: customtypes.NestedListValue[TFResultsModel]
                 schema: customtypes.NewNestedListType[TFResultsModel](ctx)
               computed_optional_required: computed

--- a/tools/codegen/models/resource_policy_api.yaml
+++ b/tools/codegen/models/resource_policy_api.yaml
@@ -29,6 +29,7 @@ schema:
           description: The user that last updated the atlas resource policy.
           custom_type:
             package: customtypes
+            name: CreatedByUser
             model: customtypes.ObjectValue[TFCreatedByUserModel]
             schema: customtypes.NewObjectType[TFCreatedByUserModel](ctx)
           computed_optional_required: computed
@@ -101,6 +102,7 @@ schema:
           description: The user that last updated the atlas resource policy.
           custom_type:
             package: customtypes
+            name: LastUpdatedByUser
             model: customtypes.ObjectValue[TFLastUpdatedByUserModel]
             schema: customtypes.NewObjectType[TFLastUpdatedByUserModel](ctx)
           computed_optional_required: computed
@@ -173,6 +175,7 @@ schema:
           description: List of policies that make up the atlas resource policy.
           custom_type:
             package: customtypes
+            name: Policies
             model: customtypes.NestedListValue[TFPoliciesModel]
             schema: customtypes.NewNestedListType[TFPoliciesModel](ctx)
           computed_optional_required: required

--- a/tools/codegen/models/search_deployment_api.yaml
+++ b/tools/codegen/models/search_deployment_api.yaml
@@ -79,6 +79,7 @@ schema:
             **NOTE**: We accept a single configuration for all nodes currently.
           custom_type:
             package: customtypes
+            name: Specs
             model: customtypes.NestedListValue[TFSpecsModel]
             schema: customtypes.NewNestedListType[TFSpecsModel](ctx)
           computed_optional_required: required

--- a/tools/codegen/models/search_index_api.yaml
+++ b/tools/codegen/models/search_index_api.yaml
@@ -133,6 +133,7 @@ schema:
                       description: List of user-defined methods to convert database field text into searchable words.
                       custom_type:
                         package: customtypes
+                        name: DefinitionAnalyzers
                         model: customtypes.NestedListValue[TFDefinitionAnalyzersModel]
                         schema: customtypes.NewNestedListType[TFDefinitionAnalyzersModel](ctx)
                       computed_optional_required: optional
@@ -197,6 +198,7 @@ schema:
                       description: Index specifications for the collection's fields.
                       custom_type:
                         package: customtypes
+                        name: DefinitionMappings
                         model: customtypes.ObjectValue[TFDefinitionMappingsModel]
                         schema: customtypes.NewObjectType[TFDefinitionMappingsModel](ctx)
                       computed_optional_required: optional
@@ -289,6 +291,7 @@ schema:
                                   description: Data set that stores words and their applicable synonyms.
                                   custom_type:
                                     package: customtypes
+                                    name: DefinitionSynonymsSource
                                     model: customtypes.ObjectValue[TFDefinitionSynonymsSourceModel]
                                     schema: customtypes.NewObjectType[TFDefinitionSynonymsSourceModel](ctx)
                                   computed_optional_required: required
@@ -303,6 +306,7 @@ schema:
                       description: Rule sets that map words to their synonyms in this index.
                       custom_type:
                         package: customtypes
+                        name: DefinitionSynonyms
                         model: customtypes.NestedListValue[TFDefinitionSynonymsModel]
                         schema: customtypes.NewNestedListType[TFDefinitionSynonymsModel](ctx)
                       computed_optional_required: optional
@@ -347,6 +351,7 @@ schema:
                       description: Type sets for the index.
                       custom_type:
                         package: customtypes
+                        name: DefinitionTypeSets
                         model: customtypes.NestedListValue[TFDefinitionTypeSetsModel]
                         schema: customtypes.NewNestedListType[TFDefinitionTypeSetsModel](ctx)
                       computed_optional_required: optional
@@ -361,6 +366,7 @@ schema:
           description: The index definition to update the search index to.
           custom_type:
             package: customtypes
+            name: Definition
             model: customtypes.ObjectValue[TFDefinitionModel]
             schema: customtypes.NewObjectType[TFDefinitionModel](ctx)
           computed_optional_required: required
@@ -496,6 +502,7 @@ schema:
                       description: List of user-defined methods to convert database field text into searchable words.
                       custom_type:
                         package: customtypes
+                        name: LatestDefinitionAnalyzers
                         model: customtypes.NestedListValue[TFLatestDefinitionAnalyzersModel]
                         schema: customtypes.NewNestedListType[TFLatestDefinitionAnalyzersModel](ctx)
                       computed_optional_required: computed
@@ -560,6 +567,7 @@ schema:
                       description: Index specifications for the collection's fields.
                       custom_type:
                         package: customtypes
+                        name: LatestDefinitionMappings
                         model: customtypes.ObjectValue[TFLatestDefinitionMappingsModel]
                         schema: customtypes.NewObjectType[TFLatestDefinitionMappingsModel](ctx)
                       computed_optional_required: computed
@@ -652,6 +660,7 @@ schema:
                                   description: Data set that stores words and their applicable synonyms.
                                   custom_type:
                                     package: customtypes
+                                    name: LatestDefinitionSynonymsSource
                                     model: customtypes.ObjectValue[TFLatestDefinitionSynonymsSourceModel]
                                     schema: customtypes.NewObjectType[TFLatestDefinitionSynonymsSourceModel](ctx)
                                   computed_optional_required: computed
@@ -666,6 +675,7 @@ schema:
                       description: Rule sets that map words to their synonyms in this index.
                       custom_type:
                         package: customtypes
+                        name: LatestDefinitionSynonyms
                         model: customtypes.NestedListValue[TFLatestDefinitionSynonymsModel]
                         schema: customtypes.NewNestedListType[TFLatestDefinitionSynonymsModel](ctx)
                       computed_optional_required: computed
@@ -710,6 +720,7 @@ schema:
                       description: Type sets for the index.
                       custom_type:
                         package: customtypes
+                        name: LatestDefinitionTypeSets
                         model: customtypes.NestedListValue[TFLatestDefinitionTypeSetsModel]
                         schema: customtypes.NewNestedListType[TFLatestDefinitionTypeSetsModel](ctx)
                       computed_optional_required: computed
@@ -723,6 +734,7 @@ schema:
                       request_only_required_on_create: false
           custom_type:
             package: customtypes
+            name: LatestDefinition
             model: customtypes.ObjectValue[TFLatestDefinitionModel]
             schema: customtypes.NewObjectType[TFLatestDefinitionModel](ctx)
           computed_optional_required: computed
@@ -762,6 +774,7 @@ schema:
           description: Object which includes the version number of the index definition and the time that the index definition was created.
           custom_type:
             package: customtypes
+            name: LatestDefinitionVersion
             model: customtypes.ObjectValue[TFLatestDefinitionVersionModel]
             schema: customtypes.NewObjectType[TFLatestDefinitionVersionModel](ctx)
           computed_optional_required: computed
@@ -880,6 +893,7 @@ schema:
                                   description: The vector search index definition set by the user.
                                   custom_type:
                                     package: customtypes
+                                    name: StatusDetailMainIndexDefinition
                                     model: customtypes.ObjectValue[TFStatusDetailMainIndexDefinitionModel]
                                     schema: customtypes.NewObjectType[TFStatusDetailMainIndexDefinitionModel](ctx)
                                   computed_optional_required: computed
@@ -919,6 +933,7 @@ schema:
                                   description: Object which includes the version number of the index definition and the time that the index definition was created.
                                   custom_type:
                                     package: customtypes
+                                    name: StatusDetailMainIndexDefinitionVersion
                                     model: customtypes.ObjectValue[TFStatusDetailMainIndexDefinitionVersionModel]
                                     schema: customtypes.NewObjectType[TFStatusDetailMainIndexDefinitionVersionModel](ctx)
                                   computed_optional_required: computed
@@ -974,6 +989,7 @@ schema:
                       description: Contains status information about a vector search index.
                       custom_type:
                         package: customtypes
+                        name: StatusDetailMainIndex
                         model: customtypes.ObjectValue[TFStatusDetailMainIndexModel]
                         schema: customtypes.NewObjectType[TFStatusDetailMainIndexModel](ctx)
                       computed_optional_required: computed
@@ -1048,6 +1064,7 @@ schema:
                                   description: The vector search index definition set by the user.
                                   custom_type:
                                     package: customtypes
+                                    name: StatusDetailStagedIndexDefinition
                                     model: customtypes.ObjectValue[TFStatusDetailStagedIndexDefinitionModel]
                                     schema: customtypes.NewObjectType[TFStatusDetailStagedIndexDefinitionModel](ctx)
                                   computed_optional_required: computed
@@ -1087,6 +1104,7 @@ schema:
                                   description: Object which includes the version number of the index definition and the time that the index definition was created.
                                   custom_type:
                                     package: customtypes
+                                    name: StatusDetailStagedIndexDefinitionVersion
                                     model: customtypes.ObjectValue[TFStatusDetailStagedIndexDefinitionVersionModel]
                                     schema: customtypes.NewObjectType[TFStatusDetailStagedIndexDefinitionVersionModel](ctx)
                                   computed_optional_required: computed
@@ -1142,6 +1160,7 @@ schema:
                       description: Contains status information about a vector search index.
                       custom_type:
                         package: customtypes
+                        name: StatusDetailStagedIndex
                         model: customtypes.ObjectValue[TFStatusDetailStagedIndexModel]
                         schema: customtypes.NewObjectType[TFStatusDetailStagedIndexModel](ctx)
                       computed_optional_required: computed
@@ -1175,6 +1194,7 @@ schema:
           description: List of documents detailing index status on each host.
           custom_type:
             package: customtypes
+            name: StatusDetail
             model: customtypes.NestedListValue[TFStatusDetailModel]
             schema: customtypes.NewNestedListType[TFStatusDetailModel](ctx)
           computed_optional_required: computed

--- a/tools/codegen/models/stream_instance_api.yaml
+++ b/tools/codegen/models/stream_instance_api.yaml
@@ -142,6 +142,7 @@ schema:
                       description: User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.
                       custom_type:
                         package: customtypes
+                        name: ConnectionsAuthentication
                         model: customtypes.ObjectValue[TFConnectionsAuthenticationModel]
                         schema: customtypes.NewObjectType[TFConnectionsAuthenticationModel](ctx)
                       computed_optional_required: computed
@@ -181,6 +182,7 @@ schema:
                       description: AWS configurations for AWS-based connection types.
                       custom_type:
                         package: customtypes
+                        name: ConnectionsAws
                         model: customtypes.ObjectValue[TFConnectionsAwsModel]
                         schema: customtypes.NewObjectType[TFConnectionsAwsModel](ctx)
                       computed_optional_required: computed
@@ -269,6 +271,7 @@ schema:
                       description: The name of a Built in or Custom DB Role to connect to an Atlas Cluster.
                       custom_type:
                         package: customtypes
+                        name: ConnectionsDbRoleToExecute
                         model: customtypes.ObjectValue[TFConnectionsDbRoleToExecuteModel]
                         schema: customtypes.NewObjectType[TFConnectionsDbRoleToExecuteModel](ctx)
                       computed_optional_required: computed
@@ -360,6 +363,7 @@ schema:
                                   description: Information about networking access.
                                   custom_type:
                                     package: customtypes
+                                    name: ConnectionsNetworkingAccess
                                     model: customtypes.ObjectValue[TFConnectionsNetworkingAccessModel]
                                     schema: customtypes.NewObjectType[TFConnectionsNetworkingAccessModel](ctx)
                                   computed_optional_required: computed
@@ -374,6 +378,7 @@ schema:
                       description: Networking configuration for Streams connections.
                       custom_type:
                         package: customtypes
+                        name: ConnectionsNetworking
                         model: customtypes.ObjectValue[TFConnectionsNetworkingModel]
                         schema: customtypes.NewObjectType[TFConnectionsNetworkingModel](ctx)
                       computed_optional_required: computed
@@ -413,6 +418,7 @@ schema:
                       description: Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.
                       custom_type:
                         package: customtypes
+                        name: ConnectionsSecurity
                         model: customtypes.ObjectValue[TFConnectionsSecurityModel]
                         schema: customtypes.NewObjectType[TFConnectionsSecurityModel](ctx)
                       computed_optional_required: computed
@@ -449,6 +455,7 @@ schema:
           description: List of connections configured in the stream workspace.
           custom_type:
             package: customtypes
+            name: Connections
             model: customtypes.NestedListValue[TFConnectionsModel]
             schema: customtypes.NewNestedListType[TFConnectionsModel](ctx)
           computed_optional_required: computed
@@ -488,6 +495,7 @@ schema:
           description: Information about the cloud provider region in which MongoDB Cloud processes the stream.
           custom_type:
             package: customtypes
+            name: DataProcessRegion
             model: customtypes.ObjectValue[TFDataProcessRegionModel]
             schema: customtypes.NewObjectType[TFDataProcessRegionModel](ctx)
           computed_optional_required: optional
@@ -558,6 +566,7 @@ schema:
           description: Sample connections to add to SPI.
           custom_type:
             package: customtypes
+            name: SampleConnections
             model: customtypes.ObjectValue[TFSampleConnectionsModel]
             schema: customtypes.NewObjectType[TFSampleConnectionsModel](ctx)
           computed_optional_required: optional
@@ -597,6 +606,7 @@ schema:
           description: Configuration options for an Atlas Stream Processing Workspace.
           custom_type:
             package: customtypes
+            name: StreamConfig
             model: customtypes.ObjectValue[TFStreamConfigModel]
             schema: customtypes.NewObjectType[TFStreamConfigModel](ctx)
           computed_optional_required: optional

--- a/tools/codegen/models/stream_processor_api.yaml
+++ b/tools/codegen/models/stream_processor_api.yaml
@@ -68,6 +68,7 @@ schema:
                       description: Dead letter queue for the stream processor.
                       custom_type:
                         package: customtypes
+                        name: OptionsDlq
                         model: customtypes.ObjectValue[TFOptionsDlqModel]
                         schema: customtypes.NewObjectType[TFOptionsDlqModel](ctx)
                       computed_optional_required: optional
@@ -93,6 +94,7 @@ schema:
           description: Optional configuration for the stream processor.
           custom_type:
             package: customtypes
+            name: Options
             model: customtypes.ObjectValue[TFOptionsModel]
             schema: customtypes.NewObjectType[TFOptionsModel](ctx)
           computed_optional_required: computed_optional


### PR DESCRIPTION
## Description

We already support overrides between set <-> list. Adding support for nested set & list as well.

Overriding org_service_account_api.secrets to a list.

Link to any related issue(s): CLOUDP-368414

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
