### PR TITLE
chore: Improve Project IP Access List concurrency handling with a MutexKV

### DIFF
--- a/internal/common/concurrency/mutexkv.go
+++ b/internal/common/concurrency/mutexkv.go
@@ -1,4 +1,4 @@
-package config
+package concurrency
 
 import (
 	"log"

--- a/internal/config/mutexkv.go
+++ b/internal/config/mutexkv.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"log"
+	"sync"
+)
+
+// Copied from Hashicorp: https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#removal-of-helper-mutexkv-package
+// "Providers that need the functionality provided by the helper/mutexkv package are encouraged to copy the types and functions
+// it provided into their own codebase, provided here under a public domain license"
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+type MutexKV struct {
+	store map[string]*sync.Mutex
+	lock  sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initialized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list.go
@@ -30,6 +30,8 @@ const (
 	minTimeoutCreateUpdate = 10 * time.Second
 )
 
+var createAccessListEntryMutex = config.NewMutexKV()
+
 type projectIPAccessListRS struct {
 	config.RSCommon
 }
@@ -271,8 +273,13 @@ func createOrUpdate(ctx context.Context, connV2 *admin.APIClient, projectIPAcces
 		Pending: []string{"pending"},
 		Target:  []string{"created", "failed"},
 		Refresh: func() (any, string, error) {
+			// Each access list entry is its own resource, processed concurrently (it's up to terraform how the provider is called).
+			// From API docs: "This endpoint doesn't support concurrent POST requests. You must submit multiple POST requests synchronously."
+			// Locking on a project level to avoid race conditions. Still, we verify that the entry was added to the access list and retry otherwise in case of an external update.
+			createAccessListEntryMutex.Lock(projectID)
 			_, httpResponse, err := connV2.ProjectIPAccessListApi.CreateAccessListEntry(ctx, projectID, NewMongoDBProjectIPAccessList(projectIPAccessListModel)).Execute()
-			// Atlas Create is called inside refresh because this limitation: This endpoint doesn't support concurrent POST requests. You must submit multiple POST requests synchronously.
+			// Unlock immediately after create to allow parallel reads (intentionally not deferring).
+			createAccessListEntryMutex.Unlock(projectID)
 			if err != nil {
 				if validate.StatusInternalServerError(httpResponse) {
 					return nil, "pending", nil

--- a/internal/service/projectipaccesslist/resource_project_ip_access_list.go
+++ b/internal/service/projectipaccesslist/resource_project_ip_access_list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mongodb/terraform-provider-mongodbatlas/internal/common/concurrency"
 	"go.mongodb.org/atlas-sdk/v20250312012/admin"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -30,7 +31,7 @@ const (
 	minTimeoutCreateUpdate = 10 * time.Second
 )
 
-var createAccessListEntryMutex = config.NewMutexKV()
+var createAccessListEntryMutex = concurrency.NewMutexKV()
 
 type projectIPAccessListRS struct {
 	config.RSCommon
@@ -273,9 +274,9 @@ func createOrUpdate(ctx context.Context, connV2 *admin.APIClient, projectIPAcces
 		Pending: []string{"pending"},
 		Target:  []string{"created", "failed"},
 		Refresh: func() (any, string, error) {
-			// Each access list entry is its own resource, processed concurrently (it's up to terraform how the provider is called).
+			// Each access list entry is its own resource, which leads to concurrent calls within a single apply unless explicitly handled by the user.
 			// From API docs: "This endpoint doesn't support concurrent POST requests. You must submit multiple POST requests synchronously."
-			// Locking on a project level to avoid race conditions. Still, we verify that the entry was added to the access list and retry otherwise in case of an external update.
+			// Locking on a project level to avoid race conditions within a single apply. Still, we verify that the entry was added to the access list and retry otherwise in case of an external update.
 			createAccessListEntryMutex.Lock(projectID)
 			_, httpResponse, err := connV2.ProjectIPAccessListApi.CreateAccessListEntry(ctx, projectID, NewMongoDBProjectIPAccessList(projectIPAccessListModel)).Execute()
 			// Unlock immediately after create to allow parallel reads (intentionally not deferring).


### PR DESCRIPTION
## Description

Adding MutexKV implementation from: https://developer.hashicorp.com/terraform/plugin/sdkv2/guides/v2-upgrade-guide#removal-of-helper-mutexkv-package

Using the mutex key-value to ensure serial calls to [CreateAccessListEntry](https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupaccesslistentry) for the same ProjectID.

The existing implementation:
- Makes a call to create the entry
- Makes a call to get the entry and verifies it was actually added to the list
- Retries if the entry is not in the list (happens if another entry was written first)

Given that each resource is processed concurrently (up to terraform to decide how the provider is called), we are almost always running into race conditions and retrying multiple times for the same entry.

Ensuring serial calls for the same project solves this problem, speeds up the entry creation and incurs in less API calls.
> Note that we are keeping the retry mechanism to protect against external updates.


Numbers from running `TestAccProjectIPAccessList_settingMultiple`, which creates 20 entries:
- Before ([run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/21294079001/job/61295197814#step:5:76)): 322.20s
- After ([run](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/21294999950/job/61298397654#step:5:76)): 61.83s

That's a 322.2/61.83s = **5.2x** speed up (80.8%) and significantly fewer API calls.

Link to any related issue(s): [CLOUDP-375578](https://jira.mongodb.org/browse/CLOUDP-375578)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
