### PR TITLE
doc: Added note about built in roles being available by default

### DIFF
--- a/docs/resources/custom_db_role.md
+++ b/docs/resources/custom_db_role.md
@@ -144,6 +144,7 @@ Each object in the inheritedRoles array represents a key-value pair indicating t
 
 * `role_name`	(Required) Name of the inherited role. This can either be another custom role or a built-in role.
 
+	-> **NOTE** Built-in roles are present in clusters by default and do not need to be redefined for their properties to be inherited by a custom role.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
## Description

There has been confusion about the reqs of defining custom roles using the properties of the built-in roles. This note clarifies that built-in roles are available by default and do not need to be redefined.

[JIRA Ticket](https://jira.mongodb.org/browse/DOCSP-49278)

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
