### PR TITLE
chore: Fix api key invalid role test

### DIFF
--- a/internal/service/projectapikey/resource_project_api_key_test.go
+++ b/internal/service/projectapikey/resource_project_api_key_test.go
@@ -245,7 +245,7 @@ func TestAccProjectAPIKey_invalidRole(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      configBasic(description, projectID, "INVALID_ROLE"),
-				ExpectError: regexp.MustCompile("INVALID_ENUM_VALUE"),
+				ExpectError: regexp.MustCompile("Invalid role"),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Test failing in last test suite run: https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/21269981480/job/61218024571
There is a new validation for invalid roles, updating the test.

Link to any related issue(s): -

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
