### PR TITLE
chore: Disable weekly autogen workflow

### DIFF
--- a/.github/workflows/generate-autogen-resources.yml
+++ b/.github/workflows/generate-autogen-resources.yml
@@ -1,7 +1,7 @@
 name: 'Generate auto-generated resources'
 
 # DISABLED
-# This workflow has been disabled to prevent automatic updates to production autogen resources.
+# This workflow has been disabled to prevent automatic updates to production autogen resources. See: CLOUDP-365514
 # Auto-generates resources and creates a pull request if there are any changes. Runs once per week and can be triggered manually.
 on:
   # schedule:

--- a/.github/workflows/generate-autogen-resources.yml
+++ b/.github/workflows/generate-autogen-resources.yml
@@ -1,9 +1,11 @@
 name: 'Generate auto-generated resources'
 
+# DISABLED
+# This workflow has been disabled to prevent automatic updates to production autogen resources.
 # Auto-generates resources and creates a pull request if there are any changes. Runs once per week and can be triggered manually.
 on:
-  schedule:
-    - cron: "30 8 * * WED" # Every Wednesday at 8:30 AM
+  # schedule:
+  #   - cron: "30 8 * * WED" # Every Wednesday at 8:30 AM
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Please include a summary of the fix/feature/change, including any relevant motivation and context.

This PR disables the 'Generate Auto-Generated Resources' workflow. This workflow has been disabled to prevent automatic updates to production autogen resources.

Link to any related issue(s): CLOUDP-372206

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
