### PR TITLE
chore: Allow use of run-script-and-commit GitHub action from non-Go projects

### DIFF
--- a/.github/templates/run-script-and-commit/action.yaml
+++ b/.github/templates/run-script-and-commit/action.yaml
@@ -46,7 +46,9 @@ runs:
       id: check-go
       shell: bash
       run: |
-        if [ -f "${{ format('{0}go.mod', inputs.repo-path) }}" ]; then
+        GO_MOD_PATH="${{ inputs.repo-path }}go.mod"
+        echo "go_mod_path=$GO_MOD_PATH" >> $GITHUB_OUTPUT
+        if [ -f "$GO_MOD_PATH" ]; then
           echo "is_go_project=true" >> $GITHUB_OUTPUT
         else
           echo "is_go_project=false" >> $GITHUB_OUTPUT
@@ -56,7 +58,7 @@ runs:
       if: steps.check-go.outputs.is_go_project == 'true'
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
       with:
-        go-version-file: ${{ format('{0}go.mod', inputs.repo-path) }}
+        go-version-file: ${{ steps.check-go.outputs.go_mod_path }}
     - name: Run specified script
       shell: bash
       run: ${{ inputs.script_call }}

--- a/.github/templates/run-script-and-commit/action.yaml
+++ b/.github/templates/run-script-and-commit/action.yaml
@@ -24,9 +24,9 @@ inputs:
   passphrase:
     description: "Passphrase for the GPG key."
     required: true
-  repo-path:
-    description: "Path to the repository."
-    default: ""
+  go-mod-path:
+    description: "Path to go.mod file. If the file exists, Go will be set up."
+    default: "go.mod"
     required: false
   branch:
     description: "Branch to checkout."
@@ -43,23 +43,11 @@ runs:
         token: ${{ inputs.apix_bot_pat }}
         ref: ${{ inputs.branch }}
 
-    - name: Check if Go project
-      id: check-go
-      shell: bash
-      run: |
-        GO_MOD_PATH="${{ inputs.repo-path }}go.mod"
-        echo "go_mod_path=$GO_MOD_PATH" >> $GITHUB_OUTPUT
-        if [ -f "$GO_MOD_PATH" ]; then
-          echo "is_go_project=true" >> $GITHUB_OUTPUT
-        else
-          echo "is_go_project=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Set up Go
-      if: steps.check-go.outputs.is_go_project == 'true'
+      if: ${{ hashFiles(inputs.go-mod-path) != '' }}
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
       with:
-        go-version-file: ${{ steps.check-go.outputs.go_mod_path }}
+        go-version-file: ${{ inputs.go-mod-path }}
     - name: Run specified script
       shell: bash
       run: ${{ inputs.script_call }}

--- a/.github/templates/run-script-and-commit/action.yaml
+++ b/.github/templates/run-script-and-commit/action.yaml
@@ -39,6 +39,7 @@ runs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       with:
         fetch-depth: 0
+        fetch-tags: true
         token: ${{ inputs.apix_bot_pat }}
         ref: ${{ inputs.branch }}
 

--- a/.github/templates/run-script-and-commit/action.yaml
+++ b/.github/templates/run-script-and-commit/action.yaml
@@ -42,7 +42,18 @@ runs:
         token: ${{ inputs.apix_bot_pat }}
         ref: ${{ inputs.branch }}
 
+    - name: Check if Go project
+      id: check-go
+      shell: bash
+      run: |
+        if [ -f "${{ format('{0}go.mod', inputs.repo-path) }}" ]; then
+          echo "is_go_project=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_go_project=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Set up Go
+      if: steps.check-go.outputs.is_go_project == 'true'
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
       with:
         go-version-file: ${{ format('{0}go.mod', inputs.repo-path) }}


### PR DESCRIPTION
## Description

Allow use of run-script-and-commit GitHub action from non-Go projects, for example Terraform module repos.

Also fetches tags in case they're needed by the script to execute.

Link to any related issue(s): CLOUDP-365072

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
