### PR TITLE
doc: Specify behaviour of `defer`, `auto_defer` and `auto_defer_once_enabled` fields for maintenance window resource

### DIFF
--- a/docs/data-sources/maintenance_window.md
+++ b/docs/data-sources/maintenance_window.md
@@ -49,7 +49,7 @@ In addition to all arguments above, the following attributes are exported:
 * `hour_of_day` - Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
 * `start_asap` - Flag indicating whether project maintenance has been directed to start immediately. If requested, this field returns true from the time the request was made until the time the maintenance event completes.
 * `number_of_deferrals` - Number of times the current maintenance event for this project has been deferred, there can be a maximum of 2 deferrals.
-* `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
+* `auto_defer_once_enabled` - When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
 * `time_zone_id` - Identifier for the current time zone of the maintenance window. This can only be updated via the Project Settings UI.
 

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -52,7 +52,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
 * `defer` - (Optional) Defer the next scheduled maintenance event for the given project by one week. Only works when maintenance is already scheduled.
-* `auto_defer` - (Optional) Toggle automatic deferral on/off. Each change flips the current state. Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation.
+* `auto_defer` - (Optional) Boolean flag to toggle automatic deferral on/off. Each change flips the current state. Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation.
 * `auto_defer_once_enabled` - (Optional) When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer` but by directly setting the value to true or false. If `auto_defer` is modified triggering a toggle, it will impact the value of this attribute.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
 

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -51,9 +51,9 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 * `project_id` - The unique identifier of the project for the Maintenance Window.
 * `day_of_week` - (Required) Day of the week when you would like the maintenance window to start as a 1-based integer: Su=1, M=2, T=3, W=4, T=5, F=6, Sa=7.
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
-* `defer` - Defer the next scheduled maintenance for the given project for one week.
-* `auto_defer` - Defer any scheduled maintenance for the given project for one week.
-* `auto_defer_once_enabled` - Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
+* `defer` - (Optional) Defer the next scheduled maintenance event for the given project by one week. Only works when maintenance is already scheduled.
+* `auto_defer` - (Optional) Toggle automatic deferral on/off. Each change flips the current state. Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation.
+* `auto_defer_once_enabled` - (Optional) When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer` but by directly setting the value to true or false.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
 
 ### Protected Hours

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -53,7 +53,7 @@ Once maintenance is scheduled for your cluster, you cannot change your maintenan
 * `hour_of_day` - (Required) Hour of the day when you would like the maintenance window to start. This parameter uses the 24-hour clock, where midnight is 0, noon is 12. Uses the project's configured timezone.
 * `defer` - (Optional) Defer the next scheduled maintenance event for the given project by one week. Only works when maintenance is already scheduled.
 * `auto_defer` - (Optional) Toggle automatic deferral on/off. Each change flips the current state. Achieves the same outcome as `auto_defer_once_enabled` but through a toggle operation.
-* `auto_defer_once_enabled` - (Optional) When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer` but by directly setting the value to true or false.
+* `auto_defer_once_enabled` - (Optional) When `true`, enables automatic deferral of all scheduled maintenance for the given project by one week. Achieves the same outcome as `auto_defer` but by directly setting the value to true or false. If `auto_defer` is modified triggering a toggle, it will impact the value of this attribute.
 * `protected_hours` - (Optional) Defines the time period during which there will be no standard updates to the clusters. See [Protected Hours](#protected-hours).
 
 ### Protected Hours


### PR DESCRIPTION
## Description

## Summary

This PR aims to clarify the documentation for the three defer-related fields in the `mongodbatlas_maintenance_window` resource: `defer`, `auto_defer`, and `auto_defer_once_enabled`. 

- `defer` corresponds to the [Defer One Maintenance Window](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Maintenance-Windows/operation/deferMaintenanceWindow) endpoint
- `auto_defer` corresponds to the [Toggle Automatic Deferral](https://www.mongodb.com/docs/atlas/cli/current/command/atlas-api-maintenanceWindows-toggleMaintenanceAutoDefer/) endpoint (toggle operation)
- `auto_defer_once_enabled` corresponds to the `autoDeferOnceEnabled` parameter in the [Update Maintenance Window](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/group/endpoint-maintenance-windows) endpoint (direct set operation)

Link to any related issue(s): https://jira.mongodb.org/browse/CLOUDP-305937

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [X] This change requires a documentation update
- [X] Documentation fix/enhancement

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [X] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [X] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run make fmt and formatted my code
- [X] If changes include deprecations or removals I have added appropriate changelog entries.
- [X] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments

Related Github issue: https://github.com/mongodb/terraform-provider-mongodbatlas/issues/3155
