### PR TITLE
doc: Adds example for `mongodbatlas_log_integration` resource using MRAP instead of bucket name

### DIFF
--- a/examples/mongodbatlas_log_integration/README.md
+++ b/examples/mongodbatlas_log_integration/README.md
@@ -1,45 +1,35 @@
-# MongoDB Atlas Log Integration Example
+# MongoDB Atlas Log Integration Examples
 
-This example demonstrates how to configure a log integration to export MongoDB Atlas logs to an Amazon S3 bucket.
+This directory contains examples demonstrating how to configure log integrations to export MongoDB Atlas logs to AWS S3.
+
+## Available Examples
+
+### [S3 Bucket](./s3bucket/)
+
+A basic example that exports logs to a single S3 bucket. This is the simplest setup and is suitable for most use cases.
+
+**Resources created:**
+- S3 bucket
+- IAM role and policy
+- MongoDB Atlas Cloud Provider Access
+- MongoDB Atlas Log Integration
+
+### [S3 Multi-Region Access Point (MRAP)](./s3bucket_mrap/)
+
+An advanced example that exports logs to an S3 Multi-Region Access Point (MRAP) instead of a single bucket. This provides high availability and lower latency by automatically routing requests to the closest available S3 bucket.
+
+**Resources created:**
+- S3 buckets in multiple AWS regions
+- S3 Multi-Region Access Point (MRAP)
+- IAM role and policy with MRAP permissions
+- MongoDB Atlas Cloud Provider Access
+- MongoDB Atlas Log Integration
 
 ## Prerequisites
 
 - MongoDB Atlas account with Organization Owner or Project Owner role.
 - AWS account with permissions to create S3 buckets and IAM roles.
 - Terraform >= `1.0`.
-
-## Resources Created
-
-This example creates the following resources:
-
-### MongoDB Atlas
-- Project
-- Cloud Provider Access Setup and Authorization.
-- Log Integration configuration.
-
-### AWS
-- S3 bucket for storing logs.
-- IAM role for Atlas to assume.
-- IAM policy for S3 access.
-
-## Usage
-
-1. Set the required variables in a `terraform.tfvars` file or via environment variables:
-
-```hcl
-atlas_org_id        = "your-org-id"
-atlas_client_id     = "your-service-account-client-id"
-atlas_client_secret = "your-service-account-client-secret"
-access_key          = "your-aws-access-key"
-secret_key          = "your-aws-secret-key"
-```
-
-2. Initialize and apply:
-
-```bash
-terraform init
-terraform apply
-```
 
 ## Log Types
 
@@ -54,4 +44,3 @@ The `log_types` attribute supports the following values:
 - The requesting Service Account or API Key must have the Organization Owner or Project Owner role.
 - MongoDB Cloud will add sub-directories based on the log type under the specified `prefix_path`.
 - Optional: Use `kms_key` to specify an AWS KMS key ID or ARN for server-side encryption.
-

--- a/examples/mongodbatlas_log_integration/s3bucket/README.md
+++ b/examples/mongodbatlas_log_integration/s3bucket/README.md
@@ -1,0 +1,96 @@
+# MongoDB Atlas Log Integration with S3 Bucket Example
+
+This example demonstrates how to configure a log integration to export MongoDB Atlas logs to an Amazon S3 bucket.
+
+## Prerequisites
+
+- MongoDB Atlas account with Organization Owner or Project Owner role.
+- AWS account with permissions to create S3 buckets and IAM roles.
+- Terraform >= `1.0`.
+
+## Resources Created
+
+This example creates the following resources:
+
+### MongoDB Atlas
+- Project
+- Cloud Provider Access Setup and Authorization.
+- Log Integration configuration.
+
+### AWS
+- S3 bucket for storing logs.
+- IAM role for Atlas to assume.
+- IAM policy for S3 access.
+
+## Usage
+
+**1\. Ensure your AWS and MongoDB Atlas credentials are set up.**
+
+This can be done using environment variables:
+
+```bash
+export MONGODB_ATLAS_CLIENT_ID="<ATLAS_CLIENT_ID>"
+export MONGODB_ATLAS_CLIENT_SECRET="<ATLAS_CLIENT_SECRET>"
+```
+
+```bash
+export AWS_ACCESS_KEY_ID='<AWS_ACCESS_KEY_ID>'
+export AWS_SECRET_ACCESS_KEY='<AWS_SECRET_ACCESS_KEY>'
+```
+
+... or the `~/.aws/credentials` file.
+
+```
+$ cat ~/.aws/credentials
+[default]
+aws_access_key_id = <AWS_ACCESS_KEY_ID>
+aws_secret_access_key = <AWS_SECRET_ACCESS_KEY>
+```
+
+... or follow as in the `variables.tf` file and create **terraform.tfvars** file with all the variable values:
+
+```hcl
+atlas_org_id        = "your-org-id"
+atlas_client_id     = "your-service-account-client-id"
+atlas_client_secret = "your-service-account-client-secret"
+access_key          = "your-aws-access-key"
+secret_key          = "your-aws-secret-key"
+```
+
+**2\. Review the Terraform plan.**
+
+Execute the following command and ensure you are happy with the plan.
+
+```bash
+terraform plan
+```
+
+**3\. Execute the Terraform apply.**
+
+Now execute the plan to provision the resources.
+
+```bash
+terraform apply
+```
+
+**4\. Destroy the resources.**
+
+When you have finished your testing, ensure you destroy the resources to avoid unnecessary Atlas charges.
+
+```bash
+terraform destroy
+```
+
+## Log Types
+
+The `log_types` attribute supports the following values:
+- `MONGOD` - MongoDB server logs.
+- `MONGOS` - MongoDB router logs.
+- `MONGOD_AUDIT` - MongoDB server audit logs.
+- `MONGOS_AUDIT` - MongoDB router audit logs.
+
+## Notes
+
+- The requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+- MongoDB Cloud will add sub-directories based on the log type under the specified `prefix_path`.
+- Optional: Use `kms_key` to specify an AWS KMS key ID or ARN for server-side encryption.

--- a/examples/mongodbatlas_log_integration/s3bucket/README.md
+++ b/examples/mongodbatlas_log_integration/s3bucket/README.md
@@ -13,7 +13,7 @@ This example demonstrates how to configure a log integration to export MongoDB A
 This example creates the following resources:
 
 ### MongoDB Atlas
-- Project
+- Project.
 - Cloud Provider Access Setup and Authorization.
 - Log Integration configuration.
 

--- a/examples/mongodbatlas_log_integration/s3bucket/aws.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/aws.tf
@@ -52,4 +52,3 @@ resource "aws_iam_role_policy" "atlas_s3_policy" {
     ]
   })
 }
-

--- a/examples/mongodbatlas_log_integration/s3bucket/main.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/main.tf
@@ -44,4 +44,3 @@ output "log_integration_bucket_name" {
 output "log_integrations_results" {
   value = data.mongodbatlas_log_integrations.example.results
 }
-

--- a/examples/mongodbatlas_log_integration/s3bucket/providers.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/providers.tf
@@ -8,4 +8,3 @@ provider "aws" {
   access_key = var.access_key
   secret_key = var.secret_key
 }
-

--- a/examples/mongodbatlas_log_integration/s3bucket/variables.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/variables.tf
@@ -50,4 +50,3 @@ variable "aws_iam_role_name" {
   default     = "atlas-log-integration-role"
   type        = string
 }
-

--- a/examples/mongodbatlas_log_integration/s3bucket/versions.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket/versions.tf
@@ -9,4 +9,3 @@ terraform {
   }
   required_version = ">= 1.0"
 }
-

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/README.md
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/README.md
@@ -1,0 +1,125 @@
+# MongoDB Atlas Log Integration with S3 Multi-Region Access Point (MRAP) Example
+
+This example demonstrates how to configure a log integration to export MongoDB Atlas logs to an AWS S3 Multi-Region Access Point (MRAP) instead of a single S3 bucket.
+
+## Overview
+
+Using a Multi-Region Access Point (MRAP) provides:
+- **High availability**: Automatic routing to the closest available S3 bucket
+- **Lower latency**: Requests are routed to the nearest regional bucket
+- **Resilience**: Continues to work even if one region becomes unavailable
+
+## Prerequisites
+
+- MongoDB Atlas account with Organization Owner or Project Owner role.
+- AWS account with permissions to create S3 buckets, S3 Multi-Region Access Points, and IAM roles.
+- Terraform >= `1.0`.
+- AWS Provider >= `5.0`.
+
+## Resources Created
+
+This example creates the following resources:
+
+### MongoDB Atlas
+- Cloud Provider Access Setup and Authorization.
+- Log Integration configuration using MRAP.
+
+### AWS
+- S3 buckets in multiple regions (us-east-1 and us-west-2).
+- S3 Multi-Region Access Point (MRAP).
+- IAM role for Atlas to assume.
+- IAM policy with permissions for MRAP and backing buckets.
+
+## Usage
+
+**1\. Ensure your AWS and MongoDB Atlas credentials are set up.**
+
+This can be done using environment variables:
+
+```bash
+export MONGODB_ATLAS_CLIENT_ID="<ATLAS_CLIENT_ID>"
+export MONGODB_ATLAS_CLIENT_SECRET="<ATLAS_CLIENT_SECRET>"
+```
+
+```bash
+export AWS_ACCESS_KEY_ID='<AWS_ACCESS_KEY_ID>'
+export AWS_SECRET_ACCESS_KEY='<AWS_SECRET_ACCESS_KEY>'
+```
+
+... or the `~/.aws/credentials` file.
+
+```
+$ cat ~/.aws/credentials
+[default]
+aws_access_key_id = <AWS_ACCESS_KEY_ID>
+aws_secret_access_key = <AWS_SECRET_ACCESS_KEY>
+```
+
+... or follow as in the `variables.tf` file and create **terraform.tfvars** file with all the variable values:
+
+```hcl
+project_id  = "your-atlas-project-id"
+name_prefix = "my-atlas-logs"
+prefix_path = "atlas-logs/"
+log_types   = ["MONGOD", "MONGOS"]
+```
+
+**2\. Review the Terraform plan.**
+
+Execute the following command and ensure you are happy with the plan.
+
+```bash
+terraform plan
+```
+
+**3\. Execute the Terraform apply.**
+
+Now execute the plan to provision the resources.
+
+```bash
+terraform apply
+```
+
+**4\. Destroy the resources.**
+
+When you have finished your testing, ensure you destroy the resources to avoid unnecessary Atlas and AWS charges.
+
+```bash
+terraform destroy
+```
+
+## Log Types
+
+The `log_types` attribute supports the following values:
+- `MONGOD` - MongoDB server logs.
+- `MONGOS` - MongoDB router logs.
+- `MONGOD_AUDIT` - MongoDB server audit logs.
+- `MONGOS_AUDIT` - MongoDB router audit logs.
+
+## Variables
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| `project_id` | MongoDB Atlas Project ID | `string` | (required) |
+| `name_prefix` | Prefix for naming AWS resources (must be globally unique for S3) | `string` | `"atlas-logs"` |
+| `prefix_path` | S3 directory path prefix for log files | `string` | `"atlas-logs/"` |
+| `log_types` | Array of log types to export | `list(string)` | `["MONGOD", "MONGOS"]` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `mrap_alias` | The MRAP alias used in bucket_name |
+| `mrap_arn` | The MRAP ARN |
+| `integration_id` | The ID of the log integration |
+| `iam_role_arn` | ARN of the IAM role used for the integration |
+| `cloud_provider_role_id` | Atlas Cloud Provider Access Role ID |
+| `backing_buckets` | The S3 buckets backing the MRAP |
+
+## Notes
+
+- The requesting Service Account or API Key must have the Organization Owner or Project Owner role.
+- MongoDB Cloud will add sub-directories based on the log type under the specified `prefix_path`.
+- MRAP creation can take several minutes to complete.
+- The IAM policy includes permissions for both the MRAP and the backing S3 buckets, as some operations require direct bucket access.
+- Optional: Use `kms_key` to specify an AWS KMS key ID or ARN for server-side encryption.

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/aws.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/aws.tf
@@ -1,0 +1,125 @@
+# Generate a random suffix for globally unique S3 bucket names
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+# S3 buckets (one per region for MRAP)
+resource "aws_s3_bucket" "mrap_bucket_us_east_1" {
+  provider      = aws.us_east_1
+  bucket        = "${var.name_prefix}-${random_id.bucket_suffix.hex}-us-east-1"
+  force_destroy = true
+
+  tags = {
+    Purpose = "Atlas Log Integration MRAP"
+    Region  = "us-east-1"
+  }
+}
+
+resource "aws_s3_bucket" "mrap_bucket_us_west_2" {
+  provider      = aws.us_west_2
+  bucket        = "${var.name_prefix}-${random_id.bucket_suffix.hex}-us-west-2"
+  force_destroy = true
+
+  tags = {
+    Purpose = "Atlas Log Integration MRAP"
+    Region  = "us-west-2"
+  }
+}
+
+# S3 Multi-Region Access Point
+resource "aws_s3control_multi_region_access_point" "atlas_logs" {
+  details {
+    name = "${var.name_prefix}-mrap-${random_id.bucket_suffix.hex}"
+
+    region {
+      bucket = aws_s3_bucket.mrap_bucket_us_east_1.id
+    }
+
+    region {
+      bucket = aws_s3_bucket.mrap_bucket_us_west_2.id
+    }
+  }
+}
+
+# IAM role for Atlas to assume
+resource "aws_iam_role" "atlas_role" {
+  name                 = "${var.name_prefix}-role-${random_id.bucket_suffix.hex}"
+  max_session_duration = 43200
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = mongodbatlas_cloud_provider_access_setup.setup.aws_config[0].atlas_aws_account_arn
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = mongodbatlas_cloud_provider_access_setup.setup.aws_config[0].atlas_assumed_role_external_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Purpose = "Atlas Log Integration MRAP"
+  }
+}
+
+# IAM policy for MRAP access
+resource "aws_iam_role_policy" "mrap_policy" {
+  name = "${var.name_prefix}-mrap-policy"
+  role = aws_iam_role.atlas_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "MRAPAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:DeleteObject"
+        ]
+        # MRAP ARN format: arn:aws:s3::ACCOUNT_ID:accesspoint/MRAP_ALIAS
+        Resource = [
+          aws_s3control_multi_region_access_point.atlas_logs.arn,
+          "${aws_s3control_multi_region_access_point.atlas_logs.arn}/object/*"
+        ]
+      },
+      {
+        Sid    = "MRAPMetadata"
+        Effect = "Allow"
+        Action = [
+          "s3:GetAccessPoint",
+          "s3:ListAccessPoints"
+        ]
+        Resource = "*"
+      },
+      {
+        # Direct bucket access is also needed for some operations
+        Sid    = "BackingBucketAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          aws_s3_bucket.mrap_bucket_us_east_1.arn,
+          "${aws_s3_bucket.mrap_bucket_us_east_1.arn}/*",
+          aws_s3_bucket.mrap_bucket_us_west_2.arn,
+          "${aws_s3_bucket.mrap_bucket_us_west_2.arn}/*"
+        ]
+      }
+    ]
+  })
+}

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/main.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/main.tf
@@ -1,0 +1,58 @@
+# Set up cloud provider access in Atlas
+resource "mongodbatlas_cloud_provider_access_setup" "setup" {
+  project_id    = var.project_id
+  provider_name = "AWS"
+}
+
+# Authorize the IAM role for Atlas access
+resource "mongodbatlas_cloud_provider_access_authorization" "auth" {
+  project_id = var.project_id
+  role_id    = mongodbatlas_cloud_provider_access_setup.setup.role_id
+
+  aws {
+    iam_assumed_role_arn = aws_iam_role.atlas_role.arn
+  }
+}
+
+# Set up log integration with MRAP
+resource "mongodbatlas_log_integration" "mrap_s3" {
+  project_id  = var.project_id
+  type        = "S3_LOG_EXPORT"
+  bucket_name = aws_s3control_multi_region_access_point.atlas_logs.arn # MRAP alias
+  iam_role_id = mongodbatlas_cloud_provider_access_authorization.auth.role_id
+  prefix_path = var.prefix_path
+  log_types   = var.log_types
+}
+
+output "mrap_alias" {
+  description = "The MRAP alias used in bucket_name"
+  value       = aws_s3control_multi_region_access_point.atlas_logs.alias
+}
+
+output "mrap_arn" {
+  description = "The MRAP ARN"
+  value       = aws_s3control_multi_region_access_point.atlas_logs.arn
+}
+
+output "integration_id" {
+  description = "The ID of the log integration"
+  value       = mongodbatlas_log_integration.mrap_s3.integration_id
+}
+
+output "iam_role_arn" {
+  description = "ARN of the IAM role used for the integration"
+  value       = aws_iam_role.atlas_role.arn
+}
+
+output "cloud_provider_role_id" {
+  description = "Atlas Cloud Provider Access Role ID"
+  value       = mongodbatlas_cloud_provider_access_authorization.auth.role_id
+}
+
+output "backing_buckets" {
+  description = "The S3 buckets backing the MRAP"
+  value = {
+    us_east_1 = aws_s3_bucket.mrap_bucket_us_east_1.bucket
+    us_west_2 = aws_s3_bucket.mrap_bucket_us_west_2.bucket
+  }
+}

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/providers.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/providers.tf
@@ -1,0 +1,13 @@
+# AWS Provider Aliases for Multi-Region Buckets
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+}
+
+# MongoDB Atlas Provider
+provider "mongodbatlas" {}

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/variables.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/variables.tf
@@ -1,0 +1,22 @@
+variable "project_id" {
+  description = "MongoDB Atlas Project ID"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for naming AWS resources (must be globally unique for S3)"
+  type        = string
+  default     = "atlas-logs"
+}
+
+variable "prefix_path" {
+  description = "S3 directory path prefix for log files"
+  type        = string
+  default     = "atlas-logs/"
+}
+
+variable "log_types" {
+  description = "Array of log types to export"
+  type        = list(string)
+  default     = ["MONGOD", "MONGOS"]
+}

--- a/examples/mongodbatlas_log_integration/s3bucket_mrap/versions.tf
+++ b/examples/mongodbatlas_log_integration/s3bucket_mrap/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = ">= 1.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+  required_version = ">= 1.0"
+}

--- a/templates/data-sources/log_integration.md.tmpl
+++ b/templates/data-sources/log_integration.md.tmpl
@@ -9,7 +9,7 @@ subcategory: "Log Integration"
 To use this data source, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
 
 ## Example Usage
-{{ tffile (printf "examples/%s/main.tf" .Name )}}
+{{ tffile (printf "examples/%s/s3bucket/main.tf" .Name )}}
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates/data-sources/log_integrations.md.tmpl
+++ b/templates/data-sources/log_integrations.md.tmpl
@@ -9,7 +9,7 @@ subcategory: "Log Integration"
 To use this data source, the requesting Service Account or API Key must have the Organization Owner or Project Owner role.
 
 ## Example Usages
-{{ tffile (printf "examples/mongodbatlas_log_integration/main.tf" )}}
+{{ tffile (printf "examples/mongodbatlas_log_integration/s3bucket/main.tf" )}}
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates/resources/log_integration.md.tmpl
+++ b/templates/resources/log_integration.md.tmpl
@@ -10,7 +10,7 @@ To use this resource, the requesting Service Account or API Key must have the Or
 
 ## Example Usage
 
-{{ tffile (printf "examples/%s/main.tf" .Name )}}
+{{ tffile (printf "examples/%s/s3bucket/main.tf" .Name )}}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
## Description

Adds example for `mongodbatlas_log_integration` resource using Multi Region Access Points (MRAP) instead of bucket name

Link to any related issue(s): - 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code
- [ ] If changes include deprecations or removals I have added appropriate changelog entries.
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
