### PR TITLE
fix: Fix encryption_at_rest support for eventual consistency of credentials

### DIFF
--- a/.changelog/4064.txt
+++ b/.changelog/4064.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/mongodbatlas_encryption_at_rest: Fixes retry process that handles eventual consistency of credentials
+```
+
+```release-note:bug
+resource/mongodbatlas_encryption_at_rest: Increases create timeout from 1 to 3 minutes to support slower eventual consistency of credentials
+```

--- a/.changelog/4064.txt
+++ b/.changelog/4064.txt
@@ -2,6 +2,6 @@
 resource/mongodbatlas_encryption_at_rest: Fixes retry process that handles eventual consistency of credentials
 ```
 
-```release-note:bug
+```release-note:enhancement
 resource/mongodbatlas_encryption_at_rest: Increases create timeout from 1 to 3 minutes to support slower eventual consistency of credentials
 ```

--- a/internal/service/encryptionatrest/resource.go
+++ b/internal/service/encryptionatrest/resource.go
@@ -2,10 +2,10 @@ package encryptionatrest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"time"
 
 	"go.mongodb.org/atlas-sdk/v20250312011/admin"
@@ -302,8 +302,8 @@ func (r *encryptionAtRestRS) Create(ctx context.Context, req resource.CreateRequ
 		Pending:    []string{retrystrategy.RetryStrategyPendingState},
 		Target:     []string{retrystrategy.RetryStrategyCompletedState, retrystrategy.RetryStrategyErrorState},
 		Refresh:    ResourceMongoDBAtlasEncryptionAtRestCreateRefreshFunc(ctx, projectID, connV2.EncryptionAtRestUsingCustomerKeyManagementApi, encryptionAtRestReq),
-		Timeout:    1 * time.Minute,
-		MinTimeout: 1 * time.Second,
+		Timeout:    3 * time.Minute,
+		MinTimeout: 5 * time.Second,
 		Delay:      0,
 	}
 
@@ -329,12 +329,11 @@ func ResourceMongoDBAtlasEncryptionAtRestCreateRefreshFunc(ctx context.Context, 
 	return func() (any, string, error) {
 		encryptionResp, _, err := client.UpdateEncryptionAtRest(ctx, projectID, encryptionAtRestReq).Execute()
 		if err != nil {
-			if errors.Is(err, errors.New("CANNOT_ASSUME_ROLE")) ||
-				errors.Is(err, errors.New("INVALID_AWS_CREDENTIALS")) ||
-				errors.Is(err, errors.New("CLOUD_PROVIDER_ACCESS_ROLE_NOT_AUTHORIZED")) {
-				log.Printf("warning issue performing authorize EncryptionsAtRest not done try again: %s \n", err.Error())
-				log.Println("retrying ")
-
+			errStr := err.Error()
+			if strings.Contains(errStr, "CANNOT_ASSUME_ROLE") ||
+				strings.Contains(errStr, "INVALID_AWS_CREDENTIALS") ||
+				strings.Contains(errStr, "CLOUD_PROVIDER_ACCESS_ROLE_NOT_AUTHORIZED") {
+				log.Printf("[WARN] error updating EncryptionAtRest: %s \nretrying\n", errStr)
 				return encryptionResp, retrystrategy.RetryStrategyPendingState, nil
 			}
 			return encryptionResp, retrystrategy.RetryStrategyErrorState, err

--- a/internal/service/encryptionatrest/resource_test.go
+++ b/internal/service/encryptionatrest/resource_test.go
@@ -463,6 +463,30 @@ func TestResourceMongoDBAtlasEncryptionAtRestCreateRefreshFunc(t *testing.T) {
 			expectedRetrystrategy: retrystrategy.RetryStrategyErrorState,
 			expectedError:         true,
 		},
+		{
+			name:                  "Retryable error: CANNOT_ASSUME_ROLE",
+			mockResponse:          nil,
+			mockError:             errors.New("CANNOT_ASSUME_ROLE"),
+			expectedResponse:      nil,
+			expectedRetrystrategy: retrystrategy.RetryStrategyPendingState,
+			expectedError:         false,
+		},
+		{
+			name:                  "Retryable error: INVALID_AWS_CREDENTIALS",
+			mockResponse:          nil,
+			mockError:             errors.New("INVALID_AWS_CREDENTIALS"),
+			expectedResponse:      nil,
+			expectedRetrystrategy: retrystrategy.RetryStrategyPendingState,
+			expectedError:         false,
+		},
+		{
+			name:                  "Retryable error: CLOUD_PROVIDER_ACCESS_ROLE_NOT_AUTHORIZED",
+			mockResponse:          nil,
+			mockError:             errors.New("CLOUD_PROVIDER_ACCESS_ROLE_NOT_AUTHORIZED"),
+			expectedResponse:      nil,
+			expectedRetrystrategy: retrystrategy.RetryStrategyPendingState,
+			expectedError:         false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Resource creation is failing to handle eventual consistency of credentials due to incorrect error checks.
- `errors.Is(err, errors.New("CANNOT_ASSUME_ROLE"))` never passes, should use `strings.Contains(errStr, "CANNOT_ASSUME_ROLE")` instead as we do at [resource_cloud_provider_access_authorization.go#L319](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/e5252d47728717d5856680dcba0dc00c89d3f877/internal/service/cloudprovideraccess/resource_cloud_provider_access_authorization.go#L319)


Link to any related issue(s): HELP-87344

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
