### PR TITLE
fix: Ensure consistency between `service_account_secret` and `project_service_account_secret` resources and DSs 

### DIFF
--- a/internal/serviceapi/serviceaccountsecret/data_source_custom_hooks.go
+++ b/internal/serviceapi/serviceaccountsecret/data_source_custom_hooks.go
@@ -1,9 +1,6 @@
 package serviceaccountsecret
 
 import (
-	"encoding/json"
-	"errors"
-
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/config"
 )
@@ -19,22 +16,8 @@ func (d *ds) PreReadAPICall(callParams config.APICallParams) config.APICallParam
 	return callParams
 }
 
+// PostReadAPICall Reads the secret from the API response Service Account secrets list and returns a new APICallResult with it.
 func (d *ds) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallResult) autogen.APICallResult {
-	if result.Err != nil {
-		return result
-	}
-	var responseJSON response
-	if err := json.Unmarshal(result.Body, &responseJSON); err != nil {
-		return autogen.APICallResult{Body: nil, Err: err}
-	}
-
 	id := req.State.(*TFDSModel).SecretId.ValueString()
-	for _, secret := range responseJSON.Secrets {
-		if secret["id"] == id {
-			marshaledSecret, err := json.Marshal(secret)
-			return autogen.APICallResult{Body: marshaledSecret, Err: err}
-		}
-	}
-
-	return autogen.APICallResult{Body: nil, Err: errors.New("secret not found in service account response")}
+	return resourcePostReadAPICall(id, result)
 }

--- a/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
+++ b/internal/serviceapi/serviceaccountsecret/resource_custom_hooks.go
@@ -9,22 +9,27 @@ import (
 
 var _ autogen.PostReadAPICallHook = (*rs)(nil)
 
-type response struct {
+type readAPIResponse struct {
 	Secrets []map[string]any
 }
 
+// PostReadAPICall Reads the secret from the API response Service Account secrets list and returns a new APICallResult with it.
 func (r *rs) PostReadAPICall(req autogen.HandleReadReq, result autogen.APICallResult) autogen.APICallResult {
+	id := req.State.(*TFModel).SecretId.ValueString()
+	return resourcePostReadAPICall(id, result)
+}
+
+func resourcePostReadAPICall(secretID string, result autogen.APICallResult) autogen.APICallResult {
 	if result.Err != nil {
 		return result
 	}
-	var responseJSON response
+	var responseJSON readAPIResponse
 	if err := json.Unmarshal(result.Body, &responseJSON); err != nil {
 		return autogen.APICallResult{Body: nil, Err: err}
 	}
 
-	id := req.State.(*TFModel).SecretId.ValueString()
 	for _, secret := range responseJSON.Secrets {
-		if secret["id"] == id {
+		if secret["id"] == secretID {
 			marshaledSecret, err := json.Marshal(secret)
 			return autogen.APICallResult{Body: marshaledSecret, Err: err}
 		}


### PR DESCRIPTION
## Description

Ensure consistency between `service_account_secret` and `project_service_account_secret` resources and DSs 

Link to any related issue(s): CLOUDP-373922

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
