### PR TITLE
feat: Add service_account_access_list_entry resource and datasources

### DIFF
--- a/.changelog/4037.txt
+++ b/.changelog/4037.txt
@@ -1,0 +1,11 @@
+```release-note:new-resource
+resource/service_account_access_list_entry
+```
+
+```release-note:new-datasource
+data-source/service_account_access_list_entry
+```
+
+```release-note:new-datasource
+data-source/service_account_access_list_entries
+```

--- a/.github/workflows/acceptance-tests-runner.yml
+++ b/.github/workflows/acceptance-tests-runner.yml
@@ -281,6 +281,7 @@ jobs:
       search_deployment: ${{ steps.filter.outputs.search_deployment == 'true' || env.mustTrigger == 'true' }}
       search_index: ${{ steps.filter.outputs.search_index == 'true' || env.mustTrigger == 'true' }}
       serverless: ${{ steps.filter.outputs.serverless == 'true' || env.mustTrigger == 'true' }}
+      service_account: ${{ steps.filter.outputs.service_account == 'true' || env.mustTrigger == 'true' }}
       stream: ${{ steps.filter.outputs.stream == 'true' || env.mustTrigger == 'true' }}
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -304,9 +305,6 @@ jobs:
             - 'internal/serviceapi/customdbroleapi/*.go'
             - 'internal/serviceapi/databaseuserapi/*.go'
             - 'internal/serviceapi/maintenancewindowapi/*.go'
-            - 'internal/serviceapi/serviceaccount/*.go'
-            - 'internal/serviceapi/serviceaccountprojectassignment/*.go'
-            - 'internal/serviceapi/serviceaccountsecret/*.go'
             - 'internal/serviceapi/projectapi/*.go'
             - 'internal/serviceapi/projectsettingsapi/*.go'
             - 'internal/serviceapi/resourcepolicyapi/*.go'
@@ -401,6 +399,12 @@ jobs:
             - 'internal/service/searchindex/*.go'
           serverless:
             - 'internal/service/serverlessinstance/*.go'
+          service_account:
+            - 'internal/common/autogen/*.go'
+            - 'internal/service/serviceaccountaccesslistentry/*.go'
+            - 'internal/serviceapi/serviceaccount/*.go'
+            - 'internal/serviceapi/serviceaccountprojectassignment/*.go'
+            - 'internal/serviceapi/serviceaccountsecret/*.go'
           stream:
             - 'internal/service/streamaccountdetails/*.go'
             - 'internal/service/streamconnection/*.go'
@@ -626,7 +630,6 @@ jobs:
             ./internal/serviceapi/customdbroleapi
             ./internal/serviceapi/databaseuserapi
             ./internal/serviceapi/maintenancewindowapi
-            ./internal/serviceapi/serviceaccount
             ./internal/serviceapi/projectapi
             ./internal/serviceapi/projectsettingsapi
         run: make testacc
@@ -1349,6 +1352,32 @@ jobs:
           MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
           ACCTEST_PACKAGES: |
             ./internal/service/serverlessinstance
+        run: make testacc
+
+  service_account:
+    needs: [change-detection, get-provider-version]
+    if: ${{ needs.change-detection.outputs.service_account == 'true' || inputs.test_group == 'service_account' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+          terraform_wrapper: false
+      - name: Acceptance Tests
+        env:
+          MONGODB_ATLAS_LAST_VERSION: ${{ needs.get-provider-version.outputs.provider_version }}
+          ACCTEST_PACKAGES: |
+            ./internal/service/serviceaccountaccesslistentry
+            ./internal/serviceapi/serviceaccount
+            ./internal/serviceapi/serviceaccountprojectassignment
+            ./internal/serviceapi/serviceaccountsecret
         run: make testacc
 
   stream:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,6 +39,7 @@ import (
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/pushbasedlogexport"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/resourcepolicy"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/searchdeployment"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/serviceaccountaccesslistentry"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamaccountdetails"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streamconnection"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/streaminstance"
@@ -308,6 +309,8 @@ func (p *MongodbatlasProvider) DataSources(context.Context) []func() datasource.
 		serviceaccountsecret.DataSource,
 		serviceaccountprojectassignment.DataSource,
 		serviceaccountprojectassignment.PluralDataSource,
+		serviceaccountaccesslistentry.DataSource,
+		serviceaccountaccesslistentry.PluralDataSource,
 	}
 	analyticsDataSources := []func() datasource.DataSource{}
 	for _, dataSourceFunc := range dataSources {
@@ -343,6 +346,7 @@ func (p *MongodbatlasProvider) Resources(context.Context) []func() resource.Reso
 		serviceaccount.Resource,
 		serviceaccountsecret.Resource,
 		serviceaccountprojectassignment.Resource,
+		serviceaccountaccesslistentry.Resource,
 	}
 	analyticsResources := []func() resource.Resource{}
 	for _, resourceFunc := range resources {

--- a/internal/service/serviceaccountaccesslistentry/data_source.go
+++ b/internal/service/serviceaccountaccesslistentry/data_source.go
@@ -1,0 +1,86 @@
+package serviceaccountaccesslistentry
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+)
+
+var _ datasource.DataSource = &ds{}
+var _ datasource.DataSourceWithConfigure = &ds{}
+
+func DataSource() datasource.DataSource {
+	return &ds{
+		DSCommon: config.DSCommon{
+			DataSourceName: resourceName,
+		},
+	}
+}
+
+type ds struct {
+	config.DSCommon
+}
+
+func (d *ds) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = conversion.DataSourceSchemaFromResource(ResourceSchema(), &conversion.DataSourceSchemaRequest{
+		RequiredFields: []string{"org_id", "client_id"},
+		OverridenFields: map[string]dsschema.Attribute{
+			"cidr_block": dsschema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: cidrBlockDesc,
+				Validators: []validator.String{
+					validate.ValidCIDR(),
+					stringvalidator.ConflictsWith(path.MatchRoot("ip_address")),
+				},
+			},
+			"ip_address": dsschema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: ipAddressDesc,
+				Validators: []validator.String{
+					validate.ValidIP(),
+					stringvalidator.ConflictsWith(path.MatchRoot("cidr_block")),
+				},
+			},
+		},
+	})
+}
+
+func (d *ds) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var conf TFServiceAccountAccessListEntryModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &conf)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if conf.CIDRBlock.ValueString() == "" && conf.IPAddress.ValueString() == "" {
+		resp.Diagnostics.AddError("validation error", "cidr_block or ip_address must be provided")
+		return
+	}
+
+	orgID := conf.OrgID.ValueString()
+	clientID := conf.ClientID.ValueString()
+	cidrOrIP := getCidrOrIP(&conf)
+
+	connV2 := d.Client.AtlasV2
+	entry, _, err := readAccessListEntry(ctx, connV2.ServiceAccountsApi, nil, orgID, clientID, cidrOrIP)
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
+	if entry == nil {
+		resp.Diagnostics.AddError("Resource not found", "The requested resource does not exist")
+		return
+	}
+
+	accessListModel := NewTFServiceAccountAccessListModel(orgID, clientID, entry)
+	resp.Diagnostics.Append(resp.State.Set(ctx, accessListModel)...)
+}

--- a/internal/service/serviceaccountaccesslistentry/main_test.go
+++ b/internal/service/serviceaccountaccesslistentry/main_test.go
@@ -1,0 +1,15 @@
+package serviceaccountaccesslistentry_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := acc.SetupSharedResources()
+	exitCode := m.Run()
+	cleanup()
+	os.Exit(exitCode)
+}

--- a/internal/service/serviceaccountaccesslistentry/model.go
+++ b/internal/service/serviceaccountaccesslistentry/model.go
@@ -1,0 +1,41 @@
+package serviceaccountaccesslistentry
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"go.mongodb.org/atlas-sdk/v20250312011/admin"
+)
+
+func NewMongoDBServiceAccountAccessListEntry(model *TFServiceAccountAccessListEntryModel) *[]admin.ServiceAccountIPAccessListEntry {
+	return &[]admin.ServiceAccountIPAccessListEntry{
+		{
+			CidrBlock: conversion.StringPtr(model.CIDRBlock.ValueString()),
+			IpAddress: conversion.StringPtr(model.IPAddress.ValueString()),
+		},
+	}
+}
+
+func NewTFServiceAccountAccessListModel(orgID, clientID string, entry *admin.ServiceAccountIPAccessListEntry) *TFServiceAccountAccessListEntryModel {
+	return &TFServiceAccountAccessListEntryModel{
+		OrgID:           types.StringValue(orgID),
+		ClientID:        types.StringValue(clientID),
+		CIDRBlock:       types.StringValue(entry.GetCidrBlock()),
+		IPAddress:       types.StringValue(entry.GetIpAddress()),
+		CreatedAt:       types.StringPointerValue(conversion.TimePtrToStringPtr(entry.CreatedAt)),
+		LastUsedAddress: types.StringPointerValue(entry.LastUsedAddress),
+		LastUsedAt:      types.StringPointerValue(conversion.TimePtrToStringPtr(entry.LastUsedAt)),
+		RequestCount:    types.Int64PointerValue(conversion.IntPtrToInt64Ptr(entry.RequestCount)),
+	}
+}
+
+func NewTFServiceAccountAccessListEntriesPluralDSModel(orgID, clientID string, entries []admin.ServiceAccountIPAccessListEntry) *TFServiceAccountAccessListEntriesPluralDSModel {
+	results := make([]*TFServiceAccountAccessListEntryModel, len(entries))
+	for i := range entries {
+		results[i] = NewTFServiceAccountAccessListModel(orgID, clientID, &entries[i])
+	}
+	return &TFServiceAccountAccessListEntriesPluralDSModel{
+		OrgID:    types.StringValue(orgID),
+		ClientID: types.StringValue(clientID),
+		Results:  results,
+	}
+}

--- a/internal/service/serviceaccountaccesslistentry/model_test.go
+++ b/internal/service/serviceaccountaccesslistentry/model_test.go
@@ -1,0 +1,240 @@
+package serviceaccountaccesslistentry_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/service/serviceaccountaccesslistentry"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20250312011/admin"
+)
+
+var (
+	modelOrgID           = "000000000000000000000000"
+	modelClientID        = "mdb_sa_id_000000000000000000000000"
+	modelCIDRBlock       = "192.168.1.0/24"
+	modelIPAddress       = "192.168.1.1"
+	modelCreatedAt       = "2025-01-01T01:01:00Z"
+	modelLastUsedAddress = "192.168.1.2"
+	modelLastUsedAt      = "2025-02-02T02:02:00Z"
+	modelRequestCount    = 42
+
+	modelCreatedAtTime, _  = conversion.StringToTime(modelCreatedAt)
+	modelLastUsedAtTime, _ = conversion.StringToTime(modelLastUsedAt)
+)
+
+func TestNewTFServiceAccountAccessListEntryModel(t *testing.T) {
+	testCases := map[string]struct {
+		sdkEntry        *admin.ServiceAccountIPAccessListEntry
+		expectedTFModel *serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel
+		orgID           string
+		clientID        string
+	}{
+		"Complete SDK response": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			sdkEntry: &admin.ServiceAccountIPAccessListEntry{
+				CidrBlock:       &modelCIDRBlock,
+				IpAddress:       &modelIPAddress,
+				CreatedAt:       &modelCreatedAtTime,
+				LastUsedAddress: &modelLastUsedAddress,
+				LastUsedAt:      &modelLastUsedAtTime,
+				RequestCount:    &modelRequestCount,
+			},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+				OrgID:           types.StringValue(modelOrgID),
+				ClientID:        types.StringValue(modelClientID),
+				CIDRBlock:       types.StringValue(modelCIDRBlock),
+				IPAddress:       types.StringValue(modelIPAddress),
+				CreatedAt:       types.StringValue(modelCreatedAt),
+				LastUsedAddress: types.StringValue(modelLastUsedAddress),
+				LastUsedAt:      types.StringValue(modelLastUsedAt),
+				RequestCount:    types.Int64Value(int64(modelRequestCount)),
+			},
+		},
+		"Only CIDR block": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			sdkEntry: &admin.ServiceAccountIPAccessListEntry{
+				CidrBlock: &modelCIDRBlock,
+			},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+				OrgID:           types.StringValue(modelOrgID),
+				ClientID:        types.StringValue(modelClientID),
+				CIDRBlock:       types.StringValue(modelCIDRBlock),
+				IPAddress:       types.StringValue(""),
+				CreatedAt:       types.StringNull(),
+				LastUsedAddress: types.StringNull(),
+				LastUsedAt:      types.StringNull(),
+				RequestCount:    types.Int64Null(),
+			},
+		},
+		"Only IP address": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			sdkEntry: &admin.ServiceAccountIPAccessListEntry{
+				IpAddress: &modelIPAddress,
+			},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+				OrgID:           types.StringValue(modelOrgID),
+				ClientID:        types.StringValue(modelClientID),
+				CIDRBlock:       types.StringValue(""),
+				IPAddress:       types.StringValue(modelIPAddress),
+				CreatedAt:       types.StringNull(),
+				LastUsedAddress: types.StringNull(),
+				LastUsedAt:      types.StringNull(),
+				RequestCount:    types.Int64Null(),
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resultModel := serviceaccountaccesslistentry.NewTFServiceAccountAccessListModel(tc.orgID, tc.clientID, tc.sdkEntry)
+			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}
+
+func TestNewMongoDBServiceAccountAccessListEntry(t *testing.T) {
+	testCases := map[string]struct {
+		tfModel        *serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel
+		expectedSDKReq *[]admin.ServiceAccountIPAccessListEntry
+	}{
+		"With CIDR block": {
+			tfModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+				OrgID:     types.StringValue(modelOrgID),
+				ClientID:  types.StringValue(modelClientID),
+				CIDRBlock: types.StringValue(modelCIDRBlock),
+				IPAddress: types.StringNull(),
+			},
+			expectedSDKReq: &[]admin.ServiceAccountIPAccessListEntry{
+				{
+					CidrBlock: &modelCIDRBlock,
+					IpAddress: nil,
+				},
+			},
+		},
+		"With IP address": {
+			tfModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+				OrgID:     types.StringValue(modelOrgID),
+				ClientID:  types.StringValue(modelClientID),
+				CIDRBlock: types.StringNull(),
+				IPAddress: types.StringValue(modelIPAddress),
+			},
+			expectedSDKReq: &[]admin.ServiceAccountIPAccessListEntry{
+				{
+					CidrBlock: nil,
+					IpAddress: &modelIPAddress,
+				},
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			apiReqResult := serviceaccountaccesslistentry.NewMongoDBServiceAccountAccessListEntry(tc.tfModel)
+			assert.Equal(t, tc.expectedSDKReq, apiReqResult, "created sdk model did not match expected output")
+		})
+	}
+}
+
+func TestNewTFServiceAccountAccessListEntriesPluralDSModel(t *testing.T) {
+	testCases := map[string]struct {
+		expectedTFModel *serviceaccountaccesslistentry.TFServiceAccountAccessListEntriesPluralDSModel
+		orgID           string
+		clientID        string
+		entries         []admin.ServiceAccountIPAccessListEntry
+	}{
+		"Single entry": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			entries: []admin.ServiceAccountIPAccessListEntry{
+				{
+					CidrBlock:       &modelCIDRBlock,
+					IpAddress:       &modelIPAddress,
+					CreatedAt:       &modelCreatedAtTime,
+					LastUsedAddress: &modelLastUsedAddress,
+					LastUsedAt:      &modelLastUsedAtTime,
+					RequestCount:    &modelRequestCount,
+				},
+			},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntriesPluralDSModel{
+				OrgID:    types.StringValue(modelOrgID),
+				ClientID: types.StringValue(modelClientID),
+				Results: []*serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+					{
+						OrgID:           types.StringValue(modelOrgID),
+						ClientID:        types.StringValue(modelClientID),
+						CIDRBlock:       types.StringValue(modelCIDRBlock),
+						IPAddress:       types.StringValue(modelIPAddress),
+						CreatedAt:       types.StringValue(modelCreatedAt),
+						LastUsedAddress: types.StringValue(modelLastUsedAddress),
+						LastUsedAt:      types.StringValue(modelLastUsedAt),
+						RequestCount:    types.Int64Value(int64(modelRequestCount)),
+					},
+				},
+			},
+		},
+		"Multiple entries": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			entries: []admin.ServiceAccountIPAccessListEntry{
+				{
+					CidrBlock: &modelCIDRBlock,
+				},
+				{
+					IpAddress:       &modelIPAddress,
+					CreatedAt:       &modelCreatedAtTime,
+					LastUsedAddress: &modelLastUsedAddress,
+					LastUsedAt:      &modelLastUsedAtTime,
+					RequestCount:    &modelRequestCount,
+				},
+			},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntriesPluralDSModel{
+				OrgID:    types.StringValue(modelOrgID),
+				ClientID: types.StringValue(modelClientID),
+				Results: []*serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{
+					{
+						OrgID:           types.StringValue(modelOrgID),
+						ClientID:        types.StringValue(modelClientID),
+						CIDRBlock:       types.StringValue(modelCIDRBlock),
+						IPAddress:       types.StringValue(""),
+						CreatedAt:       types.StringNull(),
+						LastUsedAddress: types.StringNull(),
+						LastUsedAt:      types.StringNull(),
+						RequestCount:    types.Int64Null(),
+					},
+					{
+						OrgID:           types.StringValue(modelOrgID),
+						ClientID:        types.StringValue(modelClientID),
+						CIDRBlock:       types.StringValue(""),
+						IPAddress:       types.StringValue(modelIPAddress),
+						CreatedAt:       types.StringValue(modelCreatedAt),
+						LastUsedAddress: types.StringValue(modelLastUsedAddress),
+						LastUsedAt:      types.StringValue(modelLastUsedAt),
+						RequestCount:    types.Int64Value(int64(modelRequestCount)),
+					},
+				},
+			},
+		},
+		"Empty entries": {
+			orgID:    modelOrgID,
+			clientID: modelClientID,
+			entries:  []admin.ServiceAccountIPAccessListEntry{},
+			expectedTFModel: &serviceaccountaccesslistentry.TFServiceAccountAccessListEntriesPluralDSModel{
+				OrgID:    types.StringValue(modelOrgID),
+				ClientID: types.StringValue(modelClientID),
+				Results:  []*serviceaccountaccesslistentry.TFServiceAccountAccessListEntryModel{},
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			resultModel := serviceaccountaccesslistentry.NewTFServiceAccountAccessListEntriesPluralDSModel(tc.orgID, tc.clientID, tc.entries)
+			assert.Equal(t, tc.expectedTFModel, resultModel, "created terraform model did not match expected output")
+		})
+	}
+}

--- a/internal/service/serviceaccountaccesslistentry/plural_data_source.go
+++ b/internal/service/serviceaccountaccesslistentry/plural_data_source.go
@@ -1,0 +1,58 @@
+package serviceaccountaccesslistentry
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/dsschema"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20250312011/admin"
+)
+
+var _ datasource.DataSource = &pluralDS{}
+var _ datasource.DataSourceWithConfigure = &pluralDS{}
+
+const pluralDatasourceName = "service_account_access_list_entries"
+
+func PluralDataSource() datasource.DataSource {
+	return &pluralDS{
+		DSCommon: config.DSCommon{
+			DataSourceName: pluralDatasourceName,
+		},
+	}
+}
+
+type pluralDS struct {
+	config.DSCommon
+}
+
+func (d *pluralDS) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = conversion.PluralDataSourceSchemaFromResource(ResourceSchema(), &conversion.PluralDataSourceSchemaRequest{
+		RequiredFields: []string{"org_id", "client_id"},
+	})
+}
+
+func (d *pluralDS) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var conf TFServiceAccountAccessListEntriesPluralDSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &conf)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgID := conf.OrgID.ValueString()
+	clientID := conf.ClientID.ValueString()
+
+	api := d.Client.AtlasV2.ServiceAccountsApi
+	entries, err := dsschema.AllPages(ctx, func(ctx context.Context, pageNum int) (dsschema.PaginateResponse[admin.ServiceAccountIPAccessListEntry], *http.Response, error) {
+		return api.ListOrgAccessList(ctx, orgID, clientID).PageNum(pageNum).ItemsPerPage(itemsPerPage).Execute()
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching list", err.Error())
+		return
+	}
+
+	newServiceAccountAccessListsModel := NewTFServiceAccountAccessListEntriesPluralDSModel(orgID, clientID, entries)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newServiceAccountAccessListsModel)...)
+}

--- a/internal/service/serviceaccountaccesslistentry/resource.go
+++ b/internal/service/serviceaccountaccesslistentry/resource.go
@@ -1,0 +1,189 @@
+package serviceaccountaccesslistentry
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/conversion"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
+	"go.mongodb.org/atlas-sdk/v20250312011/admin"
+)
+
+const (
+	resourceName = "service_account_access_list_entry"
+	itemsPerPage = 500 // Max items per page
+)
+
+var _ resource.ResourceWithConfigure = &rs{}
+var _ resource.ResourceWithImportState = &rs{}
+
+func Resource() resource.Resource {
+	return &rs{
+		RSCommon: config.RSCommon{
+			ResourceName: resourceName,
+		},
+	}
+}
+
+type rs struct {
+	config.RSCommon
+}
+
+func (r *rs) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = ResourceSchema()
+	conversion.UpdateSchemaDescription(&resp.Schema)
+}
+
+func (r *rs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan TFServiceAccountAccessListEntryModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.CIDRBlock.ValueString() == "" && plan.IPAddress.ValueString() == "" {
+		resp.Diagnostics.AddError("validation error", "cidr_block or ip_address must be provided")
+		return
+	}
+
+	orgID := plan.OrgID.ValueString()
+	clientID := plan.ClientID.ValueString()
+	accessListReq := NewMongoDBServiceAccountAccessListEntry(&plan)
+
+	connV2 := r.Client.AtlasV2
+	firstPage, _, err := connV2.ServiceAccountsApi.CreateOrgAccessList(ctx, orgID, clientID, accessListReq).ItemsPerPage(itemsPerPage).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("error creating resource", err.Error())
+		return
+	}
+
+	cidrOrIP := getCidrOrIP(&plan)
+	entry, _, err := readAccessListEntry(ctx, connV2.ServiceAccountsApi, firstPage, orgID, clientID, cidrOrIP)
+	if err != nil {
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
+
+	accessListModel := NewTFServiceAccountAccessListModel(orgID, clientID, entry)
+	resp.Diagnostics.Append(resp.State.Set(ctx, accessListModel)...)
+}
+
+func (r *rs) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state TFServiceAccountAccessListEntryModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgID := state.OrgID.ValueString()
+	clientID := state.ClientID.ValueString()
+	cidrOrIP := getCidrOrIP(&state)
+
+	connV2 := r.Client.AtlasV2
+	entry, apiResp, err := readAccessListEntry(ctx, connV2.ServiceAccountsApi, nil, orgID, clientID, cidrOrIP)
+	if err != nil {
+		if validate.StatusNotFound(apiResp) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("error fetching resource", err.Error())
+		return
+	}
+	if entry == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	accessListModel := NewTFServiceAccountAccessListModel(orgID, clientID, entry)
+	resp.Diagnostics.Append(resp.State.Set(ctx, accessListModel)...)
+}
+
+func (r *rs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state TFServiceAccountAccessListEntryModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgID := state.OrgID.ValueString()
+	clientID := state.ClientID.ValueString()
+	cidrOrIP := getCidrOrIP(&state)
+
+	connV2 := r.Client.AtlasV2
+	if _, err := connV2.ServiceAccountsApi.DeleteOrgAccessEntry(ctx, orgID, clientID, cidrOrIP).Execute(); err != nil {
+		resp.Diagnostics.AddError("error deleting resource", err.Error())
+		return
+	}
+}
+
+func (r *rs) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, "/", 3)
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError(
+			"invalid import ID",
+			"expected format: {org_id}/{client_id}/{cidr_block} or {org_id}/{client_id}/{ip_address}",
+		)
+		return
+	}
+
+	orgID, clientID, cidrOrIP := parts[0], parts[1], parts[2]
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("org_id"), orgID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("client_id"), clientID)...)
+	if strings.Contains(cidrOrIP, "/") {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("cidr_block"), cidrOrIP)...)
+	} else {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("ip_address"), cidrOrIP)...)
+	}
+}
+
+func getCidrOrIP(model *TFServiceAccountAccessListEntryModel) string {
+	cidrOrIP := model.IPAddress.ValueString()
+	if cidrOrIP == "" {
+		cidrOrIP = model.CIDRBlock.ValueString()
+	}
+	return cidrOrIP
+}
+
+// readAccessListEntry Iterates through access list pages looking for the entry.
+// The first page can be provided to skip an API call. Useful for Create operation, which returns the first page.
+func readAccessListEntry(
+	ctx context.Context,
+	api admin.ServiceAccountsApi,
+	firstPage *admin.PaginatedServiceAccountIPAccessEntry,
+	orgID, clientID, cidrOrIP string,
+) (*admin.ServiceAccountIPAccessListEntry, *http.Response, error) {
+	var err error
+	var apiResp *http.Response
+
+	count := 0
+	page := firstPage
+	for currentPage := 1; ; currentPage++ {
+		if page == nil {
+			page, apiResp, err = api.ListOrgAccessList(ctx, orgID, clientID).PageNum(currentPage).ItemsPerPage(itemsPerPage).Execute()
+			if err != nil {
+				return nil, apiResp, err
+			}
+		}
+
+		results := page.GetResults()
+		count += len(results)
+
+		for i := range results {
+			entry := &results[i]
+			if entry.GetIpAddress() == cidrOrIP || entry.GetCidrBlock() == cidrOrIP {
+				return entry, nil, nil
+			}
+		}
+
+		if len(results) == 0 || count >= page.GetTotalCount() {
+			break
+		}
+		page = nil
+	}
+
+	return nil, nil, nil
+}

--- a/internal/service/serviceaccountaccesslistentry/resource_test.go
+++ b/internal/service/serviceaccountaccesslistentry/resource_test.go
@@ -1,0 +1,318 @@
+package serviceaccountaccesslistentry_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/testutil/acc"
+	"go.mongodb.org/atlas-sdk/v20250312011/admin"
+)
+
+const (
+	resourceName         = "mongodbatlas_service_account_access_list_entry.test"
+	dataSourceName       = "data.mongodbatlas_service_account_access_list_entry.test"
+	dataSourcePluralName = "data.mongodbatlas_service_account_access_list_entries.test"
+)
+
+type testEntry struct {
+	cidr string
+	ip   string
+}
+
+func TestAccServiceAccountSecret_singleEntry(t *testing.T) {
+	var (
+		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name          = acc.RandomName()
+		cidrEntries   = []testEntry{{cidr: "192.168.1.0/24"}}
+		ipEntries     = []testEntry{{ip: "192.168.1.1"}}
+		resourceName0 = resourceName + "_0"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{ // Create with cidr
+				Config: configBasic(orgID, name, cidrEntries),
+				Check:  checkBasic(cidrEntries),
+			},
+			{
+				ResourceName:                         resourceName0,
+				ImportStateIdFunc:                    importStateIDFunc(resourceName0),
+				ImportStateVerifyIdentifierAttribute: "cidr_block",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{ // Replace with ip
+				Config: configBasic(orgID, name, ipEntries),
+				Check:  checkBasic(ipEntries),
+			},
+			{
+				ResourceName:                         resourceName0,
+				ImportStateIdFunc:                    importStateIDFunc(resourceName0),
+				ImportStateVerifyIdentifierAttribute: "ip_address",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+		},
+	})
+}
+
+func TestAccServiceAccountSecret_multipleEntries(t *testing.T) {
+	var (
+		orgID         = os.Getenv("MONGODB_ATLAS_ORG_ID")
+		name          = acc.RandomName()
+		entries       = []testEntry{{cidr: "100.200.30.4/32"}, {ip: "4.3.2.1"}, {cidr: "123.234.0.0/16"}}
+		resourceName0 = resourceName + "_0"
+		resourceName1 = resourceName + "_1"
+		resourceName2 = resourceName + "_2"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		CheckDestroy:             checkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic(orgID, name, entries),
+				Check:  checkBasic(entries),
+			},
+			{
+				ResourceName:                         resourceName0,
+				ImportStateIdFunc:                    importStateIDFunc(resourceName0),
+				ImportStateVerifyIdentifierAttribute: "cidr_block",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{
+				ResourceName:                         resourceName1,
+				ImportStateIdFunc:                    importStateIDFunc(resourceName1),
+				ImportStateVerifyIdentifierAttribute: "ip_address",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{
+				ResourceName:                         resourceName2,
+				ImportStateIdFunc:                    importStateIDFunc(resourceName2),
+				ImportStateVerifyIdentifierAttribute: "cidr_block",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+		},
+	})
+}
+
+func TestAccServiceAccountSecret_errors(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acc.PreCheckBasic(t) },
+		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
+		Steps: []resource.TestStep{
+			{
+				Config:      configError(testEntry{}),
+				ExpectError: regexp.MustCompile("cidr_block or ip_address must be provided"),
+			},
+			{
+				Config:      configError(testEntry{cidr: "invalid cidr"}),
+				ExpectError: regexp.MustCompile("Attribute cidr_block string value must be defined as a valid cidr"),
+			},
+			{
+				Config:      configError(testEntry{ip: "invalid ip"}),
+				ExpectError: regexp.MustCompile("Attribute ip_address string value must be defined as a valid IP Address"),
+			},
+			{
+				Config:      configError(testEntry{cidr: "192.168.1.0/24", ip: "192.168.1.1"}),
+				ExpectError: regexp.MustCompile(`Attribute "ip_address" cannot be specified when "cidr_block" is specified`),
+			},
+		},
+	})
+}
+
+func configBasic(orgID, name string, entries []testEntry) string {
+	entriesStr := ""
+	resourceNames := []string{}
+	for i, entry := range entries {
+		entriesStr += fmt.Sprintf(`
+			resource "mongodbatlas_service_account_access_list_entry" "test_%[1]d" {
+				org_id    = %[2]q
+				client_id = mongodbatlas_service_account.test.client_id
+				%[3]s
+			}
+
+			data "mongodbatlas_service_account_access_list_entry" "test_%[1]d" {
+				org_id    = %[2]q
+				client_id = mongodbatlas_service_account.test.client_id
+				%[3]s
+				depends_on = [mongodbatlas_service_account_access_list_entry.test_%[1]d]
+			}
+		`, i, orgID, entry.hclStr())
+		resourceNames = append(resourceNames, fmt.Sprintf("%s_%d", resourceName, i))
+	}
+
+	resourceNamesStr := fmt.Sprintf("[%s]", `"`+strings.Join(resourceNames, `", "`)+`"`)
+
+	return fmt.Sprintf(`
+		resource "mongodbatlas_service_account" "test" {
+			org_id                     = %[1]q
+			name                       = %[2]q
+			description                = "Acceptance Test SA for SA access list"
+			roles                      = ["ORG_OWNER"]
+			secret_expires_after_hours = 12
+		}
+
+		%[3]s
+
+		data "mongodbatlas_service_account_access_list_entries" "test" {
+			org_id = %[1]q
+			client_id = mongodbatlas_service_account.test.client_id
+			depends_on = %[4]s
+		}
+	`, orgID, name, entriesStr, resourceNamesStr)
+}
+
+func configError(entry testEntry) string {
+	return fmt.Sprintf(`
+		resource "mongodbatlas_service_account_access_list_entry" "test" {
+			org_id    = "000000000000000000000000"
+			client_id = "mdb_sa_id_000000000000000000000000"
+			%s
+		}
+	`, entry.hclStr())
+}
+
+func checkBasic(entries []testEntry) resource.TestCheckFunc {
+	// Check plural DS first result only when there is 1 entry
+	var pluralDSName *string
+	if len(entries) == 1 {
+		pluralDSName = admin.PtrString(dataSourcePluralName)
+	}
+
+	attrsSet := []string{"client_id", "created_at", "request_count"}
+	checks := []resource.TestCheckFunc{}
+	for i, entry := range entries {
+		resourceName := fmt.Sprintf("%s_%d", resourceName, i)
+		dataSourceName := fmt.Sprintf("%s_%d", dataSourceName, i)
+		checks = append(checks, acc.CheckRSAndDS(
+			resourceName, admin.PtrString(dataSourceName), pluralDSName,
+			attrsSet, entry.attrMap(),
+			checkExists(resourceName),
+		))
+	}
+
+	checks = append(checks, resource.TestCheckResourceAttr(dataSourcePluralName, "results.#", strconv.Itoa(len(entries))))
+
+	return resource.ComposeAggregateTestCheckFunc(checks...)
+}
+
+func checkExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		clientID := rs.Primary.Attributes["client_id"]
+		cidrOrIP := getCidrOrIP(rs)
+
+		if orgID == "" || clientID == "" || cidrOrIP == "" {
+			return fmt.Errorf("checkExists, attributes not found for: %s", resourceName)
+		}
+
+		entry, err := getEntry(orgID, clientID, cidrOrIP)
+		if entry == nil || err != nil {
+			return fmt.Errorf("access list entry (%s/%s/%s) does not exist", orgID, clientID, cidrOrIP)
+		}
+		return nil
+	}
+}
+
+func checkDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodbatlas_service_account_access_list_entry" {
+			continue
+		}
+
+		orgID := rs.Primary.Attributes["org_id"]
+		clientID := rs.Primary.Attributes["client_id"]
+		cidrOrIP := getCidrOrIP(rs)
+
+		if orgID == "" || clientID == "" || cidrOrIP == "" {
+			return fmt.Errorf("checkExists, attributes not found for: %s", resourceName)
+		}
+
+		entry, _ := getEntry(orgID, clientID, cidrOrIP)
+		if entry != nil {
+			return fmt.Errorf("access list entry (%s/%s/%s) still exists", orgID, clientID, cidrOrIP)
+		}
+		return nil
+	}
+	return nil
+}
+
+func importStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+		orgID := rs.Primary.Attributes["org_id"]
+		clientID := rs.Primary.Attributes["client_id"]
+		cidrOrIP := getCidrOrIP(rs)
+		if orgID == "" || clientID == "" || cidrOrIP == "" {
+			return "", fmt.Errorf("import, attributes not found for: %s", resourceName)
+		}
+		return fmt.Sprintf("%s/%s/%s", orgID, clientID, cidrOrIP), nil
+	}
+}
+
+func getCidrOrIP(rs *terraform.ResourceState) string {
+	cidrOrIP := rs.Primary.Attributes["ip_address"]
+	if cidrOrIP == "" {
+		cidrOrIP = rs.Primary.Attributes["cidr_block"]
+	}
+	return cidrOrIP
+}
+
+func getEntry(orgID, clientID, cidrOrIP string) (*admin.ServiceAccountIPAccessListEntry, error) {
+	res, _, err := acc.ConnV2().ServiceAccountsApi.ListOrgAccessList(context.Background(), orgID, clientID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access list: %w", err)
+	}
+	entries := res.GetResults()
+	for i := range entries {
+		entry := &entries[i]
+		if entry.GetIpAddress() == cidrOrIP || entry.GetCidrBlock() == cidrOrIP {
+			return entry, nil
+		}
+	}
+	return nil, nil
+}
+
+func (e testEntry) hclStr() string {
+	result := ""
+	if e.cidr != "" {
+		result += fmt.Sprintf("cidr_block = %q\n", e.cidr)
+	}
+	if e.ip != "" {
+		result += fmt.Sprintf("ip_address = %q\n", e.ip)
+	}
+	return result
+}
+
+func (e testEntry) attrMap() map[string]string {
+	result := map[string]string{}
+	if e.cidr != "" {
+		result["cidr_block"] = e.cidr
+	}
+	if e.ip != "" {
+		result["ip_address"] = e.ip
+	}
+	return result
+}

--- a/internal/service/serviceaccountaccesslistentry/schema.go
+++ b/internal/service/serviceaccountaccesslistentry/schema.go
@@ -1,0 +1,89 @@
+package serviceaccountaccesslistentry
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/validate"
+)
+
+const (
+	cidrBlockDesc = "Range of IP addresses in CIDR notation to be added to the access list. You can set a value for this parameter or **ip_address**, but not for both."
+	ipAddressDesc = "IP address to be added to the access list. You can set a value for this parameter or **cidr_block**, but not for both."
+)
+
+func ResourceSchema() schema.Schema {
+	return schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"org_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Unique 24-hexadecimal digit string that identifies the organization that contains your projects.",
+			},
+			"client_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The Client ID of the Service Account.",
+			},
+			"cidr_block": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: cidrBlockDesc,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					validate.ValidCIDR(),
+					stringvalidator.ConflictsWith(path.MatchRoot("ip_address")),
+				},
+			},
+			"ip_address": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: ipAddressDesc,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					validate.ValidIP(),
+					stringvalidator.ConflictsWith(path.MatchRoot("cidr_block")),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Date the entry was added to the access list. This attribute expresses its value in the ISO 8601 timestamp format in UTC.",
+			},
+			"last_used_address": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Network address that issued the most recent request to the API.",
+			},
+			"last_used_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Date when the API received the most recent request that originated from this network address.",
+			},
+			"request_count": schema.Int64Attribute{
+				Computed:            true,
+				MarkdownDescription: "The number of requests that has originated from this network address.",
+			},
+		},
+	}
+}
+
+type TFServiceAccountAccessListEntryModel struct {
+	OrgID           types.String `tfsdk:"org_id"`
+	ClientID        types.String `tfsdk:"client_id"`
+	IPAddress       types.String `tfsdk:"ip_address"`
+	CIDRBlock       types.String `tfsdk:"cidr_block"`
+	CreatedAt       types.String `tfsdk:"created_at"`
+	LastUsedAddress types.String `tfsdk:"last_used_address"`
+	LastUsedAt      types.String `tfsdk:"last_used_at"`
+	RequestCount    types.Int64  `tfsdk:"request_count"`
+}
+
+type TFServiceAccountAccessListEntriesPluralDSModel struct {
+	OrgID    types.String                            `tfsdk:"org_id"`
+	ClientID types.String                            `tfsdk:"client_id"`
+	Results  []*TFServiceAccountAccessListEntryModel `tfsdk:"results"`
+}


### PR DESCRIPTION
## Description

Add service_account_access_list_entry resource, singular and plural datasources.
Added Acceptance tests.

- Moved Service Account acc tests to their own job since we now have a mix of handwritten and autogenerated resources.

Link to any related issue(s): CLOUDP-369229

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [x] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
