### PR TITLE
chore: Add -local-fs flag to changelog-build command to fix changelog generation

### DIFF
--- a/scripts/update-changelog-unreleased-section.sh
+++ b/scripts/update-changelog-unreleased-section.sh
@@ -59,7 +59,6 @@ CHANGELOG=$("$(go env GOPATH)"/bin/changelog-build -this-release "$TARGET_SHA" \
                       -local-fs)
 
 restore_head
-trap - EXIT
 
 if [ -z "$CHANGELOG" ]
 then


### PR DESCRIPTION
## Description

### Problem statement

- As of 5 days the [changelog generation process](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/workflows/generate-changelog.yml) has not been working, with the script `./scripts/update-changelog-unreleased-section.sh` running indefinitely until the job is either cancelled or fails.

Gained context:
- When running locally confirmed that time was consumed when calling external tool `hashicorp/go-changelog/cmd/changelog-build` `changelog-build` command.
- A change was recently made (https://github.com/hashicorp/go-changelog/pull/49) which adds a new flag allowing the use of local file system vs having all git information loaded in memory. This change however caused a regression in performance when not using the flag, as it removed the concurrent processing of changelog entries.

### Solution

When making use of the new flag the generation process remains < 5s. As per PR description it does also optimize usage of ram which was the initial concern being solved. The only downside of using local-fs is that during execution of the command local git is used and leaves the repo checked out in a random SHA. Additional logic was used to preserve the original HEAD.

As a followup will leave a comment in related PR to mention performance regression and track if follow up adjustments will be made.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
