### PR TITLE
test: Remove testAccAdvancedClusterFlexUpgrade

### DIFF
--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -21,21 +21,20 @@ import (
 )
 
 const (
-	resourceName             = "mongodbatlas_advanced_cluster.test"
-	dataSourceName           = "data.mongodbatlas_advanced_cluster.test"
-	dataSourcePluralName     = "data.mongodbatlas_advanced_clusters.test"
-	dataSourceConfigSingular = `
+	resourceName         = "mongodbatlas_advanced_cluster.test"
+	dataSourceName       = "data.mongodbatlas_advanced_cluster.test"
+	dataSourcePluralName = "data.mongodbatlas_advanced_clusters.test"
+	dataSourcesConfig    = `
 	data "mongodbatlas_advanced_cluster" "test" {
 		project_id = mongodbatlas_advanced_cluster.test.project_id
 		name 	     = mongodbatlas_advanced_cluster.test.name
 		depends_on = [mongodbatlas_advanced_cluster.test]
-	}`
-	dataSourceConfigPlural = `
+	}
+			
 	data "mongodbatlas_advanced_clusters" "test" {
 		project_id = mongodbatlas_advanced_cluster.test.project_id
 		depends_on = [mongodbatlas_advanced_cluster.test]
 	}`
-	dataSourcesConfig           = dataSourceConfigSingular + dataSourceConfigPlural
 	freeInstanceSize            = "M0"
 	sharedInstanceSize          = "M2"
 	errDefaultMaxTimeMinVersion = "`advanced_configuration.default_max_time_ms` can only be configured if the mongo_db_major_version is 8.0 or higher"
@@ -46,46 +45,6 @@ var (
 	configServerManagementModeAtlasManaged     = "ATLAS_MANAGED"
 	mockConfig                                 = unit.MockConfigAdvancedCluster
 )
-
-func testAccAdvancedClusterFlexUpgrade(t *testing.T, projectID, clusterName, instanceSize string, includeDedicated bool) resource.TestCase {
-	t.Helper()
-	defaultZoneName := "Zone 1" // Uses backend default as in existing tests
-
-	// avoid checking plural data source to reduce risk of being impacted from failure in other test using same project, allows running in parallel
-	steps := []resource.TestStep{
-		{
-			Config: configTenant(t, projectID, clusterName, defaultZoneName, instanceSize, false),
-			Check:  checkTenant(projectID, clusterName, false),
-		},
-		{
-			Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", defaultZoneName, "", false, nil, false),
-			Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", false, false),
-		},
-	}
-	if includeDedicated {
-		steps = append(steps, resource.TestStep{
-			Config: acc.ConfigDedicatedNVMeBackupEnabled(projectID, clusterName, defaultZoneName),
-			Check:  checksDedicatedNVMeBackupEnabled(projectID, clusterName, false),
-		})
-	}
-
-	return resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps:                    steps,
-	}
-}
-
-func TestAccAdvancedCluster_basicTenant_flexUpgrade_dedicatedUpgrade(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithFreeCluster(t, 3, 1)
-	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, projectID, clusterName, freeInstanceSize, true))
-}
-
-func TestAccAdvancedCluster_sharedTier_flexUpgrade(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 1)
-	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, projectID, clusterName, sharedInstanceSize, false))
-}
 
 func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	var (
@@ -98,7 +57,7 @@ func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configTenant(t, projectID, clusterName, defaultZoneName, freeInstanceSize, true),
+				Config: configTenant(t, projectID, clusterName, defaultZoneName, freeInstanceSize),
 				Check:  checkTenant(projectID, clusterName, true),
 			},
 			{
@@ -1372,16 +1331,11 @@ func checkAggr(attrsSet []string, attrsMap map[string]string, extra ...resource.
 	return acc.CheckRSAndDS(resourceName, admin.PtrString(dataSourceName), nil, attrsSet, attrsMap, extraChecks...)
 }
 
-func configTenant(t *testing.T, projectID, name, zoneName, instanceSize string, includePluralDS bool) string {
+func configTenant(t *testing.T, projectID, name, zoneName, instanceSize string) string {
 	t.Helper()
 	zoneNameLine := ""
 	if zoneName != "" {
 		zoneNameLine = fmt.Sprintf("zone_name = %q", zoneName)
-	}
-
-	dsConfig := dataSourceConfigSingular
-	if includePluralDS {
-		dsConfig = dataSourcesConfig
 	}
 
 	return fmt.Sprintf(`
@@ -1389,7 +1343,7 @@ func configTenant(t *testing.T, projectID, name, zoneName, instanceSize string, 
 		project_id   = %[1]q
 		name         = %[2]q
 		cluster_type = "REPLICASET"
-
+		
 		replication_specs = [{
 			region_configs = [{
 			backing_provider_name = "AWS"
@@ -1403,7 +1357,7 @@ func configTenant(t *testing.T, projectID, name, zoneName, instanceSize string, 
 		 %[3]s
 		}]
 	}
-`, projectID, name, zoneNameLine, instanceSize) + dsConfig
+`, projectID, name, zoneNameLine, instanceSize) + dataSourcesConfig
 }
 
 func checkTenant(projectID, name string, checkPlural bool) resource.TestCheckFunc {
@@ -2882,7 +2836,7 @@ func configFCVPinning(t *testing.T, orgID, projectName, clusterName string, pinn
 	`, orgID, projectName, clusterName, mongoDBMajorVersion, pinnedFCVAttr) + dataSourcesConfig
 }
 
-func configFlexCluster(t *testing.T, projectID, clusterName, providerName, region, zoneName, timeoutConfig string, withTags bool, deleteOnCreateTimeout *bool, includePluralDS bool) string {
+func configFlexCluster(t *testing.T, projectID, clusterName, providerName, region, zoneName, timeoutConfig string, withTags bool, deleteOnCreateTimeout *bool) string {
 	t.Helper()
 	zoneNameLine := ""
 	if zoneName != "" {
@@ -2900,10 +2854,6 @@ func configFlexCluster(t *testing.T, projectID, clusterName, providerName, regio
 		deleteOnCreateTimeoutConfig = fmt.Sprintf(`
 			delete_on_create_timeout = %[1]t
 		`, *deleteOnCreateTimeout)
-	}
-	dsConfig := dataSourceConfigSingular
-	if includePluralDS {
-		dsConfig = dataSourcesConfig
 	}
 	return fmt.Sprintf(`
 		resource "mongodbatlas_advanced_cluster" "test" {
@@ -2924,7 +2874,7 @@ func configFlexCluster(t *testing.T, projectID, clusterName, providerName, regio
 			termination_protection_enabled = false
 			%[8]s
 		}
-	`, projectID, clusterName, providerName, region, zoneNameLine, tags, timeoutConfig, deleteOnCreateTimeoutConfig) + dsConfig +
+	`, projectID, clusterName, providerName, region, zoneNameLine, tags, timeoutConfig, deleteOnCreateTimeoutConfig) + dataSourcesConfig +
 		strings.ReplaceAll(acc.FlexDataSource, "mongodbatlas_flex_cluster.", "mongodbatlas_advanced_cluster.")
 }
 
@@ -2940,16 +2890,16 @@ func TestAccClusterFlexCluster_basic(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyFlexCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", emptyTimeoutConfig, false, nil, true),
+				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", emptyTimeoutConfig, false, nil),
 				Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", false, true),
 			},
 			{
-				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", emptyTimeoutConfig, true, nil, true),
+				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", emptyTimeoutConfig, true, nil),
 				Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", true, true),
 			},
 			acc.TestStepImportCluster(resourceName),
 			{
-				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_2", "", emptyTimeoutConfig, true, nil, true),
+				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_2", "", emptyTimeoutConfig, true, nil),
 				ExpectError: regexp.MustCompile("flex cluster update is not supported except for tags and termination_protection_enabled fields"),
 			},
 		},
@@ -2968,7 +2918,7 @@ func TestAccAdvancedCluster_createTimeoutWithDeleteOnCreateFlex(t *testing.T) {
 		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
 		Steps: []resource.TestStep{
 			{
-				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(&createTimeout, nil, nil), false, &deleteOnCreateTimeout, true),
+				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(&createTimeout, nil, nil), false, &deleteOnCreateTimeout),
 				ExpectError: regexp.MustCompile("context deadline exceeded"), // with the current implementation, this is the error that is returned
 			},
 		},
@@ -2988,10 +2938,10 @@ func TestAccAdvancedCluster_updateDeleteTimeoutFlex(t *testing.T) {
 		CheckDestroy:             acc.CheckDestroyFlexCluster,
 		Steps: []resource.TestStep{
 			{
-				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), false, nil, true),
+				Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), false, nil),
 			},
 			{
-				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), true, nil, true),
+				Config:      configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", "", acc.TimeoutConfig(nil, &updateTimeout, &deleteTimeout), true, nil),
 				ExpectError: regexp.MustCompile("timeout while waiting for state to become 'IDLE'"),
 			},
 			{

--- a/internal/service/advancedcluster/resource_test.go
+++ b/internal/service/advancedcluster/resource_test.go
@@ -46,47 +46,6 @@ var (
 	mockConfig                                 = unit.MockConfigAdvancedCluster
 )
 
-func testAccAdvancedClusterFlexUpgrade(t *testing.T, projectID, clusterName, instanceSize string, includeDedicated bool) resource.TestCase {
-	t.Helper()
-	t.Skip("Skipping until CLOUDP-357683 is implemented")
-	defaultZoneName := "Zone 1" // Uses backend default as in existing tests
-
-	// avoid checking plural data source to reduce risk of being impacted from failure in other test using same project, allows running in parallel
-	steps := []resource.TestStep{
-		{
-			Config: configTenant(t, projectID, clusterName, defaultZoneName, instanceSize),
-			Check:  checkTenant(projectID, clusterName, false),
-		},
-		{
-			Config: configFlexCluster(t, projectID, clusterName, "AWS", "US_EAST_1", defaultZoneName, "", false, nil),
-			Check:  checkFlexClusterConfig(projectID, clusterName, "AWS", "US_EAST_1", false, false),
-		},
-	}
-	if includeDedicated {
-		steps = append(steps, resource.TestStep{
-			Config: acc.ConfigDedicatedNVMeBackupEnabled(projectID, clusterName, defaultZoneName),
-			Check:  checksDedicatedNVMeBackupEnabled(projectID, clusterName, false),
-		})
-	}
-
-	return resource.TestCase{
-		PreCheck:                 acc.PreCheckBasicSleep(t, nil, projectID, clusterName),
-		ProtoV6ProviderFactories: acc.TestAccProviderV6Factories,
-		CheckDestroy:             acc.CheckDestroyCluster,
-		Steps:                    steps,
-	}
-}
-
-func TestAccAdvancedCluster_basicTenant_flexUpgrade_dedicatedUpgrade(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithFreeCluster(t, 3, 1)
-	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, projectID, clusterName, freeInstanceSize, true))
-}
-
-func TestAccAdvancedCluster_sharedTier_flexUpgrade(t *testing.T) {
-	projectID, clusterName := acc.ProjectIDExecutionWithCluster(t, 1)
-	resource.ParallelTest(t, testAccAdvancedClusterFlexUpgrade(t, projectID, clusterName, sharedInstanceSize, false))
-}
-
 func TestAccMockableAdvancedCluster_tenantUpgrade(t *testing.T) {
 	var (
 		projectID, clusterName = acc.ProjectIDExecutionWithFreeCluster(t, 3, 1)


### PR DESCRIPTION
## Description

Remove plural `advanced_cluster` datasource from testss using `testAccAdvancedClusterFlexUpgrade` as it failing because of Atlas ticket CLOUDP-357683, and that ticket won't be done in the short term.

EDIT: at the end the tests are being removed as they interfere with plural datasources in other tests in the same projects making them fail.

Link to any related issue(s): CLOUDP-357733

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR. A migration guide must be created or updated if the new feature will go in a major version.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR. A migration guide must be created or updated.
- [ ] This change requires a documentation update
- [ ] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contributing guides](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/contributing/README.md)
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run make fmt and formatted my code
- [x] If changes include deprecations or removals I have added appropriate changelog entries.
- [x] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Further comments
