### PR TITLE
chore: Use immutable_computed flag in SA resources

### DIFF
--- a/internal/serviceapi/projectserviceaccount/resource_schema.go
+++ b/internal/serviceapi/projectserviceaccount/resource_schema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
@@ -18,10 +19,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"client_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The Client ID of the Service Account.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The date that the Service Account was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"description": schema.StringAttribute{
 				Required:            true,

--- a/internal/serviceapi/serviceaccount/resource_schema.go
+++ b/internal/serviceapi/serviceaccount/resource_schema.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/autogen/customtypes"
 	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/customplanmodifier"
@@ -18,10 +19,12 @@ func ResourceSchema(ctx context.Context) schema.Schema {
 			"client_id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The Client ID of the Service Account.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The date that the Service Account was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"description": schema.StringAttribute{
 				Required:            true,

--- a/tools/codegen/config.yml
+++ b/tools/codegen/config.yml
@@ -834,6 +834,10 @@ resources:
         # The API description mentions using the /org endpoint to fetch user's organizations, removing that part.
         org_id:
           description: *org_id_description
+        client_id:
+          immutable_computed: true
+        created_at:
+          immutable_computed: true
         secret_expires_after_hours:
           # Adding clarification that the attribute is required for creation and can't be updated later.
           description: "The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings. This attribute is required when creating the Service Account and you cannot update it later."
@@ -880,6 +884,10 @@ resources:
       overrides:
         project_id:
           description: *project_id_description
+        client_id:
+          immutable_computed: true
+        created_at:
+          immutable_computed: true
         secret_expires_after_hours:
           # Adding clarification that the attribute is required for creation and can't be updated later.
           description: "The expiration time of the new Service Account secret, provided in hours. The minimum and maximum allowed expiration times are subject to change and are controlled by the organization's settings. This attribute is required when creating the Service Account and you cannot update it later."

--- a/tools/codegen/models/project_service_account.yaml
+++ b/tools/codegen/models/project_service_account.yaml
@@ -12,6 +12,7 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+          immutable_computed: true
         - string: {}
           description: The date that the Service Account was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           computed_optional_required: computed
@@ -23,6 +24,7 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+          immutable_computed: true
         - string: {}
           description: Human readable description for the Service Account.
           computed_optional_required: required

--- a/tools/codegen/models/service_account.yaml
+++ b/tools/codegen/models/service_account.yaml
@@ -12,6 +12,7 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+          immutable_computed: true
         - string: {}
           description: The date that the Service Account was created on. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
           computed_optional_required: computed
@@ -23,6 +24,7 @@ schema:
           create_only: false
           present_in_any_response: true
           request_only_required_on_create: false
+          immutable_computed: true
         - string: {}
           description: Human readable description for the Service Account.
           computed_optional_required: required


### PR DESCRIPTION
## Description

Add the new immutable_computed flag to SA resources to generate client_id and created_at with the UseStateForUnknown plan modifier.
Especially relevant to reduce plan verbosity caused by the client_id computed value.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
