### PR TITLE
chore: Adds helper for tests that require multiple projects

### DIFF
--- a/internal/testutil/acc/atlas.go
+++ b/internal/testutil/acc/atlas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -105,4 +106,8 @@ func createStreamInstance(tb testing.TB, projectID, name string) {
 
 func projectIDLocal() string {
 	return os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+}
+
+func projectIDLocalN(n int) string {
+	return os.Getenv("MONGODB_ATLAS_PROJECT_ID_" + strconv.Itoa(n))
 }

--- a/internal/testutil/acc/shared_resource.go
+++ b/internal/testutil/acc/shared_resource.go
@@ -17,6 +17,26 @@ const (
 	MaxFreeTierClusterCount   = 1  // Project can have at most 1 free tier cluster
 )
 
+type projectInfo struct {
+	id                   string
+	name                 string
+	nodeCount            int
+	freeTierClusterCount int
+}
+
+var sharedInfo = struct {
+	clusterName             string
+	streamInstanceName      string
+	privateLinkEndpointID   string
+	privateLinkProviderName string
+	projects                []projectInfo
+	mu                      sync.Mutex
+	muSleep                 sync.Mutex
+	init                    bool
+}{
+	projects: []projectInfo{},
+}
+
 // SetupSharedResources must be called from TestMain test package in order to use ProjectIDExecution.
 // It returns the cleanup function that must be called at the end of TestMain.
 func SetupSharedResources() func() {
@@ -25,35 +45,23 @@ func SetupSharedResources() func() {
 }
 
 func cleanupSharedResources() {
+	projectID := projectIDLocal()
+	if projectID == "" && len(sharedInfo.projects) > 0 {
+		projectID = sharedInfo.projects[0].id
+	}
 	if sharedInfo.clusterName != "" {
-		projectID := sharedInfo.projectID
-		if projectID == "" {
-			projectID = projectIDLocal()
-		}
 		fmt.Printf("Deleting execution cluster: %s, project id: %s\n", sharedInfo.clusterName, projectID)
 		deleteCluster(projectID, sharedInfo.clusterName)
 	}
 	if sharedInfo.streamInstanceName != "" {
-		projectID := sharedInfo.projectID
-		if projectID == "" {
-			projectID = projectIDLocal() // Maybe we are using an existing project, but stream instance is not used
-		}
 		_, err := clean.RemoveStreamInstances(context.TODO(), false, ConnV2(), projectID)
 		if err != nil {
 			fmt.Printf("Failed to delete stream instances: for execution project %s, error: %s\n", projectID, err)
 		}
 	}
 	if sharedInfo.privateLinkEndpointID != "" {
-		projectID := sharedInfo.projectID
-		if projectID == "" {
-			projectID = projectIDLocal()
-		}
 		fmt.Printf("Deleting execution private link endpoint: %s, project id: %s, provider: %s\n", sharedInfo.privateLinkEndpointID, projectID, sharedInfo.privateLinkProviderName)
 		deletePrivateLinkEndpoint(projectID, sharedInfo.privateLinkProviderName, sharedInfo.privateLinkEndpointID)
-	}
-	if sharedInfo.projectID != "" {
-		fmt.Printf("Deleting execution project: %s, id: %s\n", sharedInfo.projectName, sharedInfo.projectID)
-		deleteProject(sharedInfo.projectID)
 	}
 	for i, project := range sharedInfo.projects {
 		fmt.Printf("Deleting execution project (%d): %s, id: %s\n", i+1, project.name, project.id)
@@ -78,13 +86,52 @@ func ProjectIDExecution(tb testing.TB) string {
 	}
 
 	// lazy creation so it's only done if really needed
-	if sharedInfo.projectID == "" {
-		sharedInfo.projectName = RandomProjectName()
-		tb.Logf("Creating execution project: %s\n", sharedInfo.projectName)
-		sharedInfo.projectID = createProject(tb, sharedInfo.projectName)
+	if len(sharedInfo.projects) == 0 {
+		projectName := RandomProjectName()
+		tb.Logf("Creating execution project (%d): %s\n", len(sharedInfo.projects)+1, projectName)
+		projectID := createProject(tb, projectName)
+		sharedInfo.projects = append(sharedInfo.projects, projectInfo{
+			id:   projectID,
+			name: projectName,
+		})
+	}
+	return sharedInfo.projects[0].id
+}
+
+// MultipleProjectIDsExecution returns multiple project ids created for test execution in the resource package.
+// Even if a GH test group is run, every resource/package will create its own projects, not shared projects for all the test group.
+// Panics when `MONGODB_ATLAS_PROJECT_ID` is defined and more than 1 project is requested.
+func MultipleProjectIDsExecution(tb testing.TB, count int) []string {
+	tb.Helper()
+	SkipInUnitTest(tb)
+	require.True(tb, sharedInfo.init, "SetupSharedResources must called from TestMain test package")
+	require.Positive(tb, count, "count must be greater than 0")
+
+	if id := projectIDLocal(); id != "" {
+		if count > 1 {
+			panic("MONGODB_ATLAS_PROJECT_ID must be unset to execute tests that require > 1 projects")
+		}
+		return []string{id}
 	}
 
-	return sharedInfo.projectID
+	sharedInfo.mu.Lock()
+	defer sharedInfo.mu.Unlock()
+
+	for len(sharedInfo.projects) < count {
+		projectName := RandomProjectName()
+		tb.Logf("Creating execution project (%d): %s\n", len(sharedInfo.projects)+1, projectName)
+		projectID := createProject(tb, projectName)
+		sharedInfo.projects = append(sharedInfo.projects, projectInfo{
+			id:   projectID,
+			name: projectName,
+		})
+	}
+
+	projectIDs := make([]string, count)
+	for i, project := range sharedInfo.projects {
+		projectIDs[i] = project.id
+	}
+	return projectIDs
 }
 
 // ProjectIDExecutionWithFreeCluster is identical to ProjectIDExecutionWithCluster but also contemplates the restriction of `MaxFreeTierClusterCount`
@@ -122,10 +169,7 @@ func ClusterNameExecution(tb testing.TB, populateSampleData bool) (projectID, cl
 		return existingProjectIDClusterName()
 	}
 
-	projectID = sharedInfo.projectID
-	if projectID == "" {
-		projectID = ProjectIDExecution(tb) // ensure the execution project is created before cluster creation
-	}
+	projectID = ProjectIDExecution(tb) // ensure the execution project is created before cluster creation
 
 	sharedInfo.mu.Lock()
 	defer sharedInfo.mu.Unlock()
@@ -205,28 +249,6 @@ func PrivateLinkEndpointIDExecution(tb testing.TB, providerName, region string) 
 	}
 
 	return projectID, sharedInfo.privateLinkEndpointID
-}
-
-type projectInfo struct {
-	id                   string
-	name                 string
-	nodeCount            int
-	freeTierClusterCount int
-}
-
-var sharedInfo = struct {
-	projectName             string
-	clusterName             string
-	streamInstanceName      string
-	privateLinkEndpointID   string
-	privateLinkProviderName string
-	projectID               string
-	projects                []projectInfo
-	mu                      sync.Mutex
-	muSleep                 sync.Mutex
-	init                    bool
-}{
-	projects: []projectInfo{},
 }
 
 // NextProjectIDClusterName is an internal method used when we want to reuse a projectID respecting `MaxClustersNodesPerProject` and `MaxFreeTierClusterCount`


### PR DESCRIPTION
## Description

Added `MultipleProjectIDsExecution` for tests that require > 1 project.
- To be used in a followup to https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4030 for multiple project assignments.
- Removed `sharedInfo.projectId` in favor of always using the `sharedInfo.projects` slice.


Full test suite run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/20525416114

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
