### PR TITLE
chore: Addresses semgrep security and quality issues

### DIFF
--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -38,8 +38,10 @@ jobs:
         permissions: {}
         steps:
             - name: Validation of version format
+              env:
+                  VERSION_NUMBER: ${{ inputs.version_number }}
               run: |
-                  echo "${{ inputs.version_number }}" | grep -P '^v1\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
+                  echo "$VERSION_NUMBER" | grep -P '^v1\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
             - name: Checkout
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
               with:

--- a/internal/service/cluster/model_cluster.go
+++ b/internal/service/cluster/model_cluster.go
@@ -29,7 +29,7 @@ type ProcessArgs struct {
 func flattenCloudProviderSnapshotBackupPolicy(ctx context.Context, d *schema.ResourceData, conn *matlas.Client, projectID, clusterName string) ([]map[string]any, error) {
 	backupPolicy, res, err := conn.CloudProviderSnapshotBackupPolicies.Get(ctx, projectID, clusterName)
 	if err != nil {
-		if res.StatusCode == http.StatusNotFound ||
+		if (res != nil && res.StatusCode == http.StatusNotFound) ||
 			strings.Contains(err.Error(), "BACKUP_CONFIG_NOT_FOUND") ||
 			strings.Contains(err.Error(), "Not Found") ||
 			strings.Contains(err.Error(), "404") {


### PR DESCRIPTION
## Description

CLOUDP-370328: Fix potential nil pointer dereference in model_cluster.go by
adding nil check for response before accessing StatusCode field.

Link to any related issue(s): CLOUDP-370325, CLOUDP-370326, CLOUDP-370327, CLOUDP-370328

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
